### PR TITLE
fix: .coverage file missing from the GHA artifact

### DIFF
--- a/.github/workflows/ci-test-reusable.yml
+++ b/.github/workflows/ci-test-reusable.yml
@@ -105,6 +105,7 @@ jobs:
           path: |
             coverage.xml
             .coverage
+          include-hidden-files: true
           retention-days: 30
 
   stop-aws-runner:


### PR DESCRIPTION
**Summary**

We really want to keep the .coverage file because it's the SQLite file with all the coverage info. 

**Changes**

- we were including the file correctly but it got excluded because, by default, the action tries to filter out hidden files

**Related Issues**

**Testing**

**Other Notes**
