### PR TITLE
fix: use-msa-server and use-templates defaults

### DIFF
--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -559,8 +559,8 @@ class InferenceExperimentRunner(ExperimentRunner):
         experiment_config,
         num_diffusion_samples: int | None = None,
         num_model_seeds: int | None = None,
-        use_msa_server: bool = False,
-        use_templates: bool = False,
+        use_msa_server: bool | None = None,
+        use_templates: bool | None = None,
         output_dir: Path | None = None,
     ):
         super().__init__(experiment_config)
@@ -607,10 +607,15 @@ class InferenceExperimentRunner(ExperimentRunner):
         num_diffusion_samples: int | None,
         num_model_seeds: int | None,
         output_dir: Path | None,
-        use_msa_server: bool = False,
-        use_templates: bool = False,
+        use_msa_server: bool | None = None,
+        use_templates: bool | None = None,
     ):
-        """Updates configuration given command line args."""
+        """Updates configuration given command line args.
+
+        ``use_msa_server`` and ``use_templates`` are tri-state: ``None`` means the
+        argument was not provided, so the runner yaml / config value is left as-is.
+        An explicit ``True`` or ``False`` overrides the yaml / config value.
+        """
         if output_dir:
             self.experiment_config.experiment_settings.output_dir = output_dir
 
@@ -622,11 +627,11 @@ class InferenceExperimentRunner(ExperimentRunner):
             start_seed = 42
             self.seeds = generate_seeds(start_seed, num_model_seeds)
 
-        if use_msa_server:
-            self.experiment_config.experiment_settings.use_msa_server = True
+        if use_msa_server is not None:
+            self.experiment_config.experiment_settings.use_msa_server = use_msa_server
 
-        if use_templates:
-            self.experiment_config.experiment_settings.use_templates = True
+        if use_templates is not None:
+            self.experiment_config.experiment_settings.use_templates = use_templates
 
     @cached_property
     def use_msa_server(self) -> bool:

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -268,8 +268,8 @@ class InferenceExperimentSettings(ExperimentSettings):
     mode: ValidModeType = "predict"
     seeds: int | list[int] = [42]
     num_seeds: int | None = None
-    use_msa_server: bool = False
-    use_templates: bool = False
+    use_msa_server: bool = True
+    use_templates: bool = True
     skip_existing: bool = False
 
     @model_validator(mode="after")

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -129,15 +129,21 @@ def train(runner_yaml: Path, seed: int | None = None, data_seed: int | None = No
     "--use-msa-server",
     "--use_msa_server",
     type=bool,
-    default=True,
-    help="Use ColabFold MSA server to perform alignments.",
+    default=None,
+    help=(
+        "Use ColabFold MSA server to perform alignments. If unset, the value from"
+        " the runner yaml (or config default) is used."
+    ),
 )
 @click.option(
     "--use-templates",
     "--use_templates",
     type=bool,
-    default=True,
-    help="Use ColabFold MSA server to perform template alignments.",
+    default=None,
+    help=(
+        "Whether to use templates for prediction. If unset, the value from the"
+        " runner yaml (or config default) is used."
+    ),
 )
 @click.option(
     "--output-dir",
@@ -153,8 +159,8 @@ def predict(
     num_diffusion_samples: int | None = None,
     num_model_seeds: int | None = None,
     runner_yaml: Path | None = None,
-    use_msa_server: bool = True,
-    use_templates: bool = True,
+    use_msa_server: bool | None = None,
+    use_templates: bool | None = None,
     output_dir: Path | None = None,
 ):
     """Perform inference on a set of queries defined in the query_json."""

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -18,6 +18,7 @@ import shutil
 import tempfile
 import textwrap
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
@@ -425,22 +426,87 @@ class TestWandbHandler(unittest.TestCase):
                     self.assertEqual(data, dummy_model_config.to_dict())
 
 
-class TestInferenceCommandLineSettings:
-    @pytest.mark.parametrize("use_msa_cli_arg", [True, False])
-    def test_use_msa_cli(self, use_msa_cli_arg, tmp_path, dummy_ckpt_file):
-        expt_config = InferenceExperimentConfig(inference_ckpt_path=dummy_ckpt_file)
-        expt_runner = InferenceExperimentRunner(
-            expt_config, use_msa_server=use_msa_cli_arg
-        )
-        assert expt_runner.use_msa_server == use_msa_cli_arg
+@dataclass
+class FlagResolutionCase:
+    """One row of the use_templates / use_msa_server resolution matrix.
 
-    @pytest.mark.parametrize("use_templates_cli_arg", [True, False])
-    def test_use_templates_cli(self, use_templates_cli_arg, tmp_path, dummy_ckpt_file):
-        expt_config = InferenceExperimentConfig(inference_ckpt_path=dummy_ckpt_file)
-        expt_runner = InferenceExperimentRunner(
-            expt_config, use_templates=use_templates_cli_arg
+    ``yaml`` and ``cli`` use ``None`` to mean "not provided" (field absent from
+    the runner yaml / flag omitted on the CLI), and ``True``/``False`` for an
+    explicit value. ``expected`` is the value the runner should resolve to.
+    """
+
+    yaml: bool | None
+    cli: bool | None
+    expected: bool
+
+
+# Resolution rule: the CLI arg wins when provided; otherwise the yaml value
+# wins; otherwise the config default (True). The two cases marked "BUG #250"
+# are the regressions this matrix guards against.
+_FLAG_RESOLUTION_CASES = [
+    pytest.param(
+        FlagResolutionCase(yaml=None, cli=None, expected=True),
+        id="yaml_unset+cli_omitted->default_on",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=None, cli=True, expected=True),
+        id="yaml_unset+cli_true->on",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=None, cli=False, expected=False),
+        id="yaml_unset+cli_false->off",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=True, cli=None, expected=True),
+        id="yaml_true+cli_omitted->on",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=True, cli=True, expected=True),
+        id="yaml_true+cli_true->on",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=True, cli=False, expected=False),
+        id="yaml_true+cli_false->off(BUG#250)",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=False, cli=None, expected=False),
+        id="yaml_false+cli_omitted->off(BUG#250)",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=False, cli=True, expected=True),
+        id="yaml_false+cli_true->on",
+    ),
+    pytest.param(
+        FlagResolutionCase(yaml=False, cli=False, expected=False),
+        id="yaml_false+cli_false->off",
+    ),
+]
+
+
+class TestInferenceCommandLineSettings:
+    @pytest.mark.parametrize("setting", ["use_templates", "use_msa_server"])
+    @pytest.mark.parametrize("case", _FLAG_RESOLUTION_CASES)
+    def test_cli_and_yaml_resolution(self, setting, case, tmp_path, dummy_ckpt_file):
+        """CLI arg (when provided) overrides yaml; otherwise yaml/config default wins."""
+        runner_args = {}
+        if case.yaml is not None:
+            test_yaml_file = tmp_path / "runner.yml"
+            test_yaml_file.write_text(
+                textwrap.dedent(f"""\
+                    experiment_settings:
+                        {setting}: {str(case.yaml).lower()}
+                    """)
+            )
+            runner_args = config_utils.load_yaml(test_yaml_file)
+
+        expt_config = InferenceExperimentConfig(
+            inference_ckpt_path=dummy_ckpt_file, **runner_args
         )
