### PR TITLE
Make chunks always a power of 2

### DIFF
--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -363,7 +363,6 @@ class ChunkSizeTuner:
         candidates = [2**l for l in range(int(math.log(max_chunk_size, 2)) + 1)]
         candidates = [c for c in candidates if c > min_chunk_size]
         candidates = [min_chunk_size] + candidates
-        candidates[-1] += 4
 
         def test_chunk_size(chunk_size):
             try:


### PR DESCRIPTION
**Summary**
For some reason, the largest chunk size in chunk size tuning is incremented by 4. This was added in https://github.com/aqlaboratory/openfold-3/commit/a9a12890d without explanation. We can hypothesize that it was related to adding 4 to an input dimension in trace_utils.py (trying to get a test case to fit in one chunk?), but that file was long ago deleted. This just looks like a bug and makes us hit unhappy paths all over the place.

**Changes**
- Delete the addition of 4 to the largest chunk size

**Related Issues**
- Fixes https://github.com/aqlaboratory/openfold-3/issues/203

**Testing**
- Confirmed that attention kernel calling pattern moves from batches of 129 to 128 (since it is divided by 4 for attention).
- I didn't find a good way to unit test this that was actually a useful test (e.g. I can assert that chunk_size is now 512 instead of 516, but I don't think that test carries its weight).

**Other Notes**
- Split out from https://github.com/aqlaboratory/openfold-3/pull/207 as a separate PR since that one had ongoing discussion about the best approach (e.g. https://github.com/aqlaboratory/openfold-3/pull/213 instead)
