### PR TITLE
Removing extra contiguous calls

### DIFF
--- a/openfold3/core/model/latent/base_blocks.py
+++ b/openfold3/core/model/latent/base_blocks.py
@@ -385,8 +385,6 @@ class PairBlock(nn.Module):
         )
 
         z = z.transpose(-2, -3)
-        if inplace_safe:
-            z = z.contiguous()
 
         # Using dropout_row_layer since the dimensions were transposed before
         # calling the attention layer
@@ -408,8 +406,6 @@ class PairBlock(nn.Module):
         )
 
         z = z.transpose(-2, -3)
-        if inplace_safe:
-            z = z.contiguous()
 
         return z
 


### PR DESCRIPTION
**Summary**
Removing extra contiguous calls for triangle attention

**Changes**
Removed two unnecessary contiguous() calls in PairBlock.tri_att_start_end

**Related Issues**

**Testing**
Normal regression test

**Other Notes**
Here's what Claude is saying:
```Short answer: no, they are not strictly necessary for correctness, which is consistent with your 6484cf9c "Removing extra contiguous calls" commit. But there are a couple of things worth           
  re-verifying before calling it settled.                                                                                                                                                              
                                                                                                                                                                                                       
  Why they're redundant                                                                                                                                                                                
                                                                                                                                                                                                       
  After z = z.transpose(-2, -3) at line 387/410, z is a non-contiguous strided view. When inplace_safe=True, the next consumer is tri_att_end(z, ..., inplace_safe=True). Tracing what that actually   
  does to z:                                                                                                                                                                                           
                                                                                                                                                                                                       
  1. TriangleAttention.forward (both tri_att_start and tri_att_end are instantiated with the default starting=True, so there's no second internal transpose inside tri_att_end) begins with x =        
  self.layer_norm(x) — LayerNorm always materializes a fresh contiguous tensor regardless of whether the input was contiguous. From this point on, nothing in the attention path ever sees the         
  transposed non-contig storage again.                                                                                                                                                                 
  2. self.linear_z(x) and self.mha(q_x=x, kv_x=x, ...) → _prep_qkv does q = self.linear_q(q_x) (contig output) then q.view(...) (fine, because q_x is the contig layer_norm output).
  3. In the chunked path, _chunk(..., _out=x if inplace_safe else None) — x here is the post-layer_norm tensor, which is already a fresh contig buffer. The _out aliasing does not touch the transposed
   view.                                                                                                                                                                                               
  4. _deepspeed_evo_attn / _triton_evo_attn / _cueq_triangle_attn all do their own transposes + reshape, which materialize contig if needed.                                                           
  5. Back in tri_att_start_end, add(z, result, inplace=True) becomes z.add_(result). PyTorch's add_ supports non-contig LHS and just writes through strided indexing into the underlying storage.      
  6. The final z.transpose(-2, -3) at line 410 is the second of two transposes on the same storage, yielding a contig view of the original storage again.                                              
                                                                                                                                                                                                       
  So the contiguous() call was pre-empting a kernel-layout issue that no longer exists on the current code path.                                                                                       
                                                                                                                                                                                                       
  Caveats worth checking                                                                                                                                                                               
                                                            
  - inplace_safe also disables the extra allocation, which is its whole point. Keeping the contiguous() allocates a full [B, N, N, C] tensor and copies — bigger cost than any strided-read it was     
  avoiding.                                                 
  - The one theoretical failure mode would be if some kernel received the transposed non-contig z directly (no LayerNorm between them) and called .view(...). In TriangleAttention that's not the case,
   so you're safe — but if anything is ever refactored to skip LayerNorm on entry, this becomes load-bearing again.                                                                                    
  - Worth running test_pairformer.py, test_evoformer.py, test_triangular_attention.py, test_primitives.py and (ideally) one end-to-end test_inference_full.py run across the kernel variants
  (use_deepspeed_evo_attention, use_cueq_triangle_kernels, use_triton_triangle_kernels, and the vanilla path) with inplace_safe=True to confirm numerical equivalence.                                 
                                                            
  If those pass, the removal is fine.
  ```
