### PR TITLE
Feature/starting residue number

### DIFF
--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -57,6 +57,7 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
     "chain_ids": "A",
     "description": "Optional metadata example",
     "sequence": "PVLSCGEWQCL",
+    "starting_residue_number": 3,
     "use_msas": true,
     "use_main_msas": true,
     "use_paired_msas": true,
@@ -80,6 +81,11 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
 
   - `sequence` *(str, required)*
     - Amino acid sequence (1-letter codes), supporting standard residues, X (unknown), and U (selenocysteine).
+
+  - `starting_residue_number` *(int | null, optional, default = null)*
+    - A custom starting residue number for the chain. 
+    - If provided, the output structure's residue IDs will start from this number instead of 1. 
+    - Negative numbers are supported (e.g., for signal peptides).
 
   - `non_canonical_residues` *(dict, optional, default = null)*
     - A dictionary mapping residue indices (1-based) to non-canonical residue names.

--- a/examples/example_inference_inputs/query_ubiquitin_starting_residue_number.json
+++ b/examples/example_inference_inputs/query_ubiquitin_starting_residue_number.json
@@ -1,0 +1,16 @@
+{
+    "queries": {
+        "mature": {
+            "chains": [
+                {
+                    "molecule_type": "protein",
+                    "chain_ids": [
+                        "A"
+                    ],
+                    "sequence": "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG",
+                    "starting_residue_number": 3
+                }
+            ]
+        }
+    }
+}

--- a/openfold3/core/data/framework/data_module.py
+++ b/openfold3/core/data/framework/data_module.py
@@ -728,11 +728,25 @@ def openfold_batch_collator(samples: list[dict[str, torch.Tensor]]):
         for sample in samples:
             ref_space_uid_to_perm_dicts.append(sample.pop("ref_space_uid_to_perm"))
 
+    # residue_number_offsets is a plain Python dict {chain_id: int} — not a tensor.
+    # It must be popped before pad_sequence runs and re-inserted afterwards,
+    # mirroring the same pattern used for ref_space_uid_to_perm above.
+    has_residue_number_offsets = "residue_number_offsets" in samples[0]
+
+    if has_residue_number_offsets:
+        residue_number_offsets_list = []
+        for sample in samples:
+            residue_number_offsets_list.append(sample.pop("residue_number_offsets"))
+
     samples = dict_multimap(pad_feat_fn, samples)
 
     # Add the ref_space_uid_to_perm back to the samples
     if has_ref_space_uid_to_perm:
         samples["ref_space_uid_to_perm"] = ref_space_uid_to_perm_dicts
+
+    # Add residue_number_offsets back to the samples
+    if has_residue_number_offsets:
+        samples["residue_number_offsets"] = residue_number_offsets_list
 
     if has_pdb_id:
         samples["pdb_id"] = pdb_ids

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -298,6 +298,16 @@ class InferenceDataset(Dataset):
         features["atom_array"] = preprocessed_atom_array
         n_tokens = get_token_count(preprocessed_atom_array)
 
