### PR TITLE
Fix template chain remap crash on unmappable chains

### DIFF
--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -686,10 +686,11 @@ def remap_colabfold_template_chain_ids(
         for entry_id, l2a in label_to_author_maps.items()
     }
 
-    # Remap chain IDs
+    # Remap chain IDs, dropping rows whose author chain ID cannot be resolved
     for top_n in per_rep.values():
         remapped_ids = []
-        for template_id in top_n[1]:
+        rows_to_drop: list[int] = []
+        for idx, template_id in zip(top_n.index, top_n[1]):
             entry_id, author_chain_id = template_id.split("_")
 
             author_to_label = author_to_label_maps.get(entry_id, {})
@@ -703,15 +704,22 @@ def remap_colabfold_template_chain_ids(
                 )
                 label_chain_id = author_chain_id
             elif author_chain_id not in author_to_label:
-                raise RuntimeError(
-                    f"Author chain {author_chain_id} not found in {entry_id}. "
-                    f"Available author chains: {sorted(author_to_label.keys())}"
+                logger.warning(
+                    f"Skipping template {template_id}: author chain "
+                    f"{author_chain_id} not found in {entry_id}. "
+                    f"Available author chains: "
+                    f"{sorted(author_to_label.keys())}"
                 )
+                rows_to_drop.append(idx)
+                continue
             else:
                 label_chain_id = author_to_label[author_chain_id][0]
 
             remapped_ids.append(f"{entry_id}_{label_chain_id}")
 
+        if rows_to_drop:
+            top_n.drop(index=rows_to_drop, inplace=True)
+            top_n.reset_index(drop=True, inplace=True)
         top_n[1] = remapped_ids
 
     return per_rep

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -160,15 +160,35 @@ class TestRemapColabfoldTemplateChainIds:
         assert remapped_ids[1] == "4pqx_A"
 
     @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
-    def test_unknown_author_chain_raises(self, _mock_fetch):
-        """When the author chain ID isn't in the API response, raise."""
-        with pytest.raises(RuntimeError, match="Author chain Z not found in 1rnb"):
-            remap_colabfold_template_chain_ids(
-                template_alignments=_make_m8_dataframe(["1rnb_Z"]),
-                m_with_templates={101},
-                rep_ids=["rep1"],
-                rep_id_to_m={"rep1": 101},
-            )
+    def test_unknown_author_chain_skipped(self, _mock_fetch):
+        """When the author chain ID isn't in the API response, skip that template."""
+        result = remap_colabfold_template_chain_ids(
+            template_alignments=_make_m8_dataframe(["1rnb_Z"]),
+            m_with_templates={101},
+            rep_ids=["rep1"],
+            rep_id_to_m={"rep1": 101},
+        )
+
+        assert "rep1" in result
+        # The template with unmappable chain Z should be dropped
+        assert len(result["rep1"]) == 0
+
+    @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
+    def test_unknown_chain_drops_only_bad_rows(self, _mock_fetch):
+        """Valid templates are kept; only unmappable ones are dropped."""
+        result = remap_colabfold_template_chain_ids(
+            template_alignments=_make_m8_dataframe(["1rnb_A", "1rnb_Z", "4pqx_A"]),
+            m_with_templates={101},
+            rep_ids=["rep1"],
+            rep_id_to_m={"rep1": 101},
+        )
+
+        assert "rep1" in result
+        remapped_ids = result["rep1"][1].tolist()
+        # 1rnb_Z dropped, 1rnb_A remapped to 1rnb_B, 4pqx_A kept
+        assert len(remapped_ids) == 2
+        assert remapped_ids[0] == "1rnb_B"
+        assert remapped_ids[1] == "4pqx_A"
 
     def test_skips_rep_without_templates(self):
         """Rep IDs not in m_with_templates should be skipped (no fetch needed)."""


### PR DESCRIPTION
## Summary

- When `remap_colabfold_template_chain_ids` encounters a template whose author chain ID is not in the RCSB mapping, it now logs a warning and drops that template row instead of raising a `RuntimeError` that kills the entire prediction.
- Updated existing test from expecting `RuntimeError` to verifying the template is skipped.
- Added test for mixed valid + invalid templates (only bad rows dropped, valid ones kept).

## Why #171 didn't fix this

PR #171 addressed the case where the RCSB API returns **no chain mapping at all** (e.g. obsolete or removed PDB entries, where `author_to_label` is empty). That fix falls back to using the author chain ID as the label chain ID.

However, it explicitly kept the `raise RuntimeError` for the second failure mode: when the RCSB mapping **exists but doesn't contain the specific chain** that ColabFold assigned. This happens when ColabFold's `pdb70` hits reference a chain ID that isn't present in the RCSB author-to-label mapping. For example:

- `Author chain L not found in 2a9n. Available author chains: ['A', 'B']`
- `Author chain E not found in 3nn8. Available author chains: ['A', 'B', 'C', 'D']`
- `Author chain E not found in 4nkd. Available author chains: ['A', 'B', 'C', 'D']`

In these cases falling back to the author chain ID is not safe because the mapping is available but simply doesn't include that chain — the template hit is invalid and should be dropped.

This PR handles that second mode by dropping the unmappable template row and continuing with the remaining valid templates, rather than crashing the entire prediction.

## Test plan

- [x] Unit tests pass (valid remap, unknown chain skipped, mixed valid+invalid)