### PR TITLE
Segfault in `featurize_reference_conformers_of3()` when passing RDKit `Point3D` objects directly to `torch.tensor()`

### DIFF
--- a/openfold3/core/data/pipelines/featurization/conformer.py
+++ b/openfold3/core/data/pipelines/featurization/conformer.py
@@ -107,12 +107,9 @@ def featurize_reference_conformers_of3(
             # Intermediate reference coordinates (without random rotation & translation)
             coords = conf.GetAtomPosition(atom.GetIdx())
             mol_ref_mask.append(int(atom.GetBoolProp("annot_used_atom_mask")))
-            mol_ref_pos.append(coords)
-            # Some PyPI installations crash here due to
-            # ABI mismatch between RDKit and PyTorch
-            # Leaving a quick fix commented (beware, moving into slow python land)
-            # Remove if nobody else hits the problem
-            # mol_ref_pos.append([coords.x, coords.y, coords.z])
+            # Avoid passing RDKit Point3D objects directly into torch.tensor(),
+            # which can segfault in some RDKit/PyTorch builds.
+            mol_ref_pos.append((coords.x, coords.y, coords.z))
 
             # Atom elements (0-indexed)
             element_symbol = atom.GetSymbol()


### PR DESCRIPTION
I see a seg fault during inference/data loading that appears to come from converting RDKit `Point3D` objects directly into a PyTorch tensor. This appears to have been observed before based on a comment in the code, but there was some uncertainty about whether people actually encountered it. 


The failing code is in `openfold3/core/data/pipelines/featurization/conformer.py`:

```python
coords = conf.GetAtomPosition(atom.GetIdx())
mol_ref_pos.append(coords)
...
mol_ref_pos = torch.tensor(mol_ref_pos, dtype=torch.float32)
```

In my environment, passing RDKit `Point3D` objects directly to `torch.tensor(...)` segfaults. Converting to plain tuples fixes it:

```python
coords = conf.GetAtomPosition(atom.GetIdx())
mol_ref_pos.append((coords.x, coords.y, coords.z))
```

I verified that this change fixes the crash locally.

### Environment

Reproduced in:

- Python: `3.12.11`
- PyTorch: `2.9.1+cu128`
- `torch` package version: `2.9.1`
- RDKit import version: `2026.03.1`
- `rdkit` package version: `2026.3.1`
- PyTorch Lightning: `2.6.1`
- OpenFold3 package version: `0.4.1`
- OS: `Linux 5.14.0-570.30.1.el9_6.x86_64`

cc: @ljarosch 