### PR TITLE
fix: make test root directory where install is

### DIFF
--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -195,7 +195,8 @@ def run_integration_tests() -> None:
     exit_code = pytest.main(
         [
             "-v",
-            "--rootdir", str(Path(__file__).parent),
+            "--rootdir",
+            str(Path(__file__).parent),
             "--log-cli-level=WARNING",
             Path(__file__).parent / "tests/test_inference_full.py",
             "-m",


### PR DESCRIPTION
**Issue:**
When running integration tests via run_integration_tests(), pytest automatically sets its rootdir to some reasonable looking parent directory, instead of the project directory. However, this rootdir may not be accessible to the current user. 

**Proposed fix:**
Explicitly set the root directory when invoking pytest.main():

```
pytest.main([
    "-v",
    "--rootdir", str(Path(__file__).parent),
    "--log-cli-level=WARNING",
    str(Path(__file__).parent / "tests/test_inference_full.py"),
    "-m", "inference_verification",
])
```