### PR TITLE
fix: use user-specific temp directories to avoid permission errors

### DIFF
--- a/openfold3/core/data/pipelines/preprocessing/template.py
+++ b/openfold3/core/data/pipelines/preprocessing/template.py
@@ -14,6 +14,7 @@
 
 """Preprocessing pipelines for template data ran before training/evaluation."""
 
+import getpass
 import logging
 import multiprocessing as mp
 import os
@@ -1602,7 +1603,7 @@ class TemplatePreprocessorSettings(BaseModel):
             )
 
         self.output_directory = (
-            self.output_directory or Path(tempfile.gettempdir()) / "of3_template_data"
+            self.output_directory or Path(tempfile.gettempdir()) / f"of3_template_data_{getpass.getuser()}"
         )
         base = self.output_directory
 

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import getpass
 import json
 import logging
 import os
@@ -19,6 +20,14 @@ import random
 import shutil
 import tarfile
 import tempfile
+
+
+def _get_username() -> str:
+    """Get current username for user-specific temp directories."""
+    try:
+        return getpass.getuser()
+    except Exception:
+        return str(os.getuid()) if hasattr(os, "getuid") else "default"
 import time
 import warnings
 from dataclasses import dataclass, field
@@ -997,7 +1006,7 @@ class MsaComputationSettings(BaseModel):
     server_user_agent: str = "openfold"
     server_url: Url = Url("https://api.colabfold.com")
     save_mappings: bool = True
-    msa_output_directory: Path = Path(tempfile.gettempdir()) / "of3_colabfold_msas"
+    msa_output_directory: Path = Path(tempfile.gettempdir()) / f"of3_colabfold_msas_{_get_username()}"
     cleanup_msa_dir: bool = True
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary
Append current username to default temp directory names to prevent `PermissionError` on multi-user machines.

## Changes
- `colabfold_msa_server.py`: `/tmp/of3_colabfold_msas` → `/tmp/of3_colabfold_msas_{username}`
- `template.py`: `/tmp/of3_template_data` → `/tmp/of3_template_data_{username}`

Uses `getpass.getuser()` with fallback to `os.getuid()`.

## Test plan
- [ ] Run on multi-user machine with two different users
- [ ] Verify each user creates their own temp directory
- [ ] Verify single-user usage still works

Closes #150