### PR TITLE
Profiling tools

### DIFF
--- a/examples/example_runner_yamls/profiling.yml
+++ b/examples/example_runner_yamls/profiling.yml
@@ -1,0 +1,21 @@
+profiler:
+  enabled: true
+  # Default values:
+  dirpath: logs/profiler_traces
+  filename: profile_trace
+  skip_first: 0
+  wait: 1
+  warmup: 1
+  active: 3
+  repeat: 0
+  record_shapes: true
+  profile_memory: false
+  with_stack: true
+
+memory_snapshot:
+  enabled: true
+  # Default values:
+  output_path: memory_snapshot.pickle
+  start_step: 0
+  dump_on_oom: false
+  stacks: null  # Defaults to 'all' for x86_64, 'python' for ARM

--- a/examples/example_runner_yamls/profiling.yml
+++ b/examples/example_runner_yamls/profiling.yml
@@ -16,6 +16,6 @@ memory_snapshot:
   enabled: true
   # Default values:
   output_path: memory_snapshot.pickle
-  start_step: 0
+  step: 0
   dump_on_oom: false
   stacks: null  # Defaults to 'all' for x86_64, 'python' for ARM

--- a/openfold3/core/utils/callbacks.py
+++ b/openfold3/core/utils/callbacks.py
@@ -29,27 +29,188 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+class SecondsPerIterationProgressBar(pl.callbacks.TQDMProgressBar):
+    """Progress bar that displays s/it instead of it/s.
+
+    Lightning hardcodes {rate_noinv_fmt} in BAR_FORMAT which forces it/s.
+    Overriding with {rate_inv_fmt} to always show s/it.
+    """
+
+    BAR_FORMAT = (
+        "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, "
+        "{rate_inv_fmt}{postfix}]"
+    )
+
+
+class MemorySnapshot(pl.Callback):
+    """
+    Records memory history and dumps a snapshot pickle.
+    The pickle can be visualized at https://pytorch.org/memory_viz
+
+    Args:
+        output_path: Path to save the .pickle snapshot file.
+        start_step: Step (batch_idx) at which to start recording and dump a single-step
+            snapshot. Set to `None` to disable step-based snapshotting (useful
+            when only dump_on_oom is needed). Defaults to 0.
+        dump_on_oom: If True, attaches an OOM observer that dumps the snapshot
+            on out-of-memory. History is reset each step to keep the snapshot
+            small.
+        stacks: Stack trace mode for record_memory_history. Defaults to "all".
+    """
+
+    def __init__(
+        self,
+        output_path: str = "memory_snapshot.pickle",
+        start_step: int | None = 0,
+        dump_on_oom: bool = False,
+        stacks: str = "all",
+    ):
+        super().__init__()
+        self.output_path = output_path
+        self.start_step = start_step
+        self.dump_on_oom = dump_on_oom
+        self.stacks = stacks
+        self._oom_dumped = False
+        self._setup_done = False
+        self._global_rank = 0
+
+    def _tagged_path(self, suffix: str) -> str:
+        """Build output path with rank and suffix before the extension."""
+        p = Path(self.output_path)
+        return str(p.with_stem(f"{p.stem}{suffix}_rank{self._global_rank}"))
+
+    def _oom_observer(self, device, alloc, device_allocated, device_free):
+        if self._oom_dumped:
+            return
+
+        self._oom_dumped = True
+        oom_path = self._tagged_path("_oom")
+        logger.error(
+            f"MemorySnapshot: OOM on rank {self._global_rank} (tried to allocate "
+            f"{alloc / 1024**3:.2f} GiB, {device_free / 1024**3:.2f} GiB free). "
+            f"Dumping snapshot to {oom_path}"
+        )
+        torch.cuda.memory._dump_snapshot(oom_path)
+
+    @property
+    def step_recording_enabled(self):
+        return self.start_step is not None
+
+    def setup(self, trainer, pl_module, stage=None):
+        # Only attach oom observer once
+        if self._setup_done:
+            return
+
+        self._setup_done = True
+        self._global_rank = trainer.global_rank
+
+        if self.dump_on_oom:
+            torch.cuda.memory._record_memory_history(stacks=self.stacks)
+            if trainer.is_global_zero:
+                logger.info("MemorySnapshot: Enabling OOM observer")
+            torch._C._cuda_attach_out_of_memory_observer(self._oom_observer)
+
+    def _on_batch_start(self, batch_idx: int):
+        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        if self.dump_on_oom or record_step:
+            # Reset history so the snapshot only contains the current step
+            torch.cuda.memory._record_memory_history(enabled=None)
+            torch.cuda.memory._record_memory_history(stacks=self.stacks)
+
+    def _on_batch_end(self, batch_idx: int):
+        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        if not record_step:
+            return
+
+        output_path = self._tagged_path("")
+        logger.info(f"MemorySnapshot: Dumping snapshot to {output_path}")
+        torch.cuda.memory._dump_snapshot(output_path)
+
+        if not self.dump_on_oom:
+            torch.cuda.memory._record_memory_history(enabled=None)
+
+    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx, **kwargs):
+        self._on_batch_start(batch_idx=batch_idx)
+
+    def on_train_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, **kwargs
+    ):
+        self._on_batch_end(batch_idx=batch_idx)
+
+    def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx, **kwargs):
+        self._on_batch_start(batch_idx=batch_idx)
+
+    def on_validation_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, **kwargs
+    ):
+        self._on_batch_end(batch_idx=batch_idx)
+
+    def on_predict_batch_start(self, trainer, pl_module, batch, batch_idx, **kwargs):
+        self._on_batch_start(batch_idx=batch_idx)
+
+    def on_predict_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, **kwargs
+    ):
+        self._on_batch_end(batch_idx=batch_idx)
+
+    def on_test_batch_start(self, trainer, pl_module, batch, batch_idx, **kwargs):
+        self._on_batch_start(batch_idx=batch_idx)
+
+    def on_test_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, **kwargs
+    ):
+        self._on_batch_end(batch_idx=batch_idx)
+
+
 class PredictTimer(pl.Callback):