+        # Build per-chain residue number offsets from query
+        residue_number_offsets = {}
+        for chain in query.chains:
+            if chain.starting_residue_number is not None:
+                offset = chain.starting_residue_number - 1
+                for chain_id in chain.chain_ids:
+                    residue_number_offsets[chain_id] = offset
+        features["residue_number_offsets"] = residue_number_offsets
+
+
         # Target structure and conformer features
         structure_features = self.create_structure_features(
             atom_array=preprocessed_atom_array,

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -307,7 +307,6 @@ class InferenceDataset(Dataset):
                     residue_number_offsets[chain_id] = offset
         features["residue_number_offsets"] = residue_number_offsets
 
-
         # Target structure and conformer features
         structure_features = self.create_structure_features(
             atom_array=preprocessed_atom_array,

--- a/openfold3/core/runners/writer.py
+++ b/openfold3/core/runners/writer.py
@@ -111,6 +111,7 @@ class OF3OutputWriter(BasePredictionWriter):
         plddt: np.ndarray,
         output_file: Path,
         make_ost_compatible: bool = True,
+        residue_number_offsets: dict[str, int] | None = None,
     ):
         """Writes predicted coordinates to atom_array and writes mmcif file to disk.
 
@@ -120,6 +121,13 @@ class OF3OutputWriter(BasePredictionWriter):
         # Set coordinates and plddt scores
         atom_array.coord = predicted_coords
         atom_array.set_annotation("b_factor", plddt)
+
+        # Apply custom residue numbering offsets
+        if residue_number_offsets:
+            atom_array = atom_array.copy()  # don't mutate shared array
+            for chain_id, offset in residue_number_offsets.items():
+                chain_mask = atom_array.chain_id == chain_id
+                atom_array.res_id[chain_mask] += offset
 
         # Write the output file
         logger.info(f"Writing predicted structure to {output_file}")
@@ -237,6 +245,19 @@ class OF3OutputWriter(BasePredictionWriter):
         sample_size = outputs["atom_positions_predicted"].shape[1]
 
         # Iterate over all predictions in the batch
+
+        # Extract per-batch residue number offsets (empty dict if not provided).
+        # The dataloader may deliver this as a plain dict (batch_size=1) or a
+        # list of dicts, so we normalise to a list here.
+        raw_offsets = batch.get("residue_number_offsets", None)
+        if raw_offsets is None:
+            all_residue_number_offsets = [{}] * batch_size
+        elif isinstance(raw_offsets, list):
+            all_residue_number_offsets = raw_offsets
+        else:
+            # Single dict (batch_size == 1 or not collated into a list)
+            all_residue_number_offsets = [raw_offsets]
+
         for b in range(batch_size):
             seed = batch["seed"][b]
             query_id = batch["query_id"][b]
@@ -245,6 +266,9 @@ class OF3OutputWriter(BasePredictionWriter):
 
             # Extract attributes for the current batch
             atom_array_batch = batch["atom_array"][b]
+
+            residue_number_offsets_batch = all_residue_number_offsets[b]
+
             predicted_coords_batch = (
                 outputs["atom_positions_predicted"][b].cpu().float().numpy()
             )
@@ -265,6 +289,7 @@ class OF3OutputWriter(BasePredictionWriter):
                     predicted_coords=predicted_coords_sample,
                     plddt=confidence_scores_sample["plddt"],
                     output_file=structure_file,
+                    residue_number_offsets=residue_number_offsets_batch,
                 )
 
                 # Save confidence metrics

--- a/openfold3/core/runners/writer.py
+++ b/openfold3/core/runners/writer.py
@@ -249,7 +249,7 @@ class OF3OutputWriter(BasePredictionWriter):
         # Extract per-batch residue number offsets (empty dict if not provided).
         # The dataloader may deliver this as a plain dict (batch_size=1) or a
         # list of dicts, so we normalise to a list here.
-        raw_offsets = batch.get("residue_number_offsets", None)
+        raw_offsets = batch.get("residue_number_offsets")
         if raw_offsets is None:
             all_residue_number_offsets = [{}] * batch_size
         elif isinstance(raw_offsets, list):

--- a/openfold3/projects/of3_all_atom/config/inference_query_format.py
+++ b/openfold3/projects/of3_all_atom/config/inference_query_format.py
@@ -52,6 +52,7 @@ class Chain(BaseModel):
     chain_ids: Annotated[list[str], BeforeValidator(_ensure_list)]
     description: str | None = None
     sequence: str | None = None
+    starting_residue_number: int | None = None
     non_canonical_residues: (
         Annotated[dict[int, str], BeforeValidator(_cast_keys_to_int)] | None
     ) = None

--- a/openfold3/tests/test_custom_residue_numbering.py
+++ b/openfold3/tests/test_custom_residue_numbering.py
@@ -1,0 +1,559 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for custom residue numbering (issue #58).
+
+These tests verify that:
+1. The Chain Pydantic model accepts the new starting_residue_number field
+2. The writer correctly applies residue number offsets to output files
+"""
+
+import numpy as np
+import pytest
+from biotite import structure
+from biotite.structure.io import pdbx
+from pydantic import ValidationError
+
+from openfold3.core.runners.writer import OF3OutputWriter
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    Chain,
+    Query,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+# Real mini-protein / peptide sequences used across tests:
+#   TRH        = "QHP"          (3 aa, thyrotropin-releasing hormone)
+#   OXYTOCIN   = "CYIQNCPLG"   (9 aa, nonapeptide hormone)
+#   CHIGNOLIN  = "GYDPETGTWG"  (10 aa, smallest folding protein)
+TRH = "QHP"
+OXYTOCIN = "CYIQNCPLG"
+CHIGNOLIN = "GYDPETGTWG"
+
+
+class TestChainStartingResidueNumber:
+    """Tests for the starting_residue_number field on the Chain Pydantic model."""
+
+    def test_chain_accepts_starting_residue_number(self):
+        """Chain model should accept an integer starting_residue_number."""
+        chain = Chain.model_validate(
+            {
+                "molecule_type": "protein",
+                "chain_ids": ["A"],
+                "sequence": TRH,
+                "starting_residue_number": 25,
+            }
+        )
+        assert chain.starting_residue_number == 25
+
+    def test_chain_defaults_to_none(self):
+        """Omitting starting_residue_number should default to None (backward compat)."""
+        chain = Chain.model_validate(
+            {
+                "molecule_type": "protein",
+                "chain_ids": ["A"],
+                "sequence": TRH,
+            }
+        )
+        assert chain.starting_residue_number is None
+
+    def test_chain_rejects_invalid_type(self):
+        """Non-integer starting_residue_number should raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Chain.model_validate(
+                {
+                    "molecule_type": "protein",
+                    "chain_ids": ["A"],
+                    "sequence": TRH,
+                    "starting_residue_number": "abc",
+                }
+            )
+
+    def test_chain_allows_negative_numbers(self):
+        """PDB allows negative residue numbers (e.g., signal peptides)."""
+        chain = Chain.model_validate(
+            {
+                "molecule_type": "protein",
+                "chain_ids": ["A"],
+                "sequence": TRH,
+                "starting_residue_number": -5,
+            }
+        )
+        assert chain.starting_residue_number == -5
+
+    def test_full_query_roundtrip(self):
+        """Full Query with starting_residue_number should validate and serialize."""
+        query = Query.model_validate(
+            {
+                "query_name": "test_query",
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A", "C"],
+                        "sequence": CHIGNOLIN,
+                        "starting_residue_number": 102,
+                    },
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["B"],
+                        "sequence": OXYTOCIN,
+                        "starting_residue_number": 22,
+                    },
+                ],
+            }
+        )
+        assert query.chains[0].starting_residue_number == 102
+        assert query.chains[1].starting_residue_number == 22
+
+        # Roundtrip through JSON serialization
+        json_data = query.model_dump(mode="json")
+        query_roundtrip = Query.model_validate(json_data)
+        assert query_roundtrip.chains[0].starting_residue_number == 102
+        assert query_roundtrip.chains[1].starting_residue_number == 22
+
+
+# ---------------------------------------------------------------------------
+# Helper to create a minimal atom array for writer tests
+# ---------------------------------------------------------------------------
+
+
+def _make_atom_array(chain_ids, res_ids):
+    """Create a minimal AtomArray with the given chain_ids and res_ids.
+
+    Args:
+        chain_ids: list of chain ID strings, one per atom.
+        res_ids: list of residue ID ints, one per atom.
+
+    Returns:
+        A biotite AtomArray with the required annotations for write_structure.
+    """
+    n_atoms = len(chain_ids)
+    atoms = []
+    for i in range(n_atoms):
+        atom = structure.Atom(
+            coord=[float(i), 0.0, 0.0],
+            chain_id=chain_ids[i],
+            res_id=res_ids[i],
+            res_name="ALA",
+            atom_name="CA",
+            element="C",
+        )
+        atoms.append(atom)
+
+    atom_array = structure.array(atoms)
+    atom_array.set_annotation(
+        "entity_id", np.array([chain_ids[i] for i in range(n_atoms)])
+    )
+    atom_array.set_annotation("molecule_type_id", np.array(["0"] * n_atoms))
+    atom_array.set_annotation("pdbx_formal_charge", np.array(["0"] * n_atoms))
+
+    return atom_array
+
+
+def _read_res_ids_from_cif(cif_path):
+    """Read back residue IDs from a written CIF file.
+
+    Returns:
+        tuple of (chain_ids, res_ids) as numpy arrays.
+    """
+    read_file = pdbx.CIFFile.read(cif_path)
+    parsed = pdbx.get_structure(read_file)
+    return parsed.chain_id, parsed.res_id
+
+
+# ---------------------------------------------------------------------------
+# Writer tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriterResidueNumberOffsets:
+    """Tests that write_structure_prediction correctly applies residue offsets."""
+
+    def test_writer_applies_single_chain_offset(self, tmp_path):
+        """A single chain with starting_residue_number=25 should produce res_ids
+        starting at 25."""
+        # 3 residues in chain A: originally res_id 1, 2, 3
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "A"],
+            res_ids=[1, 2, 3],
+        )
+        new_coords = atom_array.coord.copy()
+        plddt = np.array([0.9, 0.8, 0.7])
+
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=new_coords,
+            plddt=plddt,
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={"A": 24},  # starting_residue_number=25 → offset=24
+        )
+
+        chain_ids, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids, [25, 26, 27])
+
+    def test_writer_no_offset_unchanged(self, tmp_path):
+        """Without offsets, res_id should remain at original values."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "A"],
+            res_ids=[1, 2, 3],
+        )
+        new_coords = atom_array.coord.copy()
+        plddt = np.array([0.9, 0.8, 0.7])
+
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=new_coords,
+            plddt=plddt,
+            output_file=output_file,
+            make_ost_compatible=False,
+        )
+
+        _, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids, [1, 2, 3])
+
+    def test_writer_multimer_different_offsets(self, tmp_path):
+        """Two chains with different offsets should both be renumbered correctly."""
+        # Chain A: res_ids 1,2,3 with offset 24 → 25,26,27
+        # Chain B: res_ids 1,2 with offset 21 → 22,23
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "A", "B", "B"],
+            res_ids=[1, 2, 3, 1, 2],
+        )
+        new_coords = atom_array.coord.copy()
+        plddt = np.array([0.9, 0.8, 0.7, 0.6, 0.5])
+
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=new_coords,
+            plddt=plddt,
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={"A": 24, "B": 21},
+        )
+
+        chain_ids, res_ids = _read_res_ids_from_cif(output_file)
+
+        # Chain A atoms should be 25, 26, 27
+        chain_a_mask = chain_ids == "A"
+        np.testing.assert_array_equal(res_ids[chain_a_mask], [25, 26, 27])
+
+        # Chain B atoms should be 22, 23
+        chain_b_mask = chain_ids == "B"
+        np.testing.assert_array_equal(res_ids[chain_b_mask], [22, 23])
+
+
+# ---------------------------------------------------------------------------
+# Collator tests — the exact bug that crashed the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestCollatorResidueNumberOffsets:
+    """Tests that openfold_batch_collator handles residue_number_offsets correctly.
+
+    residue_number_offsets is a plain Python dict, not a tensor. If it reaches
+    pad_sequence it raises: TypeError: expected Tensor ... but got int.
+    """
+
+    def test_collator_survives_with_offsets(self):
+        """Collator should not crash when samples contain residue_number_offsets."""
+        import torch
+
+        from openfold3.core.data.framework.data_module import (
+            openfold_batch_collator,
+        )
+
+        sample = {
+            "token_mask": torch.ones(5),
+            "residue_number_offsets": {"A": 24},
+        }
+        # Should not raise TypeError
+        batch = openfold_batch_collator([sample])
+        assert "residue_number_offsets" in batch
+        assert batch["residue_number_offsets"] == [{"A": 24}]
+
+    def test_collator_survives_with_empty_offsets(self):
+        """Collator should handle empty offsets dict (no starting_residue_number)."""
+        import torch
+
+        from openfold3.core.data.framework.data_module import (
+            openfold_batch_collator,
+        )
+
+        sample = {
+            "token_mask": torch.ones(5),
+            "residue_number_offsets": {},
+        }
+        batch = openfold_batch_collator([sample])
+        assert batch["residue_number_offsets"] == [{}]
+
+    def test_collator_preserves_per_sample_offsets(self):
+        """With batch_size > 1, each sample's offsets should be preserved."""
+        import torch
+
+        from openfold3.core.data.framework.data_module import (
+            openfold_batch_collator,
+        )
+
+        samples = [
+            {
+                "token_mask": torch.ones(5),
+                "residue_number_offsets": {"A": 24, "B": 21},
+            },
+            {
+                "token_mask": torch.ones(5),
+                "residue_number_offsets": {"C": 100},
+            },
+        ]
+        batch = openfold_batch_collator(samples)
+        assert batch["residue_number_offsets"] == [
+            {"A": 24, "B": 21},
+            {"C": 100},
+        ]
+
+    def test_collator_without_offsets_key(self):
+        """Collator should work normally when residue_number_offsets is absent."""
+        import torch
+
+        from openfold3.core.data.framework.data_module import (
+            openfold_batch_collator,
+        )
+
+        sample = {"token_mask": torch.ones(5)}
+        batch = openfold_batch_collator([sample])
+        assert "residue_number_offsets" not in batch
+
+
+# ---------------------------------------------------------------------------
+# Writer does not mutate the shared atom_array
+# ---------------------------------------------------------------------------
+
+
+class TestWriterOffsetDoesNotMutateOriginal:
+    """Calling write_structure_prediction multiple times (as happens in the
+    diffusion sample loop) must not accumulate offsets on the shared array."""
+
+    def test_repeated_writes_do_not_accumulate_offset(self, tmp_path):
+        """Two consecutive writes with the same offset should produce identical
+        numbering, proving the original array was not mutated."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "A"],
+            res_ids=[1, 2, 3],
+        )
+        offsets = {"A": 24}
+
+        for i in range(3):
+            output_file = tmp_path / f"sample_{i}.cif"
+            OF3OutputWriter.write_structure_prediction(
+                atom_array=atom_array,
+                predicted_coords=atom_array.coord.copy(),
+                plddt=np.array([0.9, 0.8, 0.7]),
+                output_file=output_file,
+                make_ost_compatible=False,
+                residue_number_offsets=offsets,
+            )
+
+        # All three files should have identical numbering (25, 26, 27)
+        for i in range(3):
+            _, res_ids = _read_res_ids_from_cif(tmp_path / f"sample_{i}.cif")
+            np.testing.assert_array_equal(
+                res_ids,
+                [25, 26, 27],
+                err_msg=f"Sample {i} has wrong numbering — offset accumulated!",
+            )
+
+        # Original atom_array should still have 1, 2, 3
+        np.testing.assert_array_equal(atom_array.res_id, [1, 2, 3])
+
+
+# ---------------------------------------------------------------------------
+# Writer edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestWriterEdgeCases:
+    """Edge cases for residue number offset application."""
+
+    def test_zero_offset_is_noop(self, tmp_path):
+        """starting_residue_number=1 produces offset=0, which should be a no-op."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A"],
+            res_ids=[1, 2],
+        )
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=atom_array.coord.copy(),
+            plddt=np.array([0.9, 0.8]),
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={"A": 0},
+        )
+        _, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids, [1, 2])
+
+    def test_negative_offset(self, tmp_path):
+        """Negative starting_residue_number (e.g., signal peptides at -5)."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "A"],
+            res_ids=[1, 2, 3],
+        )
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=atom_array.coord.copy(),
+            plddt=np.array([0.9, 0.8, 0.7]),
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={"A": -6},  # starting_residue_number=-5 → offset=-6
+        )
+        _, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids, [-5, -4, -3])
+
+    def test_empty_offsets_dict_is_noop(self, tmp_path):
+        """An empty offsets dict (no chains specified) should not change numbering."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A"],
+            res_ids=[1, 2],
+        )
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=atom_array.coord.copy(),
+            plddt=np.array([0.9, 0.8]),
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={},
+        )
+        _, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids, [1, 2])
+
+    def test_partial_offset_only_affects_specified_chain(self, tmp_path):
+        """Offset for chain A only; chain B should stay at original numbering."""
+        atom_array = _make_atom_array(
+            chain_ids=["A", "A", "B", "B"],
+            res_ids=[1, 2, 1, 2],
+        )
+        output_file = tmp_path / "test.cif"
+        OF3OutputWriter.write_structure_prediction(
+            atom_array=atom_array,
+            predicted_coords=atom_array.coord.copy(),
+            plddt=np.array([0.9, 0.8, 0.7, 0.6]),
+            output_file=output_file,
+            make_ost_compatible=False,
+            residue_number_offsets={"A": 99},  # Only chain A gets offset
+        )
+        chain_ids, res_ids = _read_res_ids_from_cif(output_file)
+        np.testing.assert_array_equal(res_ids[chain_ids == "A"], [100, 101])
+        np.testing.assert_array_equal(res_ids[chain_ids == "B"], [1, 2])
+
+
+# ---------------------------------------------------------------------------
+# Offset computation from Query objects
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetComputation:
+    """Tests that the offset dict is computed correctly from Query chains."""
+
+    @staticmethod
+    def _compute_offsets(query: Query) -> dict[str, int]:
+        """Replicate the offset computation logic from InferenceDataset."""
+        residue_number_offsets = {}
+        for chain in query.chains:
+            if chain.starting_residue_number is not None:
+                offset = chain.starting_residue_number - 1
+                for chain_id in chain.chain_ids:
+                    residue_number_offsets[chain_id] = offset
+        return residue_number_offsets
+
+    def test_single_chain_offset(self):
+        """Single chain with starting_residue_number=25 → offset 24."""
+        query = Query.model_validate(
+            {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A"],
+                        "sequence": TRH,
+                        "starting_residue_number": 25,
+                    }
+                ]
+            }
+        )
+        offsets = self._compute_offsets(query)
+        assert offsets == {"A": 24}
+
+    def test_homomer_shares_offset(self):
+        """A homomer (chain_ids [A, B]) should give both chains the same offset."""
+        query = Query.model_validate(
+            {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A", "B"],
+                        "sequence": TRH,
+                        "starting_residue_number": 102,
+                    }
+                ]
+            }
+        )
+        offsets = self._compute_offsets(query)
+        assert offsets == {"A": 101, "B": 101}
+
+    def test_no_offset_produces_empty_dict(self):
+        """When no chain specifies starting_residue_number, offsets dict is empty."""
+        query = Query.model_validate(
+            {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A"],
+                        "sequence": TRH,
+                    }
+                ]
+            }
+        )
+        offsets = self._compute_offsets(query)
+        assert offsets == {}
+
+    def test_mixed_offset_and_no_offset(self):
+        """One chain with offset, another without — only the first gets an offset."""
+        query = Query.model_validate(
+            {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A"],
+                        "sequence": TRH,
+                        "starting_residue_number": 50,
+                    },
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["B"],
+                        "sequence": OXYTOCIN,
+                        # no starting_residue_number
+                    },
+                ]
+            }
+        )
+        offsets = self._compute_offsets(query)
+        assert offsets == {"A": 49}
+        assert "B" not in offsets

