### PR TITLE
fix: scm version breakns checkpoint compatibility

### DIFF
--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -422,10 +422,14 @@ class InferenceExperimentConfig(ExperimentConfig):
                     self.inference_ckpt_name
                 ].version_compatibility
             )
-            if current_openfold3_version not in allowed_versions:
+            # Use prereleases=True so that dev versions (e.g. 0.4.1.dev0
+            # from setuptools_scm) are not excluded by the specifier check.
+            if not allowed_versions.contains(
+                current_openfold3_version, prereleases=True
+            ):
                 raise ValueError(
-                    f"Selected checkpoint {self.inference_ckpt_name} is not compatible"
-                    "with the currently installed OpenFold3 version"
+                    f"Selected checkpoint {self.inference_ckpt_name} is not compatible "
+                    "with the currently installed OpenFold3 version "
                     f"{current_openfold3_version}. Allowed versions for this "
                     f"checkpoint are {allowed_versions}."
                 )


### PR DESCRIPTION
**Summary**

This PR https://github.com/aqlaboratory/openfold-3/pull/174 caused an issue with checkpoint compatibility check

**Changes**

The new `packaging` v25 requires a relaxed 'prerelease=True' flag to be set to ensure that dev versions pass the checkpoint check. 

**Related Issues**

**Testing**

**Other Notes**
