### PR TITLE
Triton attn backward: atomic-free d_pair_bias via dedicated kernel

### DIFF
--- a/openfold3/core/kernels/triton/evoformer.py
+++ b/openfold3/core/kernels/triton/evoformer.py
@@ -387,7 +387,6 @@ if _TRITON_AVAILABLE:
         dQ,
         dK,
         dV,
-        d_pair_bias,
         M,
         D,
         stride_batch,
@@ -401,10 +400,6 @@ if _TRITON_AVAILABLE:
         stride_mask_batch,
         stride_mask_msa,
         stride_mask_seq,
-        stride_d_pair_bias_batch,
-        stride_d_pair_bias_head,
-        stride_d_pair_bias_seq1,
-        stride_d_pair_bias_seq2,
         HEAD,
         N_SEQ,
         SEQ_LEN,
@@ -416,7 +411,7 @@ if _TRITON_AVAILABLE:
         BLOCK_SIZE_Q: tl.constexpr,
         BLOCK_SIZE_KV: tl.constexpr,
     ):
-        """Run the backward pass of the attention mechanism."""
+        """Attention backward pass: compute the query gradient dQ."""
         index_batch_msa_head = tl.program_id(1)
         index_batch_msa = index_batch_msa_head // HEAD
         index_head = index_batch_msa_head % HEAD
@@ -505,13 +500,6 @@ if _TRITON_AVAILABLE:
             + offs_kv[None, :] * stride_pair_bias_seq2
         )
 
-        d_pair_bias_block_ptr = (
-            d_pair_bias
-            + index_batch.to(tl.int64) * stride_d_pair_bias_batch
-            + index_head.to(tl.int64) * stride_d_pair_bias_head
-            + (offs_q[:, None] * stride_d_pair_bias_seq1)
-            + (offs_kv[None, :] * stride_d_pair_bias_seq2)
-        )
         res_mask_block_ptr = (
             res_mask
             + index_batch.to(tl.int64) * stride_mask_batch
@@ -593,14 +581,6 @@ if _TRITON_AVAILABLE:
 
             dP_block = tl.dot(dO_block, V_T_block).to(tl.float32)
             dS_block = P_block * (dP_block - Di[:, None])
-
-            # Update d_pair_bias atomic add with float32 precision
-            tl.atomic_add(
-                d_pair_bias_block_ptr,
-                dS_block,
-                mask=(offs_q[:, None] < SEQ_LEN)
-                & ((blk_idx * BLOCK_SIZE_KV + offs_kv)[None, :] < SEQ_LEN),
-            )
             dS_block = dS_block.to(K_T_block.dtype)
 
             dQ_block += softmax_scale * tl.dot(dS_block, tl.trans(K_T_block))
@@ -609,7 +589,6 @@ if _TRITON_AVAILABLE:
             kT_ptrs += BLOCK_SIZE_KV * stride_seq
             vT_ptrs += BLOCK_SIZE_KV * stride_seq
             pair_bias_block_ptr += BLOCK_SIZE_KV * stride_pair_bias_seq2
-            d_pair_bias_block_ptr += BLOCK_SIZE_KV * stride_d_pair_bias_seq2
             res_mask_block_ptr += BLOCK_SIZE_KV * stride_mask_seq
 
         dQ_block_ptrs = dQ + offs_q[:, None] * stride_seq + offs_dim[None, :]
@@ -671,7 +650,7 @@ if _TRITON_AVAILABLE:
         BLOCK_SIZE_Q: tl.constexpr,
         BLOCK_SIZE_KV: tl.constexpr,
     ):
-        """Run the backward pass of the attention mechanism."""
+        """Attention backward pass: compute the key and value gradients dK and dV."""
         index_batch_msa_head = tl.program_id(1)
         index_batch_msa = index_batch_msa_head // HEAD
         index_head = index_batch_msa_head % HEAD
@@ -878,6 +857,138 @@ if _TRITON_AVAILABLE:
                     mask=(offs_kv[:, None] < SEQ_LEN) & (offs_dim[None, :] < DIM),
                 )
 