-    def __init__(self, output_dir: Path):
+    def __init__(self, output_dir: Path | None):
         super().__init__()
         self.output_dir = output_dir
 
         # For recording runtime per batch
         self.batch_start_time = None
 
-    def on_predict_batch_start(
-        self, trainer, pl_module, batch, batch_idx, dataloader_idx: int = 0
-    ):
+    def _get_start_time(self, sync=True):
+        if sync and torch.cuda.is_available():
+            torch.cuda.synchronize()
+
         self.batch_start_time = time.perf_counter()
 
-    def _get_runtime(self):
+    def _get_runtime(self, sync=True):
         """Record the runtime for the current batch."""
-        if torch.cuda.is_available():
+        if sync and torch.cuda.is_available():
             torch.cuda.synchronize()
 
         batch_end_time = time.perf_counter()
 
         return batch_end_time - self.batch_start_time
+
+    def on_train_batch_start(
+        self, trainer, pl_module, batch, batch_idx, dataloader_idx: int = 0
+    ):
+        self._get_start_time()
+
+    def on_train_batch_end(
+        self,
+        trainer,
+        pl_module,
+        outputs,
+        batch,
+        batch_idx,
+        dataloader_idx=0,
+    ):
+        # Get batch runtime
+        runtime = self._get_runtime()
+
+        if pl_module.logger is not None:
+            pl_module.logger.log_metrics(
+                {"seconds_per_iteration": runtime}, step=pl_module.global_step
+            )
+
+    def on_predict_batch_start(
+        self, trainer, pl_module, batch, batch_idx, dataloader_idx: int = 0
+    ):
+        self._get_start_time()
 
     def on_predict_batch_end(
         self,

--- a/openfold3/core/utils/callbacks.py
+++ b/openfold3/core/utils/callbacks.py
@@ -49,7 +49,7 @@ class MemorySnapshot(pl.Callback):
 
     Args:
         output_path: Path to save the .pickle snapshot file.
-        start_step: Step (batch_idx) at which to start recording and dump a single-step
+        step: Step (batch_idx) at which to record and dump a single-step
             snapshot. Set to `None` to disable step-based snapshotting (useful
             when only dump_on_oom is needed). Defaults to 0.
         dump_on_oom: If True, attaches an OOM observer that dumps the snapshot
@@ -61,13 +61,13 @@ class MemorySnapshot(pl.Callback):
     def __init__(
         self,
         output_path: str = "memory_snapshot.pickle",
-        start_step: int | None = 0,
+        step: int | None = 0,
         dump_on_oom: bool = False,
         stacks: str = "all",
     ):
         super().__init__()
         self.output_path = output_path
-        self.start_step = start_step
+        self.step = step
         self.dump_on_oom = dump_on_oom
         self.stacks = stacks
         self._oom_dumped = False
@@ -94,7 +94,7 @@ class MemorySnapshot(pl.Callback):
 
     @property
     def step_recording_enabled(self):
-        return self.start_step is not None
+        return self.step is not None
 
     def setup(self, trainer, pl_module, stage=None):
         # Only attach oom observer once
@@ -111,14 +111,14 @@ class MemorySnapshot(pl.Callback):
             torch._C._cuda_attach_out_of_memory_observer(self._oom_observer)
 
     def _on_batch_start(self, batch_idx: int):
-        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        record_step = self.step_recording_enabled and batch_idx == self.step
         if self.dump_on_oom or record_step:
             # Reset history so the snapshot only contains the current step
             torch.cuda.memory._record_memory_history(enabled=None)
             torch.cuda.memory._record_memory_history(stacks=self.stacks)
 
     def _on_batch_end(self, batch_idx: int):
-        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        record_step = self.step_recording_enabled and batch_idx == self.step
         if not record_step:
             return
 

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -34,6 +34,7 @@ from pytorch_lightning.callbacks.lr_monitor import LearningRateMonitor
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
 from pytorch_lightning.plugins.environments import MPIEnvironment
+from pytorch_lightning.profilers import PyTorchProfiler
 from pytorch_lightning.strategies import DDPStrategy, DeepSpeedStrategy
 
 from openfold3.core.data.framework.data_module import (
@@ -44,8 +45,10 @@ from openfold3.core.data.framework.data_module import (
 from openfold3.core.runners.writer import OF3OutputWriter
 from openfold3.core.utils.callbacks import (
     LogInferenceQuerySet,
+    MemorySnapshot,
     PredictTimer,
     RankSpecificSeedCallback,
+    SecondsPerIterationProgressBar,
 )
 from openfold3.core.utils.checkpoint_loading_utils import (
     get_state_dict_from_checkpoint,
@@ -110,6 +113,8 @@ class ExperimentRunner(ABC):
 
         # typical model update config
         self.model_update = experiment_config.model_update
+        self.memory_snapshot = experiment_config.memory_snapshot
+        self.profiler_config = experiment_config.profiler
 
     def setup(self) -> None:
         """Set up the experiment environment.
@@ -244,8 +249,19 @@ class ExperimentRunner(ABC):
 
     @cached_property
     def callbacks(self):
-        """Set up and return the list of training callbacks."""
-        _callbacks = []
+        """Set up and return the list of callbacks."""
+        _callbacks = [SecondsPerIterationProgressBar()]
+
+        if self.memory_snapshot.enabled:
+            _callbacks.append(
+                MemorySnapshot(
+                    output_path=self.memory_snapshot.output_path,
+                    start_step=self.memory_snapshot.start_step,
+                    dump_on_oom=self.memory_snapshot.dump_on_oom,
+                    stacks=self.memory_snapshot.stacks,
+                )
+            )
+
         return _callbacks
 
     @cached_property
@@ -257,6 +273,29 @@ class ExperimentRunner(ABC):
     ###############
     # pl.Trainer class and run command
     ###############
+
+    def _build_profiler(self) -> PyTorchProfiler:
+        """Build a PyTorch profiler from the profiler config."""
+        cfg = self.profiler_config
+        return PyTorchProfiler(
+            dirpath=cfg.dirpath,
+            filename=cfg.filename,
+            schedule=torch.profiler.schedule(
+                skip_first=cfg.skip_first,
+                wait=cfg.wait,
+                warmup=cfg.warmup,
+                active=cfg.active,
+                repeat=cfg.repeat,
+            ),
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            record_shapes=cfg.record_shapes,
+            profile_memory=cfg.profile_memory,
+            with_stack=cfg.with_stack,
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(cfg.dirpath),
+        )
 
     @cached_property
     def trainer(self) -> pl.Trainer:
@@ -272,6 +311,9 @@ class ExperimentRunner(ABC):
                 "logger": self.loggers,
             }
         )
+
+        if self.profiler_config.enabled:
+            trainer_args["profiler"] = self._build_profiler()
 
         return pl.Trainer(**trainer_args)
 
@@ -523,11 +565,16 @@ class TrainingExperimentRunner(ExperimentRunner):
     @cached_property
     def callbacks(self):
         """Set up and return the list of training callbacks."""
-        _callbacks = [RankSpecificSeedCallback(base_seed=self.seed)]
+        _callbacks = list(super().callbacks)
+
+        _callbacks.append(RankSpecificSeedCallback(base_seed=self.seed))
 
         _checkpoint = self.checkpoint_config
         if _checkpoint is not None:
             _callbacks.append(ModelCheckpoint(**_checkpoint.model_dump()))
+
+        if self.model_config.settings.debug.log_iteration_time:
+            _callbacks.append(PredictTimer(output_dir=None))
 
         _log_lr = self.logging_config.log_lr
         if _log_lr and self.use_wandb:
@@ -724,14 +771,17 @@ class InferenceExperimentRunner(ExperimentRunner):
     @cached_property
     def callbacks(self):
         """Set up prediction writer callback."""
-        _callbacks = [
-            OF3OutputWriter(
-                output_dir=self.output_dir,
-                **self.output_writer_settings.model_dump(),
-            ),
-            PredictTimer(self.output_dir),
-            LogInferenceQuerySet(self.output_dir),
-        ]
+        _callbacks = list(super().callbacks)
+        _callbacks.extend(
+            [
+                OF3OutputWriter(
+                    output_dir=self.output_dir,
+                    **self.output_writer_settings.model_dump(),
+                ),
+                PredictTimer(self.output_dir),
+                LogInferenceQuerySet(self.output_dir),
+            ]
+        )
         return _callbacks
 
     @cached_property

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -250,19 +250,7 @@ class ExperimentRunner(ABC):
     @cached_property
     def callbacks(self):
         """Set up and return the list of callbacks."""
-        _callbacks = [SecondsPerIterationProgressBar()]
-
-        if self.memory_snapshot.enabled:
-            _callbacks.append(
-                MemorySnapshot(
-                    output_path=self.memory_snapshot.output_path,
-                    start_step=self.memory_snapshot.start_step,
-                    dump_on_oom=self.memory_snapshot.dump_on_oom,
-                    stacks=self.memory_snapshot.stacks,
-                )
-            )
-
-        return _callbacks
+        return [SecondsPerIterationProgressBar()]
 
     @cached_property
     def loggers(self):
@@ -576,6 +564,18 @@ class TrainingExperimentRunner(ExperimentRunner):
         if self.model_config.settings.debug.log_iteration_time:
             _callbacks.append(PredictTimer(output_dir=None))
 
+        # Registered after PredictTimer so the snapshot dump stays outside the
+        # timer's measurement window.
+        if self.memory_snapshot.enabled:
+            _callbacks.append(
+                MemorySnapshot(
+                    output_path=self.memory_snapshot.output_path,
+                    step=self.memory_snapshot.step,
+                    dump_on_oom=self.memory_snapshot.dump_on_oom,
+                    stacks=self.memory_snapshot.stacks,
+                )
+            )
+
         _log_lr = self.logging_config.log_lr
         if _log_lr and self.use_wandb:
             _callbacks.append(LearningRateMonitor(logging_interval="step"))
@@ -782,6 +782,19 @@ class InferenceExperimentRunner(ExperimentRunner):
                 LogInferenceQuerySet(self.output_dir),
             ]
         )
+
+        # Registered after PredictTimer so the snapshot dump stays outside the
+        # timer's measurement window.
+        if self.memory_snapshot.enabled:
+            _callbacks.append(
+                MemorySnapshot(
+                    output_path=self.memory_snapshot.output_path,
+                    step=self.memory_snapshot.step,
+                    dump_on_oom=self.memory_snapshot.dump_on_oom,
+                    stacks=self.memory_snapshot.stacks,
+                )
+            )
+
         return _callbacks
 
     @cached_property

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import platform
 import random
 import warnings
 from datetime import timedelta
@@ -196,6 +197,48 @@ class CheckpointLoadingSettings(BaseModel):
     strict_loading: bool = True
 
 
+class ProfilerConfig(BaseModel):
+    """
+    Configuration for PyTorch profiler with Chrome trace output.
+    When enabled, wraps training with torch.profiler and writes Chrome trace
+    files that can be viewed in chrome://tracing or Perfetto.
+    """
+
+    enabled: bool = False
+    dirpath: str = "logs/profiler_traces"
+    filename: str = "profile_trace"
+    skip_first: int = 0
+    wait: int = 1
+    warmup: int = 1
+    active: int = 3
+    repeat: int = 0
+    record_shapes: bool = True
+    profile_memory: bool = False
+    with_stack: bool = True
+
+
+class MemorySnapshotConfig(BaseModel):
+    """
+    Configuration for memory snapshot profiling.
+    When enabled, records GPU memory allocation history and dumps a pickle
+    file that can be visualized at https://pytorch.org/memory_viz
+    """
+
+    enabled: bool = False
+    output_path: str = "memory_snapshot.pickle"
+    # Step to record a snapshot. Set to null to disable step-based snapshotting.
+    start_step: int | None = 0
+    dump_on_oom: bool = False
+    stacks: str | None = None
+
+    @model_validator(mode="after")
+    def default_stacks_for_platform(self):
+        if self.stacks is None:
+            # "all" (C++ + Python) requires libunwind which is x86_64 only
+            self.stacks = "all" if platform.machine() == "x86_64" else "python"
+        return self
+
+
 class TrainingExperimentSettings(ExperimentSettings):
     """General settings specific for training experiments"""
 
@@ -297,6 +340,8 @@ class ExperimentConfig(BaseModel):
     experiment_settings: ExperimentSettings
     pl_trainer_args: PlTrainerArgs = PlTrainerArgs()
     model_update: ModelUpdate
+    memory_snapshot: MemorySnapshotConfig = MemorySnapshotConfig()
+    profiler: ProfilerConfig = ProfilerConfig()
 
 
 class TrainingExperimentConfig(ExperimentConfig):

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -227,7 +227,7 @@ class MemorySnapshotConfig(BaseModel):
     enabled: bool = False
     output_path: str = "memory_snapshot.pickle"
     # Step to record a snapshot. Set to null to disable step-based snapshotting.
-    start_step: int | None = 0
+    step: int | None = 0
     dump_on_oom: bool = False
     stacks: str | None = None
 

--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -165,6 +165,7 @@ model_config = mlc.ConfigDict(
                 "log_grad_norm": False,
                 "log_extra_grad_metrics": False,
                 "profile_grad_logging": False,
+                "log_iteration_time": False,
             },
         },
         "architecture": {


### PR DESCRIPTION
Added general profiling stuff and other utils. Includes:

1. SecondsPerIterationProgressBar() callback to flip the progress bar to seconds/iteration
2. MemorySnapshot() callback to create the torch pkl mem dumps. Also has an oom_observer to save a snapshot of memory right after OOM (useful for backward pass where error message is ambiguous about location)
3. PredictTimer(): Add iteration time step logging for training. More lightweight than profiling to see spikes/stalls in iteration time at scale and over time.
4. ProfilerConfig to add torch profiler to lightning module when enabled

@GMNGeoffrey This is a copy of my internal PR, it has a some extra stuff outside of the memory snapshot callback. LMK what changes you'd like to add from your PR.
