### PR TITLE
Reduce `get_token_frame_atoms` memory usage

### DIFF
--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -762,23 +762,23 @@ def get_token_frame_atoms(
         valid_frame_mask:
             [*, N_token] Mask denoting valid frames
     """
-    # Create pairwise atom mask
-    pair_mask = atom_mask[..., None] * atom_mask[..., None, :]
+    # Pairwise atom mask, kept as bool throughout to avoid materializing
+    # large fp32 [N_atom, N_atom] intermediates.
+    am_bool = atom_mask.bool()
+    pair_mask = am_bool[..., None] & am_bool[..., None, :]
 
-    # Update pairwise atom mask
     # Restrict to atoms within the same chain
     atom_asym_id = broadcast_token_feat_to_atoms(
         token_mask=batch["token_mask"],
         num_atoms_per_token=batch["num_atoms_per_token"],
         token_feat=batch["asym_id"],
     )
-    atom_asym_id_mask = atom_asym_id[..., None] == atom_asym_id[..., None, :]
-    pair_mask = pair_mask * atom_asym_id_mask
+    pair_mask &= atom_asym_id[..., None] == atom_asym_id[..., None, :]
 
     # Compute distance matrix. Use cdist to avoid materializing N*N*3 intermediate
     # [*, N_atom, N_atom]
     d = torch.cdist(x, x)
-    d = d * pair_mask + inf * (1 - pair_mask)
+    d.masked_fill_(~pair_mask, inf)
 
     # Find indices of two closest atoms for start atoms
     # [*, N_token]

--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -775,9 +775,9 @@ def get_token_frame_atoms(
     atom_asym_id_mask = atom_asym_id[..., None] == atom_asym_id[..., None, :]
     pair_mask = pair_mask * atom_asym_id_mask
 
-    # Compute distance matrix
+    # Compute distance matrix. Use cdist to avoid materializing N*N*3 intermediate
     # [*, N_atom, N_atom]
-    d = torch.sum(eps + (x[..., None, :] - x[..., None, :, :]) ** 2, dim=-1) ** 0.5
+    d = torch.cdist(x, x)
     d = d * pair_mask + inf * (1 - pair_mask)
 
     # Find indices of two closest atoms for start atoms


### PR DESCRIPTION
**Summary**
I am hitting OOMs in `get_token_frame_atoms` for large monomer inputs around 5k residues (42K atoms). This function contributes ~47GB to the peak memory usage. We can bring that down to ~10GB by avoiding intermediate materializations and operating on boolean rather than fp32 masks.

**Changes**
- Replace manual pairwise distance computation with `torch.cdist`
- Convert masks to booleans
- Use in-place operations 

**Related Issues**
- Fixes https://github.com/aqlaboratory/openfold-3/issues/225

**Testing**
Verified outputs change only marginally across 14 monomer inputs with a range of sizes (49-4563 residues, 366-36,356 atoms). cdist changes the output of phi for four atoms total in the dataset (per input mean 0.05%, max 0.5%). The mask changes don't affect the output at all.

**Other Notes**
Using `torch.cdist` can create numerics issues with floating point math, as it computes a small number as the subtraction of two large ones. Since we are feeding the result directly into topk, I think this doesn't end up mattering too much. In my testing, there were only a few cases where the output differed at all.