### PR TITLE
dtype options float32/16 for full confidence npz output

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -208,7 +208,7 @@ Configures the format of output files.
 **All Options**:
 - `structure_format` *(Literal["pdb", "cif", "cif.gz"])*: Output format (default: `cif`)
 - `full_confidence_output_format` *(Literal["json", "npz"])*: Confidence output format (default: `json`)
-- `full_confidence_output_dtype` *(Literal["float32", "float16"])*: Data type for confidence scores when using npz format (default: `float32`)
+- `full_confidence_output_dtype` *(Literal["float32", "float16"])*: Data type for confidence scores when using npz format (default: `float16`)
 - `write_features` *(bool)*: Write intermediate features (default: `false`)
 - `write_latent_outputs` *(bool)*: Write model intermediate outputs (default: `false`)
 - `write_full_confidence_scores` *(bool)*: Write full confidence scores, e.g. PAE, PDE, PLDDT (default: `true`)

--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -208,7 +208,7 @@ Configures the format of output files.
 **All Options**:
 - `structure_format` *(Literal["pdb", "cif", "cif.gz"])*: Output format (default: `cif`)
 - `full_confidence_output_format` *(Literal["json", "npz"])*: Confidence output format (default: `json`)
-- `full_confidence_output_dtype` (Literal["float16", "float32"])*: Data type for confidence scores when using npz format (default: `float32`)
+- `full_confidence_output_dtype` *(Literal["float32", "float16"])*: Data type for confidence scores when using npz format (default: `float32`)
 - `write_features` *(bool)*: Write intermediate features (default: `false`)
 - `write_latent_outputs` *(bool)*: Write model intermediate outputs (default: `false`)
 - `write_full_confidence_scores` *(bool)*: Write full confidence scores, e.g. PAE, PDE, PLDDT (default: `true`)

--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -208,6 +208,7 @@ Configures the format of output files.
 **All Options**:
 - `structure_format` *(Literal["pdb", "cif", "cif.gz"])*: Output format (default: `cif`)
 - `full_confidence_output_format` *(Literal["json", "npz"])*: Confidence output format (default: `json`)
+- `full_confidence_output_dtype` (Literal["float16", "float32"])*: Data type for confidence scores when using npz format (default: `float32`)
 - `write_features` *(bool)*: Write intermediate features (default: `false`)
 - `write_latent_outputs` *(bool)*: Write model intermediate outputs (default: `false`)
 - `write_full_confidence_scores` *(bool)*: Write full confidence scores, e.g. PAE, PDE, PLDDT (default: `true`)

--- a/examples/reference_full_config/full_config.yml
+++ b/examples/reference_full_config/full_config.yml
@@ -120,7 +120,7 @@ dataset_config_kwargs:
 output_writer_settings: 
   structure_format: cif  [cif | pdb | cif.gz]
   full_confidence_output_format: json [json | npz]
-  full_confidence_output_dtype: float32 [float32 | float16]
+  full_confidence_output_dtype: float16 [float32 | float16]
   write_features: false
   write_latent_outputs: false
   write_full_confidence_scores: true

--- a/examples/reference_full_config/full_config.yml
+++ b/examples/reference_full_config/full_config.yml
@@ -117,11 +117,13 @@ dataset_config_kwargs:
 
 # OutputWriterSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/entry_points/validator.py#L141
 # Configure the output formats / content
-output_writing_settings: 
+output_writer_settings: 
   structure_format: cif  [cif | pdb | cif.gz]
   full_confidence_output_format: json [json | npz]
+  full_confidence_output_dtype: float32 [float32 | float16]
   write_features: false
   write_latent_outputs: false
+  write_full_confidence_scores: true
 
 # MSAComputationSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py#L904
 # Configure MSA server settings for colabfold 

--- a/openfold3/core/runners/writer.py
+++ b/openfold3/core/runners/writer.py
@@ -76,7 +76,7 @@ class OF3OutputWriter(BasePredictionWriter):
         output_dir: Path,
         structure_format: str = "pdb",
         full_confidence_output_format: str = "json",
-        full_confidence_output_dtype: Literal["float32", "float16"] = "float32",
+        full_confidence_output_dtype: Literal["float32", "float16"] = "float16",
         write_features: bool = False,
         write_latent_outputs: bool = False,
         write_full_confidence_scores: bool = True,

