### PR TITLE
Pin lightning version below 2.6.2

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -243,19 +243,19 @@ mkl = "*"
 # --- Pytorch & Cuda
 
 [feature.pytorch-conda-cuda.dependencies]
-pytorch-lightning = "*"
+pytorch-lightning = "<=2.6.1"
 pytorch-gpu = "*"
 
 [feature.pytorch-conda.dependencies]
-pytorch-lightning = "*"
+pytorch-lightning = "<=2.6.1"
 pytorch = "*"
 
 [feature.pytorch-pypi-cuda12.pypi-dependencies]
-pytorch-lightning = "*"
+pytorch-lightning = "<=2.6.1"
 torch = { version = "*", index = "https://download.pytorch.org/whl/cu129" }
 
 [feature.pytorch-pypi-cuda13.pypi-dependencies]
-pytorch-lightning = "*"
+pytorch-lightning = "<=2.6.1"
 torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
 
 [feature.pytorch-pypi-rocm7]


### PR DESCRIPTION
There was a supply chain attack through lightning version 2.6.2 and 2.6.3 c.f. https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3