### PR TITLE
Add Template Offloading on inference to further reduce memory consumption

### DIFF
--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -21,6 +21,7 @@ These modules embed templates into pair embeddings. Note that this includes the 
 feature embedding functions in openfold3.core.model.feature_embedders.
 """
 
+import sys
 from functools import partial
 
 import torch
@@ -502,7 +503,7 @@ class TemplateEmbedderAllAtom(nn.Module):
         )
         self.linear_t = Linear(config.c_t, config.c_z, **templ_init.linear_t)
 
-    def forward(
+    def _forward_offload(
         self,
         batch: dict,
         z: torch.Tensor,
@@ -540,17 +541,77 @@ class TemplateEmbedderAllAtom(nn.Module):
             t:
                 [*, N_token, N_token, C_z] Template embedding
         """
+        batch_dims = z.shape[:-3]
+        n_token = z.shape[-2]
+        out_device = z.device
+        n_templ = batch["template_restype"].shape[-3]
 
+        # [*, 1, N_token, N_token]
+        pair_mask = pair_mask[..., None, :, :].to(dtype=z.dtype)
+
+        t_out = torch.zeros(
+            (*batch_dims, n_templ, n_token, n_token, self.config.c_t), device="cpu"
+        )
+
+        for i in range(n_templ):
+            batch_templ = {}
+            for k, v in batch.items():
+                if isinstance(v, torch.Tensor) and k.startswith("template_"):
+                    batch_templ[k] = v[:, i : i + 1]
+                else:
+                    batch_templ[k] = v
+
+            # [*, N, N, C_t]
+            t = self.template_pair_embedder(
+                batch=batch_templ,
+                z=z,
+            )
+
+            # [*, N_templ, N_token, N_token, C_z]
+            t = self.template_pair_stack(
+                t,
+                pair_mask,
+                chunk_size=chunk_size,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+                _mask_trans=_mask_trans,
+            )
+
+            assert sys.getrefcount(t) == 2
+
+            t_out[..., i : i + 1, :, :, :] = t.cpu()
+
+            del t
+
+        del z
+
+        return t_out.to(device=out_device)
+
+    def _forward(
+        self,
+        batch: dict,
+        z: torch.Tensor,
+        pair_mask: torch.Tensor,
+        chunk_size: int | None = None,
+        _mask_trans: bool = True,
+        use_deepspeed_evo_attention: bool = False,
+        use_cueq_triangle_kernels: bool = False,
+        use_triton_triangle_kernels: bool = False,
+        use_lma: bool = False,
+        inplace_safe: bool = False,
+    ) -> torch.Tensor:
         # [*, N_templ, N_token, N_token, C_t]
-        template_embeds = self.template_pair_embedder(batch, z)
-        n_templ = template_embeds.shape[-4]
+        t = self.template_pair_embedder(batch, z)
 
         # [*, 1, N_token, N_token]
         pair_mask = pair_mask[..., None, :, :].to(dtype=z.dtype)
 
         # [*, N_templ, N_token, N_token, C_z]
         t = self.template_pair_stack(
-            template_embeds,
+            t,
             pair_mask,
             chunk_size=chunk_size,
             use_deepspeed_evo_attention=use_deepspeed_evo_attention,
@@ -560,6 +621,80 @@ class TemplateEmbedderAllAtom(nn.Module):
             inplace_safe=inplace_safe,
             _mask_trans=_mask_trans,
         )
+
+        return t
+
+    def forward(
+        self,
+        batch: dict,
+        z: torch.Tensor,
+        pair_mask: torch.Tensor,
+        chunk_size: int | None = None,
+        _mask_trans: bool = True,
+        use_deepspeed_evo_attention: bool = False,
+        use_cueq_triangle_kernels: bool = False,
+        use_triton_triangle_kernels: bool = False,
+        use_lma: bool = False,
+        inplace_safe: bool = False,
+        offload_inference: bool = False,
+    ) -> torch.Tensor:
+        """
+        Args:
+            batch:
+                Input feature dictionary
+            z:
+                [*, N_token, N_token, C_z] Pair embedding
+            pair_mask:
+                [*, N_token, N_token] Pair mask
+            chunk_size:
+                Inference-time subbatch size.
+            _mask_trans:
+                Whether to mask the output of the transition layers
+            use_deepspeed_evo_attention:
+                Whether to use DeepSpeed memory efficient kernel.
+                Mutually exclusive with use_lma.
+            use_cueq_triangle_kernels:
+                Whether to use cuEq triangle kernels
+            use_lma:
+                Whether to use low-memory attention during inference.
+                Mutually exclusive with and use_deepspeed_evo_attention.
+            inplace_safe:
+                Whether inplace operations can be performed
+            offload_inference:
+                Whether to offload some computation to CPU
+
+        Returns:
+            t:
+                [*, N_token, N_token, C_z] Template embedding
+        """
+        n_templ = batch["template_restype"].shape[-3]
+
+        if offload_inference:
+            t = self._forward_offload(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=chunk_size,
+                _mask_trans=True,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+            )
+        else:
+            t = self._forward(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=chunk_size,
+                _mask_trans=True,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+            )
 
         # [*, N_token, N_token, C_z]
         t = torch.sum(t, dim=-4) / n_templ

