### PR TITLE
Make template preprocessing timeout configurable via CLI

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -268,6 +268,7 @@ Configures template structure preprocessing and filtering.
 - `create_logs` *(bool)*: Create preprocessing logs (default: `false`)
 - `n_processes` *(int)*: Number of preprocessing processes (default: `1`)
 - `chunksize` *(int)*: Tasks per worker in multiprocessing (default: `1`)
+- `preprocess_timeout` *(int)*: Maximum preprocessing time in seconds (default: `60`)
 - `structure_directory` *(Path | None)*: Directory for template structures (default: `null`)
 - `structure_file_format` *(str)*: File format of structures - `cif` or `pdb` (default: `cif`)
 - `output_directory` *(Path | None)*: Output directory for templates (default: `null`)

--- a/examples/reference_full_config/full_config.yml
+++ b/examples/reference_full_config/full_config.yml
@@ -154,6 +154,7 @@ template_preprocessor_settings:
   create_logs: false
   n_processes: 1
   chunksize: 1
+  preprocess_timeout: 60
   structure_directory: <tmp-dir>/of3-of-<user>/template_data/template_structures
   structure_file_format: cif
   output_directory: <tmp-dir>/of3-of-<user>/template_data

--- a/openfold3/core/data/pipelines/preprocessing/template.py
+++ b/openfold3/core/data/pipelines/preprocessing/template.py
@@ -33,6 +33,7 @@ from biotite.structure import AtomArray
 from biotite.structure.io import pdbx
 from biotite.structure.io.pdbx import CIFFile
 from func_timeout import func_timeout
+from func_timeout.exceptions import FunctionTimedOut
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -1537,6 +1538,9 @@ class TemplatePreprocessorSettings(BaseModel):
             Number of processes to use template preprocessing.
         chunksize (int):
             Number of tasks per worker in multiprocessing.
+        preprocess_timeout (int):
+                Maximum time in seconds allowed for preprocessing templates for a
+                single query chain. Defaults to 60.
         structure_directory (DirectoryPath):
             Directory containing raw template structures or where template structures
             are to be downloaded.
@@ -1577,6 +1581,7 @@ class TemplatePreprocessorSettings(BaseModel):
     create_logs: bool = False
     n_processes: int = 1
     chunksize: int = 1
+    preprocess_timeout: int = 60
 
     structure_directory: Path | None = None
     structure_file_format: str = "cif"
@@ -1669,6 +1674,7 @@ class TemplatePreprocessor:
         self.create_logs = config.create_logs
         self.n_processes = config.n_processes
         self.chunksize = config.chunksize
+        self.preprocess_timeout = config.preprocess_timeout
 
         self.structure_directory = config.structure_directory
         self.structure_file_format = config.structure_file_format
@@ -1789,7 +1795,14 @@ class TemplatePreprocessor:
         input_data: TemplatePreprocessorInputTrain | TemplatePreprocessorInputInference,
     ) -> None:
         try:
-            func_timeout(60, self._preprocess_templates_for_query, args=(input_data,))
+            func_timeout(self.preprocess_timeout, self._preprocess_templates_for_query, args=(input_data,))
+        except FunctionTimedOut:
+            print(
+                f"\n Template preprocessing TIMED OUT after {self.preprocess_timeout}s "
+                f"for {input_data.aln_path}.\n"
+                f"Skipping templates for this query chain.\n"
+                f"Hint: increase the timeout with --preprocess-timeout <seconds>\n"
+            )
         except Exception as e:
             print(
                 f"Failed to preprocess template alignment "
@@ -2115,6 +2128,7 @@ class TemplatePrecachePreprocessor:
         self.moltypes = config.moltypes
         self.n_processes = config.n_processes
         self.chunksize = config.chunksize
+        self.preprocess_timeout = config.preprocess_timeout
 
         self.structure_directory = config.structure_directory
         self.structure_file_format = config.structure_file_format

--- a/openfold3/core/data/pipelines/preprocessing/template.py
+++ b/openfold3/core/data/pipelines/preprocessing/template.py
@@ -1795,7 +1795,11 @@ class TemplatePreprocessor:
         input_data: TemplatePreprocessorInputTrain | TemplatePreprocessorInputInference,
     ) -> None:
         try:
