### PR TITLE
Support for kalign>=3

### DIFF
--- a/openfold3/core/data/tools/kalign.py
+++ b/openfold3/core/data/tools/kalign.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import shutil
-import tempfile
 import subprocess
+import tempfile
 from functools import lru_cache
 
 


### PR DESCRIPTION
**Summary**
Output of `kalign` starting from `kalign3` includes some license and logging headers which breaks our fasta parsing logic.

If we change our kalign call to write the alignment output to a temporary file, we can exclude these headers from the aligned fasta.

**Changes**
In `run_kalign` change the subprocess call to use a temporary file to write the alignment output from `kalign`. The output in this temporary file will exclude the headers and can be processed by our `parse_fasta` code.

**Related Issues**
- By enabling support for `kalign3`, some issues observed in #101 may be resolved.
- This update will also enable us to use [`kalign=v3.4.6-rc1`](https://github.com/TimoLassmann/kalign/releases/tag/v3.4.6-rc1) which includes a pyproject recipe. This means that we can allow users to install kalign using pip instead of mamba only.

**Testing**
Behavior of `run_kalign` can be tested using the tests in `test_template_parsers.py`, e.g.

```
pytest openfold3/tests/test_template_parsers.py  -vvv -k a3m
```

- [x] Verify that this update also backwards compatible with kalign2

**Other Notes**


<details>
<summary>A sample of the kalign headers generated from `kalign3`, see the alignment at the end of the output</summary>

```
$ kalign -i tmp.fasta

Kalign (3.4.0)

Copyright (C) 2006,2019,2020,2021,2023 Timo Lassmann

This program comes with ABSOLUTELY NO WARRANTY; for details type:
`kalign -showw'.
This is free software, and you are welcome to redistribute it
under certain conditions; consult the COPYING file for details.

Please cite:
  Lassmann, Timo.
  "Kalign 3: multiple sequence alignment of large data sets."
  Bioinformatics (2019)
  https://doi.org/10.1093/bioinformatics/btz795

[2026-01-29 15:17:27] :     LOG : Detected protein sequences.
[2026-01-29 15:17:27] : WARNING : -------------------------------------------- (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 522)
[2026-01-29 15:17:27] : WARNING : All input sequences have the same length.    (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 523)
[2026-01-29 15:17:27] : WARNING : BUT there are no gap characters.             (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 524)
[2026-01-29 15:17:27] : WARNING :                                              (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 525)
[2026-01-29 15:17:27] : WARNING : Unable to determine whether the sequences    (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 526)
[2026-01-29 15:17:27] : WARNING : are already aligned.                         (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 527)
[2026-01-29 15:17:27] : WARNING : Kalign will align the sequences.             (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 528)
[2026-01-29 15:17:27] : WARNING : -------------------------------------------- (/opt/mambaforge/envs/bioconda/conda-bld/kalign3_1733863649254/work/lib/src/msa_op.c line 529)
[2026-01-29 15:17:27] :     LOG : Read 2 sequences from tmp.fasta.
[2026-01-29 15:17:27] :     LOG : CPU Time: 0.00u 00:00:00.00 Elapsed: 00:00:00.00
[2026-01-29 15:17:27] :     LOG : Calculating pairwise distances
[2026-01-29 15:17:27] :     LOG : CPU Time: 0.00u 00:00:00.00 Elapsed: 00:00:00.00
[2026-01-29 15:17:27] :     LOG : Building guide tree.
[2026-01-29 15:17:27] :     LOG : CPU Time: 0.00u 00:00:00.00 Elapsed: 00:00:00.00
[2026-01-29 15:17:27] :     LOG : Aligning
[2026-01-29 15:17:27] :     LOG : CPU Time: 0.00u 00:00:00.00 Elapsed: 00:00:00.00
>query
AQVINTFDGVADYLQTYHKLPDNYITKSEAQALGWVASKGNLADVAPGKSIGGDIFSNRE
GKLPGKSGRTWREADINYTSGFRNSDRILYSSDWLIYKTTDHYQTFTKIR
>1b27_B
AQVINTFDGVADYLQTYHKLPDNYITKSEAQALGWVASKGNLADVAPGKSIGGDIFSNRE
GKLPGKSGRTWREADINYTSGFRNSDRILYSSDWLIYKTTDHYQTFTKIR
```
</details>

<details>
<summary>Sample contents of kalign output file</summary>

```
$ kalign -i tmp.fasta -o tmp_aligned.fasta
$ cat tmp_aligned.fasta
>query
AQVINTFDGVADYLQTYHKLPDNYITKSEAQALGWVASKGNLADVAPGKSIGGDIFSNRE
GKLPGKSGRTWREADINYTSGFRNSDRILYSSDWLIYKTTDHYQTFTKIR
>1b27_B
AQVINTFDGVADYLQTYHKLPDNYITKSEAQALGWVASKGNLADVAPGKSIGGDIFSNRE
GKLPGKSGRTWREADINYTSGFRNSDRILYSSDWLIYKTTDHYQTFTKIR 
```
</details>