### PR TITLE
Fix Quick-Start Guide Command

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,7 +31,7 @@ setup_openfold
 ``` 
 3. Make your first prediction with:
 ```bash
-run_openfold predict query_json=examples/example_inference_inputs/query_ubiquitin.json
+run_openfold predict --query_json=examples/example_inference_inputs/query_ubiquitin.json
 ```
 
 


### PR DESCRIPTION
**Summary**

The current command does not work, it misses the keyword "predict" and the examples folder structure path does not correspond to the current example folder structure of the project (it probably evolved). Let's fix it. thxs!
