### PR TITLE
Update Dockerfile to install openfold3 for aqaffinity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,6 +138,9 @@ FROM devel AS affinity
 
 WORKDIR /opt/openfold3
 
+# Install openfold3 package (required by aqaffinity)
+RUN uv pip install --no-deps .
+
 RUN uv pip install huggingface_hub
 
 RUN --mount=type=secret,id=hf_token \


### PR DESCRIPTION
Add openfold3 installation to affinity stage of Dockerfile for successful prediction on clean AWS EC2 instance.

**Summary**

Addresses issue with missing openfold3 dependencty when running aqaffinity predict. The affinity stage inherits from devel, which copies the source code to /opt/openfold3 but never installs the openfold3 package. The devel stage only copies files - it doesn't run uv pip install. Compare this to the test stage which correctly includes RUN uv pip install --no-deps --editable .. The fix is to add the openfold3 installation to the affinity stage

**Changes**

Adds `RUN uv pip install --no-deps .` to affinity build stage

**Related Issues**

#111 
#102 

**Testing**

```bash
git clone https://github.com/aqlaboratory/openfold-3.git
cd openfold-3
docker build \
  -f docker/Dockerfile \
  --secret id=hf_token,src=$HOME/.cache/huggingface/token \
  --target affinity \
  -t openfold-docker:affinity . \
docker run --rm \
  --gpus all \
  --ipc=host \
  -v "${HOME}/.openfold3/:/root/.openfold3" \
  -v "${PWD}/output:/output" \
  -it openfold-docker:affinity \
  aqaffinity predict \
    --query_json ./examples/example_inference_inputs/query_single_protein_single_ligand.json \
    --runner_yaml ./examples/example_runner_yamls/affinity.yaml \
    --num_diffusion_samples=1 \
    --use_templates=false \
    --output_dir /output \
    --binding_affinity_ckpt_path /opt/aqaffinity/model_weights/model_weights_only.pt
```

**Other Notes**

Small fix to big update made in #102 . Nice work, all!