### PR TITLE
Update kalign usage to use python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Make your first predictions with OpenFold3-preview in a few easy steps:
 1. Install OpenFold3-preview using our pip package
 ```bash
 pip install openfold3 
-mamba install kalign2 -c bioconda
 ```
 
 2. Setup your installation of OpenFold3-preview and download model parameters:

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -12,13 +12,13 @@ It is also recommended to use [Mamba](https://mamba.readthedocs.io/en/latest/) t
 
 ### Installation via pip and mamba (recommended) 
 
-1. Create a fresh mamba environment with python. Python versions 3.10 - 3.13 are supported
+0. [Optional] Create a fresh mamba environment with python. Python versions 3.10 - 3.13 are supported
 
 ```bash
 mamba create -n of3-pip-Oct24-server python=3.13 
 ```
 
-2. Install openfold3 the pypi server:
+1. Install openfold3 the pypi server:
 
 ```bash
 pip install openfold3

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -30,12 +30,6 @@ to install GPU accelerated {doc}`cuEquivariance attention kernels <kernels>`, us
 pip install openfold3[cuequivariance]
 ```
 
-3. Install `kalign2` using mamba.
-
-```bash
-mamba install kalign2 -c bioconda
-```
-
 ### OpenFold3 Docker Image
 
 The OpenFold3 Docker Image is now available on Docker Hub: [openfoldconsortium/openfold3](https://hub.docker.com/repository/docker/openfoldconsortium/openfold3/general)

--- a/environments/production-linux-64.yml
+++ b/environments/production-linux-64.yml
@@ -28,7 +28,6 @@ dependencies:
   - mmseqs2
   - bioconda::hmmer
   - bioconda::hhsuite
-  - bioconda::kalign2
   - bioconda::snakemake
   - pytorch::pytorch
   - pytorch::pytorch-cuda
@@ -40,3 +39,4 @@ dependencies:
   - pip:
       - deepspeed
       - pdbeccdutils
+      - kalign

--- a/openfold3/core/data/io/sequence/template.py
+++ b/openfold3/core/data/io/sequence/template.py
@@ -726,7 +726,7 @@ class A3mParser(TemplateParser):
             # - Realign is explicitly requested, O
             # - Headers lack coordinate information
             seq_list = [query_seq_str]
-            for header, seq in zip(headers_raw, alignments, strict=True):
+            for seq in alignments:
                 ungapped_seq = "".join(c for c in seq if c.isupper())
                 seq_list.append(ungapped_seq)
 

--- a/openfold3/core/data/io/sequence/template.py
+++ b/openfold3/core/data/io/sequence/template.py
@@ -634,14 +634,13 @@ class StoParser(TemplateParser):
                 query_start_idx=query_start_idx,
             )
         else:
-            all_sequences = f">query\n{query_seq_str}\n"
+            seq_list = [query_seq_str]
             for _, row in headers.iterrows():
                 full_id = f"{row['id']}/{row['start']}-{row['end']}"
                 ungapped_seq = aln_row_map[full_id].replace(".", "").replace("-", "")
-                all_sequences += f">{full_id}\n{ungapped_seq}\n"
+                seq_list.append(ungapped_seq)
 
-            realigned_str = run_kalign(all_sequences)
-            alignments, _ = parse_fasta(realigned_str)
+            alignments = run_kalign(seq_list)
 
             return self._process_alignment_hits(
                 query_seq_str=query_seq_str,
@@ -724,15 +723,14 @@ class A3mParser(TemplateParser):
         else:
             # Realign with kalign if:
             # - Query is not first, OR
-            # - Realign is explicitly requested, OR
+            # - Realign is explicitly requested, O
             # - Headers lack coordinate information
-            all_sequences = f">query\n{query_seq_str}\n"
+            seq_list = [query_seq_str]
             for header, seq in zip(headers_raw, alignments, strict=True):
                 ungapped_seq = "".join(c for c in seq if c.isupper())
-                all_sequences += f">{header}\n{ungapped_seq}\n"
+                seq_list.append(ungapped_seq)
 
-            realigned_str = run_kalign(all_sequences)
-            realigned_alignments, _ = parse_fasta(realigned_str)
+            realigned_alignments = run_kalign(seq_list)
 
             return self._process_alignment_hits(
                 query_seq_str=query_seq_str,

--- a/openfold3/core/data/tools/kalign.py
+++ b/openfold3/core/data/tools/kalign.py
@@ -12,49 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
-import subprocess
+import kalign
 from functools import lru_cache
 
 
 @lru_cache(maxsize=512)
+def _run_kalign_cached(sequences: tuple[str, ...]) -> str:
+    """Wrapper around kalign.align with caching."""
+    return kalign.align(list(sequences))
+
+
 def run_kalign(
-    a3m_string: str,
-) -> str:
+    sequences: list[str],
+) -> list[str]:
     """Runs Kalign on the provided A3M string and returns the aligned sequences.
 
     Args:
-        a3m_string (str):
-            A3M formatted string containing the sequences to be aligned. In the template
-            pipeline, the first sequence is the query, and the rest are templates
+        sequences (list[str]):
+            Sequences to be aligned. In the template pipeline, 
+            the first sequence is the query, and the rest are templates
             sequences to be realigned to it from hmmsearch.
-
-    Raises:
-        RuntimeError:
-            If Kalign is not available.
-        subprocess.CalledProcessError:
-            If the Kalign command fails.
-
     Returns:
-        str:
-            The aligned sequences in A3M format as a string.
+        list:
+            The aligned sequences as a list of strings.
     """
-    kalign_available = shutil.which("kalign") is not None
-
-    if not kalign_available:
-        raise RuntimeError(
-            "Kalign is not available. Please install it and ensure it is in your PATH."
-        )
-
-    try:
-        result = subprocess.run(
-            ["kalign"], input=a3m_string, capture_output=True, text=True, check=True
-        )
-
-        # The resulting MSA is stored in the variable
-        alignment_result = result.stdout
-
-    except subprocess.CalledProcessError as e:
-        print(f"Kalign command failed:\n{e.stderr}")
-
-    return alignment_result
+    return _run_kalign_cached(tuple(sequences))

--- a/openfold3/core/data/tools/kalign.py
+++ b/openfold3/core/data/tools/kalign.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kalign
 from functools import lru_cache
+
+import kalign
 
 
 @lru_cache(maxsize=512)
@@ -29,7 +30,7 @@ def run_kalign(
 
     Args:
         sequences (list[str]):
-            Sequences to be aligned. In the template pipeline, 
+            Sequences to be aligned. In the template pipeline,
             the first sequence is the query, and the rest are templates
             sequences to be realigned to it from hmmsearch.
     Returns:

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -40,17 +40,18 @@ logger = logging.getLogger(__name__)
 def check_conda_use() -> bool:
     """Check the current environment and return environment info."""
     logger.info("Checking environment...")
-    
+
     use_conda = bool(os.environ.get("CONDA_PREFIX"))
     if use_conda:
         logger.info(
-        f"Running in conda environment: {os.path.basename(os.environ['CONDA_PREFIX'])}"
-    )
+            "Running in conda environment: "
+            f"{os.path.basename(os.environ['CONDA_PREFIX'])}"
+        )
     else:
         logger.info("Not running in a conda environment.")
         logger.info("The script will run without conda-specific features.")
-    
-    return use_conda 
+
+    return use_conda
 
 
 def setup_openfold_cache(use_conda) -> tuple[Path, Path]:
@@ -99,9 +100,13 @@ def setup_openfold_cache(use_conda) -> tuple[Path, Path]:
             )
             logger.warning("Variable is set for current session only")
     else:
-        logger.info("OPENFOLD_CACHE environment variable is set for current session only")
-        logger.info("If not using the default directory, please save "
-                    f"`export $OPENFOLD_CACHE={openfold_cache}` for future use.") 
+        logger.info(
+            "OPENFOLD_CACHE environment variable is set for current session only"
+        )
+        logger.info(
+            "If not using the default directory, please save "
+            f"`export $OPENFOLD_CACHE={openfold_cache}` for future use."
+        )
 
     return openfold_cache, ckpt_root_file
 

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -37,22 +37,23 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 
-def setup_conda_commands():
-    """Check if running in a conda environment."""
-    logger.info("Setting up conda shell environment...")
-
-    if not os.environ.get("CONDA_PREFIX"):
-        logger.error("Error: This script must be run from within a conda environment.")
-        logger.error("Please activate your conda environment first:")
-        logger.error("  conda activate your_env_name")
-        sys.exit(1)
-
-    logger.info(
+def check_conda_use() -> bool:
+    """Check the current environment and return environment info."""
+    logger.info("Checking environment...")
+    
+    use_conda = bool(os.environ.get("CONDA_PREFIX"))
+    if use_conda:
+        logger.info(
         f"Running in conda environment: {os.path.basename(os.environ['CONDA_PREFIX'])}"
     )
+    else:
+        logger.info("Not running in a conda environment.")
+        logger.info("The script will run without conda-specific features.")
+    
+    return use_conda 
 
 
-def setup_openfold_cache() -> tuple[Path, Path]:
+def setup_openfold_cache(use_conda) -> tuple[Path, Path]:
     """Set up the OpenFold cache directory."""
     logger.info("Setting up OpenFold cache directory...")
 
@@ -73,29 +74,34 @@ def setup_openfold_cache() -> tuple[Path, Path]:
     os.environ["OPENFOLD_CACHE"] = str(openfold_cache)
 
     # Set conda environment variable
-    try:
-        subprocess.run(
-            [
-                "conda",
-                "env",
-                "config",
-                "vars",
-                "set",
-                f"OPENFOLD_CACHE={openfold_cache}",
-            ],
-            check=True,
-            capture_output=True,
-        )
-        logger.info(f"OPENFOLD_CACHE set to: {openfold_cache}")
-        logger.info(
-            "Variable will persist when you reactivate: "
-            f"conda activate {os.path.basename(os.environ['CONDA_PREFIX'])}"
-        )
-    except subprocess.CalledProcessError:
-        logger.warning(
-            "Warning: Could not set OPENFOLD_CACHE in conda environment config"
-        )
-        logger.warning("Variable is set for current session only")
+    if use_conda:
+        try:
+            subprocess.run(
+                [
+                    "conda",
+                    "env",
+                    "config",
+                    "vars",
+                    "set",
+                    f"OPENFOLD_CACHE={openfold_cache}",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            logger.info(f"OPENFOLD_CACHE set to: {openfold_cache}")
+            logger.info(
+                "Variable will persist when you reactivate: "
+                f"conda activate {os.path.basename(os.environ['CONDA_PREFIX'])}"
+            )
+        except subprocess.CalledProcessError:
+            logger.warning(
+                "Warning: Could not set OPENFOLD_CACHE in conda environment config"
+            )
+            logger.warning("Variable is set for current session only")
+    else:
+        logger.info("OPENFOLD_CACHE environment variable is set for current session only")
+        logger.info("If not using the default directory, please save "
+                    f"`export $OPENFOLD_CACHE={openfold_cache}` for future use.") 
 
     return openfold_cache, ckpt_root_file
 
@@ -242,10 +248,10 @@ def run_integration_tests() -> None:
 def main():
     """Main execution."""
     # Step 1: Set up conda environment
-    setup_conda_commands()
+    use_conda = check_conda_use()
 
     # Step 2: Set up OpenFold cache directory
-    openfold_cache, ckpt_root_file = setup_openfold_cache()
+    openfold_cache, ckpt_root_file = setup_openfold_cache(use_conda)
 
     # Step 3: Set up checkpoint directory
     param_dir, should_download = setup_param_directory(openfold_cache, ckpt_root_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ name = "openfold3"
 version = "0.3.1"
 dependencies = [
   "awscli",
+  "awscrt",
   "torch",# ==2.5.1",
   "pytorch-lightning >=2.1",
   "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   # For cutlass >=4, import library is cutlass_cppgen, but deepspeed is
   # currently using cutlass.
   "nvidia-cutlass <4",
+  "kalign",
 
   # additional pins
 


### PR DESCRIPTION
**Summary**

Updates usage of kalign to use python API and updates kalign installation to use pypi. 

After this change, openfold3 will be available to install entirely from pypi. Thank you @etowahadams and @TimoLassmann for the work to enable these changes in https://github.com/TimoLassmann/kalign/pull/53

BREAKING: After this set of changes is merged in, OpenFold3 will no longer be compatible with kalign2. Kalign must be installed via pypi

**Changes**

- Updates usage of kalign to use python API. This means we no longer create fastas / parse fastas for use with kalign.
- Changes setup_openfold to make conda environment setup optional
- Changes installation documentation to remove mamba installation of kalign2
- Changes production.yml recipe. TOOD: Generate new lockfile


**Related Issues**
#115 

**Testing**
- [x] Test that `openfold3/tests/tests_template_parsers.py` path
- [ ] Test setup and inference with `setup_openfold` 


**Other Notes**
Attention @gnikolenyi  for updates to kalign usage and @sdvillal for updates in dependencies.
