### PR TITLE
docs: improve pytest-cov configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,3 +161,22 @@ markers = [
     "inference_verification: Tests to verify installation on inference example",
     "slow: Large size test"
 ]
+
+# Exclude directories during collection
+[tool.coverage.run]
+omit = [
+    "openfold3/tests/*",
+]
+
+# Exclude directories from reporting
+[tool.coverage.report]
+omit = [
+    "openfold3/tests/*",
+]
+
+# Map /opt/openfold3/openfold3/ (docker path) to openfold3/ (local path) during `coverage combine`
+[tool.coverage.paths]
+source = [
+    "openfold3/",
+    "/opt/openfold3/openfold3/",
+]


### PR DESCRIPTION
**Summary**

Improve pytest-cov reporting by excluding certain directories (notably openfold3/test), and re-mapping certain docker-specific paths so that the .coverage file (generated on the docker image) can be analyzed locally. 

**Changes**

**Related Issues**

**Testing**

**Other Notes**
