### PR TITLE
refactor: dummy_atom_array

### DIFF
--- a/openfold3/tests/conftest.py
+++ b/openfold3/tests/conftest.py
@@ -18,5 +18,4 @@ def dummy_atom_array():
     )
     atom_array = AtomArray(len(coords))
     atom_array.coord = coords
-    atom_array.chain_id = np.array(["A", "A", "B", "B", "B"])
     return atom_array

--- a/openfold3/tests/test_writer.py
+++ b/openfold3/tests/test_writer.py
@@ -93,6 +93,8 @@ class TestPredictionWriter:
     ):
         n_tokens = 3
         n_atoms = 5
+        dummy_atom_array.chain_id = np.array(["A", "A", "B", "B", "B"])
+
         confidence_scores = {
             "plddt": np.random.uniform(size=n_atoms),
             "pde_probs": np.random.uniform(size=(n_tokens, n_tokens, 64)),
@@ -141,6 +143,7 @@ class TestPredictionWriter:
     def test_confidence_writer_with_pae(self, tmp_path, output_fmt, dummy_atom_array):
         n_tokens = 3
         n_atoms = 5
+        dummy_atom_array.chain_id = np.array(["A", "A", "B", "B", "B"])
 
         confidence_scores = {
             "plddt": np.random.uniform(size=n_atoms),


### PR DESCRIPTION
**Summary**

Refactor mentioned in review of #87 

**Changes**

Pull out `chain_id` from the `dummy_atom_array` fixture, which are quite specific to the `test_writer.py`

**Related Issues**

**Testing**

**Other Notes**