+    @triton.jit
+    def _attn_bwd_dpair_bias(
+        Q,
+        K,
+        V,
+        res_mask,
+        pair_bias,
+        M,
+        D,
+        dO,
+        d_pair_bias,
+        softmax_scale,
+        stride_batch,
+        stride_msa,
+        stride_head,
+        stride_seq,
+        stride_pb_batch,
+        stride_pb_head,
+        stride_pb_seq1,
+        stride_pb_seq2,
+        stride_dpb_batch,
+        stride_dpb_head,
+        stride_dpb_seq1,
+        stride_dpb_seq2,
+        stride_mask_batch,
+        stride_mask_msa,
+        stride_mask_seq,
+        HEAD,
+        N_SEQ,
+        SEQ_LEN,
+        DIM: tl.constexpr,
+        BLOCK_DIM: tl.constexpr,
+        BLOCK_SIZE_Q: tl.constexpr,
+        BLOCK_SIZE_KV: tl.constexpr,
+    ):
+        """Attention backward pass: compute the pair_bias gradient.
+
+        d_pair_bias[b, h, q, kv] = sum over m of dS[b, m, h, q, kv], where dS is
+        the attention-score gradient and m indexes the (msa) batch dimension
+        that pair_bias is broadcast over. Each program owns one
+        (b, h, q_block, kv_block) tile, reduces over m internally, and writes
+        the tile with a single store. The score is recomputed from the saved
+        Q/K/V/M/D/dO.
+
+        d_pair_bias can alternatively be accumulated inside the dQ kernel with
+        tl.atomic_add, but since pair_bias is shared across m every program then
+        contends on the same elements; reducing over m within one program here
+        is much faster.
+        """
+        pid_q = tl.program_id(0)
+        pid_kv = tl.program_id(1)
+        pid_bh = tl.program_id(2)
+        index_batch = pid_bh // HEAD
+        index_head = pid_bh % HEAD
+
+        offs_q = pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q)
+        offs_kv = pid_kv * BLOCK_SIZE_KV + tl.arange(0, BLOCK_SIZE_KV)
+        offs_dim = tl.arange(0, BLOCK_DIM)
+        mask_q = offs_q < SEQ_LEN
+        mask_kv = offs_kv < SEQ_LEN
+        mask_dim = offs_dim < DIM
+
+        # Cast indices to int64 to avoid int32 overflow for large sequences.
+        offset_batch_head = (
+            index_batch.to(tl.int64) * stride_batch
+            + index_head.to(tl.int64) * stride_head
+        )
+
+        # pair_bias tile is constant over the msa reduction.
+        pb_ptr = (
+            pair_bias
+            + index_batch.to(tl.int64) * stride_pb_batch
+            + index_head.to(tl.int64) * stride_pb_head
+            + offs_q[:, None] * stride_pb_seq1
+            + offs_kv[None, :] * stride_pb_seq2
+        )
+        pb = tl.load(pb_ptr, mask=mask_q[:, None] & mask_kv[None, :], other=0.0).to(
+            tl.float32
+        )
+
+        acc = tl.zeros([BLOCK_SIZE_Q, BLOCK_SIZE_KV], dtype=tl.float32)
+
+        for m in range(N_SEQ):
+            base = offset_batch_head + m.to(tl.int64) * stride_msa
+            Qb = tl.load(
+                Q + base + offs_q[:, None] * stride_seq + offs_dim[None, :],
+                mask=mask_q[:, None] & mask_dim[None, :],
+                other=0.0,
+            )
+            Kb = tl.load(
+                K + base + offs_kv[:, None] * stride_seq + offs_dim[None, :],
+                mask=mask_kv[:, None] & mask_dim[None, :],
+                other=0.0,
+            )
+            Vb = tl.load(
+                V + base + offs_kv[:, None] * stride_seq + offs_dim[None, :],
+                mask=mask_kv[:, None] & mask_dim[None, :],
+                other=0.0,
+            )
+            dOb = tl.load(
+                dO + base + offs_q[:, None] * stride_seq + offs_dim[None, :],
+                mask=mask_q[:, None] & mask_dim[None, :],
+                other=0.0,
+            )
+            md_base = ((index_batch * N_SEQ + m) * HEAD + index_head).to(
+                tl.int64
+            ) * SEQ_LEN
+            Mb = tl.load(M + md_base + offs_q, mask=mask_q, other=0.0)
+            Db = tl.load(D + md_base + offs_q, mask=mask_q, other=0.0)
+            rmask = tl.load(
+                res_mask
+                + index_batch.to(tl.int64) * stride_mask_batch
+                + m.to(tl.int64) * stride_mask_msa
+                + offs_kv * stride_mask_seq,
+                mask=mask_kv,
+                other=float("-inf"),
+            )
+
+            QK = tl.dot(Qb, tl.trans(Kb)) * softmax_scale + pb + rmask[None, :]
+            P = tl.math.exp(QK - Mb[:, None])
+            dP = tl.dot(dOb, tl.trans(Vb)).to(tl.float32)
+            acc += P * (dP - Db[:, None])
+
+        dpb_ptr = (
+            d_pair_bias
+            + index_batch.to(tl.int64) * stride_dpb_batch
+            + index_head.to(tl.int64) * stride_dpb_head
+            + offs_q[:, None] * stride_dpb_seq1
+            + offs_kv[None, :] * stride_dpb_seq2
+        )
+        tl.store(dpb_ptr, acc, mask=mask_q[:, None] & mask_kv[None, :])
+
     class EvoformerAttention(torch.autograd.Function):
         @staticmethod
         def forward(ctx, Q, K, V, res_mask, pair_bias, has_pair_bias=True):
