### PR TITLE
MemorySnapshot: rename step param, register after PredictTimer

### DIFF
--- a/examples/example_runner_yamls/profiling.yml
+++ b/examples/example_runner_yamls/profiling.yml
@@ -16,6 +16,6 @@ memory_snapshot:
   enabled: true
   # Default values:
   output_path: memory_snapshot.pickle
-  start_step: 0
+  step: 0
   dump_on_oom: false
   stacks: null  # Defaults to 'all' for x86_64, 'python' for ARM

--- a/openfold3/core/utils/callbacks.py
+++ b/openfold3/core/utils/callbacks.py
@@ -49,7 +49,7 @@ class MemorySnapshot(pl.Callback):
 
     Args:
         output_path: Path to save the .pickle snapshot file.
-        start_step: Step (batch_idx) at which to start recording and dump a single-step
+        step: Step (batch_idx) at which to record and dump a single-step
             snapshot. Set to `None` to disable step-based snapshotting (useful
             when only dump_on_oom is needed). Defaults to 0.
         dump_on_oom: If True, attaches an OOM observer that dumps the snapshot
@@ -61,13 +61,13 @@ class MemorySnapshot(pl.Callback):
     def __init__(
         self,
         output_path: str = "memory_snapshot.pickle",
-        start_step: int | None = 0,
+        step: int | None = 0,
         dump_on_oom: bool = False,
         stacks: str = "all",
     ):
         super().__init__()
         self.output_path = output_path
-        self.start_step = start_step
+        self.step = step
         self.dump_on_oom = dump_on_oom
         self.stacks = stacks
         self._oom_dumped = False
@@ -94,7 +94,7 @@ class MemorySnapshot(pl.Callback):
 
     @property
     def step_recording_enabled(self):
-        return self.start_step is not None
+        return self.step is not None
 
     def setup(self, trainer, pl_module, stage=None):
         # Only attach oom observer once
@@ -111,14 +111,14 @@ class MemorySnapshot(pl.Callback):
             torch._C._cuda_attach_out_of_memory_observer(self._oom_observer)
 
     def _on_batch_start(self, batch_idx: int):
-        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        record_step = self.step_recording_enabled and batch_idx == self.step
         if self.dump_on_oom or record_step:
             # Reset history so the snapshot only contains the current step
             torch.cuda.memory._record_memory_history(enabled=None)
             torch.cuda.memory._record_memory_history(stacks=self.stacks)
 
     def _on_batch_end(self, batch_idx: int):
-        record_step = self.step_recording_enabled and batch_idx == self.start_step
+        record_step = self.step_recording_enabled and batch_idx == self.step
         if not record_step:
             return
 

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -250,19 +250,7 @@ class ExperimentRunner(ABC):
     @cached_property
     def callbacks(self):
         """Set up and return the list of callbacks."""
-        _callbacks = [SecondsPerIterationProgressBar()]
-
-        if self.memory_snapshot.enabled:
-            _callbacks.append(
-                MemorySnapshot(
-                    output_path=self.memory_snapshot.output_path,
-                    start_step=self.memory_snapshot.start_step,
-                    dump_on_oom=self.memory_snapshot.dump_on_oom,
-                    stacks=self.memory_snapshot.stacks,
-                )
-            )
-
-        return _callbacks
+        return [SecondsPerIterationProgressBar()]
 
     @cached_property
     def loggers(self):
@@ -576,6 +564,18 @@ class TrainingExperimentRunner(ExperimentRunner):
         if self.model_config.settings.debug.log_iteration_time:
             _callbacks.append(PredictTimer(output_dir=None))
 
+        # Registered after PredictTimer so the snapshot dump stays outside the
+        # timer's measurement window.
+        if self.memory_snapshot.enabled:
+            _callbacks.append(
+                MemorySnapshot(
+                    output_path=self.memory_snapshot.output_path,
+                    step=self.memory_snapshot.step,
+                    dump_on_oom=self.memory_snapshot.dump_on_oom,
+                    stacks=self.memory_snapshot.stacks,
+                )
+            )
+
         _log_lr = self.logging_config.log_lr
         if _log_lr and self.use_wandb:
             _callbacks.append(LearningRateMonitor(logging_interval="step"))
@@ -782,6 +782,19 @@ class InferenceExperimentRunner(ExperimentRunner):
                 LogInferenceQuerySet(self.output_dir),
             ]
         )
+
+        # Registered after PredictTimer so the snapshot dump stays outside the
+        # timer's measurement window.
+        if self.memory_snapshot.enabled:
+            _callbacks.append(
+                MemorySnapshot(
+                    output_path=self.memory_snapshot.output_path,
+                    step=self.memory_snapshot.step,
+                    dump_on_oom=self.memory_snapshot.dump_on_oom,
+                    stacks=self.memory_snapshot.stacks,
+                )
+            )
+
         return _callbacks
 
     @cached_property

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -227,7 +227,7 @@ class MemorySnapshotConfig(BaseModel):
     enabled: bool = False
     output_path: str = "memory_snapshot.pickle"
     # Step to record a snapshot. Set to null to disable step-based snapshotting.
-    start_step: int | None = 0
+    step: int | None = 0
     dump_on_oom: bool = False
     stacks: str | None = None
 


### PR DESCRIPTION
**Summary**
A couple of edits to the MemorySnapshot callback in #251 (this is deliberately against that branch, not the main branch). Rename `start_step` for clarity and run memory tracking outside of the timed part of the step.

**Changes**
- Rename `start_step` -> `step`. The previous name implied later steps would also be recorded, which is not the case; only the single named step is dumped.
- Flatten callback registration: drop the base-class MemorySnapshot construction and append it inline in each runner after PredictTimer. This keeps the memory snapshot dump outside the predict timer's measurement window so a single run can capture both memory usage and a relatively-close-to-production latency.