### PR TITLE
Add checks against expanded pair bias

### DIFF
--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -904,6 +904,22 @@ if _TRITON_AVAILABLE:
             ).contiguous()  # (BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM)
 
             BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = Q.shape
+
+            assert res_mask.shape == (
+                BATCH_SIZE,
+                N_SEQ,
+                1,
+                1,
+                SEQ_LEN,
+            ), f"{tuple(res_mask.shape)} != {(BATCH_SIZE, N_SEQ, 1, 1, SEQ_LEN)}"
+            assert pair_bias.shape == (
+                BATCH_SIZE,
+                1,
+                HEAD,
+                SEQ_LEN,
+                SEQ_LEN,
+            ), f"{tuple(pair_bias.shape)} != {(BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN)}"
+
             softmax_scale = DIM**-0.5
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)
 

--- a/openfold3/core/model/heads/prediction_heads.py
+++ b/openfold3/core/model/heads/prediction_heads.py
@@ -207,10 +207,9 @@ class PairformerEmbedding(nn.Module):
         single_mask = reshape_inputs(x=single_mask, feat_dims=single_mask.shape[-1:])
         pair_mask = reshape_inputs(x=pair_mask, feat_dims=pair_mask.shape[-2:])
 
-        # Using the DS kernel with chunk tuning and multiple samples causes shape issues
-        # in the DS kernel. To avoid this, chunk tuning is disabled in this case.
-        # TODO: cuEq seems to fail comparison unit tests with the same settings,
-        #  disable for now and verify behavior
+        # The optimized kernels all require that pair bias have size 1 in the
+        # second dimension and cross-sample chunking has to combine the batch
+        # dimensions and expand it.
         use_kernels = (
             use_deepspeed_evo_attention
             or use_cueq_triangle_kernels

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -438,8 +438,7 @@ class TestKernels(unittest.TestCase):
         if chunk_size is not None and (
             use_deepspeed_evo_attention or use_triton_triangle_kernels
         ):
-            # Chunk tuning is not supported with batch size > 1 for DeepSpeed kernel
-            # Triton kernel works with these shapes but has some numerical differences
+            # Chunk tuning is not supported with batch size > 1 for these kernels
             batch_size = 1
 
         n_res = 200  # Avoid cuEq seq len constraints
@@ -724,8 +723,10 @@ class TestKernels(unittest.TestCase):
         Template Pair Stack.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None:
-            # Chunking is not supported with batch size > 1 for optimized kernels
+        if chunk_size is not None and (
+            use_deepspeed_evo_attention or use_triton_triangle_kernels
+        ):
+            # Chunk tuning is not supported with batch size > 1 for these kernels
             batch_size = 1
 
         n_templ = 3

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -719,13 +719,13 @@ class TestKernels(unittest.TestCase):
         chunk_size=None,
     ):
         """
-        Compare Template Stack output with and without using DeepSpeed Evoformer
-        attention kernel. Kernel can be used for Triangle Attention in the Template Pair
-        Stack.
+        Compare Template Stack output with and without using different optimized
+        attention kernels. Kernel can be used for Triangle Attention in the
+        Template Pair Stack.
         """
         batch_size = consts.batch_size
-        if chunk_size is not None and use_deepspeed_evo_attention:
-            # Chunk tuning is not supported with batch size > 1 for DeepSpeed kernel
+        if chunk_size is not None:
+            # Chunking is not supported with batch size > 1 for optimized kernels
             batch_size = 1
 
         n_templ = 3
@@ -793,7 +793,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
         )
 
@@ -801,7 +800,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_bf16(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.bfloat16,
         )
 
@@ -809,7 +807,6 @@ class TestKernels(unittest.TestCase):
     def test_compare_template_stack_dsk_fp32_chunk(self):
         self._compare_template_stack(
             use_deepspeed_evo_attention=True,
-            use_cueq_triangle_kernels=False,
             dtype=torch.float32,
             chunk_size=4,
         )
@@ -817,7 +814,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -825,7 +821,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.bfloat16,
         )
@@ -833,7 +828,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_cueq_installed()
     def test_compare_template_stack_cueq_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
             use_cueq_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -842,8 +836,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32_chunk(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
             chunk_size=4,
@@ -852,8 +844,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_fp32(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
         )
@@ -861,8 +851,6 @@ class TestKernels(unittest.TestCase):
     @compare_utils.skip_unless_triton_installed()
     def test_compare_template_stack_triton_bf16(self):
         self._compare_template_stack(
-            use_deepspeed_evo_attention=False,
-            use_cueq_triangle_kernels=False,
             use_triton_triangle_kernels=True,
             dtype=torch.bfloat16,
         )


### PR DESCRIPTION
**Summary**
The Triton kernel assumes that pair bias has size 1 in the N_seq dimension and does an implicit broadcast (`pair_bias.stride(1)` is not even passed to the kernel), but this isn't actually checked. This is the reason chunking is turned off when batch size > 1 and we're using optimized kernels, because the chunker expands the implicit broadcast dimensions. Added asserts for this and documented the issue.

**Changes**
- Assert on expected bias shapes in Triton triangle attention
- document why chunking gets turned off in prediction_heads.py when using optimized kernels
- Update tests for Triton kernels in test_kernels.py to avoid batch_size > 1 + chunking (was only set for deepspeed). Cuequivariance has a workaround, so its tests still use the larger batch.

**Related Issues**
- Related to #206

**Testing**
- Updated the tests to not use batch size > 1 (existing tests would have thrown)
- I don't think a test checking for the assert is very useful

**Other Notes**
This, along with #226, contains the parts of #207 that I think we still want even if the approach in #213 is preferred overall. If we merge this, then I'll close #207 and iterate on #213 instead.