@@ -1000,6 +1111,7 @@ if _TRITON_AVAILABLE:
             ctx.grid = grid
             ctx.softmax_scale = softmax_scale
             ctx.DIM = DIM
+            ctx.has_pair_bias = has_pair_bias
 
             O = O.transpose(-2, -3).contiguous()
 
@@ -1019,13 +1131,14 @@ if _TRITON_AVAILABLE:
             dK = torch.empty_like(K)
             dV = torch.empty_like(V)
 
-            BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = dQ.shape
+            # Explicitly contiguous because pair_bias isn't necessarily, unlike
+            # QKV. Ensures the reduction kernel's tile stores stay coalesced.
+            # Zero because when has_pair_bias is false this is returned directly.
+            d_pair_bias = torch.zeros_like(
+                pair_bias, memory_format=torch.contiguous_format
+            )
 
-            d_pair_bias = torch.empty(
-                (BATCH_SIZE, 1, HEAD, SEQ_LEN, SEQ_LEN),
-                device=pair_bias.device,
-                dtype=torch.float32,
-            ).zero_()
+            BATCH_SIZE, N_SEQ, HEAD, SEQ_LEN, DIM = dQ.shape
 
             BLOCK_DIM = max(triton.next_power_of_2(DIM), 32)
 
@@ -1104,7 +1217,6 @@ if _TRITON_AVAILABLE:
                 dQ=dQ,
                 dK=dK,
                 dV=dV,
-                d_pair_bias=d_pair_bias,
                 M=M,
                 D=D,
                 stride_batch=Q.stride(0),
@@ -1118,10 +1230,6 @@ if _TRITON_AVAILABLE:
                 stride_mask_batch=res_mask.stride(0),
                 stride_mask_msa=res_mask.stride(1),
                 stride_mask_seq=res_mask.stride(4),
-                stride_d_pair_bias_batch=d_pair_bias.stride(0),
-                stride_d_pair_bias_head=d_pair_bias.stride(2),
-                stride_d_pair_bias_seq1=d_pair_bias.stride(3),
-                stride_d_pair_bias_seq2=d_pair_bias.stride(4),
                 HEAD=HEAD,
                 N_SEQ=N_SEQ,
                 SEQ_LEN=SEQ_LEN,
@@ -1132,6 +1240,49 @@ if _TRITON_AVAILABLE:
                 num_warps=4,
                 num_stages=1,
             )
+
+            if ctx.has_pair_bias:
+                dpb_grid = lambda args: (  # noqa: E731
+                    triton.cdiv(SEQ_LEN, args["BLOCK_SIZE_Q"]),
+                    triton.cdiv(SEQ_LEN, args["BLOCK_SIZE_KV"]),
+                    BATCH_SIZE * HEAD,
+                )
+                _attn_bwd_dpair_bias[dpb_grid](
+                    Q=Q,
+                    K=K,
+                    V=V,
+                    res_mask=res_mask,
+                    pair_bias=pair_bias,
+                    M=M,
+                    D=D,
+                    dO=dO,
+                    d_pair_bias=d_pair_bias,
+                    softmax_scale=ctx.softmax_scale,
+                    stride_batch=Q.stride(0),
+                    stride_msa=Q.stride(1),
+                    stride_head=Q.stride(2),
+                    stride_seq=Q.stride(3),
+                    stride_pb_batch=pair_bias.stride(0),
+                    stride_pb_head=pair_bias.stride(2),
+                    stride_pb_seq1=pair_bias.stride(3),
+                    stride_pb_seq2=pair_bias.stride(4),
+                    stride_dpb_batch=d_pair_bias.stride(0),
+                    stride_dpb_head=d_pair_bias.stride(2),
+                    stride_dpb_seq1=d_pair_bias.stride(3),
+                    stride_dpb_seq2=d_pair_bias.stride(4),
+                    stride_mask_batch=res_mask.stride(0),
+                    stride_mask_msa=res_mask.stride(1),
+                    stride_mask_seq=res_mask.stride(4),
+                    HEAD=HEAD,
+                    N_SEQ=N_SEQ,
+                    SEQ_LEN=SEQ_LEN,
+                    DIM=ctx.DIM,
+                    BLOCK_DIM=BLOCK_DIM,
+                    BLOCK_SIZE_Q=64,
+                    BLOCK_SIZE_KV=64,
+                    num_warps=4,
+                    num_stages=1,
+                )
 
             dQ = dQ.transpose(-2, -3).contiguous()
             dK = dK.transpose(-2, -3).contiguous()

