### PR TITLE
fix: missing import in preprocess_pdb_of3

### DIFF
--- a/scripts/data_preprocessing/preprocess_pdb_of3.py
+++ b/scripts/data_preprocessing/preprocess_pdb_of3.py
@@ -1,4 +1,5 @@
 import logging
+import logging.handlers
 import multiprocessing
 from pathlib import Path
 from typing import Literal
@@ -175,7 +176,7 @@ def main(
     )
 
     # Multiprocessing queue for logs
-    log_queue = multiprocessing.Queue(-1)
+    log_queue: multiprocessing.Queue = multiprocessing.Queue(-1)
 
     # Set up Queue listener for multi-worker logging
     listener = logging.handlers.QueueListener(


### PR DESCRIPTION
**Summary**

Small bug when running `preprocess_pdb_of3.py`

I get this error message 

```
Traceback (most recent call last):
  File "/home/jandom/workspace/omsf/OpenFold/openfold3/scripts/data_preprocessing/preprocess_pdb_of3.py", line 220, in <module>
    main()
  File "/home/jandom/micromamba/envs/openfold3-env/lib/python3.12/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jandom/micromamba/envs/openfold3-env/lib/python3.12/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/jandom/micromamba/envs/openfold3-env/lib/python3.12/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jandom/micromamba/envs/openfold3-env/lib/python3.12/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jandom/workspace/omsf/OpenFold/openfold3/scripts/data_preprocessing/preprocess_pdb_of3.py", line 182, in main
    listener = logging.handlers.QueueListener(
               ^^^^^^^^^^^^^^^^
AttributeError: module 'logging' has no attribute 'handlers'. Did you mean: '_handlers'?
```

**Changes**

Just import the module needed

**Related Issues**

**Testing**

**Other Notes**