-            func_timeout(self.preprocess_timeout, self._preprocess_templates_for_query, args=(input_data,))
+            func_timeout(
+                self.preprocess_timeout,
+                self._preprocess_templates_for_query,
+                args=(input_data,)
+            )
         except FunctionTimedOut:
             print(
                 f"\n Template preprocessing TIMED OUT after {self.preprocess_timeout}s "

--- a/openfold3/core/data/pipelines/preprocessing/template.py
+++ b/openfold3/core/data/pipelines/preprocessing/template.py
@@ -1798,7 +1798,7 @@ class TemplatePreprocessor:
             func_timeout(
                 self.preprocess_timeout,
                 self._preprocess_templates_for_query,
-                args=(input_data,)
+                args=(input_data,),
             )
         except FunctionTimedOut:
             print(

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -146,14 +146,6 @@ def train(runner_yaml: Path, seed: int | None = None, data_seed: int | None = No
     required=False,
     help="Output directory for writing results",
 )
-@click.option(
-    "--preprocess-timeout",
-    "--preprocess_timeout",
-    type=int,
-    default=60,
-    required=False,
-    help="Change default 60 seconds for pre-processing",
-)
 def predict(
     query_json: Path,
     inference_ckpt_path: Path | None = None,
@@ -164,7 +156,6 @@ def predict(
     use_msa_server: bool = True,
     use_templates: bool = True,
     output_dir: Path | None = None,
-    preprocess_timeout: int = 60,
 ):
     """Perform inference on a set of queries defined in the query_json."""
     _torch_gpu_setup()
@@ -187,7 +178,6 @@ def predict(
         inference_ckpt_name=inference_ckpt_name,
         **runner_args,
     )
-    expt_config.template_preprocessor_settings.preprocess_timeout = preprocess_timeout
     expt_runner = InferenceExperimentRunner(
         expt_config,
         num_diffusion_samples,

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -146,6 +146,14 @@ def train(runner_yaml: Path, seed: int | None = None, data_seed: int | None = No
     required=False,
     help="Output directory for writing results",
 )
+@click.option(
+    "--preprocess-timeout",
+    "--preprocess_timeout",
+    type=int,
+    default=60,
+    required=False,
+    help="Change default 60 seconds for pre-processing",
+)
 def predict(
     query_json: Path,
     inference_ckpt_path: Path | None = None,
@@ -156,6 +164,7 @@ def predict(
     use_msa_server: bool = True,
     use_templates: bool = True,
     output_dir: Path | None = None,
+    preprocess_timeout: int = 60,
 ):
     """Perform inference on a set of queries defined in the query_json."""
     _torch_gpu_setup()
@@ -178,6 +187,7 @@ def predict(
         inference_ckpt_name=inference_ckpt_name,
         **runner_args,
     )
+    expt_config.template_preprocessor_settings.preprocess_timeout = preprocess_timeout
     expt_runner = InferenceExperimentRunner(
         expt_config,
         num_diffusion_samples,


### PR DESCRIPTION
**Resolves #164**

### Summary
Replaces the hardcoded 60-second limit in template preprocessing with a configurable `--preprocess-timeout` CLI parameter. This is necessary to prevent crashes when processing exceptionally large protein sequences.

### Changes Made

**1. `openfold3/core/data/pipelines/preprocessing/template.py`**
- Added `preprocess_timeout` (default: 60) to the `TemplatePreprocessorSettings` model.
- Updated `func_timeout` to evaluate this dynamic variable instead of the static `60`.
- Added an `except FunctionTimedOut:` block catch timeouts, skip the offending template chain, and print a helpful warning suggesting the user increase `--preprocess-timeout`.

**2. `openfold3/run_openfold.py`**
- Exposed `--preprocess-timeout` as a Click option in the `predict` CLI function.
- Piped the argument directly into `expt_config.template_preprocessor_settings.preprocess_timeout`.

### Testing Performed
- **Ubiquitin (`query_ubiquitin.json`)**: Verified that sequences for short proteins complete with the standard and custom timeout, and that a forced failure can be achieved with a `--preprocess-timeout` of 1.

```bash
pixi run -e openfold3-cuda13 python openfold3/run_openfold.py predict \
    --query_json examples/example_inference_inputs/query_ubiquitin.json \
    --use_templates True
```
### Titin (Q8WZ42.fasta)
Attempted to replicate the issue where exceptionally long sequences time out during template processing. Verified that extending the limit with --preprocess-timeout 300 correctly intercepts the limit and prevents the crash.

```bash
pixi run -e openfold3-cuda13 python openfold3/run_openfold.py predict \
    --query-json ../query_Q8WZ42.json \
    --use_templates True \
    --preprocess-timeout 300
```