--- a/openfold3/core/runners/writer.py
+++ b/openfold3/core/runners/writer.py
@@ -39,8 +39,16 @@ class NumpyEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, np.ndarray):
+            if obj.dtype == np.float16:
+                return obj.astype(np.float64).round(3).tolist()
+            elif obj.dtype == np.float32:
+                return obj.astype(np.float64).round(6).tolist()
             return obj.tolist()
         elif isinstance(obj, np.generic):
+            if obj.dtype == np.float16:
+                return round(obj.item(), 3)
+            elif obj.dtype == np.float32:
+                return round(obj.item(), 6)
             return obj.item()
         return super().default(obj)
 

--- a/openfold3/core/runners/writer.py
+++ b/openfold3/core/runners/writer.py
@@ -17,6 +17,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import torch
@@ -75,6 +76,7 @@ class OF3OutputWriter(BasePredictionWriter):
         output_dir: Path,
         structure_format: str = "pdb",
         full_confidence_output_format: str = "json",
+        full_confidence_output_dtype: Literal["float32", "float16"] = "float32",
         write_features: bool = False,
         write_latent_outputs: bool = False,
         write_full_confidence_scores: bool = True,
@@ -83,6 +85,7 @@ class OF3OutputWriter(BasePredictionWriter):
         self.output_dir = output_dir
         self.structure_format = structure_format
         self.full_confidence_format = full_confidence_output_format
+        self.full_confidence_dtype = np.dtype(full_confidence_output_dtype)
         self.write_features = write_features
         self.write_latent_outputs = write_latent_outputs
         self.write_full_confidence_scores = write_full_confidence_scores
@@ -207,7 +210,17 @@ class OF3OutputWriter(BasePredictionWriter):
                     )
                 )
             elif out_fmt == "npz":
-                np.savez_compressed(out_file_full, **full_confidence_scores)
+                for key, val in full_confidence_scores.items():
+                    if (
+                        isinstance(val, np.ndarray)
+                        and val.dtype != self.full_confidence_dtype
+                    ):
+                        full_confidence_scores[key] = val.astype(
+                            self.full_confidence_dtype
+                        )
+                np.savez_compressed(
+                    out_file_full, **full_confidence_scores, allow_pickle=False
+                )
 
     def write_all_outputs(self, batch: dict, outputs: dict, confidence_scores: dict):
         """Writes all outputs for a given batch."""

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -158,7 +158,7 @@ class OutputWritingSettings(BaseModel):
 
     structure_format: Literal["pdb", "cif", "cif.gz"] = "cif"
     full_confidence_output_format: Literal["json", "npz"] = "json"
-    full_confidence_output_dtype: Literal["float16", "float32"] = "float32"
+    full_confidence_output_dtype: Literal["float16", "float32"] = "float16"
     write_features: bool = False
     write_latent_outputs: bool = False
     write_full_confidence_scores: bool = True

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -158,6 +158,7 @@ class OutputWritingSettings(BaseModel):
 
     structure_format: Literal["pdb", "cif", "cif.gz"] = "cif"
     full_confidence_output_format: Literal["json", "npz"] = "json"
+    full_confidence_output_dtype: Literal["float16", "float32"] = "float32"
     write_features: bool = False
     write_latent_outputs: bool = False
     write_full_confidence_scores: bool = True

--- a/openfold3/tests/test_writer.py
+++ b/openfold3/tests/test_writer.py
@@ -28,27 +28,31 @@ from openfold3.core.runners.writer import OF3OutputWriter
 def dummy_confidence_scores():
     n_tokens = 3
     n_atoms = 5