--- a/openfold3/tests/test_custom_residue_numbering.py
+++ b/openfold3/tests/test_custom_residue_numbering.py
@@ -31,7 +31,6 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
     Query,
 )
 
-
 # ---------------------------------------------------------------------------
 # Schema validation tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# **Summary**

Implements the feature requested in issue #58: "Allow to specify the number of the first residue of a chain".

Protein fragments predicted by OpenFold-3 always come out numbered from residue 1. This adds a convenience option, starting_residue_number, that lets the user choose what number to assign to the first residue of a given chain, useful for matching PDB conventions, mature protein numbering, or signal peptide regions.

**Usage**

Add starting_residue_number to any protein chain definition. Omitting it (or setting it to null) preserves the default 1-based behavior — fully backward-compatible.

json
```
{
    "queries": {
        "mature_ubiquitin": {
            "chains": [
                {
                    "molecule_type": "protein",
                    "chain_ids": ["A"],
                    "sequence": "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG",
                    "starting_residue_number": 3
                }
            ]
        }
    }
}


```
# **Supported values:**

- Any integer, including zero and negative numbers (e.g., -5 for signal peptides)
- Multi-copy chains ("chain_ids": ["C", "D"]) all receive the same offset
- Ligand chains ignore the field

# **Changes**

- inference_query_format.py — Added starting_residue_number: int | None = None to Chain. Accepts any integer including negative. Fully backward-compatible.

