### PR TITLE
fix: missing AWS credentials in GHA

### DIFF
--- a/openfold3/core/utils/s3.py
+++ b/openfold3/core/utils/s3.py
@@ -19,11 +19,13 @@ from pathlib import Path
 
 import boto3
 from awscrt import checksums
+from botocore import UNSIGNED
+from botocore.config import Config
 
 
 def get_s3_checksum(bucket: str, key: str) -> str | None:
     """Get CRC64NVME checksum from S3 object metadata (HEAD request, no download)."""
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
     response = s3.head_object(Bucket=bucket, Key=key, ChecksumMode="ENABLED")
 
     if "ChecksumCRC64NVME" in response:


### PR DESCRIPTION
**Summary**

Woopsy, I broken main – AWS credentials are not shared with purest

**Changes**

~~This is actually a potentially dangerous change, some of these short-lived tokens could still be displayed in the output of the tests. We might be better off just using unsigned requests for checking what's on S3 (it needs to head an object to check the checksum)~~

Switched to unsigned requests for the CCD check

**Related Issues**

**Testing**

**Other Notes**
