### PR TITLE
refactor: migrate test_kernel.py to pytest

### DIFF
--- a/openfold3/tests/compare_utils.py
+++ b/openfold3/tests/compare_utils.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import importlib
-import unittest
 
+import pytest
 import torch
 
 from openfold3.core.kernels.cueq_utils import (
@@ -25,7 +25,7 @@ from openfold3.core.kernels.cueq_utils import (
 
 def skip_if_rocm():
     is_rocm = torch.cuda.is_available() and torch.version.hip is not None
-    return unittest.skipIf(is_rocm, "Not supported on ROCm/HIP")
+    return pytest.mark.skipif(is_rocm, reason="Not supported on ROCm/HIP")
 
 
 def skip_unless_ds4s_installed():
@@ -35,9 +35,9 @@ def skip_unless_ds4s_installed():
         and importlib.util.find_spec("deepspeed.ops.deepspeed4science") is not None
     )
     is_rocm = torch.cuda.is_available() and torch.version.hip is not None
-    return unittest.skipUnless(
-        ds4s_is_installed and not is_rocm,
-        "Requires DeepSpeed with version ≥ 0.10.4 (not supported on ROCm/HIP)",
+    return pytest.mark.skipif(
+        not (ds4s_is_installed and not is_rocm),
+        reason="Requires DeepSpeed with version ≥ 0.10.4 (not supported on ROCm/HIP)",
     )
 
 
@@ -47,17 +47,17 @@ def skip_unless_cueq_installed():
     elif not torch.cuda.is_available():
         reason = "Requires CUDA (cuequivariance is installed but no GPU available)"
     else:
-        reason = ""
-    return unittest.skipUnless(is_cuequivariance_available(), reason)
+        reason = "cuequivariance not available"
+    return pytest.mark.skipif(not is_cuequivariance_available(), reason=reason)
 
 
 def skip_unless_triton_installed():
     triton_is_installed = importlib.util.find_spec("triton") is not None
-    return unittest.skipUnless(triton_is_installed, "Requires Triton")
+    return pytest.mark.skipif(not triton_is_installed, reason="Requires Triton")
 
 
 def skip_unless_cuda_available():
-    return unittest.skipUnless(torch.cuda.is_available(), "Requires GPU")
+    return pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
 
 
 def _assert_abs_diff_small_base(compare_func, expected, actual, eps):

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -100,7 +100,7 @@ class TestKernels(unittest.TestCase):
             ).cpu()
 
         err = torch.max(torch.abs(kernel_out - real_out))
-        self.assertTrue(err < eps, f"Error: {err}")
+        assert err < eps, f"Error: {err}"
 
     @compare_utils.skip_unless_ds4s_installed()
     def test_dsk_forward_bf16(self):
@@ -244,7 +244,7 @@ class TestKernels(unittest.TestCase):
         for i, item in enumerate(pairs):
             t_repro, t_gt = item
             err = torch.max(torch.abs(t_repro.grad.cpu() - t_gt.grad.cpu()))
-            self.assertTrue(err < eps, f"Error item #{i}: {err}")
+            assert err < eps, f"Error item #{i}: {err}"
 
         # Compare the grads of model weights
         a_repro_params = dict(a_repro.named_parameters())
@@ -253,7 +253,7 @@ class TestKernels(unittest.TestCase):
             t_repro = a_repro_params[name]
             t_gt = a_gt_params[name]
             err = torch.max(torch.abs(t_repro.grad.cpu() - t_gt.grad.cpu()))
-            self.assertTrue(err < eps, f"Error item {name}: {err}")
+            assert err < eps, f"Error item {name}: {err}"
 
     @compare_utils.skip_unless_ds4s_installed()
     def test_dsk_backward_bf16(self):
@@ -329,7 +329,7 @@ class TestKernels(unittest.TestCase):
             )
         err = torch.max(torch.abs(fwd_reg - fwd_cueq))
         eps = 2e-2
-        self.assertTrue(err < eps, f"Error: {err}")
+        assert err < eps, f"Error: {err}"
 
     @compare_utils.skip_unless_cueq_installed()
     def test_cueq_tri_mult_bwd(self):
@@ -406,7 +406,7 @@ class TestKernels(unittest.TestCase):
             t_repro = tm_repro_params[name]
             t_gt = tm_gt_params[name]
             err = torch.max(torch.abs(t_repro.grad.cpu() - t_gt.grad.cpu()))
-            self.assertTrue(err < eps, f"Error item {name}: {err}")
+            assert err < eps, f"Error item {name}: {err}"
 
     def _initialize_model_weights(self, model):
         for module in model.modules():

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -19,8 +19,6 @@ attention kernel, DS4Sci_EvoformerAttention vs. a stock PyTorch attention
 implementation.
 """
 
-import unittest
-
 import pytest
 import torch
 from torch.nn import functional as F
@@ -49,7 +47,7 @@ torch.backends.cuda.preferred_blas_library("cublas")
 
 
 @compare_utils.skip_unless_cuda_available()
-class TestKernels(unittest.TestCase):
+class TestKernels:
     def _compare_attn_kernel_forward(
         self,
         use_deepspeed_evo_attention=False,
@@ -857,7 +855,3 @@ class TestKernels(unittest.TestCase):
             use_triton_triangle_kernels=True,
             dtype=torch.bfloat16,
         )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
**Summary**

We're working a lot on kernels this month, and one thing that's a silly blocker to some of this work is that these are the legacy unittest.TestCases

**Changes**

Mostly mechanical migration of test_kernel.py

**Related Issues**

N/A

**Testing**

Passes locally

**Other Notes**

N/A
