### PR TITLE
fix: colabfold stale cache for multimer example

### DIFF
--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -53,6 +53,15 @@ TQDM_BAR_FORMAT = (
 )
 
 
+class ColabFoldServerResultError(RuntimeError):
+    """Raised when a ColabFold MSA server download is missing expected outputs.
+
+    The public ColabFold server can return the wrong cached job for a ticket --
+    e.g. an unpaired MSA (no ``pair.a3m``) in response to a paired request -- which
+    otherwise surfaces as an opaque ``FileNotFoundError`` downstream (issue #269).
+    """
+
+
 class MsaServerPairingStrategy(IntEnum):
     """Enum for MSA server pairing strategy."""
 
@@ -61,6 +70,50 @@ class MsaServerPairingStrategy(IntEnum):
 
     def __str__(self) -> str:
         return self.name.lower()
+
+
+def _validate_expected_msa_files(
+    a3m_files: list[str], tar_gz_file: str, *, use_pairing: bool
+) -> None:
+    """Verify the download produced every expected a3m file (present and non-empty).
+
+    Guards against the ColabFold server returning an unexpected or incomplete result
+    (issue #269): instead of letting a later ``open()`` raise a bare
+    ``FileNotFoundError``, raise a clear error naming the expected files, the missing
+    ones, and what the downloaded tarball actually contained.
+
+    Args:
+        a3m_files: Absolute paths of the a3m files this query is expected to yield.
+        tar_gz_file: Path of the downloaded ``out.tar.gz`` (read only for diagnostics).
+        use_pairing: Whether this was a paired query (used only for the message).
+
+    Raises:
+        ColabFoldServerResultError: If any expected file is missing or empty.
+    """
+    missing: list[str] = [
+        f for f in a3m_files if not os.path.isfile(f) or os.path.getsize(f) == 0
+    ]
+    if not missing:
+        return
+
+    try:
+        with tarfile.open(tar_gz_file) as tar_gz:
+            members: list[str] = sorted(m.name for m in tar_gz.getmembers())
+    except (tarfile.TarError, OSError):
+        members = ["<missing or unreadable out.tar.gz>"]
+
+    query_kind = "paired" if use_pairing else "unpaired"
+    raise ColabFoldServerResultError(
+        f"ColabFold {query_kind} MSA query returned an unexpected or incomplete "
+        "result.\n"
+        f"  expected (non-empty): {[os.path.basename(f) for f in a3m_files]}\n"
+        f"  missing/empty:        {[os.path.basename(f) for f in missing]}\n"
+        f"  tarball contained:    {members}\n"
+        f"  download:             {tar_gz_file}\n"
+        "The MSA server likely returned the wrong cached job for this query "
+        "(e.g. an unpaired result for a paired request; see issue #269). Delete the "
+        "raw output directory and retry."
+    )
 
 
 def query_colabfold_msa_server(
@@ -338,6 +391,10 @@ def query_colabfold_msa_server(
     if any(not os.path.isfile(a3m_file) for a3m_file in a3m_files):
         with tarfile.open(tar_gz_file) as tar_gz:
             tar_gz.extractall(path)
+
+    # Validate the download produced the expected outputs before any downstream
+    # code blindly opens them (issue #269).
+    _validate_expected_msa_files(a3m_files, tar_gz_file, use_pairing=use_pairing)
 
     # Process templates
     if use_templates:

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -14,10 +14,13 @@
 
 """Tests for the ColabFold MSA server module."""
 
+import io
 import json
 import shutil
+import tarfile
 import textwrap
 from pathlib import Path
+from typing import NamedTuple
 from unittest.mock import patch
 
 import pandas as pd
@@ -30,6 +33,7 @@ from openfold3.core.data.pipelines.preprocessing.template import (
 )
 from openfold3.core.data.tools.colabfold_msa_server import (
     ColabFoldQueryRunner,
+    ColabFoldServerResultError,
     ComplexGroup,
     MsaComputationSettings,
     add_msa_paths_to_iqs,
@@ -550,6 +554,102 @@ class TestColabFoldQueryRunner:
             preprocess_colabfold_msas(
                 inference_query_set=query, compute_settings=msa_compute_settings
             )
+
+
+class _ValidationCase(NamedTuple):
+    """A bad ColabFold download and the error it should trigger (issue #269)."""
+
+    members: dict[str, bytes]  # tarball contents (name -> bytes)
+    use_pairing: bool
+    match: str  # substring expected in the raised error message
+
+
+# The server returned the wrong/incomplete job: the expected a3m file is absent or
+# empty in the downloaded tarball.
+_VALIDATION_CASES = [
+    pytest.param(
+        _ValidationCase(
+            members={
+                "uniref.a3m": b">101\nAAAA\n",
+                "bfd.mgnify30.metaeuk30.smag30.a3m": b">101\nAAAA\n",
+                "pdb70.m8": b"",
+            },
+            use_pairing=True,
+            match="pair.a3m",
+        ),
+        id="paired_gets_unpaired_tarball",
+    ),
+    pytest.param(
+        _ValidationCase(
+            members={"pdb70.m8": b"templates\n"},
+            use_pairing=False,
+            match="uniref.a3m",
+        ),
+        id="unpaired_missing_uniref",
+    ),
+    pytest.param(
+        _ValidationCase(
+            members={"pair.a3m": b""},
+            use_pairing=True,
+            match="pair.a3m",
+        ),
+        id="empty_pair_a3m",
+    ),
+]
+
+
+class TestQueryColabFoldServerValidation:
+    """Regression tests for issue #269.
+
+    The ColabFold server can return the wrong cached job for a ticket (e.g. an
+    unpaired MSA -- no ``pair.a3m`` -- for a paired request). ``query_colabfold_msa_
+    server`` must reject such a download with a clear ``ColabFoldServerResultError``
+    instead of crashing later on a bare ``FileNotFoundError``.
+    """
+
+    @staticmethod
+    def _write_tarball(out_tar_gz: Path, members: dict[str, bytes]) -> None:
+        """Write a gzipped tar of ``members`` (name -> bytes) at ``out_tar_gz``."""
+        with tarfile.open(out_tar_gz, "w:gz") as tar:
+            for name, data in members.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+    @pytest.mark.parametrize("case", _VALIDATION_CASES)
+    def test_rejects_unexpected_download(
+        self, case: _ValidationCase, tmp_path: Path
+    ) -> None:
+        """A download missing an expected a3m file raises ColabFoldServerResultError.
+
+        Pre-creating ``out.tar.gz`` makes ``query_colabfold_msa_server`` skip the
+        submit/download (no network) and go straight to extraction + validation.
+        """
+        self._write_tarball(tmp_path / "out.tar.gz", case.members)
+
+        with pytest.raises(ColabFoldServerResultError, match=case.match):
+            query_colabfold_msa_server(
+                ["AAAA", "CCCC"],
+                prefix=tmp_path,
+                user_agent="test-agent",
+                use_pairing=case.use_pairing,
+            )
+
+    def test_valid_paired_download_passes(self, tmp_path: Path) -> None:
+        """A paired download containing a valid pair.a3m returns the alignments."""
+        self._write_tarball(
+            tmp_path / "out.tar.gz",
+            {"pair.a3m": b">101\nAAAA\n\x00>102\nCCCC\n", "pair.sh": b"#\n"},
+        )
+
+        result = query_colabfold_msa_server(
+            ["AAAA", "CCCC"],
+            prefix=tmp_path,
+            user_agent="test-agent",
+            use_pairing=True,
+        )
+
+        assert len(result) == 2
 
 
 class TestRemapObsoletePdb:


### PR DESCRIPTION
**Summary**

Fixes https://github.com/aqlaboratory/openfold-3/issues/269

**Changes**

Check the tar.gz we get out of the colabfold server, check if expected files exist. We obviously can't control what's in their caches, so I will just raise an error. 

**Related Issues**

**Testing**

**Other Notes**
