### PR TITLE
Make `tune_chunk_size` a top-level config field

### DIFF
--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -112,6 +112,7 @@ model_config = mlc.ConfigDict(
                 },
                 "eval": {
                     "chunk_size": None,
+                    "tune_chunk_size": tune_chunk_size,
                     "use_deepspeed_evo_attention": not _is_rocm,
                     "use_cueq_triangle_kernels": False,
                     "use_triton_triangle_kernels": _is_rocm,


### PR DESCRIPTION
**Summary**
Currently `tune_chunk_size` is a field reference used in various subconfigs. Setting it in any of htem changes the value in all of them. I think given that, it makes sense to have one obviously canonical top-level place to set it. Otherwise you have to pick one arbitrary module to set it in, and I think having done that it's surprising that it gets set everywhere. This matches the behavior of similar fields `per_sample_token_cutoff`, `per_sample_atom_cutoff`, and `low_mem_validation`.

An alternative would be to unlink the module-level settings so they could be set independently (and optionally having a top-level setting that controls the default).

**Changes**
Add `tune_chunk_size` to `settings.memory.eval`.

**Related Issues**
None

**Testing**
Ran examples manually using the setting here or in any one of the modules and confirmed chunk tuning is turned off everywhere.