### PR TITLE
Make chunking for Triton kernels closer to cueq

### DIFF
--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -29,9 +29,8 @@ from torch import nn
 
 from openfold3.core.utils.checkpointing import checkpoint_blocks
 from openfold3.core.utils.chunk_utils import (
-    CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
-    TRITON_MAX_CHUNK_SIZE,
+    FLASH_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 
@@ -127,12 +126,14 @@ class MSAStack(nn.Module, ABC):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
-            if use_cueq_triangle_kernels:
-                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
-            if use_triton_triangle_kernels:
-                max_chunk_size = TRITON_MAX_CHUNK_SIZE
-
+            use_flash_kernels = (
+                use_cueq_triangle_kernels
+                or use_triton_triangle_kernels
+                or use_deepspeed_evo_attention
+            )
+            max_chunk_size = (
+                FLASH_MAX_CHUNK_SIZE if use_flash_kernels else DEFAULT_MAX_CHUNK_SIZE
+            )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 # Tensors cloned to avoid getting written to in-place
@@ -146,9 +147,7 @@ class MSAStack(nn.Module, ABC):
                 max_chunk_size=max_chunk_size,
             )
             attn_chunk = (
-                tuned_chunk_size
-                if use_cueq_triangle_kernels or use_triton_triangle_kernels
-                else (tuned_chunk_size // 4)
+                tuned_chunk_size if use_flash_kernels else (tuned_chunk_size // 4)
             )
             blocks = [
                 partial(

--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -31,6 +31,7 @@ from openfold3.core.utils.checkpointing import checkpoint_blocks
 from openfold3.core.utils.chunk_utils import (
     CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
+    TRITON_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 
@@ -126,11 +127,12 @@ class MSAStack(nn.Module, ABC):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = (
-                CUEQ_MAX_CHUNK_SIZE
-                if use_cueq_triangle_kernels
-                else DEFAULT_MAX_CHUNK_SIZE
-            )
+            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
+            if use_cueq_triangle_kernels:
+                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
+            if use_triton_triangle_kernels:
+                max_chunk_size = TRITON_MAX_CHUNK_SIZE
+
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 # Tensors cloned to avoid getting written to in-place
@@ -145,7 +147,7 @@ class MSAStack(nn.Module, ABC):
             )
             attn_chunk = (
                 tuned_chunk_size
-                if use_cueq_triangle_kernels
+                if use_cueq_triangle_kernels or use_triton_triangle_kernels
                 else (tuned_chunk_size // 4)
             )
             blocks = [

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -31,6 +31,7 @@ from openfold3.core.utils.checkpointing import checkpoint_blocks
 from openfold3.core.utils.chunk_utils import (
     CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
+    TRITON_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 from openfold3.core.utils.tensor_utils import add
@@ -371,11 +372,11 @@ class PairFormerStack(nn.Module):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = (
-                CUEQ_MAX_CHUNK_SIZE
-                if use_cueq_triangle_kernels
-                else DEFAULT_MAX_CHUNK_SIZE
-            )
+            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
+            if use_cueq_triangle_kernels:
+                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
+            if use_triton_triangle_kernels:
+                max_chunk_size = TRITON_MAX_CHUNK_SIZE
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 # We don't want to write in-place during chunk tuning runs
@@ -388,7 +389,7 @@ class PairFormerStack(nn.Module):
             )
             attn_chunk = (
                 tuned_chunk_size
-                if use_cueq_triangle_kernels
+                if use_cueq_triangle_kernels or use_triton_triangle_kernels
                 else (tuned_chunk_size // 4)
             )
             blocks = [

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -29,9 +29,8 @@ from openfold3.core.model.layers.attention_pair_bias import AttentionPairBias
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.utils.checkpointing import checkpoint_blocks
 from openfold3.core.utils.chunk_utils import (
-    CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
-    TRITON_MAX_CHUNK_SIZE,
+    FLASH_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 from openfold3.core.utils.tensor_utils import add
@@ -372,11 +371,14 @@ class PairFormerStack(nn.Module):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
-            if use_cueq_triangle_kernels:
-                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
-            if use_triton_triangle_kernels:
-                max_chunk_size = TRITON_MAX_CHUNK_SIZE
+            use_flash_kernels = (
+                use_cueq_triangle_kernels
+                or use_triton_triangle_kernels
+                or use_deepspeed_evo_attention
+            )
+            max_chunk_size = (
+                FLASH_MAX_CHUNK_SIZE if use_flash_kernels else DEFAULT_MAX_CHUNK_SIZE
+            )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 # We don't want to write in-place during chunk tuning runs
@@ -388,9 +390,7 @@ class PairFormerStack(nn.Module):
                 max_chunk_size=max_chunk_size,
             )
             attn_chunk = (
-                tuned_chunk_size
-                if use_cueq_triangle_kernels or use_triton_triangle_kernels
-                else (tuned_chunk_size // 4)
+                tuned_chunk_size if use_flash_kernels else (tuned_chunk_size // 4)
             )
             blocks = [
                 partial(

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -37,6 +37,7 @@ from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_sec
 from openfold3.core.utils.chunk_utils import (
     CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
+    TRITON_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 from openfold3.core.utils.tensor_utils import add
@@ -387,11 +388,11 @@ class TemplatePairStack(nn.Module):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = (
-                CUEQ_MAX_CHUNK_SIZE
-                if use_cueq_triangle_kernels
-                else DEFAULT_MAX_CHUNK_SIZE
-            )
+            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
+            if use_cueq_triangle_kernels:
+                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
+            if use_triton_triangle_kernels:
+                max_chunk_size = TRITON_MAX_CHUNK_SIZE
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 args=(t.clone(),),
@@ -400,7 +401,7 @@ class TemplatePairStack(nn.Module):
             )
             attn_chunk = (
                 tuned_chunk_size
-                if use_cueq_triangle_kernels
+                if use_cueq_triangle_kernels or use_triton_triangle_kernels
                 else (tuned_chunk_size // 4)
             )
             blocks = [

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -35,9 +35,8 @@ from openfold3.core.model.feature_embedders.template_embedders import (
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
 from openfold3.core.utils.chunk_utils import (
-    CUEQ_MAX_CHUNK_SIZE,
     DEFAULT_MAX_CHUNK_SIZE,
-    TRITON_MAX_CHUNK_SIZE,
+    FLASH_MAX_CHUNK_SIZE,
     ChunkSizeTuner,
 )
 from openfold3.core.utils.tensor_utils import add
@@ -388,11 +387,14 @@ class TemplatePairStack(nn.Module):
 
         if chunk_size is not None and self.chunk_size_tuner is not None:
             assert not self.training
-            max_chunk_size = DEFAULT_MAX_CHUNK_SIZE
-            if use_cueq_triangle_kernels:
-                max_chunk_size = CUEQ_MAX_CHUNK_SIZE
-            if use_triton_triangle_kernels:
-                max_chunk_size = TRITON_MAX_CHUNK_SIZE
+            use_flash_kernels = (
+                use_cueq_triangle_kernels
+                or use_triton_triangle_kernels
+                or use_deepspeed_evo_attention
+            )
+            max_chunk_size = (
+                FLASH_MAX_CHUNK_SIZE if use_flash_kernels else DEFAULT_MAX_CHUNK_SIZE
+            )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
                 args=(t.clone(),),
@@ -400,9 +402,7 @@ class TemplatePairStack(nn.Module):
                 max_chunk_size=max_chunk_size,
             )
             attn_chunk = (
-                tuned_chunk_size
-                if use_cueq_triangle_kernels or use_triton_triangle_kernels
-                else (tuned_chunk_size // 4)
+                tuned_chunk_size if use_flash_kernels else (tuned_chunk_size // 4)
             )
             blocks = [
                 partial(

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -27,6 +27,7 @@ from openfold3.core.utils.tensor_utils import (
 
 DEFAULT_MAX_CHUNK_SIZE = 512
 CUEQ_MAX_CHUNK_SIZE = 1024
+TRITON_MAX_CHUNK_SIZE = 1024
 
 
 def _fetch_dims(tree):

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -26,8 +26,7 @@ from openfold3.core.utils.tensor_utils import (
 )
 
 DEFAULT_MAX_CHUNK_SIZE = 512
-CUEQ_MAX_CHUNK_SIZE = 1024
-TRITON_MAX_CHUNK_SIZE = 1024
+FLASH_MAX_CHUNK_SIZE = 1024
 
 
 def _fetch_dims(tree):


### PR DESCRIPTION
**Summary**
Make the chunking values used for Triton kernels the same as those used for cuequivariance kernels

Rationale: the Triton kernels are very similar to the cuequivariance kernels and both use a memory efficient flash-attention-style algorithm. I think it makes sense to default to having them use the same code paths for chunk size. Some of the chunking subdivisions had explicit comments about being to work around errors specific to native PyTorch ops (I think maybe when I was looking through history: not now). We might want to further tune the chunking based on more detailed benchmarking, but assuming the Triton kernels behave similar to the cuequivariance kernels seems like a better starting point than assuming they behave like native PyTorch. This also reduces the number of unique call signatures the attention kernel sees which makes it easier to tune.

**Changes**
- The max chunk size when using the cuequivariance kernels is double the default (1024 instead of 512). Make the Triton kernels use the same.
- There are a few places where the already tuned chunk size is divided by 4, but that subdivision is skipped when using the cuequivariance kernels. Make the Triton kernels the same.

**Related Issues**
Sort of related to #203 and #206. It was noticing the weird calling pattern of chunks of 129 (`(512+4)/4`) that caused me to dive into the chunking logic in the first place

**Testing**
- Did a quick spot check that this doesn't blow up memory usage (test was based on top of #207 to split per sample). Using the largest inference example (the protein ligand complex, which still only has 737 tokens), peak memory usage went from 7.2GB to 8.2GB.

**Other Notes**
We could have a single "optimized attention kernels" chunk size variable rather than having separate ones.