### PR TITLE
Avoid flattening and expanding broadcast dimensions when chunking

### DIFF
--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -905,8 +905,20 @@ if _TRITON_AVAILABLE:
 
             BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = Q.shape
 
-            assert res_mask.shape == (BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
-            assert pair_bias.shape == (BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
+            assert res_mask.shape == (
+                BATCH_SIZE,
+                N_SEQ,
+                1,
+                1,
+                SEQ_LEN,
+            ), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
+            assert pair_bias.shape == (
+                BATCH_SIZE,
+                1,
+                HEAD,
+                SEQ_LEN,
+                SEQ_LEN,
+            ), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
 
             softmax_scale = DIM**-0.5
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)

--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -904,6 +904,10 @@ if _TRITON_AVAILABLE:
             ).contiguous()  # (BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM)
 
             BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = Q.shape
+
+            assert res_mask.shape == (BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
+            assert pair_bias.shape == (BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
+
             softmax_scale = DIM**-0.5
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)
 

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -187,16 +187,8 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         apply_per_sample = (
             not torch.is_grad_enabled()
             and num_samples > 1
-            and (
-                (self.per_sample_token_cutoff is not None
-                and repr_x_pred.shape[-2] > self.per_sample_token_cutoff)
-                # The optimized attention kernels do not support cross-sample
-                # chunking because it requires expanding the pair bias. For now
-                # we just always apply per sample if these kernels are in use.
-                or use_deepspeed_evo_attention
-                or use_cueq_triangle_kernels
-                or use_triton_triangle_kernels
-            )
+            and (self.per_sample_token_cutoff is not None
+            and repr_x_pred.shape[-2] > self.per_sample_token_cutoff)
         )
         out_device = atom_positions_predicted.device
 

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -187,8 +187,16 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         apply_per_sample = (
             not torch.is_grad_enabled()
             and num_samples > 1
-            and self.per_sample_token_cutoff is not None
-            and repr_x_pred.shape[-2] > self.per_sample_token_cutoff
+            and (
+                (self.per_sample_token_cutoff is not None
+                and repr_x_pred.shape[-2] > self.per_sample_token_cutoff)
+                # The optimized attention kernels do not support cross-sample
+                # chunking because it requires expanding the pair bias. For now
+                # we just always apply per sample if these kernels are in use.
+                or use_deepspeed_evo_attention
+                or use_cueq_triangle_kernels
+                or use_triton_triangle_kernels
+            )
         )
         out_device = atom_positions_predicted.device
 

--- a/openfold3/core/model/heads/prediction_heads.py
+++ b/openfold3/core/model/heads/prediction_heads.py
@@ -209,10 +209,11 @@ class PairformerEmbedding(nn.Module):
         single_mask = reshape_inputs(x=single_mask, feat_dims=single_mask.shape[-1:])
         pair_mask = reshape_inputs(x=pair_mask, feat_dims=pair_mask.shape[-2:])
 
-        # Using the DS kernel with chunk tuning and multiple samples causes shape issues
-        # in the DS kernel. To avoid this, chunk tuning is disabled in this case.
-        # TODO: cuEq seems to fail comparison unit tests with the same settings,
-        #  disable for now and verify behavior
+        # The optimized kernels all require that pair bias have size 1 in the
+        # second dimension and cross-sample chunking has to combine the batch
+        # dimensions and expand it. We mostly avoid this path entirely by
+        # splitting per-sample when using the optimized kernels, but this avoids
+        # a potential correctness issue here.
         use_kernels = (
             use_deepspeed_evo_attention
             or use_cueq_triangle_kernels

--- a/openfold3/core/model/heads/prediction_heads.py
+++ b/openfold3/core/model/heads/prediction_heads.py
@@ -209,19 +209,6 @@ class PairformerEmbedding(nn.Module):
         single_mask = reshape_inputs(x=single_mask, feat_dims=single_mask.shape[-1:])
         pair_mask = reshape_inputs(x=pair_mask, feat_dims=pair_mask.shape[-2:])
 
-        # The optimized kernels all require that pair bias have size 1 in the
-        # second dimension and cross-sample chunking has to combine the batch
-        # dimensions and expand it. We mostly avoid this path entirely by
-        # splitting per-sample when using the optimized kernels, but this avoids
-        # a potential correctness issue here.
-        use_kernels = (
-            use_deepspeed_evo_attention
-            or use_cueq_triangle_kernels
-            or use_triton_triangle_kernels
-        )
-        if use_kernels and si.shape[0] > 1:
-            chunk_size = None
-
         si, zij = self.pairformer_stack(
             si,
             zij,

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -363,7 +363,6 @@ class ChunkSizeTuner:
         candidates = [2**l for l in range(int(math.log(max_chunk_size, 2)) + 1)]
         candidates = [c for c in candidates if c > min_chunk_size]
         candidates = [min_chunk_size] + candidates
-        candidates[-1] += 4
 
         def test_chunk_size(chunk_size):
             try:

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -310,7 +310,7 @@ def _chunk_layer_broadcast(
     for chunk_slices in _plan_chunks(orig_batch_dims, chunk_size):
         # Slice every input by its own shape (broadcast dims stay size 1).
         chunks = tensor_tree_map(
-            lambda t: _slice_input_for_chunk(t, chunk_slices),
+            lambda t, cs=chunk_slices: _slice_input_for_chunk(t, cs),
             inputs,
         )
 
@@ -403,8 +403,9 @@ def chunk_layer(
     initial_dims = [shape[:no_batch_dims] for shape in _fetch_dims(inputs)]
     orig_batch_dims = tuple([max(s) for s in zip(*initial_dims, strict=True)])
 
-    # Check whether we need Validate broadcast compatibility (raises on incompatible dims) and decide
-    # whether we need the multi-dim broadcast path.
+    # Check whether we need Validate broadcast compatibility (raises on
+    # incompatible dims) and decide whether we need the multi-dim broadcast
+    # path.
     has_broadcast = _has_broadcast_batch_dims(initial_dims, orig_batch_dims)
 
     # When inputs have mixed batch shapes (broadcast), use the multi-dim

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -14,7 +14,7 @@
 
 import logging
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from functools import partial
 from typing import Any
 
@@ -209,6 +209,153 @@ def _chunk_slice(
     return torch.cat([s.view((-1,) + t.shape[no_batch_dims:]) for s in sliced_tensors])
 
 
+def _plan_chunks(
+    batch_dims: tuple[int, ...], chunk_size: int
+) -> Iterator[tuple[slice, ...]]:
+    """Yield row-major multi-dim slice tuples that tile ``batch_dims``.
+
+    Each yielded tuple is a per-dim ``slice`` selecting a contiguous region
+    (assuming row-major layout). The product of region sizes is at most
+    ``chunk_size``. Slices are emitted in row-major (last-dim-fastest) order and
+    together cover the full index space of ``batch_dims`` exactly once.
+
+    Packing rule: fill the innermost dim first. If the innermost dim fits
+    entirely within ``chunk_size``, pack as many positions of the next-outer
+    dim as fit; recurse outward. If it doesn't fit, split the innermost dim
+    into ``chunk_size``-sized pieces, with one outer position per chunk.
+    """
+    if not batch_dims:
+        yield ()
+        return
+
+    inner = batch_dims[-1]
+    outer = batch_dims[:-1]
+
+    if chunk_size >= inner:
+        # Innermost fits entirely; pack outer dims with remaining budget.
+        outer_budget = chunk_size // inner
+        if not outer:
+            # Only one dim; everything fits in one chunk.
+            yield (slice(0, inner),)
+            return
+        for outer_slices in _plan_chunks(outer, outer_budget):
+            yield outer_slices + (slice(0, inner),)
+    else:
+        # Innermost too big; one outer position per chunk, split inner.
+        for outer_slices in _plan_chunks(outer, 1):
+            for start in range(0, inner, chunk_size):
+                end = min(start + chunk_size, inner)
+                yield outer_slices + (slice(start, end),)
+
+
+def _assign_output_chunk(
+    out: Any, output_chunk: Any, slices: tuple[slice, ...], add_into_out: bool
+) -> None:
+    """Write ``output_chunk`` into ``out`` at the given multi-dim slice.
+
+    Handles output as a tensor, a tuple of tensors, or a (possibly nested)
+    dict of tensors / sub-dicts. ``slices`` is a tuple of slices applied to
+    the leading dims; trailing dims are taken whole automatically.
+    """
+    if isinstance(out, dict):
+        for k, v in out.items():
+            _assign_output_chunk(v, output_chunk[k], slices, add_into_out)
+    elif isinstance(out, tuple):
+        for x_out, x_chunk in zip(out, output_chunk, strict=True):
+            _assign_output_chunk(x_out, x_chunk, slices, add_into_out)
+    elif isinstance(out, torch.Tensor):
+        if add_into_out:
+            out[slices] += output_chunk
+        else:
+            out[slices] = output_chunk
+    else:
+        raise ValueError(f"Unsupported output type: {type(out).__name__}")
+
+
+def _slice_input_for_chunk(
+    t: torch.Tensor, chunk_slices: tuple[slice, ...]
+) -> torch.Tensor:
+    """Slice an input tensor according to a multi-dim chunk plan.
+
+    For each batch dim, if the input's size is 1 (broadcast), force ``[0:1]``
+    so the broadcast is preserved. Otherwise apply the planned slice. Trailing
+    non-batch dims are taken whole automatically (PyTorch fills missing
+    trailing slices).
+    """
+    per_dim_slices = tuple(
+        slice(0, 1) if t.shape[d] == 1 else planned
+        for d, planned in enumerate(chunk_slices)
+    )
+    return t[per_dim_slices]
+
+
+def _chunk_layer_broadcast(
+    layer: Callable,
+    inputs: dict[str, Any],
+    chunk_size: int,
+    no_batch_dims: int,
+    orig_batch_dims: tuple[int, ...],
+    _out: Any = None,
+    _add_into_out: bool = False,
+) -> Any:
+    """Multi-dim chunking that preserves broadcast batch dims.
+
+    Each iteration slices every input on its own per-dim shape: for dims where
+    the input is size-1 (broadcast), the slice is always ``[0:1]``; otherwise
+    the planned slice is used. Outputs are written into a buffer of shape
+    ``orig_batch_dims + trailing`` at the corresponding multi-dim slot.
+    """
+    out = _out
+
+    for chunk_slices in _plan_chunks(orig_batch_dims, chunk_size):
+        # Slice every input by its own shape (broadcast dims stay size 1).
+        chunks = tensor_tree_map(
+            lambda t: _slice_input_for_chunk(t, chunk_slices),
+            inputs,
+        )
+
+        output_chunk = layer(**chunks)
+
+        # Allocate output on first iteration.
+        if out is None:
+
+            def allocate(t):
+                return t.new_zeros(orig_batch_dims + t.shape[no_batch_dims:])
+
+            out = tensor_tree_map(allocate, output_chunk)
+
+        _assign_output_chunk(out, output_chunk, chunk_slices, _add_into_out)
+
+    return out
+
+
+def _has_broadcast_batch_dims(initial_dims: list, orig_batch_dims: tuple) -> bool:
+    """True if any input has a size-1 leading dim where another has size > 1.
+
+    When this is the case, flattening the batch dims would force materialization
+    of the broadcast input across the full flattened axis. Multi-dim chunking
+    (see ``_plan_chunks``) avoids that materialization by slicing each input on
+    its own shape.
+
+    Also validates that any per-input leading dim that doesn't match
+    ``orig_batch_dims`` is exactly 1. Anything else is broadcast-incompatible
+    and would silently produce wrong results, so we raise instead.
+    """
+    has_broadcast = False
+    for input_dims in initial_dims:
+        for d, full in zip(input_dims, orig_batch_dims, strict=True):
+            if d == full:
+                continue
+            if d == 1:
+                has_broadcast = True
+            else:
+                raise ValueError(
+                    f"Incompatible batch dims: input has size {d} where another "
+                    f"has size {full}; only 1 (broadcast) or matching sizes allowed."
+                )
+    return has_broadcast
+
+
 def chunk_layer(
     layer: Callable,
     inputs: dict[str, Any],
@@ -229,8 +376,12 @@ def chunk_layer(
         layer:
             The layer to be applied chunk-wise
         inputs:
-            A (non-nested) dictionary of keyworded inputs. All leaves must
-            be tensors and must share the same batch dimensions.
+            A (non-nested) dictionary of keyworded inputs. All leaves must be
+            tensors. Inputs may differ in their batch dimensions subject to
+            implicit broadcasting (e.g. one input has shape ``[B, N, ...]`` and
+            another has ``[B, 1, ...]``); the broadcast structure is preserved
+            through chunking instead of being materialized at the cost of
+            potentially less efficient chunk shapes.
         chunk_size:
             The number of sub-batches per chunk. If multiple batch
             dimensions are specified, a "sub-batch" is defined as a single
@@ -251,6 +402,23 @@ def chunk_layer(
 
     initial_dims = [shape[:no_batch_dims] for shape in _fetch_dims(inputs)]
     orig_batch_dims = tuple([max(s) for s in zip(*initial_dims, strict=True)])
+
+    # Check whether we need Validate broadcast compatibility (raises on incompatible dims) and decide
+    # whether we need the multi-dim broadcast path.
+    has_broadcast = _has_broadcast_batch_dims(initial_dims, orig_batch_dims)
+
+    # When inputs have mixed batch shapes (broadcast), use the multi-dim
+    # planner to preserve the broadcast through chunking.
+    if has_broadcast:
+        return _chunk_layer_broadcast(
+            layer=layer,
+            inputs=inputs,
+            chunk_size=chunk_size,
+            no_batch_dims=no_batch_dims,
+            orig_batch_dims=orig_batch_dims,
+            _out=_out,
+            _add_into_out=_add_into_out,
+        )
 
     def _prep_inputs(t):
         if not low_mem:
@@ -310,33 +478,9 @@ def chunk_layer(
             out = tensor_tree_map(allocate, output_chunk)
 
         # Put the chunk in its pre-allocated space
-        out_type = type(output_chunk)
-        if out_type is dict:
-
-            def assign(d1, d2):
-                for k, v in d1.items():
-                    if isinstance(v, dict):
-                        assign(v, d2[k])
-                    else:
-                        if _add_into_out:
-                            v[i : i + chunk_size] += d2[k]  # noqa: B023
-                        else:
-                            v[i : i + chunk_size] = d2[k]  # noqa: B023
-
-            assign(out, output_chunk)
-        elif out_type is tuple:
-            for x1, x2 in zip(out, output_chunk, strict=True):
-                if _add_into_out:
-                    x1[i : i + chunk_size] += x2
-                else:
-                    x1[i : i + chunk_size] = x2
-        elif out_type is torch.Tensor:
-            if _add_into_out:
-                out[i : i + chunk_size] += output_chunk
-            else:
-                out[i : i + chunk_size] = output_chunk
-        else:
-            raise ValueError("Not supported")
+        _assign_output_chunk(
+            out, output_chunk, (slice(i, i + chunk_size),), _add_into_out
+        )
 
         i += chunk_size
 

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -719,13 +719,13 @@ class TestKernels(unittest.TestCase):
         chunk_size=None,
     ):
         """
-        Compare Template Stack output with and without using DeepSpeed Evoformer
-        attention kernel. Kernel can be used for Triangle Attention in the Template Pair
-        Stack.
+        Compare Template Stack output with and without using different optimized
+        attention kernels. Kernel can be used for Triangle Attention in the
+        Template Pair Stack.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None and use_deepspeed_evo_attention:
-            # Chunk tuning is not supported with batch size > 1 for DeepSpeed kernel
+        if chunk_size is not None:
+            # Chunking is not supported with batch size > 1 for optimized kernels
             batch_size = 1
 
         n_templ = 3
@@ -793,7 +793,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
         )
 
@@ -801,7 +800,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_bf16(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.bfloat16,
         )
 
@@ -809,7 +807,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32_chunk(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
             chunk_size=4,
         )
@@ -817,7 +814,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -825,7 +821,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.bfloat16,
         )
@@ -833,7 +828,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -842,8 +836,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -852,8 +844,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -861,8 +851,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.bfloat16,
         )

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -435,7 +435,6 @@ class TestKernels(unittest.TestCase):
           instead of a newly initialized block.
         """
         batch_size = consts.batch_size
-
         n_res = 200  # Avoid cuEq seq len constraints
         c_s = consts.c_s
         c_z = consts.c_z
@@ -718,10 +717,6 @@ class TestKernels(unittest.TestCase):
         Template Pair Stack.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None:
-            # Chunking is not supported with batch size > 1 for optimized kernels
-            batch_size = 1
-
         n_templ = 3
         n_token = 200  # Avoid cuEq seq len constraints
 

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -435,12 +435,6 @@ class TestKernels(unittest.TestCase):
           instead of a newly initialized block.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None and (
-            use_deepspeed_evo_attention or use_triton_triangle_kernels
-        ):
-            # Chunk tuning is not supported with batch size > 1 for DeepSpeed kernel
-            # Triton kernel works with these shapes but has some numerical differences
-            batch_size = 1
 
         n_res = 200  # Avoid cuEq seq len constraints
         c_s = consts.c_s

--- a/openfold3/tests/test_utils.py
+++ b/openfold3/tests/test_utils.py
@@ -18,7 +18,7 @@ import unittest
 import torch
 
 from openfold3.core.model.primitives import Linear
-from openfold3.core.utils.chunk_utils import _chunk_slice, chunk_layer
+from openfold3.core.utils.chunk_utils import _chunk_slice, _plan_chunks, chunk_layer
 from openfold3.core.utils.rigid_utils import (
     Rigid,
     Rotation,
@@ -196,3 +196,128 @@ class TestUtils(unittest.TestCase):
                 chunked_flattened = x_flat[i:j]
 
                 self.assertTrue(torch.all(chunked == chunked_flattened))
+
+    def _collect_plan(self, batch_dims, chunk_size):
+        return list(_plan_chunks(batch_dims, chunk_size))
+
+    def _slices_size(self, slices):
+        prod = 1
+        for s in slices:
+            prod *= s.stop - s.start
+        return prod
+
+    def test_plan_chunks_inner_fits_one_outer_per_chunk(self):
+        # (5, 76) cs=128: inner 76 fits, only 1 outer per chunk (152 > 128)
+        plan = self._collect_plan((5, 76), 128)
+        self.assertEqual(len(plan), 5)
+        for i, slices in enumerate(plan):
+            self.assertEqual(slices, (slice(i, i + 1), slice(0, 76)))
+
+    def test_plan_chunks_inner_split(self):
+        # (5, 76) cs=64: inner 76 > 64, split into [64, 12]; one outer at a time
+        plan = self._collect_plan((5, 76), 64)
+        self.assertEqual(len(plan), 10)
+        # First sample: [0:64], [64:76]
+        self.assertEqual(plan[0], (slice(0, 1), slice(0, 64)))
+        self.assertEqual(plan[1], (slice(0, 1), slice(64, 76)))
+        # Last sample
+        self.assertEqual(plan[-2], (slice(4, 5), slice(0, 64)))
+        self.assertEqual(plan[-1], (slice(4, 5), slice(64, 76)))
+
+    def test_plan_chunks_pack_outer(self):
+        # (5, 76) cs=256: inner 76 fits, 256//76 = 3 outer per chunk
+        plan = self._collect_plan((5, 76), 256)
+        self.assertEqual(len(plan), 2)
+        self.assertEqual(plan[0], (slice(0, 3), slice(0, 76)))
+        self.assertEqual(plan[1], (slice(3, 5), slice(0, 76)))
+
+    def test_plan_chunks_covers_index_space_exactly(self):
+        # For varied (batch_dims, chunk_size), ensure the plan tiles the full index space
+        # and each chunk's volume is <= chunk_size.
+        for batch_dims in [(5, 76), (2, 100), (3,), (4, 8, 5), (1, 50)]:
+            for cs in [16, 32, 64, 128, 256]:
+                with self.subTest(batch_dims=batch_dims, cs=cs):
+                    plan = self._collect_plan(batch_dims, cs)
+                    # Volume per chunk
+                    for slices in plan:
+                        self.assertLessEqual(self._slices_size(slices), cs)
+                    # Total covered = product(batch_dims)
+                    total = sum(self._slices_size(s) for s in plan)
+                    expected = 1
+                    for d in batch_dims:
+                        expected *= d
+                    self.assertEqual(total, expected)
+
+    def test_plan_chunks_chunk_size_larger_than_total(self):
+        # cs >= product(batch_dims): single chunk covering everything
+        plan = self._collect_plan((3, 4), 100)
+        self.assertEqual(len(plan), 1)
+        self.assertEqual(plan[0], (slice(0, 3), slice(0, 4)))
+
+    def test_plan_chunks_single_dim(self):
+        plan = self._collect_plan((10,), 4)
+        self.assertEqual(plan, [
+            (slice(0, 4),), (slice(4, 8),), (slice(8, 10),)
+        ])
+
+    def test_chunk_layer_rejects_incompatible_batch_dims(self):
+        # When two inputs have different sizes in the same batch dim and
+        # neither is 1, broadcasting is undefined; chunk_layer should error
+        # rather than silently producing wrong results.
+        a = torch.rand(5, 76, 4)
+        b = torch.rand(3, 76, 4)
+        with self.assertRaises(ValueError):
+            chunk_layer(
+                lambda a, b: a + b,
+                {"a": a, "b": b},
+                chunk_size=32,
+                no_batch_dims=2,
+            )
+
+    def test_chunk_layer_broadcast(self):
+        # B1*B2 isn't evenly divisble by any power of 2, so we can test the
+        # uneven chunk tail behavior.
+        B1, B2, N, C = 5, 76, 76, 4
+        a = torch.rand(B1, B2, N, C)
+        b = torch.rand(B1, 1, N, C)
+
+        def add_layer(a, b):
+            return a + b
+
+        unchunked = add_layer(a, b)
+
+        for cs in [32, 64, 128, 256]:
+            with self.subTest(chunk_size=cs):
+                chunked = chunk_layer(
+                    add_layer,
+                    {"a": a, "b": b},
+                    chunk_size=cs,
+                    no_batch_dims=2,
+                )
+                self.assertEqual(chunked.shape, unchunked.shape)
+                self.assertTrue(torch.allclose(chunked, unchunked))
+
+    def test_chunk_layer_broadcast_does_not_materialize(self):
+        B1, B2, N, C = 5, 76, 76, 4
+        a = torch.rand(B1, B2, N, C)
+        b = torch.rand(B1, 1, N, C)
+
+        seen_b_shapes = []
+
+        def spy(a, b):
+            seen_b_shapes.append(tuple(b.shape))
+            return a + b
+
+        chunk_layer(
+            spy,
+            {"a": a, "b": b},
+            chunk_size=128,
+            no_batch_dims=2,
+        )
+        # Every call's b must keep the broadcast `1` in its second dim.
+        self.assertGreater(len(seen_b_shapes), 0)
+        for shape in seen_b_shapes:
+            self.assertEqual(
+                shape[1], 1,
+                f"b was materialized along the broadcast dim: {shape}",
+            )


### PR DESCRIPTION
**Summary**
This is an alternative, more complicated fix for #206 instead of #207. To avoid the expansion of an implicit broadcast dimension (e.g. in pair bias), if one exists it chunks across each batch dimension discretely. If the innermost batch dimension (usually N_seq) is larger than chunk_size then this is equivalent to splitting per sample. If it's smaller though, then we might fit multiple samples in a single chunk.

So as an example when we have diffusion_samples 5 and sequence length 76 in the pairformer embedding we have batch dims [5, 76] for QKV but for the pair bias it's [5, 1]. Rather than flattening to [380], we chunk each dimension separately. If chunk size were 128 then we'd split into 5 chunks of [1, 76]; if it were 64, then we'd split into 5 chunks of [1, 64] and 5 chunks of [1, 12]; if chunk size were 256, then we'd split into chunks of [3, 76] and [2, 76], etc.

Doing this in the `chunk_layer` function allows us to be chunk-size-aware, which we can't be at higher levels when chunk size has potentially not yet been determined due to chunk size tuning. I think this could completely replace `apply_per_sample` and `per_sample_token_cutoff` as well and is more robust.

**Changes**
- Add new function for dimension-aware chunking employed when inputs would be broadcast in their batch dimensions 
- Remove workarounds that avoid chunking when using optimized kernels and batch size > 1
- Allow kernel tests to use batch_size > 1

**Related Issues**
- Fixes https://github.com/aqlaboratory/openfold-3/issues/206
- Fixes https://github.com/aqlaboratory/openfold-3/issues/203

**Testing**
- Unit tests for chunking logic
- Integration tests for kernels now work with batch==2

**Other Notes**
- I have not done performance testing on this yet, which I think we may want to do before merging.
- This is based on #207 but reverts some of the changes it makes. If we want to go this direction then we could close #207 and use this instead.
- This was partially authored by Claude