### PR TITLE
ci: replace retired CUDA AMI with DLAMI Base OSS GPU SSM alias

### DIFF
--- a/.github/workflows/ci-integration-test-conda-reusable.yml
+++ b/.github/workflows/ci-integration-test-conda-reusable.yml
@@ -36,7 +36,7 @@ jobs:
         id: aws-start
         uses: omsf/start-aws-gha-runner@v1.1.1
         with:
-          aws_image_id: ami-00839c71d8f6096b4  # Deep Learning Base AMI with Single CUDA (Ubuntu 22.04)
+          aws_image_id: resolve:ssm:/aws/service/deeplearning/ami/x86_64/base-oss-nvidia-driver-gpu-ubuntu-22.04/latest/ami-id  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), latest
           aws_instance_type: "g5.4xlarge" # A10G 64 GB 
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200

--- a/.github/workflows/ci-integration-test-pixi-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-reusable.yml
@@ -37,7 +37,7 @@ jobs:
         id: aws-start
         uses: omsf/start-aws-gha-runner@v1.1.1
         with:
-          aws_image_id: ami-00839c71d8f6096b4  # Deep Learning Base AMI with Single CUDA (Ubuntu 22.04)
+          aws_image_id: resolve:ssm:/aws/service/deeplearning/ami/x86_64/base-oss-nvidia-driver-gpu-ubuntu-22.04/latest/ami-id  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), latest
           aws_instance_type: "g5.4xlarge" # A10G 64 GB
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200


### PR DESCRIPTION
**Summary**
The previous CUDA AMI (ami-00839c71d8f6096b4) has been deprecated. Replacing the AMI used by the two GPU integration workflows with an ssm: id that should hopefully not go stale.

**Changes**
- Replace ami used in `ci-integration-test*-reusable.yml` worflows

**Related Issues**

**Testing**

**Other Notes**