--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -124,6 +124,7 @@ model_config = mlc.ConfigDict(
                     "per_sample_atom_cutoff": per_sample_atom_cutoff,
                     "low_mem_validation": low_mem_validation,
                     "offload_inference": {
+                        "template_module": False,
                         "msa_module": False,
                         "confidence_heads": False,
                         "token_cutoff": None,

--- a/openfold3/projects/of3_all_atom/config/model_setting_presets.yml
+++ b/openfold3/projects/of3_all_atom/config/model_setting_presets.yml
@@ -25,6 +25,7 @@ low_mem:
         per_sample_token_cutoff: 0
         per_sample_atom_cutoff: 0
         offload_inference:
+          template_module: true
           msa_module: true
           confidence_heads: true
           token_cutoff: 0

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -49,6 +49,7 @@ MODEL_VERSION = torch.tensor([1, 0, 0], dtype=torch.float32)
 
 
 class OffloadModules(Enum):
+    TEMPLATE_MODULE = "template_module"
     MSA_MODULE = "msa_module"
     CONFIDENCE_HEADS = "confidence_heads"
 
@@ -197,6 +198,11 @@ class OpenFold3(nn.Module):
             module_name=OffloadModules.MSA_MODULE.value,
         )
 
+        offload_template_module = self._do_inference_offload(
+            seq_len=batch["token_mask"].shape[-1],
+            module_name=OffloadModules.TEMPLATE_MODULE.value,
+        )
+
         s_input, s_init, z_init = self.input_embedder(
             batch=batch,
             inplace_safe=inplace_safe,
@@ -244,6 +250,7 @@ class OpenFold3(nn.Module):
                         use_cueq_triangle_kernels=mode_mem_settings.use_cueq_triangle_kernels,
                         use_lma=mode_mem_settings.use_lma,
                         inplace_safe=inplace_safe,
+                        offload_inference=offload_template_module,
                     ),
                     inplace=inplace_safe,
                 )

--- a/openfold3/tests/test_embedders.py
+++ b/openfold3/tests/test_embedders.py
@@ -249,9 +249,7 @@ class TestMSAModuleStack:
         stack.eval()
 
         with torch.no_grad():
-            z_no_offload = stack(
-                m=m, z=z, msa_mask=msa_mask, pair_mask=pair_mask
-            )
+            z_no_offload = stack(m=m, z=z, msa_mask=msa_mask, pair_mask=pair_mask)
             # Clone the input tensors since forward_offload will modify them in-place
             z_offload = stack.forward_offload(
                 input_tensors=[m.clone(), z.clone()],

--- a/openfold3/tests/test_embedders.py
+++ b/openfold3/tests/test_embedders.py
@@ -24,6 +24,7 @@ from openfold3.core.model.feature_embedders.input_embedders import (
 from openfold3.core.model.feature_embedders.template_embedders import (
     TemplatePairEmbedderAllAtom,
 )
+from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
 from openfold3.tests.data_utils import random_asym_ids, random_of3_features
@@ -140,22 +141,12 @@ class TestMSAModuleEmbedder:
                 )
 
 
-class TestTemplatePairEmbedders:
-    def test_all_atom(self):
+class TestTemplateEmbedders:
+    @pytest.fixture
+    def template_batch(self):
         batch_size = 2
         n_templ = 3
         n_token = 10
-
-        proj_entry = OF3ProjectEntry()
-        of3_config = proj_entry.get_model_config_with_presets()
-
-        c_in = of3_config.architecture.template.template_pair_embedder.c_in
-        c_t = of3_config.architecture.template.template_pair_embedder.c_out
-
-        tpe = TemplatePairEmbedderAllAtom(
-            **of3_config.architecture.template.template_pair_embedder
-        )
-
         batch = {
             "asym_id": torch.ones((batch_size, n_token)),
             "template_restype": torch.ones((batch_size, n_templ, n_token, 32)),
@@ -168,13 +159,55 @@ class TestTemplatePairEmbedders:
                 (batch_size, n_templ, n_token, n_token, 3)
             ),
         }
+        return {"batch_size": batch_size, "n_templ": n_templ, "n_token": n_token, "batch": batch}
+
+    def test_template_pair_embedder_all_atom(self, template_batch):
+        batch_size = template_batch["batch_size"]
+        n_templ = template_batch["n_templ"]
+        n_token = template_batch["n_token"]
+        batch = template_batch["batch"]
+
+        proj_entry = OF3ProjectEntry()
+        of3_config = proj_entry.get_model_config_with_presets()
+
+        c_in = of3_config.architecture.template.template_pair_embedder.c_in
+        c_t = of3_config.architecture.template.template_pair_embedder.c_out
+
+        tpe = TemplatePairEmbedderAllAtom(
+            **of3_config.architecture.template.template_pair_embedder
+        )
 
         z = torch.ones((batch_size, n_token, n_token, c_in))
 
         emb = tpe(batch, z)
 
         assert emb.shape == (batch_size, n_templ, n_token, n_token, c_t)
