### PR TITLE
Change default region of ci tests to us-east-2

### DIFF
--- a/.github/workflows/ci-integration-test-conda-reusable.yml
+++ b/.github/workflows/ci-integration-test-conda-reusable.yml
@@ -31,7 +31,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::203627415330:role/of-gha-runner
-          aws-region: us-east-1
+          aws-region: us-east-2
       - name: Create cloud runner
         id: aws-start
         uses: omsf/start-aws-gha-runner@v1.1.1
@@ -118,7 +118,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::203627415330:role/of-gha-runner
-          aws-region: us-east-1
+          aws-region: us-east-2
       - name: Stop instances
         uses: omsf/stop-aws-gha-runner@v1.0.0
         with:

--- a/.github/workflows/ci-integration-test-pixi-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-reusable.yml
@@ -32,7 +32,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::203627415330:role/of-gha-runner
-          aws-region: us-east-1
+          aws-region: us-east-2
       - name: Create cloud runner
         id: aws-start
         uses: omsf/start-aws-gha-runner@v1.1.1
@@ -119,7 +119,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::203627415330:role/of-gha-runner
-          aws-region: us-east-1
+          aws-region: us-east-2
       - name: Stop instances
         uses: omsf/stop-aws-gha-runner@v1.0.0
         with:


### PR DESCRIPTION
**Summary**
Change default region of AWS instances for CI on GPU to be us-east-2 for hopefully less traffic

**Changes**

**Related Issues**
Similar in vein to #257 

**Testing**

**Other Notes**
