### PR TITLE
Create '--non-interactive' option for setup_openfold

### DIFF
--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -179,10 +179,16 @@ On the first inference run, default model parameters will be downloaded to the `
 
 ### Using `setup_openfold` 
 
-We provide a one-stop binary that sets up openfold and runs integration tests. This binary can be called with:
+We provide a one-stop binary that sets up openfold and runs integration tests.
 
-```bash
-setup_openfold
+```
+Usage: setup_openfold [OPTIONS]
+
+Options:
+  --non-interactive  Non-interactively run setup using all default config
+                     values.
+  --config FILE      Path to a JSON file containing an OpenFoldSetupConfig.
+  --help             Show this message and exit.
 ```
 
 This script will:

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -22,12 +22,16 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import Literal
 
 import biotite.setup_ccd
 import click
+import pydantic
+from pydantic import Field
 
 from openfold3.core.utils.s3 import download_s3_file, s3_file_matches_local
 from openfold3.entry_points.parameters import (
+    CHECKPOINT_ROOT_FILENAME,
     DEFAULT_CHECKPOINT_NAME,
     LEGACY_CHECKPOINTS,
     OPENFOLD_MODEL_CHECKPOINT_REGISTRY,
@@ -37,186 +41,175 @@ from openfold3.entry_points.parameters import (
 S3_BUCKET = "openfold3-data"
 S3_KEY = "components.bcif"
 
-
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 
-def setup_openfold_cache(*, run_with_defaults: bool = False) -> tuple[Path, Path]:
-    """Set up the OpenFold cache directory."""
-    logger.info("Setting up OpenFold cache directory...")
+class OpenFoldSetupConfig(pydantic.BaseModel):
+    """Configuration for the OpenFold3 setup script.
+
+    Can be serialised to/from JSON and passed to ``setup_openfold --config``.
+    """
+
+    openfold_cache: Path = Field(
+        default_factory=lambda: Path.home() / ".openfold3",
+        description="Root cache directory for OpenFold3 artifacts.",
+    )
+    param_directory: Path = Field(
+        default_factory=lambda: Path.home() / ".openfold3",
+        description=(
+            "Directory where model parameters are downloaded. "
+            "Defaults to openfold_cache."
+        ),
+    )
+    # Accepts "default", "all", or any valid checkpoint name from
+    # OPENFOLD_MODEL_CHECKPOINT_REGISTRY.
+    selected_parameters: Literal["default", "all"] | str = Field(
+        default="default",
+        description=(
+            'Which model parameters to download. "default" downloads only the '
+            'default checkpoint, "all" downloads every non-legacy checkpoint, '
+            "or supply a specific checkpoint name."
+        ),
+    )
+    force_download_parameters: bool = Field(
+        default=False,
+        description=(
+            "If True, re-download model parameters even when they already exist "
+            "at the target path. Defaults to False (skip download if present)."
+        ),
+    )
+    run_integration_tests: bool = Field(
+        default=False,
+        description="Whether to run integration tests after downloading parameters.",
+    )
+
+    @pydantic.field_validator("selected_parameters")
+    @classmethod
+    def _validate_selected_parameters(cls, v: str) -> str:
+        valid = {"default", "all"} | set(OPENFOLD_MODEL_CHECKPOINT_REGISTRY)
+        if v not in valid:
+            valid_names = ", ".join(OPENFOLD_MODEL_CHECKPOINT_REGISTRY)
+            raise ValueError(
+                "selected_parameters must be 'default', 'all', or a valid checkpoint "
+                f"name. Valid checkpoint names: {valid_names}"
+            )
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _prompt_for_config() -> OpenFoldSetupConfig:
+    """Interactively prompt the user and return a populated config."""
+    logger.info("Setting up OpenFold3...")
 
     default_cache = Path.home() / ".openfold3"
-    if run_with_defaults:
-        openfold_cache = default_cache
-    else:
-        user_input = input(
-            f"Please specify the OpenFold cache directory (default: {default_cache}): "
-        ).strip()
-        openfold_cache = Path(user_input).expanduser() if user_input else default_cache
+    user_input = input(
+        f"Please specify the OpenFold cache directory (default: {default_cache}): "
+    ).strip()
+    openfold_cache = Path(user_input).expanduser() if user_input else default_cache
 
-    openfold_cache.mkdir(parents=True, exist_ok=True)
-    ckpt_root_file = openfold_cache / "ckpt_root"
+    user_input = input(
+        "Please specify the directory for parameter download "
+        f"(default: {openfold_cache}): "
+    ).strip()
+    param_directory = Path(user_input).expanduser() if user_input else openfold_cache
 
-    os.environ["OPENFOLD_CACHE"] = str(openfold_cache)
-
-    return openfold_cache, ckpt_root_file
-
-
-def setup_param_directory(
-    openfold_cache: Path, ckpt_root_file: Path, *, run_with_defaults: bool = False
-) -> tuple[Path, bool]:
-    """Check and set up the parameter directory."""
-
-    # Check if parameters have already been downloaded
-    ckpt_path = ckpt_root_file.read_text().strip() if ckpt_root_file.exists() else None
-    checkpoint_file_name = OPENFOLD_MODEL_CHECKPOINT_REGISTRY[
-        DEFAULT_CHECKPOINT_NAME
-    ].file_name
-    if ckpt_path and (Path(ckpt_path) / checkpoint_file_name).exists():
-        existing_path = Path(ckpt_root_file.read_text().strip())
-        logger.info(
-            f"OpenFold3 parameters may already be installed at: {existing_path}"
-        )
-        if run_with_defaults:
-            logger.info("Using existing parameters (run-with-defaults).")
-            return existing_path, False  # Don't download
-        logger.info("Do you want to:")
-        logger.info("1) Use existing parameters (skip download)")
-        logger.info("2) Download to a new location")
-        logger.info("3) Re-download to existing location")
-
-        choice = input("Enter your choice (1/2/3): ").strip()
-
-        if choice == "1":
-            logger.info(f"Using existing parameters at: {existing_path}")
-            return existing_path, False  # Don't download
-        elif choice == "2":
-            user_input = input(
-                "Please specify a new directory to save the parameters: "
-            ).strip()
-            if not user_input:
-                logger.error("No directory specified. Exiting.")
-                sys.exit(1)
-            param_dir = Path(user_input).expanduser()
-        elif choice == "3":
-            logger.info(f"Re-downloading to: {existing_path}")
-            param_dir = existing_path
-        else:
-            logger.error("Invalid choice. Exiting.")
-            sys.exit(1)
-    else:
-        # First time setup
-        logger.info("Downloading OpenFold3 parameters...")
-        if run_with_defaults:
-            param_dir = openfold_cache
-        else:
-            user_input = input(
-                "Please specify the directory for parameter download "
-                f"(default: {openfold_cache}): "
-            ).strip()
-            param_dir = Path(user_input).expanduser() if user_input else openfold_cache
-
-    # Create the directory if it doesn't exist
-    param_dir.mkdir(parents=True, exist_ok=True)
-
-    # Save the path to ckpt_root file
-    ckpt_root_file.write_text(str(param_dir))
-
-    logger.info(f"Parameters directory set to: {param_dir}")
-    logger.info(f"Path saved to: {ckpt_root_file}")
-
-    return param_dir, True  # Proceed with download
-
-
-def download_parameters(param_dir, *, run_with_defaults: bool = False) -> None:
-    """Perform the parameter download."""
-    # Exclude incompatible checkpoints:
     all_checkpoints = [
         name
         for name in OPENFOLD_MODEL_CHECKPOINT_REGISTRY
         if name not in LEGACY_CHECKPOINTS
     ]
-
-    if run_with_defaults:
-        choice = "1"
-    else:
-        logger.info("Select parameters to download:")
-        logger.info(
-            f"1) Download only the default checkpoint ({DEFAULT_CHECKPOINT_NAME})"
-        )
-        logger.info(
-            f"2) Download all parameters ({', '.join(all_checkpoints)}) (default)"
-        )
-        logger.info("3) Download a specific parameter by name")
-        choice = input("Enter your choice (1/2/3, default: 1): ").strip() or "1"
-
-    logger.info("Starting parameter download...")
+    logger.info("Select parameters to download:")
+    logger.info(f"1) Download only the default checkpoint ({DEFAULT_CHECKPOINT_NAME})")
+    logger.info(f"2) Download all parameters ({', '.join(all_checkpoints)})")
+    logger.info("3) Download a specific parameter by name")
+    choice = input("Enter your choice (1/2/3, default: 1): ").strip() or "1"
 
     if choice == "1":
-        download_model_parameters(
-            Path(param_dir),
-            DEFAULT_CHECKPOINT_NAME,
-            force_download=True,
-            skip_confirmation=True,
-        )
+        selected_parameters = "default"
     elif choice == "2":
-        for name in all_checkpoints:
-            download_model_parameters(
-                Path(param_dir), name, force_download=True, skip_confirmation=True
-            )
+        selected_parameters = "all"
     elif choice == "3":
         print("\nAvailable parameters:")
         for name in all_checkpoints:
-            print(f"\n  - {name}")
-        param_name = input("Enter parameter name: ").strip()
-        if param_name not in OPENFOLD_MODEL_CHECKPOINT_REGISTRY:
-            logger.error(
-                f"Unknown parameter name '{param_name}'. "
-                f"Available parameter names are: {', '.join(all_checkpoints)}"
-            )
-            sys.exit(1)
-        download_model_parameters(
-            Path(param_dir), param_name, force_download=True, skip_confirmation=True
-        )
+            print(f"  - {name}")
+        selected_parameters = input("Enter parameter name: ").strip()
     else:
         logger.error("Invalid choice. Exiting.")
         sys.exit(1)
 
+    force_input = input(
+        "Force re-download parameters even if they already exist? "
+        "(yes/no, default: no) "
+    ).strip()
+    force_download_parameters = force_input.lower() in ["yes", "y"]
+
+    confirm = input("Run integration tests? (yes/no) ").strip()
+    run_integration_tests = confirm.lower() in ["yes", "y"]
+
+    return OpenFoldSetupConfig(
+        openfold_cache=openfold_cache,
+        param_directory=param_directory,
+        selected_parameters=selected_parameters,
+        force_download_parameters=force_download_parameters,
+        run_integration_tests=run_integration_tests,
+    )
+
+
+def _download_parameters(
+    param_dir: Path, selected_parameters: str, *, force_download: bool
+) -> None:
+    all_checkpoints = [
+        name
+        for name in OPENFOLD_MODEL_CHECKPOINT_REGISTRY
+        if name not in LEGACY_CHECKPOINTS
+    ]
+    logger.info("Starting parameter download...")
+    if selected_parameters == "default":
+        download_model_parameters(
+            param_dir,
+            DEFAULT_CHECKPOINT_NAME,
+            force_download=force_download,
+            skip_confirmation=True,
+        )
+    elif selected_parameters == "all":
+        for name in all_checkpoints:
+            download_model_parameters(
+                param_dir, name, force_download=force_download, skip_confirmation=True
+            )
+    else:
+        download_model_parameters(
+            param_dir,
+            selected_parameters,
+            force_download=force_download,
+            skip_confirmation=True,
+        )
     logger.info("Download completed successfully.")
 
 
 def setup_biotite_ccd(*, ccd_path: Path, force_download: bool) -> bool:
-    def ccd_is_stale(*, ccd_path: Path) -> bool:
+    def _ccd_is_stale(*, ccd_path: Path) -> bool:
         if not ccd_path.exists():
             return True
         return not s3_file_matches_local(ccd_path, S3_BUCKET, S3_KEY)
 
     logger.info("Starting Biotite CCD setup...")
-    if force_download or ccd_is_stale(ccd_path=ccd_path):
+    if force_download or _ccd_is_stale(ccd_path=ccd_path):
         download_s3_file(S3_BUCKET, S3_KEY, ccd_path)
         return True
-    else:
-        logger.info(
-            f"Biotite CCD file at {ccd_path} is up-to-date with "
-            f"s3://{S3_BUCKET}/{S3_KEY}, skipping."
-        )
-        return False
+    logger.info(
+        f"Biotite CCD file at {ccd_path} is up-to-date with "
+        f"s3://{S3_BUCKET}/{S3_KEY}, skipping."
+    )
+    return False
 
 
-def run_integration_tests(*, run_with_defaults: bool = False) -> None:
-    """Run integration tests."""
-    if run_with_defaults:
-        logger.info("Skipping integration tests (run-with-defaults).")
-        return
-    confirm = input("Run integration tests? (yes/no)")
-    if confirm.lower() not in ["yes", "y"]:
-        logger.info("Skipping integration tests, exiting setup.")
-        return
-
+def _run_integration_tests() -> None:
     logger.info("Running integration tests...")
-
-    # Set environment variables for tests
     os.environ["OPENFOLD_SETUP_SCRIPT"] = "1"
     import unittest
 
@@ -231,47 +224,69 @@ def run_integration_tests(*, run_with_defaults: bool = False) -> None:
         )
     finally:
         root_logger.setLevel(original_level)
-    exit_code = 0 if program.result.wasSuccessful() else 1
 
-    if exit_code != 0:
+    if not program.result.wasSuccessful():
         logger.error("Integration tests failed. Please check the output above.")
         sys.exit(1)
-
     logger.info("Integration tests passed!")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_setup(config: OpenFoldSetupConfig) -> None:
+    """Execute the setup described by *config* without any interactive prompts."""
+    config.openfold_cache.mkdir(parents=True, exist_ok=True)
+    os.environ["OPENFOLD_CACHE"] = str(config.openfold_cache)
+
+    config.param_directory.mkdir(parents=True, exist_ok=True)
+    ckpt_root_file = config.openfold_cache / CHECKPOINT_ROOT_FILENAME
+    ckpt_root_file.write_text(str(config.param_directory))
+    logger.info(f"Parameters directory set to: {config.param_directory}")
+
+    _download_parameters(
+        config.param_directory,
+        config.selected_parameters,
+        force_download=config.force_download_parameters,
+    )
+    setup_biotite_ccd(ccd_path=biotite.setup_ccd.OUTPUT_CCD, force_download=False)
+
+    if config.run_integration_tests:
+        _run_integration_tests()
+    else:
+        logger.info("Skipping integration tests.")
 
 
 @click.command()
 @click.option(
-    "--run-with-defaults",
+    "--non-interactive",
     is_flag=True,
     default=False,
-    help=(
-        "Non-interactively run setup with all default options: use the default "
-        "cache directory, download only the default checkpoint, and skip "
-        "integration tests."
-    ),
+    help="Non-interactively run setup using all default config values.",
 )
-def main(run_with_defaults: bool = False):
-    """Set up OpenFold3 parameters."""
-    # Step 1: Set up OpenFold cache directory
-    openfold_cache, ckpt_root_file = setup_openfold_cache(
-        run_with_defaults=run_with_defaults
-    )
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to a JSON file containing an OpenFoldSetupConfig.",
+)
+def main(non_interactive: bool = False, config_path: Path | None = None):
+    """Set up OpenFold3 model parameters."""
+    if config_path is not None:
+        config = OpenFoldSetupConfig.model_validate_json(config_path.read_text())
+    elif non_interactive:
+        config = OpenFoldSetupConfig()
+    else:
+        config = _prompt_for_config()
 