+    
+    def test_template_module_offload(self, template_batch):
+        batch_size = template_batch["batch_size"]
+        n_token = template_batch["n_token"]
+        batch = template_batch["batch"]
 
+        proj_entry = OF3ProjectEntry()
+        of3_config = proj_entry.get_model_config_with_presets()
+
+        c_in = of3_config.architecture.template.template_pair_embedder.c_in
+
+        embedder = TemplateEmbedderAllAtom(of3_config.architecture.template)
+        embedder.eval()
+
+        z = torch.ones((batch_size, n_token, n_token, c_in))
+        pair_mask = torch.ones((batch_size, n_token, n_token))
+
+        with torch.no_grad():
+            t_no_offload = embedder(
+                batch=batch, z=z, pair_mask=pair_mask, offload_inference=False
+            )
+            t_offload = embedder(
+                batch=batch, z=z, pair_mask=pair_mask, offload_inference=True
+            )
+
+        assert torch.allclose(t_no_offload, t_offload)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/test_embedders.py
+++ b/openfold3/tests/test_embedders.py
@@ -24,6 +24,7 @@ from openfold3.core.model.feature_embedders.input_embedders import (
 from openfold3.core.model.feature_embedders.template_embedders import (
     TemplatePairEmbedderAllAtom,
 )
+from openfold3.core.model.latent.msa_module import MSAModuleStack
 from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
@@ -159,7 +160,12 @@ class TestTemplateEmbedders:
                 (batch_size, n_templ, n_token, n_token, 3)
             ),
         }
-        return {"batch_size": batch_size, "n_templ": n_templ, "n_token": n_token, "batch": batch}
+        return {
+            "batch_size": batch_size,
+            "n_templ": n_templ,
+            "n_token": n_token,
+            "batch": batch,
+        }
 
     def test_template_pair_embedder_all_atom(self, template_batch):
         batch_size = template_batch["batch_size"]
@@ -182,7 +188,7 @@ class TestTemplateEmbedders:
         emb = tpe(batch, z)
 
         assert emb.shape == (batch_size, n_templ, n_token, n_token, c_t)
-    
+
     def test_template_module_offload(self, template_batch):
         batch_size = template_batch["batch_size"]
         n_token = template_batch["n_token"]
@@ -208,6 +214,53 @@ class TestTemplateEmbedders:
             )
 
         assert torch.allclose(t_no_offload, t_offload)
+
+
+class TestMSAModuleStack:
+    @pytest.fixture
+    def msa_inputs(self):
+        batch_size = 2
+        n_seq = 4
+        n_token = 10
+
+        proj_entry = OF3ProjectEntry()
+        of3_config = proj_entry.get_model_config_with_presets()
+
+        c_m = of3_config.architecture.msa.msa_module.c_m
+        c_z = of3_config.architecture.msa.msa_module.c_z
+
+        return {
+            "m": torch.rand(batch_size, n_seq, n_token, c_m),
+            "z": torch.rand(batch_size, n_token, n_token, c_z),
+            "msa_mask": torch.ones(batch_size, n_seq, n_token),
+            "pair_mask": torch.ones(batch_size, n_token, n_token),
+        }
+
+    def test_msa_module_stack_offload(self, msa_inputs):
+        m = msa_inputs["m"]
+        z = msa_inputs["z"]
+        msa_mask = msa_inputs["msa_mask"]
+        pair_mask = msa_inputs["pair_mask"]
+
+        proj_entry = OF3ProjectEntry()
+        of3_config = proj_entry.get_model_config_with_presets()
+
+        stack = MSAModuleStack(**of3_config.architecture.msa.msa_module)
+        stack.eval()
+
+        with torch.no_grad():
+            z_no_offload = stack(
+                m=m, z=z, msa_mask=msa_mask, pair_mask=pair_mask
+            )
+            # Clone the input tensors since forward_offload will modify them in-place
+            z_offload = stack.forward_offload(
+                input_tensors=[m.clone(), z.clone()],
+                msa_mask=msa_mask,
+                pair_mask=pair_mask,
+            )
+
+        assert torch.allclose(z_no_offload, z_offload)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Summary**
Adds an option to offload the template module to CPU to reduce GPU memory consumption. This option is now added to the `low_mem` model preset.

Also adds offload tests for the MSAModule. I tested adding offload tests for the confidence heads, but ran into #199 

**Changes**
- Template module offload option added to model config, and added to `low_mem` preset
- Added unit tests to test offload behavior for the TemplateModule and MSAModule.

**Related Issues**
#199 

**Testing**
- The new offload tests in `pixi run -e openfold3-cpu pytest openfold3/tests/test_embedders.py` pass

