### PR TITLE
in openfold3.entry_points.parameters: allow creation of ckpt_root_file directory if it does not already exist

### DIFF
--- a/openfold3/entry_points/parameters.py
+++ b/openfold3/entry_points/parameters.py
@@ -123,6 +123,7 @@ def get_default_checkpoint_dir(cache_path: Path | None = None) -> Path:
         logger.info(
             f"Storing path to OpenFold parameters {param_dir} in {ckpt_root_file}"
         )
+        ckpt_root_file.parent.mkdir(parents=True, exist_ok=True)
         with open(ckpt_root_file, "w") as f:
             f.write(str(param_dir))
     return param_dir


### PR DESCRIPTION
**Summary**
In CI testing, we occasionally observe the following failures on the `TestOF3ModelCheckpointing` tests

```
openfold3/entry_points/parameters.py:126: FileNotFoundError
```
Example CI test run with failure: https://github.com/aqlaboratory/openfold-3/actions/runs/26453509424/job/77881128202

The underlying cause is that `entry_poitns.parameters` does not have a guard to create the checkpoint root directory when none is specified. The reason this was not an issue during normal inference runs or the infernece integration tests is because `setup_openfold` does have a catch to create the checkpoint root directory when it is not created. This issue does not occur consistently because for CI testing, these tests are run in parllel and `setup_openfold` might have run already to create the `ckpt_root` directory.

**Changes**
- Add line to create `ckpt_root_file` parent directory in `parameters.py` if one does not already exist.

**Related Issues**
NA

**Testing**
- [x] `test_model_checkpoint.py` tests pass on a local machine
- [ ] Observe CI testing, ensure we do not observe failure in `test_model_checkpoint.py`