- single_datasets/inference.py — After building the AtomArray, computes offset = starting_residue_number - 1 per chain and stores it (e.g., {"A": offset}) in the feature dict. The AtomArray stays 1-based so the model is unaffected.

- data_module.py — Pops residue_number_offsets from samples before pad_sequence (a plain dict would cause a TypeError), then re-inserts it as a list of dicts.

- writer.py — Before writing each diffusion sample, copies the shared AtomArray and adds the per-chain offset to res_id at the very last moment — after the model has finished.

- docs/source/input_format_reference.md — Documented the new field in the protein chain schema (Section 3.1).

- examples/example_inference_inputs/query_ubiquitin_starting_residue_number.json — Added example input file demonstrating the feature.

# **Design Decision**
The offset is applied at write-time in OF3OutputWriter rather than earlier in the pipeline. This keeps the model's internal 1-based indexing untouched throughout inference, ensuring zero risk of regression in the folding logic.

# **Related Issues**

Closes #58

# **Testing**

## **Unit Tests**

21 tests in openfold3/tests/test_custom_residue_numbering.py covering:

- Schema Validation: Confirms starting_residue_number accepts integers (including negatives) and defaults to None for backward compatibility.
- Data Pipeline: Ensures the dictionary of offsets safely bypasses tensor collation in the data loader without crashing PyTorch's pad_sequence.
- Offset Computation: Validates the logic mapping the JSON offsets to specific chains, particularly for homomers sharing offsets.
- Writer Output: Proves the output writer correctly shifts the res_id in the final CIF file for specified chains without altering the model's internal 1-based indexing.


## **Manual Verification**
Inference was run for several configurations (single chain, multiple chains with different offsets, protein-ligand complexes) and the resulting CIF files were inspected both with a text editor and structurally in PyMOL, confirming:

- Residue numbering in the output starts at the specified value
- 3D coordinates are correctly placed in both runs, with and without starting_residue_number — the offset is metadata-only and does not enter the model.
- Multi-chain queries correctly apply independent offsets per chain

<img width="886" height="599" alt="image" src="https://github.com/user-attachments/assets/ee08ac41-329c-4f37-a53d-812b4924b2bf" />


## **Full Test Suite**

Ran `pixi run -e openfold3-cpu pytest openfold3/tests/` twice. 487 passed, 46 skipped, 86 warnings in 1381.04s (0:23:01). One unrelated timing benchmark failed (test_inference_load_state_dict_benchmark_under_ten_seconds — took 23s under high CPU load; not related to this PR).

# **Other Notes**

- Code formatted with ruff format and ruff check --fix.
- LLM disclosure: Used an LLM to assist in designing some of the tests in openfold3/tests/test_custom_residue_numbering.py.
