### PR TITLE
Apply power-of-two chunking consistently

### DIFF
--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -905,8 +905,20 @@ if _TRITON_AVAILABLE:
 
             BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = Q.shape
 
-            assert res_mask.shape == (BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
-            assert pair_bias.shape == (BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
+            assert res_mask.shape == (
+                BATCH_SIZE,
+                N_SEQ,
+                1,
+                1,
+                SEQ_LEN,
+            ), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
+            assert pair_bias.shape == (
+                BATCH_SIZE,
+                1,
+                HEAD,
+                SEQ_LEN,
+                SEQ_LEN,
+            ), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
 
             softmax_scale = DIM**-0.5
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)

--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -904,6 +904,10 @@ if _TRITON_AVAILABLE:
             ).contiguous()  # (BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM)
 
             BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = Q.shape
+
+            assert res_mask.shape == (BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
+            assert pair_bias.shape == (BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
+
             softmax_scale = DIM**-0.5
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)
 

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -187,8 +187,16 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         apply_per_sample = (
             not torch.is_grad_enabled()
             and num_samples > 1
-            and self.per_sample_token_cutoff is not None
-            and repr_x_pred.shape[-2] > self.per_sample_token_cutoff
+            and (
+                (self.per_sample_token_cutoff is not None
+                and repr_x_pred.shape[-2] > self.per_sample_token_cutoff)
+                # The optimized attention kernels do not support cross-sample
+                # chunking because it requires expanding the pair bias. For now
+                # we just always apply per sample if these kernels are in use.
+                or use_deepspeed_evo_attention
+                or use_cueq_triangle_kernels
+                or use_triton_triangle_kernels
+            )
         )
         out_device = atom_positions_predicted.device
 

--- a/openfold3/core/model/heads/prediction_heads.py
+++ b/openfold3/core/model/heads/prediction_heads.py
@@ -209,10 +209,11 @@ class PairformerEmbedding(nn.Module):
         single_mask = reshape_inputs(x=single_mask, feat_dims=single_mask.shape[-1:])
         pair_mask = reshape_inputs(x=pair_mask, feat_dims=pair_mask.shape[-2:])
 
-        # Using the DS kernel with chunk tuning and multiple samples causes shape issues
-        # in the DS kernel. To avoid this, chunk tuning is disabled in this case.
-        # TODO: cuEq seems to fail comparison unit tests with the same settings,
-        #  disable for now and verify behavior
+        # The optimized kernels all require that pair bias have size 1 in the
+        # second dimension and cross-sample chunking has to combine the batch
+        # dimensions and expand it. We mostly avoid this path entirely by
+        # splitting per-sample when using the optimized kernels, but this avoids
+        # a potential correctness issue here.
         use_kernels = (
             use_deepspeed_evo_attention
             or use_cueq_triangle_kernels

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -363,7 +363,6 @@ class ChunkSizeTuner:
         candidates = [2**l for l in range(int(math.log(max_chunk_size, 2)) + 1)]
         candidates = [c for c in candidates if c > min_chunk_size]
         candidates = [min_chunk_size] + candidates
-        candidates[-1] += 4
 
         def test_chunk_size(chunk_size):
             try:

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -719,13 +719,13 @@ class TestKernels(unittest.TestCase):
         chunk_size=None,
     ):
         """
-        Compare Template Stack output with and without using DeepSpeed Evoformer
-        attention kernel. Kernel can be used for Triangle Attention in the Template Pair
-        Stack.
+        Compare Template Stack output with and without using different optimized
+        attention kernels. Kernel can be used for Triangle Attention in the
+        Template Pair Stack.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None and use_deepspeed_evo_attention:
-            # Chunk tuning is not supported with batch size > 1 for DeepSpeed kernel
+        if chunk_size is not None:
+            # Chunking is not supported with batch size > 1 for optimized kernels
             batch_size = 1
 
         n_templ = 3
@@ -793,7 +793,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
         )
 
@@ -801,7 +800,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_bf16(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.bfloat16,
         )
 
@@ -809,7 +807,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32_chunk(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
             chunk_size=4,
         )
@@ -817,7 +814,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -825,7 +821,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.bfloat16,
         )
@@ -833,7 +828,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -842,8 +836,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -852,8 +844,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -861,8 +851,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.bfloat16,
         )


### PR DESCRIPTION
**Summary**
Currently chunking of the `AuxiliaryHeadsAllAtom` pairformer stack is disabled if using optimized attention kernels to avoid a bug with multi-sample chunking. This is the largest-memory attention call, so it doesn't make a whole lot of sense to disable it here. Instead, we split by sample when using optimized kernels. Additionally makes chunk sizes consistently a power of two rather than 4 being added to the largest chunk size (it was suggested to combine these changes. Happy to split them up if desired).

**Changes**
- Avoid weird addition of 4 to power-of-two chunk sizes. This was added in https://github.com/aqlaboratory/openfold-3/commit/a9a12890d without explanation. We can hypothesize that it was related to adding 4 to an input dimension in trace_utils.py (trying to get a test case to fit in one chunk?), but that file was long ago deleted. This just looks like a bug and makes us hit unhappy paths all over the place. Fixes https://github.com/aqlaboratory/openfold-3/issues/203
- Enable chunking for `AuxiliaryHeadsAllAtom` pairformer embedding when using optimized kernels. Without chunking, this is the first call to cause OOMs because its `diffusion_samples*sequence_length` batches. Chunking gets turned off in prediction_heads.py due to batch size > 1 and use of optimized kernels because cross-sample chunking requires expanding out pair bias and they all require it to have size 1 in the second dimension with implicit broadcasting. So we turn on `apply_per_sample` when optimized kernels are in use. This splits the > 1 batch dimension, which avoids this problematic path and then we can do normal chunking for the rest if it's still too large. We could do something more elaborate (see suggestions in linked issue), but this is an improvement for now. Fixes https://github.com/aqlaboratory/openfold-3/issues/206
- Assert in Triton triangle attention kernel that the second dim of pair bias has size 1. This was implicitly assumed with `pair_bias.stride(1)` not even passed into the function.
- Update tests for all optimized kernels in test_kernels.py to avoid batch_size > 1 + chunking
- Document specific issue with multi-sample chunking and optimized kernels

**Related Issues**
- https://github.com/aqlaboratory/openfold-3/issues/203
- https://github.com/aqlaboratory/openfold-3/issues/206

**Testing**
- Confirmed that when limiting torch GPU memory usage to 12GB, the multimer example OOMed prior to this change and runs to completion after.
- Confirmed that attention kernel calling pattern moves from batches of 516 to 512.
- I didn't find a good way to unit test this that was actually a useful test (e.g. I can assert that chunk_size is now 512 instead of 516, but I don't think that test carries its weight).

**Other Notes**
I'm happy to make some of the more elaborate changes discussed in https://github.com/aqlaboratory/openfold-3/issues/206 either in this PR or a separate one, but wanted to share this relatively simple fix.