### PR TITLE
fix: namespace temp directories by username to avoid multi-user conflicts

### DIFF
--- a/openfold3/core/data/pipelines/preprocessing/template.py
+++ b/openfold3/core/data/pipelines/preprocessing/template.py
@@ -14,6 +14,7 @@
 
 """Preprocessing pipelines for template data ran before training/evaluation."""
 
+import getpass
 import logging
 import multiprocessing as mp
 import os
@@ -1602,7 +1603,7 @@ class TemplatePreprocessorSettings(BaseModel):
             )
 
         self.output_directory = (
-            self.output_directory or Path(tempfile.gettempdir()) / "of3_template_data"
+            self.output_directory or Path(tempfile.gettempdir()) / f"of3-{getpass.getuser()}" / "template_data"
         )
         base = self.output_directory
 

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import getpass
 import json
 import logging
 import os
@@ -997,7 +998,7 @@ class MsaComputationSettings(BaseModel):
     server_user_agent: str = "openfold"
     server_url: Url = Url("https://api.colabfold.com")
     save_mappings: bool = True
-    msa_output_directory: Path = Path(tempfile.gettempdir()) / "of3_colabfold_msas"
+    msa_output_directory: Path = Path(tempfile.gettempdir()) / f"of3-{getpass.getuser()}" / "colabfold_msas"
     cleanup_msa_dir: bool = True
 
     @model_validator(mode="after")

--- a/openfold3/core/data/tools/jackhmmer.py
+++ b/openfold3/core/data/tools/jackhmmer.py
@@ -15,11 +15,14 @@
 
 """Library to run Jackhmmer from Python."""
 
+import getpass
 import glob
 import logging
 import os
 import subprocess
+import tempfile
 from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
 from concurrent import futures
 from typing import Any
 from urllib import request
@@ -203,7 +206,9 @@ class Jackhmmer:
             return f"{self.database_path}.{db_idx}"
 
         def db_local_chunk(db_idx):
-            return f"/tmp/ramdisk/{db_basename}.{db_idx}"
+            ramdisk_dir = Path(tempfile.gettempdir()) / f"of3-{getpass.getuser()}" / "ramdisk"
+            ramdisk_dir.mkdir(parents=True, exist_ok=True)
+            return str(ramdisk_dir / f"{db_basename}.{db_idx}")
 
         # Remove existing files to prevent OOM
         for f in glob.glob(db_local_chunk("[0-9]*")):


### PR DESCRIPTION
## Problem

As reported in #150, OpenFold3 uses hardcoded paths under `/tmp/` for temporary directories. On multi-user machines, this causes `PermissionError` when user A creates a directory (e.g., `/tmp/of3_colabfold_msas/`) and user B tries to write to it.

### Affected paths:
| Default path | Location |
|---|---|
| `/tmp/of3_colabfold_msas/` | `openfold3/core/data/tools/colabfold_msa_server.py:1000` |
| `/tmp/of3_template_data/` | `openfold3/core/data/pipelines/preprocessing/template.py:1605` |
| `/tmp/ramdisk/` | `openfold3/core/data/tools/jackhmmer.py:206` |

## Analysis

The issue occurs because:
1. Directories are created with default permissions (755)
2. The paths are identical for all users on the same machine
3. When user A creates the directory first, user B gets a permission denied error

## Solution

Namespace the temporary directories by username, following the pattern used by pytest (`/tmp/pytest-of-{user}/`):

```
/tmp/of3-{username}/colabfold_msas/
/tmp/of3-{username}/template_data/
/tmp/of3-{username}/ramdisk/
```

This ensures each user gets their own isolated directory hierarchy, preventing permission conflicts while maintaining backward compatibility (users can still override via configuration).

## Changes

- `colabfold_msa_server.py`: Added `getpass` import, namespaced the default MSA output directory
- `template.py`: Added `getpass` import, namespaced the default template data directory  
- `jackhmmer.py`: Added `getpass` and `tempfile` imports, namespaced the ramdisk directory with automatic directory creation

## Testing

- Verified syntax with `python3 -m py_compile` on all modified files
- Tested path generation logic confirms proper user isolation
- Confirmed no hardcoded `/tmp` paths remain in the modified files

## Notes

- This fix is minimal and non-breaking — users who explicitly set output directories are unaffected
- The pattern mirrors pytest's proven approach for temp directory isolation
- Fixes #150