-        assert expt_runner.use_templates == use_templates_cli_arg
+
+        cli_kwargs = {} if case.cli is None else {setting: case.cli}
+        expt_runner = InferenceExperimentRunner(expt_config, **cli_kwargs)
+
+        assert getattr(expt_runner, setting) is case.expected
 
     def test_seeding_from_num_seeds(self, dummy_ckpt_file):
         expt_config = InferenceExperimentConfig(inference_ckpt_path=dummy_ckpt_file)


### PR DESCRIPTION
**Summary**

Fixes a bug where the inference `use_templates` (and `use_msa_server`) yaml setting was silently overwritten. Previously, a user setting `use_templates: false` in their runner yaml would still run inference with templates enabled, and an explicit `--use_templates False` on the CLI did not override a yaml `use_templates: true`.

The root cause was a two-part mismatch:
1. The CLI options defaulted to `True`, so even when the user passed nothing, `True` was handed to the runner.
2. The runner only applied the override when the value was truthy (`if use_templates:`), so it (a) clobbered a yaml `False` with the `True` CLI default and (b) ignored an explicit CLI `False`.

The flags are now tri-state: `None` means "not specified" (the yaml / config value is used), while an explicit `True` or `False` overrides it. To preserve today's behavior when nothing is specified, the inference config defaults are set to `True` (templates + MSA server on).

**Changes**

- `openfold3/run_openfold.py` — `--use-msa-server` and `--use-templates` now default to `None` instead of `True`; updated the `predict()` signature accordingly. Also corrected the inaccurate `--use-templates` help text (it previously described MSA-server template alignment; it actually controls whether templates are used for prediction).
- `openfold3/entry_points/experiment_runner.py` — `InferenceExperimentRunner.__init__` and `update_config_with_cli_args` default `use_msa_server` / `use_templates` to `None`; the override now uses `if x is not None:` and assigns the actual value, so explicit `True` and `False` both override the yaml while `None` leaves it untouched.
- `openfold3/entry_points/validator.py` — `InferenceExperimentSettings` defaults for `use_msa_server` / `use_templates` changed from `False` to `True` to preserve the current "on" behavior when neither yaml nor CLI specifies a value. This class is used only by the `predict` path (training/validation use `TrainingExperimentSettings`), so the change is scoped to inference.
- `openfold3/tests/test_entry_points.py` — replaced the two-state CLI tests with a single readable, fully-parametrized resolution matrix.

**Resulting behavior**

| yaml setting | CLI arg | result |
|---|---|---|
| unset | omitted | `True` (unchanged from today) |
| `False` | omitted | `False` (bug fixed) |
| `True` | `--use_templates False` | `False` (bug fixed) |
| `False` | `--use_templates True` | `True` |

**Related Issues**

Closes #250

**Testing**

Added `TestInferenceCommandLineSettings::test_cli_and_yaml_resolution`, a 3×3 matrix (CLI omitted / `True` / `False` × yaml unset / `True` / `False`) parametrized over both `use_templates` and `use_msa_server`, with named `pytest.param` ids and hardcoded expected values. The two issue-#250 regression rows are tagged `BUG#250` in their ids.

```
.pixi/envs/openfold3-cuda13-pypi/bin/pytest \
  openfold3/tests/test_entry_points.py::TestInferenceCommandLineSettings -v
```

All 18 resolution cases pass (plus the existing seeding tests in the class). Also verified `run_openfold predict --help` shows the corrected help text and no longer forces a `True` default.

**Other Notes**

This changes the no-input default source from the CLI to the config (both still resolve to "on"), so behavior is unchanged for users who pass nothing. Users who explicitly set `use_templates: false` in their yaml will now correctly get template-free inference.