-    # Step 2: Set up checkpoint directory
-    param_dir, should_download = setup_param_directory(
-        openfold_cache, ckpt_root_file, run_with_defaults=run_with_defaults
-    )
+    run_setup(config)
 
-    # Step 3: Perform download if needed
-    if should_download:
-        download_parameters(param_dir, run_with_defaults=run_with_defaults)
-
-    # Step 4: Setup CCD with biotite
-    setup_biotite_ccd(ccd_path=biotite.setup_ccd.OUTPUT_CCD, force_download=False)
-
-    # Step 5: Run tests (always run regardless of download status)
-    run_integration_tests(run_with_defaults=run_with_defaults)
+    setup_config_path = config.openfold_cache / "setup_config.json"
+    setup_config_path.write_text(config.model_dump_json(indent=4))
+    logger.info(f"Setup configuration saved to {setup_config_path}")
 
 
 if __name__ == "__main__":

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -24,6 +24,7 @@ import sys
 from pathlib import Path
 
 import biotite.setup_ccd
+import click
 
 from openfold3.core.utils.s3 import download_s3_file, s3_file_matches_local
 from openfold3.entry_points.parameters import (
@@ -41,20 +42,18 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 
-def setup_openfold_cache() -> tuple[Path, Path]:
+def setup_openfold_cache(*, run_with_defaults: bool = False) -> tuple[Path, Path]:
     """Set up the OpenFold cache directory."""
     logger.info("Setting up OpenFold cache directory...")
 
     default_cache = Path.home() / ".openfold3"
-    user_input = input(
-        f"Please specify the OpenFold cache directory (default: {default_cache}): "
-    ).strip()
-
-    # Use user input if provided, otherwise use default
-    if user_input:
-        openfold_cache = Path(user_input).expanduser()
-    else:
+    if run_with_defaults:
         openfold_cache = default_cache
+    else:
+        user_input = input(
+            f"Please specify the OpenFold cache directory (default: {default_cache}): "
+        ).strip()
+        openfold_cache = Path(user_input).expanduser() if user_input else default_cache
 
     openfold_cache.mkdir(parents=True, exist_ok=True)
     ckpt_root_file = openfold_cache / "ckpt_root"
@@ -65,7 +64,7 @@ def setup_openfold_cache() -> tuple[Path, Path]:
 
 
 def setup_param_directory(
-    openfold_cache: Path, ckpt_root_file: Path
+    openfold_cache: Path, ckpt_root_file: Path, *, run_with_defaults: bool = False
 ) -> tuple[Path, bool]:
     """Check and set up the parameter directory."""
 
@@ -79,6 +78,9 @@ def setup_param_directory(
         logger.info(
             f"OpenFold3 parameters may already be installed at: {existing_path}"
         )
+        if run_with_defaults:
+            logger.info("Using existing parameters (run-with-defaults).")
+            return existing_path, False  # Don't download
         logger.info("Do you want to:")
         logger.info("1) Use existing parameters (skip download)")
         logger.info("2) Download to a new location")
@@ -106,16 +108,14 @@ def setup_param_directory(
     else:
         # First time setup
         logger.info("Downloading OpenFold3 parameters...")
-        user_input = input(
-            "Please specify the directory for parameter download "
-            f"(default: {openfold_cache}): "
-        ).strip()
-
-        # Use user input if provided, otherwise use default (the cache directory)
-        if user_input:
-            param_dir = Path(user_input).expanduser()
-        else:
+        if run_with_defaults:
             param_dir = openfold_cache
+        else:
+            user_input = input(
+                "Please specify the directory for parameter download "
+                f"(default: {openfold_cache}): "
+            ).strip()
+            param_dir = Path(user_input).expanduser() if user_input else openfold_cache
 
     # Create the directory if it doesn't exist
     param_dir.mkdir(parents=True, exist_ok=True)
@@ -129,7 +129,7 @@ def setup_param_directory(
     return param_dir, True  # Proceed with download
 
 
-def download_parameters(param_dir) -> None:
+def download_parameters(param_dir, *, run_with_defaults: bool = False) -> None:
     """Perform the parameter download."""
     # Exclude incompatible checkpoints:
     all_checkpoints = [
@@ -138,12 +138,18 @@ def download_parameters(param_dir) -> None:
         if name not in LEGACY_CHECKPOINTS
     ]
 
-    logger.info("Select parameters to download:")
-    logger.info(f"1) Download only the default checkpoint ({DEFAULT_CHECKPOINT_NAME})")
-    logger.info(f"2) Download all parameters ({', '.join(all_checkpoints)}) (default)")
-    logger.info("3) Download a specific parameter by name")
-
-    choice = input("Enter your choice (1/2/3, default: 1): ").strip() or "1"
+    if run_with_defaults:
+        choice = "1"
+    else:
+        logger.info("Select parameters to download:")
+        logger.info(
+            f"1) Download only the default checkpoint ({DEFAULT_CHECKPOINT_NAME})"
+        )
+        logger.info(
+            f"2) Download all parameters ({', '.join(all_checkpoints)}) (default)"
+        )
+        logger.info("3) Download a specific parameter by name")
+        choice = input("Enter your choice (1/2/3, default: 1): ").strip() or "1"
 
     logger.info("Starting parameter download...")
 
@@ -198,8 +204,11 @@ def setup_biotite_ccd(*, ccd_path: Path, force_download: bool) -> bool:
         return False
 
 
-def run_integration_tests() -> None:
+def run_integration_tests(*, run_with_defaults: bool = False) -> None:
     """Run integration tests."""
+    if run_with_defaults:
+        logger.info("Skipping integration tests (run-with-defaults).")
+        return
     confirm = input("Run integration tests? (yes/no)")
     if confirm.lower() not in ["yes", "y"]:
         logger.info("Skipping integration tests, exiting setup.")
@@ -231,23 +240,38 @@ def run_integration_tests() -> None:
     logger.info("Integration tests passed!")
 
 
-def main():
-    """Main execution."""
+@click.command()
+@click.option(
+    "--run-with-defaults",
+    is_flag=True,
+    default=False,
+    help=(
+        "Non-interactively run setup with all default options: use the default "
+        "cache directory, download only the default checkpoint, and skip "
+        "integration tests."
+    ),
+)
+def main(run_with_defaults: bool = False):
+    """Set up OpenFold3 parameters."""
     # Step 1: Set up OpenFold cache directory
-    openfold_cache, ckpt_root_file = setup_openfold_cache()
+    openfold_cache, ckpt_root_file = setup_openfold_cache(
+        run_with_defaults=run_with_defaults
+    )
 
     # Step 2: Set up checkpoint directory
-    param_dir, should_download = setup_param_directory(openfold_cache, ckpt_root_file)
+    param_dir, should_download = setup_param_directory(
+        openfold_cache, ckpt_root_file, run_with_defaults=run_with_defaults
+    )
 
     # Step 3: Perform download if needed
     if should_download:
-        download_parameters(param_dir)
+        download_parameters(param_dir, run_with_defaults=run_with_defaults)
 
     # Step 4: Setup CCD with biotite
     setup_biotite_ccd(ccd_path=biotite.setup_ccd.OUTPUT_CCD, force_download=False)
 
     # Step 5: Run tests (always run regardless of download status)
-    run_integration_tests()
+    run_integration_tests(run_with_defaults=run_with_defaults)
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -54,6 +54,7 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
 from openfold3.projects.of3_all_atom.project_entry import ModelUpdate, OF3ProjectEntry
+from openfold3.setup_openfold import OpenFoldSetupConfig
 
 
 @pytest.fixture
@@ -736,15 +737,15 @@ class TestRemoveQuerySetDuplicates:
 
 
 class TestSetupOpenFold:
-    def test_run_with_defaults(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
-
-        with patch(
+    def test_non_interactive(self, tmp_path):
+        env_patch = patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=False)
+        s3_patch = patch(
             "openfold3.setup_openfold.download_s3_file",
             side_effect=_fake_download_s3_file,
-        ):
-            result = CliRunner().invoke(setup_openfold.main, ["--run-with-defaults"])
+        )
+        with env_patch, s3_patch:
+            os.environ.pop("OPENFOLD_CACHE", None)
+            result = CliRunner().invoke(setup_openfold.main, ["--non-interactive"])
 
         assert result.exit_code == 0, result.output
         expected_cache = tmp_path / ".openfold3"
@@ -757,52 +758,86 @@ class TestSetupOpenFold:
             / OPENFOLD_MODEL_CHECKPOINT_REGISTRY[DEFAULT_CHECKPOINT_NAME].file_name
         ).exists()
 
-    def test_fresh_parameter_default_download(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
-        stdin_input = "\n".join(
-            [
-                str(tmp_path),  # Set cache directory
-                "",  # Use default (cache) directory for params directory
-                "1",  # download choice: default checkpoint only
-                "no",  # skip integration tests
-            ]
+    def test_existing_parameter_installation(self, tmp_path):
+        # Pre-seed the checkpoint file and ckpt_root as if a prior install ran.
+        existing_ckpt = (
+            tmp_path
+            / OPENFOLD_MODEL_CHECKPOINT_REGISTRY[DEFAULT_CHECKPOINT_NAME].file_name
         )
+        pre_existing_content = "pre-existing dummy content"
+        existing_ckpt.write_text(pre_existing_content)
+        (tmp_path / CHECKPOINT_ROOT_FILENAME).write_text(str(tmp_path))
+
+        # force_download_parameters defaults to False, so the existing file should
+        # be left untouched.
+        config = OpenFoldSetupConfig(
+            openfold_cache=tmp_path,
+            param_directory=tmp_path,
+            selected_parameters="default",
+            run_integration_tests=False,
+        )
+        config_file = tmp_path / "input_setup_config.json"
+        config_file.write_text(config.model_dump_json())
 
         with patch(
             "openfold3.setup_openfold.download_s3_file",
             side_effect=_fake_download_s3_file,
         ):
-            result = CliRunner().invoke(setup_openfold.main, [], input=stdin_input)
+            result = CliRunner().invoke(
+                setup_openfold.main, ["--config", str(config_file)]
+            )
 
         assert result.exit_code == 0, result.output
-        # Check that the checkpoint root file exists and has the expected path
+        assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)
+        # Content must be unchanged — download_model_parameters skips files that
+        # already exist when force_download_parameters=False.
+        assert existing_ckpt.read_text() == pre_existing_content
+
+    def test_fresh_parameter_default_download(self, tmp_path):
+        config = OpenFoldSetupConfig(
+            openfold_cache=tmp_path,
+            param_directory=tmp_path,
+            selected_parameters="default",
+            run_integration_tests=False,
+        )
+        config_file = tmp_path / "input_setup_config.json"
+        config_file.write_text(config.model_dump_json())
+
+        with patch(
+            "openfold3.setup_openfold.download_s3_file",
+            side_effect=_fake_download_s3_file,
+        ):
+            result = CliRunner().invoke(
+                setup_openfold.main, ["--config", str(config_file)]
+            )
+
+        assert result.exit_code == 0, result.output
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).exists()
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)
-        # Check that dummy checkpoint file has been installed correctly
         assert (
             tmp_path
             / OPENFOLD_MODEL_CHECKPOINT_REGISTRY[DEFAULT_CHECKPOINT_NAME].file_name
         ).exists()
 
-    def test_fresh_parameter_download_all(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
-        stdin_input = "\n".join(
-            [
-                str(tmp_path),  # Set cache directory
-                "",  # Use default (cache) directory for params directory
-                "2",  # download choice: all parameters
-                "no",  # skip integration tests
-            ]
+    def test_fresh_parameter_download_all(self, tmp_path):
+        config = OpenFoldSetupConfig(
+            openfold_cache=tmp_path,
+            param_directory=tmp_path,
+            selected_parameters="all",
+            run_integration_tests=False,
         )
+        config_file = tmp_path / "input_setup_config.json"
+        config_file.write_text(config.model_dump_json())
 
         with patch(
             "openfold3.setup_openfold.download_s3_file",
             side_effect=_fake_download_s3_file,
         ):
-            result = CliRunner().invoke(setup_openfold.main, [], input=stdin_input)
+            result = CliRunner().invoke(
+                setup_openfold.main, ["--config", str(config_file)]
+            )
 
         assert result.exit_code == 0, result.output
-        # Check that the checkpoint root file exists and has the expected path
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).exists()
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)
 

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import ml_collections as mlc
 import pytest
+from click.testing import CliRunner
 from pytorch_lightning.loggers import WandbLogger
 
 import openfold3.core.model.primitives.initialization as initialization
@@ -735,9 +736,30 @@ class TestRemoveQuerySetDuplicates:
 
 
 class TestSetupOpenFold:
+    def test_run_with_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "openfold3.setup_openfold.download_s3_file",
+            side_effect=_fake_download_s3_file,
+        ):
+            result = CliRunner().invoke(setup_openfold.main, ["--run-with-defaults"])
+
+        assert result.exit_code == 0, result.output
+        expected_cache = tmp_path / ".openfold3"
+        assert (expected_cache / CHECKPOINT_ROOT_FILENAME).exists()
+        assert (expected_cache / CHECKPOINT_ROOT_FILENAME).read_text() == str(
+            expected_cache
+        )
+        assert (
+            expected_cache
+            / OPENFOLD_MODEL_CHECKPOINT_REGISTRY[DEFAULT_CHECKPOINT_NAME].file_name
+        ).exists()
+
     def test_fresh_parameter_default_download(self, tmp_path, monkeypatch):
         monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
-        inputs = iter(
+        stdin_input = "\n".join(
             [
                 str(tmp_path),  # Set cache directory
                 "",  # Use default (cache) directory for params directory
@@ -746,15 +768,13 @@ class TestSetupOpenFold:
             ]
         )
 
-        with (
-            patch("builtins.input", side_effect=inputs),
-            patch(
-                "openfold3.setup_openfold.download_s3_file",
-                side_effect=_fake_download_s3_file,
-            ),
+        with patch(
+            "openfold3.setup_openfold.download_s3_file",
+            side_effect=_fake_download_s3_file,
         ):
-            setup_openfold.main()
+            result = CliRunner().invoke(setup_openfold.main, [], input=stdin_input)
 
+        assert result.exit_code == 0, result.output
         # Check that the checkpoint root file exists and has the expected path
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).exists()
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)
@@ -766,7 +786,7 @@ class TestSetupOpenFold:
 
     def test_fresh_parameter_download_all(self, tmp_path, monkeypatch):
         monkeypatch.delenv("OPENFOLD_CACHE", raising=False)
-        inputs = iter(
+        stdin_input = "\n".join(
             [
                 str(tmp_path),  # Set cache directory
                 "",  # Use default (cache) directory for params directory
@@ -775,15 +795,13 @@ class TestSetupOpenFold:
             ]
         )
 
-        with (
-            patch("builtins.input", side_effect=inputs),
-            patch(
-                "openfold3.setup_openfold.download_s3_file",
-                side_effect=_fake_download_s3_file,
-            ),
+        with patch(
+            "openfold3.setup_openfold.download_s3_file",
+            side_effect=_fake_download_s3_file,
         ):
-            setup_openfold.main()
+            result = CliRunner().invoke(setup_openfold.main, [], input=stdin_input)
 
+        assert result.exit_code == 0, result.output
         # Check that the checkpoint root file exists and has the expected path
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).exists()
         assert (tmp_path / CHECKPOINT_ROOT_FILENAME).read_text() == str(tmp_path)


### PR DESCRIPTION
**Summary**
`setup_openfold` is currently an interactive script that asks 4 questions regarding where to download the model parameters, which model parameter(s) to download, and whether to run integration tests.

For automated workflows, it is convenient to provide a "--non-interactive" option for the script such that all default options are automatically selected. One immediate use case is in TestSetupOpenfold (in test_entry_points.py), where we need to provide fake values for setup_openfold.main(). Another use case is in example colabfold notebooks, such as #255 



**Changes**
- Refactor setup_openfold to use a `OpenFoldSetupConfig` pydantic model to record options, and store default settings. Interactive mode now populates OpenFoldSetupConfig with user input through the same set of queries provided previously.
- Updates setup_openfold to include `--non-interactive` option, which will use the default settings of `OpenFoldSetupConfig`
- Updates `test_entry_points.TestSetupOpenFold` with additional test to test default settings and incorporate cli_runner.
- [x] update documentation

**Related Issues**
#255 

**Testing**
- [x] `test_entry_points.py` tests pass
- [x] `test_inference_full.py` passes
- [x] Manually run setup_openfold on existing .openfold3 cache and new cache directory