+
+    def rand(*shape):
+        return np.random.uniform(size=shape).astype(np.float32)
+
     return {
-        "plddt": np.random.uniform(size=n_atoms),
-        "pde_probs": np.random.uniform(size=(n_tokens, n_tokens, 64)),
-        "pde": np.random.uniform(size=(n_tokens, n_tokens)),
-        "gpde": np.random.uniform(size=(1,)),
-        "pae_probs": np.random.uniform(size=(n_tokens, n_tokens, 64)),
-        "pae": np.random.uniform(size=(n_tokens, n_tokens)),
-        "iptm": np.random.uniform(size=(1,)),
-        "ptm": np.random.uniform(size=(1,)),
-        "disorder": np.random.uniform(size=(1,)),
+        "plddt": rand(n_atoms),
+        "pde_probs": rand(n_tokens, n_tokens, 64),
+        "pde": rand(n_tokens, n_tokens),
+        "gpde": rand(1),
+        "pae_probs": rand(n_tokens, n_tokens, 64),
+        "pae": rand(n_tokens, n_tokens),
+        "iptm": rand(1),
+        "ptm": rand(1),
+        "disorder": rand(1),
         "has_clash": np.float32(0.0),
-        "sample_ranking_score": np.random.uniform(size=(1,)),
+        "sample_ranking_score": rand(1),
         "chain_ptm": {
-            "1": np.random.uniform(size=(1,)),
-            "2": np.random.uniform(size=(1,)),
+            "1": rand(1),
+            "2": rand(1),
         },
         "chain_pair_iptm": {
-            "(1, 2)": np.random.uniform(size=(1,)),
+            "(1, 2)": rand(1),
         },
         "bespoke_iptm": {
-            "(1, 2)": np.random.uniform(size=(1,)),
+            "(1, 2)": rand(1),
         },
     }
 
@@ -181,8 +185,9 @@ class TestPredictionWriter:
 
         for k in expected_full_scores:
             assert k in actual_full_scores, f"Key {k} not found in actual scores"
+            expected_decimal = 3 if output_dtype == "float16" else 6
             np.testing.assert_array_almost_equal(
-                expected_full_scores[k], actual_full_scores[k], decimal=3
+                expected_full_scores[k], actual_full_scores[k], decimal=expected_decimal
             )
             if output_fmt == "npz":
                 assert actual_full_scores[k].dtype == np.dtype(output_dtype), (

--- a/openfold3/tests/test_writer.py
+++ b/openfold3/tests/test_writer.py
@@ -23,6 +23,7 @@ from biotite.structure.io import pdb, pdbx
 
 from openfold3.core.runners.writer import OF3OutputWriter
 
+
 @pytest.fixture(params=[np.float16, np.float32])
 def dummy_confidence_scores(request):
     dtype = request.param

--- a/openfold3/tests/test_writer.py
+++ b/openfold3/tests/test_writer.py
@@ -23,14 +23,14 @@ from biotite.structure.io import pdb, pdbx
 
 from openfold3.core.runners.writer import OF3OutputWriter
 
-
-@pytest.fixture
-def dummy_confidence_scores():
+@pytest.fixture(params=[np.float16, np.float32])
+def dummy_confidence_scores(request):
+    dtype = request.param
     n_tokens = 3
     n_atoms = 5
 
     def rand(*shape):
-        return np.random.uniform(size=shape).astype(np.float32)
+        return np.random.uniform(size=shape).astype(dtype)
 
     return {
         "plddt": rand(n_atoms),
@@ -42,7 +42,7 @@ def dummy_confidence_scores():
         "iptm": rand(1),
         "ptm": rand(1),
         "disorder": rand(1),
-        "has_clash": np.float32(0.0),
+        "has_clash": np.dtype(dtype).type(0.0),
         "sample_ranking_score": rand(1),
         "chain_ptm": {
             "1": rand(1),
@@ -144,14 +144,12 @@ class TestPredictionWriter:
             confidence_scores, atom_array, output_prefix
         )
 
-    @pytest.mark.parametrize(
-        "output_fmt, output_dtype",
-        [("json", "float32"), ("npz", "float32"), ("npz", "float16")],
-        ids=lambda x: x,
-    )
+    @pytest.mark.parametrize("output_fmt", ["json", "npz"], ids=lambda x: x)
     def test_full_confidence_scores_written(
-        self, tmp_path, output_fmt, output_dtype, dummy_confidence_scores
+        self, tmp_path, output_fmt, dummy_confidence_scores
     ):
+        # infer the dtype from the dummy_confidence_scores fixture
+        output_dtype = dummy_confidence_scores["plddt"].dtype.name
         self.write_confidence_scores(
             tmp_path, output_fmt, output_dtype, True, dummy_confidence_scores
         )
@@ -183,9 +181,9 @@ class TestPredictionWriter:
         }
         actual_full_scores = self._load_full_confidence_scores(out_file_full)
 
+        expected_decimal = 3 if output_dtype == "float16" else 6
         for k in expected_full_scores:
             assert k in actual_full_scores, f"Key {k} not found in actual scores"
-            expected_decimal = 3 if output_dtype == "float16" else 6
             np.testing.assert_array_almost_equal(
                 expected_full_scores[k], actual_full_scores[k], decimal=expected_decimal
             )

--- a/openfold3/tests/test_writer.py
+++ b/openfold3/tests/test_writer.py
@@ -118,7 +118,12 @@ class TestPredictionWriter:
         return actual_full_scores
 
     def write_confidence_scores(
-        self, output_path, output_fmt, write_full_output, confidence_scores
+        self,
+        output_path,
+        output_fmt,
+        output_dtype,
+        write_full_output,
+        confidence_scores,
     ):
         atom_array = structure.AtomArray(5)
         atom_array.coord = np.zeros((5, 3))
@@ -127,6 +132,7 @@ class TestPredictionWriter:
         output_writer = OF3OutputWriter(
             output_dir=output_path,
             full_confidence_output_format=output_fmt,
+            full_confidence_output_dtype=output_dtype,
             write_full_confidence_scores=write_full_output,
         )
         output_prefix = output_path / "test"
@@ -135,15 +141,15 @@ class TestPredictionWriter:
         )
 
     @pytest.mark.parametrize(
-        "output_fmt",
-        ["json", "npz"],
+        "output_fmt, output_dtype",
+        [("json", "float32"), ("npz", "float32"), ("npz", "float16")],
         ids=lambda x: x,
     )
     def test_full_confidence_scores_written(
-        self, tmp_path, output_fmt, dummy_confidence_scores
+        self, tmp_path, output_fmt, output_dtype, dummy_confidence_scores
     ):
         self.write_confidence_scores(
-            tmp_path, output_fmt, True, dummy_confidence_scores
+            tmp_path, output_fmt, output_dtype, True, dummy_confidence_scores
         )
 
         output_prefix = tmp_path / "test"