--- a/openfold3/tests/custom_assert_utils.py
+++ b/openfold3/tests/custom_assert_utils.py
@@ -15,6 +15,7 @@
 """Module for any added custom assert functions."""
 
 import numpy as np
+import torch
 from biotite.structure import AtomArray
 from rdkit import Chem
 
@@ -139,3 +140,28 @@ def assert_ref_mols_equal(
             assert np.array_equal(perm_1, perm_2), (
                 "Reference molecules have different permutations."
             )
+
+
+def assert_close_nondegenerate(actual, expected, *, atol, rtol):
+    """Assert ``actual`` matches ``expected`` and that the test is meaningful.
+
+    On top of an elementwise ``torch.testing.assert_close``, this checks:
+      - ``actual`` and ``expected`` are all finite
+      - ``expected`` is not close to zero everywhere (which suggests the test
+        accidentally multiplied everything by zero, e.g. with a zero-initialized
+        linear layer).
+      - ``actual`` and ``expected`` are not within 1e-9 of each other everywhere
+        (which suggests the test didn't actually exercise different code paths).
+        This is disabled if atol and rtol are tighter than this bound, since in
+        that case the close agreement is expected.
+    """
+    assert torch.isfinite(expected).all(), "Expected tensor has non-finite values"
+    assert torch.isfinite(actual).all(), "Actual tensor has non-finite values"
+    assert not torch.allclose(
+        expected, torch.zeros_like(expected), atol=atol, rtol=rtol
+    ), f"Expected tensor is ~= 0 everywhere (within atol={atol} and rtol={rtol})"
+    if atol > 1e-9 or rtol > 1e-9:
+        assert not torch.allclose(actual, expected, atol=1e-9, rtol=1e-9), (
+            "Actual and expected tensors are within 1e-9. Is test degenerate?"
+        )
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)

--- a/openfold3/tests/data_utils.py
+++ b/openfold3/tests/data_utils.py
@@ -139,20 +139,24 @@ def random_attention_inputs(
     inf=1e9,
     dtype=torch.float32,
     requires_grad=False,
+    bias_scale=0.1,
 ):
