### PR TITLE
Fix link to contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/openfold3-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/openfold3-issue-template.md
@@ -12,7 +12,7 @@ Thank you for taking the time to file a bug report. Please help us help you. Pro
 
 OpenFold3 has documentation available at https://openfold-3.readthedocs.io/en/latest/ with several how-to guides. Check there to see if your question might already be answered.
 
-Please refer to our [contribution guide](https://openfold-3.readthedocs.io/en/latest/contributing.html) for more details. In particular, all issues should be opened directly by a human, and issues that do not meet this policy may be closed without review.
+Please refer to our [contribution guide](https://openfold-3.readthedocs.io/en/latest/contribution.html) for more details. In particular, all issues should be opened directly by a human, and issues that do not meet this policy may be closed without review.
 
 PLEASE DELETE THIS SECTION AFTER YOU HAVE READ IT
 -----------------------------------------

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-Thank you for taking the time to file a pull request. Please refer to our [contribution guide](https://openfold-3.readthedocs.io/en/latest/contributing.html) for guidance on opening a PR. In particular, for faster review, please include clearly summarize the contribution, describe the changes, and describe the tests that you used to verify the changes.
+Thank you for taking the time to file a pull request. Please refer to our [contribution guide](https://openfold-3.readthedocs.io/en/latest/contribution.html) for guidance on opening a PR. In particular, for faster review, please include clearly summarize the contribution, describe the changes, and describe the tests that you used to verify the changes.
 
-Please also note our policies around [AI agentic contributions](https://openfold-3.readthedocs.io/en/latest/contributing.html#ai-contribution-guidelines). In particular, all pull requests should be opened directly by a human, and pull requests that do not meet this policy may be closed without review.
+Please also note our policies around [AI agentic contributions](https://openfold-3.readthedocs.io/en/latest/contribution.html#ai-contribution-guidelines). In particular, all pull requests should be opened directly by a human, and pull requests that do not meet this policy may be closed without review.
 
 PLEASE DELETE THIS SECTION AFTER YOU HAVE READ IT
 

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,1 +1,1 @@
-Please see [our documentation for contributions on readthedocs.io](https://openfold-3.readthedocs.io/en/latest/contributing.html)
+Please see [our documentation for contributions on readthedocs.io](https://openfold-3.readthedocs.io/en/latest/contribution.html)


### PR DESCRIPTION
The current link is dead (404). I believe this is the correct one. I verified that the updated links work including the anchor to the ai-contribution-guidelines section.