### PR TITLE
docs: updating broken slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The final OpenFold3 model is still in development, and we are actively working o
 If you encounter problems using OpenFold3-preview, feel free to create an issue! We also
 welcome pull requests from the community.
 
-In addition, we offer a [public Slack channel](https://join.slack.com/share/enQtMTA2ODc5MzU5NjYxNzktY2FjMjg5Y2NhNTJmMzExODIyNzkxNTZiMGYzZGVmOTY1ZDEyMWZiZTRjN2U1YTNlNjkxN2YyZDdlNzFmMGRiZQ) for discussions and questions around OpenFold3.
+In addition, we offer a [public Slack channel](https://join.slack.com/t/openfoldworkspace/shared_invite/zt-3xosl7w1s-w4iDMzRRrSGk517UQKTlbg) for discussions and questions around OpenFold3.
 
 ## Citing this Work
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The final OpenFold3 model is still in development, and we are actively working o
 If you encounter problems using OpenFold3-preview, feel free to create an issue! We also
 welcome pull requests from the community.
 
-In addition, we offer a [public Slack channel](https://join.slack.com/t/openfoldworkspace/shared_invite/zt-3xosl7w1s-w4iDMzRRrSGk517UQKTlbg) for discussions and questions around OpenFold3.
+In addition, we offer a [public Slack channel](https://join.slack.com/t/openfoldworkspace/shared_invite/zt-40rax5ape-96NkpN_EYgp5~vELu_IdQg) for discussions and questions around OpenFold3.
 
 ## Citing this Work
 


### PR DESCRIPTION
**Summary**

Simply updating the slack invite link. The current link is expired and lands you on a slack page saying as much. I got the correct link from a LinkedIn post [here](https://www.linkedin.com/posts/openfold-is-more-than-an-open-source-model-share-7459907405355794432--mGE/). I simply followed the redirect via curl to get the correct url.

### Before
<img width="697" height="274" alt="image" src="https://github.com/user-attachments/assets/e1598024-4b7a-4fb9-b7dc-6af8cc6e708e" />

### After
<img width="823" height="338" alt="image" src="https://github.com/user-attachments/assets/94bcb46b-9990-4a49-a7a5-cb6335b364c3" />

**Changes**

- Updating the readme with a valid slack invite

**Related Issues**

N/A

**Testing**

See above screenshot

**Other Notes**

The previous link was an ephemeral `/share/` invite. The new one is a `shared_invite` link, which is longer-lived. A core maintainer may prefer to mint their own permanent invite.