-    q = torch.rand(
+    q = torch.randn(
         batch_size, n_seq, n, c_hidden, dtype=dtype, requires_grad=requires_grad
     ).cuda()
-    kv = torch.rand(
+    kv = torch.randn(
         batch_size, n_seq, n, c_hidden, dtype=dtype, requires_grad=requires_grad
     ).cuda()
 
     mask = torch.randint(
         0, 2, (batch_size, n_seq, 1, 1, n), dtype=dtype, requires_grad=False
     ).cuda()
-    z_bias = torch.rand(
-        batch_size, 1, no_heads, n, n, dtype=dtype, requires_grad=requires_grad
-    ).cuda()
+    z_bias = (
+        bias_scale
+        * torch.randn(
+            batch_size, 1, no_heads, n, n, dtype=dtype, requires_grad=requires_grad
+        ).cuda()
+    )
     mask_bias = inf * (mask - 1)
 
     biases = [mask_bias, z_bias]

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -46,21 +46,6 @@ pytestmark = [pytest.mark.slow]
 torch.backends.cuda.preferred_blas_library("cublas")
 
 
-_BASE_TOLS = {
-    torch.float64: 1e-6,
-    torch.float32: 1e-3,
-    torch.bfloat16: 1e-2,
-    torch.float16: 1e-2,
-}
-
-
-def get_tols(dtype, *, backward=False, atol=None, rtol=None):
-    if dtype not in _BASE_TOLS:
-        raise ValueError(f"Unsupported dtype {dtype}")
-    base = _BASE_TOLS[dtype] * (2 if backward else 1)
-    return atol if atol is not None else base, rtol if rtol is not None else base
-
-
 @pytest.mark.usefixtures("seeded_rng")
 @compare_utils.skip_unless_cuda_available()
 class TestKernels:
@@ -70,8 +55,10 @@ class TestKernels:
         use_cueq_triangle_kernels=False,
         use_triton_triangle_kernels=False,
         dtype=torch.float32,
-        atol=None,
-        rtol=None,
+        # Even for f32 input, all the kernels use reduced precision, so this is
+        # pretty loose.
+        atol=1e-2,
+        rtol=1e-2,
     ):
         """
         Check a kernel's attention forward against reference.
@@ -87,8 +74,6 @@ class TestKernels:
         n_res = 200  # Avoid cuEq seq len constraints
         c_hidden = 32
         no_heads = 4
-
-        atol, rtol = get_tols(dtype, atol=atol, rtol=rtol)
 
         q, kv, _, (mask_bias, z_bias) = random_attention_inputs(
             batch_size=batch_size,
@@ -171,14 +156,9 @@ class TestKernels:
 
     @compare_utils.skip_unless_triton_installed()
     def test_triton_forward_fp32(self):
-        # The Triton kernel currently downcasts to bf16 internally, so it needs
-        # the bf16-level tolerance even though the inputs are fp32.
-        atol, rtol = get_tols(torch.bfloat16)
         self._compare_attn_kernel_forward(
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
-            atol=atol,
-            rtol=rtol,
         )
 
     def _compare_attn_kernel_backward(
@@ -187,8 +167,10 @@ class TestKernels:
         use_cueq_triangle_kernels=False,
         use_triton_triangle_kernels=False,
         dtype=torch.float32,
-        atol=None,
-        rtol=None,
+        # Even for f32 input, all the kernels use reduced precision, so this is
+        # pretty loose.
+        atol=2e-2,
+        rtol=2e-2,
     ):
         """
         Check a kernel's attention backward against reference.
@@ -202,8 +184,6 @@ class TestKernels:
         n_res = 200  # Avoid cuEq seq len constraints
         c_hidden = 32
         no_heads = 4
-
-        atol, rtol = get_tols(dtype, backward=True, atol=atol, rtol=rtol)
 
         q, kv, _, (mask_bias, z_bias) = random_attention_inputs(
             batch_size=batch_size,
@@ -294,14 +274,9 @@ class TestKernels:
 
     @compare_utils.skip_unless_triton_installed()
     def test_triton_backward_fp32(self):
-        # The Triton kernel downcasts to bf16 internally, so it needs the
-        # bf16-level backward tolerance even though the inputs are fp32.
-        atol, rtol = get_tols(torch.bfloat16, backward=True)
         self._compare_attn_kernel_backward(
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
-            atol=atol,
-            rtol=rtol,
         )
 
     @compare_utils.skip_unless_cueq_installed()

--- a/openfold3/tests/test_kernels.py
+++ b/openfold3/tests/test_kernels.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 """
-Unit tests to compare components of OpenFold run with the DeepSpeed memory-efficient
-attention kernel, DS4Sci_EvoformerAttention vs. a stock PyTorch attention
-implementation.
+Unit tests to compare components of OpenFold run with an optimized flash-style
+attention kernel vs. a stock PyTorch attention implementation.
 """
 
 import pytest
@@ -35,6 +34,7 @@ from openfold3.core.model.primitives.initialization import lecun_normal_init_
 from openfold3.core.utils.tensor_utils import tensor_tree_map
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
+from openfold3.tests.custom_assert_utils import assert_close_nondegenerate
 from openfold3.tests.data_utils import (
     random_attention_inputs,
 )
@@ -46,6 +46,22 @@ pytestmark = [pytest.mark.slow]
 torch.backends.cuda.preferred_blas_library("cublas")
 
 
+_BASE_TOLS = {
+    torch.float64: 1e-6,
+    torch.float32: 1e-3,
+    torch.bfloat16: 1e-2,
+    torch.float16: 1e-2,
+}
+
+
+def get_tols(dtype, *, backward=False, atol=None, rtol=None):
+    if dtype not in _BASE_TOLS:
+        raise ValueError(f"Unsupported dtype {dtype}")
+    base = _BASE_TOLS[dtype] * (2 if backward else 1)
+    return atol if atol is not None else base, rtol if rtol is not None else base
+
+
+@pytest.mark.usefixtures("seeded_rng")
 @compare_utils.skip_unless_cuda_available()
 class TestKernels:
     def _compare_attn_kernel_forward(
@@ -54,16 +70,27 @@ class TestKernels:
         use_cueq_triangle_kernels=False,
         use_triton_triangle_kernels=False,
         dtype=torch.float32,
+        atol=None,
+        rtol=None,
     ):
-        """Compare attention with and without using DeepSpeed Evoformer kernel."""
+        """
+        Check a kernel's attention forward against reference.
+
+        The reference output is computed by the stock PyTorch attention in
+        float64, from the same inputs generated in ``dtype`` and upcast (so they
+        are exactly representable in ``dtype``). Comparing against float64
+        rather than against PyTorch in the same dtype avoids 'penalizing' the
+        kernel for the floating point error in the native PyTorch implementation.
+        """
         batch_size = consts.batch_size
         n_seq = 18
         n_res = 200  # Avoid cuEq seq len constraints
         c_hidden = 32
         no_heads = 4
-        eps = 2e-2
 
-        q, kv, mask, biases = random_attention_inputs(
+        atol, rtol = get_tols(dtype, atol=atol, rtol=rtol)
+
+        q, kv, _, (mask_bias, z_bias) = random_attention_inputs(
             batch_size=batch_size,
             n_seq=n_seq,
             n=n_res,
@@ -72,33 +99,36 @@ class TestKernels:
             dtype=dtype,
         )
 
-        a = Attention(
-            c_hidden,
-            c_hidden,
-            c_hidden,
-            c_hidden,
-            no_heads,
-        ).cuda()
-
-        # Change output params init for testing since they are initialized with 'final'
-        # init (zeros) Otherwise both will just return zero.
+        attn = Attention(c_hidden, c_hidden, c_hidden, c_hidden, no_heads).cuda()
+        # Change output params init for testing since they are initialized with
+        # 'final' init (zeros), otherwise the output would just be zero.
         with torch.no_grad():
-            lecun_normal_init_(a.linear_g.weight)
-            lecun_normal_init_(a.linear_o.weight)
+            lecun_normal_init_(attn.linear_g.weight)
+            lecun_normal_init_(attn.linear_o.weight)
 
-            real_out = a(q, kv, biases=biases).cpu()
+        def forward(run_dtype, use_kernel):
+            a = Attention(c_hidden, c_hidden, c_hidden, c_hidden, no_heads).to(
+                device="cuda", dtype=run_dtype
+            )
+            a.load_state_dict(
+                {k: v.to(run_dtype) for k, v in attn.state_dict().items()}
+            )
+            with torch.no_grad():
+                return a(
+                    q.to(run_dtype),
+                    kv.to(run_dtype),
+                    biases=[mask_bias.to(run_dtype), z_bias.to(run_dtype)],
+                    use_deepspeed_evo_attention=use_kernel
+                    and use_deepspeed_evo_attention,
+                    use_cueq_triangle_kernels=use_kernel and use_cueq_triangle_kernels,
+                    use_triton_triangle_kernels=use_kernel
+                    and use_triton_triangle_kernels,
+                )
 
-            kernel_out = a(
-                q,
-                kv,
-                biases=biases,
-                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
-                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
-                use_triton_triangle_kernels=use_triton_triangle_kernels,
-            ).cpu()
+        ref = forward(torch.float64, use_kernel=False)
+        kernel = forward(dtype, use_kernel=True)
 
-        err = torch.max(torch.abs(kernel_out - real_out))
-        assert err < eps, f"Error: {err}"
+        assert_close_nondegenerate(kernel.to(torch.float64), ref, atol=atol, rtol=rtol)
 
     @compare_utils.skip_unless_ds4s_installed()
     def test_dsk_forward_bf16(self):
@@ -141,9 +171,14 @@ class TestKernels:
 
     @compare_utils.skip_unless_triton_installed()
     def test_triton_forward_fp32(self):
+        # The Triton kernel currently downcasts to bf16 internally, so it needs
+        # the bf16-level tolerance even though the inputs are fp32.
+        atol, rtol = get_tols(torch.bfloat16)
         self._compare_attn_kernel_forward(
             use_triton_triangle_kernels=True,
             dtype=torch.float32,
+            atol=atol,
+            rtol=rtol,
         )
 
     def _compare_attn_kernel_backward(
@@ -152,106 +187,71 @@ class TestKernels:
         use_cueq_triangle_kernels=False,
         use_triton_triangle_kernels=False,
         dtype=torch.float32,
+        atol=None,
+        rtol=None,
     ):
         """
-        Compare backward pass for regular attention vs. DeepSpeed Evoformer kernel.
+        Check a kernel's attention backward against reference.
+
+        The reference gradients are computed by the stock PyTorch attention in
+        float64, from the same inputs generated in ``dtype`` and upcast (so
+        they are exactly representable in ``dtype``).
         """
         batch_size = consts.batch_size
         n_seq = 18
         n_res = 200  # Avoid cuEq seq len constraints
         c_hidden = 32
         no_heads = 4
-        eps = consts.eps
 
-        q, kv, _, biases = random_attention_inputs(
+        atol, rtol = get_tols(dtype, backward=True, atol=atol, rtol=rtol)
+
+        q, kv, _, (mask_bias, z_bias) = random_attention_inputs(
             batch_size=batch_size,
             n_seq=n_seq,
             n=n_res,
             no_heads=no_heads,
             c_hidden=c_hidden,
-            requires_grad=True,
             dtype=dtype,
         )
+        cotangent = torch.randn(
+            batch_size, n_seq, n_res, c_hidden, dtype=dtype, device="cuda"
+        )
 
-        attn = Attention(
-            c_hidden,
-            c_hidden,
-            c_hidden,
-            c_hidden,
-            no_heads,
-        ).cuda()
-
+        attn = Attention(c_hidden, c_hidden, c_hidden, c_hidden, no_heads).cuda()
         with torch.no_grad():
             lecun_normal_init_(attn.linear_g.weight)
             lecun_normal_init_(attn.linear_o.weight)
 
-        def clone(t):
-            # Create new params, clone values
-            t = t.clone()
-            if t.requires_grad:
-                t.retain_grad()
-            return t
+        def grads(run_dtype, use_kernel):
+            a = Attention(c_hidden, c_hidden, c_hidden, c_hidden, no_heads).to(
+                device="cuda", dtype=run_dtype
+            )
+            a.load_state_dict(
+                {k: v.to(run_dtype) for k, v in attn.state_dict().items()}
+            )
+            q_in = q.to(run_dtype).clone().requires_grad_(True)
+            kv_in = kv.to(run_dtype).clone().requires_grad_(True)
+            z_bias_in = z_bias.to(run_dtype).clone().requires_grad_(True)
+            mask_bias_in = mask_bias.to(run_dtype)
+            out = a(
+                q_in,
+                kv_in,
+                biases=[mask_bias_in, z_bias_in],
+                use_deepspeed_evo_attention=use_kernel and use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_kernel and use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_kernel and use_triton_triangle_kernels,
+            )
+            loss = (out * cotangent.to(run_dtype)).sum()
+            loss.backward()
+            return {"q": q_in.grad, "kv": kv_in.grad, "bias": z_bias_in.grad}
 
-        def init_attn():
-            # Create new attention object with same initial weights
-            a_clone = Attention(
-                c_hidden,
-                c_hidden,
-                c_hidden,
-                c_hidden,
-                no_heads,
-            ).cuda()
+        ref = grads(torch.float64, use_kernel=False)
+        kernel = grads(dtype, use_kernel=True)
 
-            a_clone.load_state_dict(attn.state_dict())
-            return a_clone
-
-        # Clone param values and run attention with DS kernel
-        q_repro = clone(q)
-        kv_repro = clone(kv)
-        biases_repro = [clone(b) for b in biases]
-
-        a_repro = init_attn()
-        out_repro = a_repro(
-            q_repro,
-            kv_repro,
-            biases=biases_repro,
-            use_deepspeed_evo_attention=use_deepspeed_evo_attention,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
-            use_triton_triangle_kernels=use_triton_triangle_kernels,
-        )
-        loss_repro = torch.mean(out_repro)
-        loss_repro.backward()
-
-        q_gt = clone(q)
-        kv_gt = clone(kv)
-        biases_gt = [clone(b) for b in biases]
-
-        # Clone param values and run attention without DS kernel
-        a_gt = init_attn()
-        out_gt = a_gt(q_gt, kv_gt, biases=biases_gt)
-
-        loss_gt = torch.mean(out_gt)
-        loss_gt.backward()
-
-        # Compare the grads of attention inputs
-        pairs = zip(
-            [q_repro, kv_repro, biases_repro[1]],
-            [q_gt, kv_gt, biases_gt[1]],
-            strict=False,
-        )
-        for i, item in enumerate(pairs):
-            t_repro, t_gt = item
-            err = torch.max(torch.abs(t_repro.grad.cpu() - t_gt.grad.cpu()))
-            assert err < eps, f"Error item #{i}: {err}"
-
-        # Compare the grads of model weights
-        a_repro_params = dict(a_repro.named_parameters())
-        a_gt_params = dict(a_gt.named_parameters())
-        for name in a_gt_params:
-            t_repro = a_repro_params[name]
-            t_gt = a_gt_params[name]
-            err = torch.max(torch.abs(t_repro.grad.cpu() - t_gt.grad.cpu()))
-            assert err < eps, f"Error item {name}: {err}"
+        for name, ref_grad in ref.items():
+            assert_close_nondegenerate(
+                kernel[name].to(torch.float64), ref_grad, atol=atol, rtol=rtol
+            )
 
     @compare_utils.skip_unless_ds4s_installed()
     def test_dsk_backward_bf16(self):
@@ -290,6 +290,18 @@ class TestKernels:
         self._compare_attn_kernel_backward(
             use_triton_triangle_kernels=True,
             dtype=torch.bfloat16,
+        )
+
+    @compare_utils.skip_unless_triton_installed()
+    def test_triton_backward_fp32(self):
+        # The Triton kernel downcasts to bf16 internally, so it needs the
+        # bf16-level backward tolerance even though the inputs are fp32.
+        atol, rtol = get_tols(torch.bfloat16, backward=True)
+        self._compare_attn_kernel_backward(
+            use_triton_triangle_kernels=True,
+            dtype=torch.float32,
+            atol=atol,
+            rtol=rtol,
         )
 
     @compare_utils.skip_unless_cueq_installed()


### PR DESCRIPTION
**Summary**
Using the Triton kernels, training is currently significantly slower and `_attn_bwd_dq` is ~35% of total training GPU time on MI300X. The culprit is the atomic add to compute dpair_bias. This PR replaces it with a separate kernel that reduces over the msa dimension internally (one plain store per tile, no atomics).

This gives a ~20-30x speedup of the Triton attention backward in microbenchmarks. Full e2e training speedup is ~2-3.5x and attention backward is no longer the bottleneck (<5% of total GPU time). It brings the Triton path down to ~10-25% faster than stock torch using the crop sizes in the examples. The performance improvement is not as dramatic as in inference, likely because of the much smaller token counts.

**Changes**
Add new `_attn_bwd_dpair_bias` Triton kernel for computing pair bias gradient

**Testing**
Passes the kernel unit tests (fixed in #258, so actually testing something).

Ran 8 steps of training using both random inputs and a subset of real inputs with both random initialized weights and fine tuning from the published checkpoint. Generally in bf16 gradients match with >0.99 cosine similarity. When fine-tuning from the existing checkpoint, gradient norms sometimes blow up, all in diffusion, when QK is very large and the true gradient is very small (<1e-6). The wrong gradients can be up to ~1e0, so a huge multiple, but not large in absolute terms. These all come from dV and dK, so I think the issue is not with the new kernel. This appears to be a feature of bf16 specifically: running the Triton kernel in fp32 does not exhibit it (gradients match to within 0.15%).

Verified DDP works (adds 10% step overhead)

**Other Notes**
I didn't do full e2e training to test convergence. I think this is sufficient evidence that the replacement kernel is generally correct and significantly better than the current Triton one (which is unusably slow). I'm not sure whether these grad blow-ups would actually cause problems in practice since they start small and there's clipping.

The bf16 gradient blow-up also points to a weirdness in the way we're currently force-casting to bf16 for these kernels. Contrary to the comment there, the kernel runs fine with fp32; it's just slightly slower. The Triton kernel also isn't a huge win for diffusion anyways (since it doesn't have the same N_seq scaling), so we could turn it off there if it proves to be the primary 

These concerns seem somewhat orthogonal to the kernel itself though, and I thought it was better to share this as it stands and we can continue doing further validation.

This PR includes changes from PR #258 to make the kernel tests not degenerate, since otherwise the CI won't really be validating much. I can rebase or update when that is merged. Only the last commit is part of this PR.