### PR TITLE
Preserve Raw ColabFold MSA Output Files

### DIFF
--- a/openfold3/tests/test_colabfold_msa.py
+++ b/openfold3/tests/test_colabfold_msa.py
@@ -30,6 +30,7 @@ from openfold3.core.data.tools.colabfold_msa_server import (
     ColabFoldQueryRunner,
     ComplexGroup,
     MsaComputationSettings,
+    _parse_a3m_file_by_m,
     collect_colabfold_msa_data,
     get_sequence_hash,
     preprocess_colabfold_msas,
@@ -316,4 +317,270 @@ class TestMsaComputationSettings:
 
         assert "Output directory mismatch" in str(exc_info.value), (
             "Expected ValueError on output directory conflict"
+        )
+
+
+class TestParseA3mFileByM:
+    """Test suite for _parse_a3m_file_by_m function."""
+
+    def test_parse_single_m_value(self, tmp_path):
+        """Test parsing a3m file with a single M value."""
+        a3m_content = textwrap.dedent(
+            """\
+            >101
+            SEQUENCE1
+            >UniRef100_A0A123
+            MATCH1
+            MATCH1CONT
+            >UniRef100_B0B456
+            MATCH2
+            """
+        )
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_text(a3m_content)
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert 101 in result, "Expected M value 101 in result"
+        assert len(result) == 1, "Expected only one M value"
+        lines = result[101]
+        assert len(lines) == 7, "Expected 7 lines for M=101 (M header, sequence, 2 UniRef headers, 3 match lines)"
+        assert lines[0] == ">101\n", "First line should be M header"
+        assert lines[1] == "SEQUENCE1\n", "Second line should be sequence"
+        assert ">UniRef100_A0A123\n" in lines, "Should contain UniRef header"
+        assert "MATCH1\n" in lines, "Should contain match sequence"
+        assert "MATCH1CONT\n" in lines, "Should contain continuation of match sequence"
+        assert ">UniRef100_B0B456\n" in lines, "Should contain second UniRef header"
+        assert "MATCH2\n" in lines, "Should contain second match sequence"
+
+    def test_parse_multiple_m_values(self, tmp_path):
+        """Test parsing a3m file with multiple M values separated by null bytes."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\n>UniRef100_A0A123\nMATCH1\n\x00>102\nSEQUENCE2\n>UniRef100_B0B456\nMATCH2\n\x00>103\nSEQUENCE3\n>UniRef100_C0C789\nMATCH3\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 3, "Expected 3 M values"
+        assert 101 in result, "Expected M value 101"
+        assert 102 in result, "Expected M value 102"
+        assert 103 in result, "Expected M value 103"
+
+        # Check M=101 section
+        lines_101 = result[101]
+        assert lines_101[0] == ">101\n", "M=101 should start with >101"
+        assert "SEQUENCE1\n" in lines_101, "M=101 should contain SEQUENCE1"
+        assert ">UniRef100_A0A123\n" in lines_101, "M=101 should contain UniRef header"
+        assert ">102\n" not in lines_101, "M=101 should not contain >102"
+
+        # Check M=102 section
+        lines_102 = result[102]
+        assert lines_102[0] == ">102\n", "M=102 should start with >102"
+        assert "SEQUENCE2\n" in lines_102, "M=102 should contain SEQUENCE2"
+        assert ">UniRef100_B0B456\n" in lines_102, "M=102 should contain UniRef header"
+        assert ">103\n" not in lines_102, "M=102 should not contain >103"
+
+        # Check M=103 section
+        lines_103 = result[103]
+        assert lines_103[0] == ">103\n", "M=103 should start with >103"
+        assert "SEQUENCE3\n" in lines_103, "M=103 should contain SEQUENCE3"
+
+    def test_parse_with_m_filter(self, tmp_path):
+        """Test parsing with M value filter."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\n>UniRef100_A0A123\nMATCH1\n\x00>102\nSEQUENCE2\n>UniRef100_B0B456\nMATCH2\n\x00>103\nSEQUENCE3\n>UniRef100_C0C789\nMATCH3\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        # Filter to only include M=101 and M=103
+        m_filter = {101: "rep1", 103: "rep3"}
+        result = _parse_a3m_file_by_m(a3m_file, m_filter=m_filter)
+
+        assert len(result) == 2, "Expected 2 M values after filtering"
+        assert 101 in result, "Expected M value 101"
+        assert 103 in result, "Expected M value 103"
+        assert 102 not in result, "M=102 should be filtered out"
+
+        # Check that filtered sections are correct
+        lines_101 = result[101]
+        assert "SEQUENCE1\n" in lines_101, "M=101 should contain SEQUENCE1"
+        assert "SEQUENCE2\n" not in lines_101, "M=101 should not contain SEQUENCE2"
+
+        lines_103 = result[103]
+        assert "SEQUENCE3\n" in lines_103, "M=103 should contain SEQUENCE3"
+        assert "SEQUENCE2\n" not in lines_103, "M=103 should not contain SEQUENCE2"
+
+    def test_parse_with_null_bytes(self, tmp_path):
+        """Test parsing a3m file with null bytes (\\x00) that trigger M updates."""
+        a3m_content = ">101\nSEQUENCE1\n\x00>102\nSEQUENCE2\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 2, "Expected 2 M values"
+        assert 101 in result, "Expected M value 101"
+        assert 102 in result, "Expected M value 102"
+
+        # Check that null bytes are removed
+        lines_101 = result[101]
+        assert "\x00" not in "".join(lines_101), "Null bytes should be removed from M=101"
+        assert "SEQUENCE1\n" in lines_101, "M=101 should contain SEQUENCE1"
+
+        lines_102 = result[102]
+        assert "\x00" not in "".join(lines_102), "Null bytes should be removed from M=102"
+        assert "SEQUENCE2\n" in lines_102, "M=102 should contain SEQUENCE2"
+
+    def test_parse_empty_file(self, tmp_path):
+        """Test parsing an empty a3m file."""
+        a3m_file = tmp_path / "empty.a3m"
+        a3m_file.write_text("")
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 0, "Expected empty result for empty file"
+
+    def test_parse_file_with_no_m_values(self, tmp_path):
+        """Test parsing a3m file with no M value headers."""
+        a3m_content = textwrap.dedent(
+            """\
+            >UniRef100_A0A123
+            MATCH1
+            >UniRef100_B0B456
+            MATCH2
+            """
+        )
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_text(a3m_content)
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 0, "Expected empty result when no M values present"
+
+    def test_parse_file_with_m_value_less_than_101(self, tmp_path):
+        """Test parsing a3m file with M value less than 101 (should still parse)."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">100\nSEQUENCE1\n>UniRef100_A0A123\nMATCH1\n\x00>101\nSEQUENCE2\n>UniRef100_B0B456\nMATCH2\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        # Should parse both M=100 and M=101 (function doesn't filter by >= 101)
+        assert 100 in result, "Expected M value 100"
+        assert 101 in result, "Expected M value 101"
+
+    def test_parse_with_complex_uniref_headers(self, tmp_path):
+        """Test parsing with complex UniRef headers that might look like M values."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\n>UniRef100_10566|scaffold\nMATCH1\n>UniRef100_A0A208S2R6\nMATCH2\n\x00>102\nSEQUENCE2\n>UniRef100_12345\nMATCH3\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 2, "Expected 2 M values"
+        assert 101 in result, "Expected M value 101"
+        assert 102 in result, "Expected M value 102"
+
+        # Check that complex UniRef headers are included in correct sections
+        lines_101 = result[101]
+        assert ">UniRef100_10566|scaffold\n" in lines_101, "Complex UniRef header should be in M=101"
+        assert ">UniRef100_A0A208S2R6\n" in lines_101, "UniRef header should be in M=101"
+        assert ">UniRef100_12345\n" not in lines_101, "UniRef header should not be in M=101"
+
+        lines_102 = result[102]
+        assert ">UniRef100_12345\n" in lines_102, "UniRef header should be in M=102"
+
+    def test_parse_with_whitespace_in_m_header(self, tmp_path):
+        """Test parsing M headers with whitespace."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101 \nSEQUENCE1\n\x00>102\t\nSEQUENCE2\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 2, "Expected 2 M values"
+        assert 101 in result, "Expected M value 101"
+        assert 102 in result, "Expected M value 102"
+
+    def test_parse_with_filter_excluding_all(self, tmp_path):
+        """Test parsing with filter that excludes all M values."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\n\x00>102\nSEQUENCE2\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        # Filter that doesn't include any M values
+        m_filter = {999: "dummy"}
+        result = _parse_a3m_file_by_m(a3m_file, m_filter=m_filter)
+
+        assert len(result) == 0, "Expected empty result when all M values filtered out"
+
+    def test_parse_nonexistent_file(self, tmp_path):
+        """Test parsing a non-existent file."""
+        nonexistent_file = tmp_path / "nonexistent.a3m"
+
+        result = _parse_a3m_file_by_m(nonexistent_file)
+
+        assert len(result) == 0, "Expected empty result for non-existent file"
+
+    def test_parse_with_multiline_sequences(self, tmp_path):
+        """Test parsing with sequences that span multiple lines."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\nPART1\nPART2\n>UniRef100_A0A123\nMATCH1\nMATCH1CONT\n\x00>102\nSEQUENCE2\nPART3\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 2, "Expected 2 M values"
+        lines_101 = result[101]
+        assert "SEQUENCE1\n" in lines_101, "Should contain first part of sequence"
+        assert "PART1\n" in lines_101, "Should contain second part"
+        assert "PART2\n" in lines_101, "Should contain third part"
+        assert "PART3\n" not in lines_101, "Should not contain parts from M=102"
+
+    def test_parse_with_uniref_header_with_metadata(self, tmp_path):
+        """Test parsing with UniRef headers that have metadata (e.g., >10648|Ga0318525_12252441_1|+3|11...)."""
+        # Real a3m files have null bytes (\x00) before new M value headers
+        a3m_content = ">101\nSEQUENCE1\n>UniRef100_A0A123\nMATCH1\n>10648|Ga0318525_12252441_1|+3|11\t57\t0.284\t3.822E-04\t143\t229\t747\t7\t91\t95\nMATCH2\n\x00>102\nSEQUENCE2\n>UniRef100_B0B456\nMATCH3\n>10566|scaffold|+1|5\t42\t0.500\t1.444E-49\t0\t121\t122\t42\t162\t163\nMATCH4\n"
+        a3m_file = tmp_path / "test.a3m"
+        a3m_file.write_bytes(a3m_content.encode("utf-8"))
+
+        result = _parse_a3m_file_by_m(a3m_file)
+
+        assert len(result) == 2, "Expected 2 M values"
+        assert 101 in result, "Expected M value 101"
+        assert 102 in result, "Expected M value 102"
+
+        # Check M=101 section - should contain the UniRef header with metadata
+        lines_101 = result[101]
+        assert ">101\n" in lines_101, "M=101 should start with >101"
+        assert "SEQUENCE1\n" in lines_101, "M=101 should contain SEQUENCE1"
+        assert ">UniRef100_A0A123\n" in lines_101, "M=101 should contain simple UniRef header"
+        assert ">10648|Ga0318525_12252441_1|+3|11" in "".join(lines_101), (
+            "M=101 should contain UniRef header with metadata (10648|...)"
+        )
+        assert "MATCH2\n" in lines_101, "M=101 should contain match sequence after metadata header"
+        # Should NOT contain M=102 content
+        assert ">102\n" not in lines_101, "M=101 should not contain >102"
+        assert "SEQUENCE2\n" not in lines_101, "M=101 should not contain SEQUENCE2"
+
+        # Check M=102 section - should contain the other UniRef header with metadata
+        lines_102 = result[102]
+        assert ">102\n" in lines_102, "M=102 should start with >102"
+        assert "SEQUENCE2\n" in lines_102, "M=102 should contain SEQUENCE2"
+        assert ">UniRef100_B0B456\n" in lines_102, "M=102 should contain simple UniRef header"
+        assert ">10566|scaffold|+1|5" in "".join(lines_102), (
+            "M=102 should contain UniRef header with metadata (10566|...)"
+        )
+        assert "MATCH4\n" in lines_102, "M=102 should contain match sequence after metadata header"
+        # Should NOT contain M=101 content
+        assert ">101\n" not in lines_102, "M=102 should not contain >101"
+        assert "SEQUENCE1\n" not in lines_102, "M=102 should not contain SEQUENCE1"
+        assert ">10648|Ga0318525_12252441_1|+3|11" not in "".join(lines_102), (
+            "M=102 should not contain metadata header from M=101"
         )


### PR DESCRIPTION
**Summary**

These changes preserve raw ColabFold MSA output files (`.a3m` files) if the user disables `cleanup_msa_dir`. Previously, the `raw` directory containing batch MSA files was always deleted, regardless of the `cleanup_msa_dir` setting, preventing users from accessing the raw colabfold MSA data for inspection or reuse.

The pipeline sends batched requests to Colabfold containing multiple sequences. Suggested change in this PR separates out the resulting files by the unique sequence identifier `rep_id` and stores them in a new `raw_colabfold_output` folder which persists between runs.


**Changes**

1. **`_parse_a3m_file_by_m()` function**: util function to parse batch A3M files and extract individual MSA sections by M value (ColabFold's internal sequence identifier). This function handles:
   - Null byte delimiters (`\x00`) that separate M sections in batch files
   - UniRef headers vs. M value headers
   - Optional filtering by M values

2. **`_organize_raw_main_outputs_by_query()` method**: Extracts individual MSA sections from batch A3M files and saves them in a persistent directory `raw_colabfold_output`:
   - **Directory structure**: `raw_colabfold_output/{rep_id}/{filename}.a3m`
   - **Files preserved**: `uniref.a3m` and `bfd.mgnify30.metaeuk30.smag30.a3m` for each `rep_id`
   - **Called after**: Main MSA processing completes, before cleanup

3.  **`class TestParseA3mFileByM`** contains a few pytests to check `_parse_a3m_file_by_m()` functionality. 

Closes #31 