### PR TITLE
Fix setup-openfold for download all parameters option

### DIFF
--- a/openfold3/entry_points/parameters.py
+++ b/openfold3/entry_points/parameters.py
@@ -36,18 +36,22 @@ class CheckpointEntry:
 
 
 OPENFOLD_MODEL_CHECKPOINT_REGISTRY = {
-    "openfold3-p1": CheckpointEntry(
-        file_name="of3_ft3_v1.pt", version_compatibility="<0.4"
-    ),
     "openfold3-p2-145k": CheckpointEntry(
         file_name="of3-p2-145k.pt", version_compatibility=">=0.4"
     ),
     "openfold3-p2-155k": CheckpointEntry(
         file_name="of3-p2-155k.pt", version_compatibility=">=0.4"
     ),
+    "openfold3-p1": CheckpointEntry(  # legacy
+        file_name="of3_ft3_v1.pt", version_compatibility="<0.4"
+    ),
 }
 
 DEFAULT_CHECKPOINT_NAME = "openfold3-p2-155k"
+
+# These checkpoints are not supported for download and use in the current version,
+# but are left in the registry for record-keeping and compatibility checks.
+LEGACY_CHECKPOINTS = ["openfold3-p1"]
 
 
 def download_model_parameters(

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -29,6 +29,7 @@ import biotite.setup_ccd
 from openfold3.core.utils.s3 import download_s3_file, s3_file_matches_local
 from openfold3.entry_points.parameters import (
     DEFAULT_CHECKPOINT_NAME,
+    LEGACY_CHECKPOINTS,
     OPENFOLD_MODEL_CHECKPOINT_REGISTRY,
     download_model_parameters,
 )
@@ -132,11 +133,10 @@ def setup_param_directory(
 def download_parameters(param_dir) -> None:
     """Perform the parameter download."""
     # Exclude incompatible checkpoints:
-    legacy_checkpoints = ["openfold3-p1"]
     all_checkpoints = [
         name
         for name in OPENFOLD_MODEL_CHECKPOINT_REGISTRY
-        if name not in legacy_checkpoints
+        if name not in LEGACY_CHECKPOINTS
     ]
 
     logger.info("Select parameters to download:")

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -36,6 +36,7 @@ from openfold3.entry_points.experiment_runner import (
 from openfold3.entry_points.parameters import (
     CHECKPOINT_ROOT_FILENAME,
     DEFAULT_CHECKPOINT_NAME,
+    LEGACY_CHECKPOINTS,
     OPENFOLD_MODEL_CHECKPOINT_REGISTRY,
     CheckpointEntry,
 )
@@ -750,7 +751,9 @@ class TestSetupOpenFold:
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).exists()
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)
 
-        expected_checkpoints = ["openfold3-p2-145k", "openfold3-p2-155k"]
+        expected_checkpoints = list(
+            set(OPENFOLD_MODEL_CHECKPOINT_REGISTRY.keys()) - set(LEGACY_CHECKPOINTS)
+        )
         for ckpt_name in expected_checkpoints:
             assert (
                 tmp_path / OPENFOLD_MODEL_CHECKPOINT_REGISTRY[ckpt_name].file_name


### PR DESCRIPTION
**Summary**
Fixes an issue in the setup_openfold script when the download all parameter option is selected

**Changes**
- Excludes legacy checkpoints from the download parameter list
- Adds a test to check this option.

**Related Issues**
The setup_openfold option of downloading all parameters was breaking with the following error:

```
botocore.exceptions.ClientError: An error occurred (404) when calling the HeadObject operation: Not Found
```

This error is caused because the script attempted to download a legacy checkpoint is not present at that location

**Testing**
- Adds unit test to test this option (`openfold3/tests/test_entry_points.py::TestSetupOpenFold::test_fresh_parameter_download_all`)
- Test running `setup_openfold` script with second option.