@@ -175,12 +181,18 @@ class TestPredictionWriter:
 
         for k in expected_full_scores:
             assert k in actual_full_scores, f"Key {k} not found in actual scores"
-            np.testing.assert_array_equal(
-                expected_full_scores[k], actual_full_scores[k]
+            np.testing.assert_array_almost_equal(
+                expected_full_scores[k], actual_full_scores[k], decimal=3
             )
+            if output_fmt == "npz":
+                assert actual_full_scores[k].dtype == np.dtype(output_dtype), (
+                    f"Expected dtype {output_dtype} for {k}, but got {actual_full_scores[k].dtype}"
+                )
 
     def test_skip_full_confidence_scores(self, tmp_path, dummy_confidence_scores):
-        self.write_confidence_scores(tmp_path, "json", False, dummy_confidence_scores)
+        self.write_confidence_scores(
+            tmp_path, "json", "float32", False, dummy_confidence_scores
+        )
         expected_output_contents = [tmp_path / "test_confidences_aggregated.json"]
         actual_output_contents = [f for f in tmp_path.glob("*")]
         assert expected_output_contents == actual_output_contents, (


### PR DESCRIPTION
**Summary**

Allows explicitly setting the dtype for the writeout of the full confidence for npz files to either float16 or float32 (default is float32), by setting this inside a runner.yaml like this:

```yaml
output_writer_settings:
  full_confidence_output_format: npz
  full_confidence_output_dtype: float16
  write_full_confidence_scores: true
```

**Changes**

* Added an option to cast to float16 or float32 for npz writeout inside `writer.py`
* Documentation + typo fix

**Related Issues**

**Testing**

Added parameter combinations to `test_writer.py` and changed `assert_array_equal` to `assert_array_almost_equal`. 

(While using `almost_equal` is clearly required for the float16 option, the float32 option also requires this since the fixture matrices are initialized as float64 due to `np.random.uniform`. In practice, `pae`, `pde` and `plddt` are predicted in float32 however, so the default float32 option would lead to exactly equal values)

**Other Notes**

The PAE and PDE matrices scale with N^2, so their output files can be very large, particularly if written out as json. Writing them out as npz with float16 cuts down file sizes somewhat. 

A next possible step might be to quantize them to uint8, similar to how the official AFDB/EMBL [does it for the PAE](https://www.alphafold.ebi.ac.uk/faq) (they output a JSON with the quants and a range and expect the user to postprocess/dequantize the values). uint8 would have the added benefit of being easy to compress.