### PR TITLE
tweak: include .coverage

### DIFF
--- a/.github/workflows/ci-test-reusable.yml
+++ b/.github/workflows/ci-test-reusable.yml
@@ -102,7 +102,9 @@ jobs:
         if: always()
         with:
           name: coverage-report-${{ inputs.build_mode }}-${{ inputs.cuda_base_image_tag }}
-          path: coverage.xml
+          path: |
+            coverage.xml
+            .coverage
           retention-days: 30
 
   stop-aws-runner:


### PR DESCRIPTION

**Summary**

This is the native sqlite file pytest-cov generates that can be used (more easily than the .xml) to generate other coverage formats.

It's my bad for forgetting this file in the 1st version of the PR 

**Changes**

**Related Issues**

**Testing**

**Other Notes**
