### PR TITLE
Fixing Triton mixed precision mismatch

### DIFF
--- a/openfold3/core/model/layers/triangular_multiplicative_update.py
+++ b/openfold3/core/model/layers/triangular_multiplicative_update.py
@@ -441,6 +441,10 @@ def triton_linear(
     Returns:
         Output tensor [..., N]
     """
+    weight = weight.to(x.dtype)
+    if bias is not None:
+        bias = bias.to(x.dtype)
+
     input_shape = x.shape
     K = input_shape[-1]
     M = x.numel() // K
@@ -507,6 +511,10 @@ def triton_linear_fused(
     Returns:
         Output tensor [..., N]
     """
+    weight = weight.to(x.dtype)
+    if bias is not None:
+        bias = bias.to(x.dtype)
+
     input_shape = x.shape
     K = input_shape[-1]
     M = x.numel() // K


### PR DESCRIPTION
**Summary**
tests/test_inference_full.py fails with ''Both operands must be same dtype. Got bf16 and fp32" error 
when precision: bf16-mixed and use_triton_triangle_kernels: true

**Changes**
Added casts to Triton kernels to fix operand precision mismatch

**Related Issues**

**Testing**
Apply this patch to reproduce the error: 
```
diff --git a/openfold3/tests/test_inference_full.py b/openfold3/tests/test_inference_full.py
index 35d66835..ff2627a8 100644
--- a/openfold3/tests/test_inference_full.py
+++ b/openfold3/tests/test_inference_full.py
@@ -82,6 +82,8 @@ protein_and_ligand_query = InferenceQuerySet.model_validate(
 )

 inference_test_yaml_str = textwrap.dedent("""\
+    pl_trainer_args:
+      precision: bf16-mixed
     model_update:
       presets:
         - predict
@@ -91,6 +93,7 @@ inference_test_yaml_str = textwrap.dedent("""\
           memory:
             eval:
               use_deepspeed_evo_attention: false
+              use_triton_triangle_kernels: true
     """)
```
**Other Notes**
Error happens here, tests/test_kernels.py::TestKernels::test_compare_template_stack_triton_bf16 does not catch it:
```
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bfomitchev_sw/git/openfold3/openfold3/core/model/latent/template_module.py", line 457, in forward
    blocks = self._prep_blocks(
             ^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bfomitchev_sw/git/openfold3/openfold3/core/model/latent/template_module.py", line 394, in _prep_blocks
    tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bfomitchev_sw/git/openfold3/openfold3/core/utils/chunk_utils.py", line 425, in tune_chunk_size
    self.cached_chunk_size = self._determine_favorable_chunk_size(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bfomitchev_sw/git/openfold3/openfold3/core/utils/chunk_utils.py", line 379, in _determine_favorable_chunk_size
    viable = test_chunk_size(candidates[i])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             ......
```