### PR TITLE
Update CI test configuration

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request_target' && 
-       contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'safe-to-test')
     permissions:
       id-token: write
       contents: read
@@ -42,6 +44,10 @@ jobs:
       - start-aws-runner
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && 
+                   format('refs/pull/{0}/merge', github.event.pull_request.number) || 
+                   github.ref }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.6.0


### PR DESCRIPTION
**Summary**
Configure CI test workflow to run CI testing on PRs after a `safe-to-test` label has been applied. This label should only be applied by repository maintainers.

CI test workflows that are triggered upon push updates or manual workflow dispatch should be unaffected

**Changes**
Configuration settings for CI workflow

**Testing**
Tested on manual workflow dispatch, was unable to test PR labeling on this PR. Will test triggering CI test workflow after this PR has been merged into main

