### PR TITLE
Do boolean mask sums directly in fp32

### DIFF
--- a/openfold3/core/loss/confidence.py
+++ b/openfold3/core/loss/confidence.py
@@ -252,7 +252,7 @@ def all_atom_plddt_loss(
         * ((d < 0.5).int() + (d < 1).int() + (d < 2).int() + (d < 4).int())
         * pair_mask,
         dim=-1,
-    ) / (torch.sum(pair_mask, dim=-1) + eps)
+    ) / (torch.sum(pair_mask, dim=-1, dtype=torch.float32) + eps)
 
     # Compute binned lddt
     # [*, N_atom, no_bins]
@@ -264,7 +264,7 @@ def all_atom_plddt_loss(
 
     # Compute loss on plddt
     l_plddt = torch.sum(errors * atom_mask_gt, dim=-1) / (
-        torch.sum(atom_mask_gt, dim=-1) + eps
+        torch.sum(atom_mask_gt, dim=-1, dtype=torch.float32) + eps
     )
 
     return l_plddt
@@ -423,7 +423,7 @@ def pde_loss(
 
     # Compute loss on predicted distance error
     l_pde = torch.sum(errors * pair_mask, dim=(-1, -2)) / (
-        torch.sum(pair_mask, dim=(-1, -2)) + eps
+        torch.sum(pair_mask, dim=(-1, -2), dtype=torch.float32) + eps
     )
 
     return l_pde
@@ -460,7 +460,7 @@ def all_atom_experimentally_resolved_loss(
     errors = softmax_cross_entropy(logits, y_b)
 
     l_resolved = torch.sum(errors * atom_mask, dim=-1) / (
-        torch.sum(atom_mask, dim=-1) + eps
+        torch.sum(atom_mask, dim=-1, dtype=torch.float32) + eps
     )
 
     return l_resolved

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -229,8 +229,11 @@ def bond_loss(x: torch.Tensor, batch: dict, eps: float) -> torch.Tensor:
     # Compute polymer-ligand bond loss
     mask = (bond_mask * (atom_mask_gt[..., None] * atom_mask_gt[..., None, :])).bool()
 
+    # Sum the mask directly in fp32 to avoids a slow int64 reduce followed by
+    # immediately throwing away the accuracy that gave us when addition of eps
+    # autocasts to float.
     loss = torch.sum((dx - dx_gt) ** 2 * mask, dim=(-1, -2)) / (
-        torch.sum(mask, dim=(-1, -2)) + eps
+        torch.sum(mask, dim=(-1, -2), dtype=torch.float32) + eps
     )
 
     return loss
@@ -407,10 +410,12 @@ def smooth_lddt_loss(
 
     mask = (mask * (loss_atom_mask[..., None] * loss_atom_mask[..., None, :])).bool()
 
-    ce_mean = torch.sum(c * e * mask, dim=(-1, -2)) / (
-        torch.sum(mask, dim=(-1, -2)) + eps
-    )
-    c_mean = torch.sum(c * mask, dim=(-1, -2)) / (torch.sum(mask, dim=(-1, -2)) + eps)
+    # Sum the mask directly in fp32 to avoids a slow int64 reduce followed by
+    # immediately throwing away the accuracy that gave us when addition of eps
+    # autocasts to float.
+    mask_sum = torch.sum(mask, dim=(-1, -2), dtype=torch.float32) + eps
+    ce_mean = torch.sum(c * e * mask, dim=(-1, -2)) / mask_sum
+    c_mean = torch.sum(c * mask, dim=(-1, -2)) / mask_sum
     lddt = ce_mean / (c_mean + eps)
 
     return 1 - lddt

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -55,13 +55,13 @@ def weighted_rigid_align(
 
     # Mean-centre positions
     w_mean = torch.sum(w * atom_mask_gt, dim=-1, keepdim=True) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True) + eps
+        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
     )
     wx_mean = torch.sum(x * w[..., None] * atom_mask_gt[..., None], dim=-2) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True) + eps
+        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
     )
     wx_gt_mean = torch.sum(x_gt * w[..., None] * atom_mask_gt[..., None], dim=-2) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True) + eps
+        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
     )
     mu = wx_mean / w_mean
     mu_gt = wx_gt_mean / w_mean

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -229,9 +229,6 @@ def bond_loss(x: torch.Tensor, batch: dict, eps: float) -> torch.Tensor:
     # Compute polymer-ligand bond loss
     mask = (bond_mask * (atom_mask_gt[..., None] * atom_mask_gt[..., None, :])).bool()
 
-    # Sum the mask directly in fp32 to avoids a slow int64 reduce followed by
-    # immediately throwing away the accuracy that gave us when addition of eps
-    # autocasts to float.
     loss = torch.sum((dx - dx_gt) ** 2 * mask, dim=(-1, -2)) / (
         torch.sum(mask, dim=(-1, -2), dtype=torch.float32) + eps
     )
@@ -410,9 +407,6 @@ def smooth_lddt_loss(
 
     mask = (mask * (loss_atom_mask[..., None] * loss_atom_mask[..., None, :])).bool()
 
-    # Sum the mask directly in fp32 to avoids a slow int64 reduce followed by
-    # immediately throwing away the accuracy that gave us when addition of eps
-    # autocasts to float.
     mask_sum = torch.sum(mask, dim=(-1, -2), dtype=torch.float32) + eps
     ce_mean = torch.sum(c * e * mask, dim=(-1, -2)) / mask_sum
     c_mean = torch.sum(c * mask, dim=(-1, -2)) / mask_sum

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -53,18 +53,13 @@ def weighted_rigid_align(
     """
     atom_mask_gt = atom_mask_gt.bool()
 
-    # Mean-centre positions
-    w_mean = torch.sum(w * atom_mask_gt, dim=-1, keepdim=True) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
+    # Mean-centre positions. The atom-count normaliser cancels between the
+    # weighted-position mean and the weight mean, so divide the sums directly.
+    w_sum = torch.sum(w * atom_mask_gt, dim=-1, keepdim=True)
+    mu = torch.sum(x * w[..., None] * atom_mask_gt[..., None], dim=-2) / (w_sum + eps)
+    mu_gt = torch.sum(x_gt * w[..., None] * atom_mask_gt[..., None], dim=-2) / (
+        w_sum + eps
     )
-    wx_mean = torch.sum(x * w[..., None] * atom_mask_gt[..., None], dim=-2) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
-    )
-    wx_gt_mean = torch.sum(x_gt * w[..., None] * atom_mask_gt[..., None], dim=-2) / (
-        torch.sum(atom_mask_gt, dim=-1, keepdim=True, dtype=torch.float32) + eps
-    )
-    mu = wx_mean / w_mean
-    mu_gt = wx_gt_mean / w_mean
     x = x - mu[..., None, :]
     x_gt = x_gt - mu_gt[..., None, :]
 
@@ -407,10 +402,11 @@ def smooth_lddt_loss(
 
     mask = (mask * (loss_atom_mask[..., None] * loss_atom_mask[..., None, :])).bool()
 
-    mask_sum = torch.sum(mask, dim=(-1, -2), dtype=torch.float32) + eps
-    ce_mean = torch.sum(c * e * mask, dim=(-1, -2)) / mask_sum
-    c_mean = torch.sum(c * mask, dim=(-1, -2)) / mask_sum
-    lddt = ce_mean / (c_mean + eps)
+    # The atom-pair-count normaliser cancels between ce_mean and c_mean, so take
+    # the ratio of the masked sums directly.
+    lddt = torch.sum(c * e * mask, dim=(-1, -2)) / (
+        torch.sum(c * mask, dim=(-1, -2)) + eps
+    )
 
     return 1 - lddt
 

--- a/openfold3/core/loss/distogram.py
+++ b/openfold3/core/loss/distogram.py
@@ -124,7 +124,7 @@ def all_atom_distogram_loss(
 
     # Compute distogram loss
     loss = torch.sum(errors * pair_mask, dim=(-1, -2)) / (
-        torch.sum(pair_mask, dim=(-1, -2)) + eps
+        torch.sum(pair_mask, dim=(-1, -2), dtype=torch.float32) + eps
     )
 
     distogram_weight = batch["loss_weights"]["distogram"]

--- a/openfold3/core/loss/loss_utils.py
+++ b/openfold3/core/loss/loss_utils.py
@@ -175,4 +175,4 @@ def loss_masked_batch_mean(
     if apply_weight:
         loss = loss * weight
 
-    return torch.sum(loss * mask) / (torch.sum(mask) + eps)
+    return torch.sum(loss * mask) / (torch.sum(mask, dtype=torch.float32) + eps)

--- a/openfold3/tests/data_utils.py
+++ b/openfold3/tests/data_utils.py
@@ -317,3 +317,31 @@ def create_atomarray_with_bondlist(
     atom_array.bonds = bondlist
 
     return atom_array
+
+
+def atomized_single_atom_batch(n_token: int) -> dict:
+    """Batch of ``n_token`` single-atom, atomized tokens for loss tests.
+
+    Every token is atomized with exactly one atom, so the representative-atom
+    and atom masks are all-true and their counts scale directly with
+    ``n_token``.
+    """
+    return {
+        "token_mask": torch.ones((1, n_token)),
+        "atom_mask": torch.ones((1, n_token)),
+        "restype": torch.nn.functional.one_hot(
+            torch.zeros(1, n_token).long(), 32
+        ).float(),
+        "num_atoms_per_token": torch.ones((1, n_token)),
+        "start_atom_index": torch.arange(n_token).unsqueeze(0).float(),
+        "asym_id": torch.zeros((1, n_token)),
+        "is_protein": torch.zeros((1, n_token)),
+        "is_rna": torch.zeros((1, n_token)),
+        "is_dna": torch.zeros((1, n_token)),
+        "is_atomized": torch.ones((1, n_token)),
+        "ground_truth": {
+            "atom_resolved_mask": torch.ones((1, n_token)),
+            "atom_positions": torch.randn((1, n_token, 3)),
+        },
+        "loss_weights": {"distogram": torch.Tensor([1.0])},
+    }

--- a/openfold3/tests/test_confidence_loss.py
+++ b/openfold3/tests/test_confidence_loss.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import unittest
 
+import pytest
 import torch
 import torch.nn.functional as F
 
@@ -25,8 +27,10 @@ from openfold3.core.loss.confidence import (
     pde_loss,
 )
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
+from openfold3.tests.data_utils import atomized_single_atom_batch
 
 
+@pytest.mark.usefixtures("seeded_rng")
 class TestConfidenceLoss(unittest.TestCase):
     def setup_features(self):
         # Example: UNK UNK UNK ALA GLY/A A DT
@@ -155,6 +159,29 @@ class TestConfidenceLoss(unittest.TestCase):
 
         self.assertTrue(l_pde.shape == (batch_size,))
 
+    def test_pde_loss_zero_logits(self):
+        # With an all-true mask and all-zero logits, softmax_cross_entropy
+        # returns log(no_bins) for every (one-hot) target, so the true loss is
+        # log(no_bins). This test is constructed such that if we were to
+        # accumulate the mask sum divisor in bfloat16, it would fail because
+        # n_token**2 = 122,500 is not precisely representable.
+        n_token, no_bins = 350, 8
+        batch = atomized_single_atom_batch(n_token)
+        x = torch.randn((1, n_token, 3))
+        logits = torch.zeros((1, n_token, n_token, no_bins))
+
+        loss = pde_loss(
+            batch=batch,
+            x=x,
+            logits=logits,
+            no_bins=no_bins,
+            bin_min=0,
+            bin_max=32,
+            eps=1e-8,
+        )
+
+        self.assertAlmostEqual(loss.item(), math.log(no_bins), delta=1e-6)
+
     def test_resolved_loss(self):
         no_bins = 2
         eps = 1e-8
@@ -169,6 +196,18 @@ class TestConfidenceLoss(unittest.TestCase):
         )
 
         self.assertTrue(l_resolved.shape == (batch_size,))
+
+    def test_resolved_loss_zero_logits(self):
+        # Same idea as test_pde_loss_zero_logits.
+        n_atom, no_bins = 50000, 2
+        batch = atomized_single_atom_batch(n_atom)
+        logits = torch.zeros((1, n_atom, no_bins))
+
+        loss = all_atom_experimentally_resolved_loss(
+            batch=batch, logits=logits, no_bins=no_bins, eps=1e-8
+        )
+
+        self.assertAlmostEqual(loss.item(), math.log(no_bins), delta=1e-6)
 
     def test_confidence_loss(self):
         batch = self.setup_features()

--- a/openfold3/tests/test_diffusion_loss.py
+++ b/openfold3/tests/test_diffusion_loss.py
@@ -14,8 +14,10 @@
 
 import unittest
 
+import pytest
 import torch
 import torch.nn.functional as F
+from torch.testing import assert_close
 
 from openfold3.core.loss.diffusion import (
     bond_loss,
@@ -28,6 +30,7 @@ from openfold3.core.model.structure.diffusion_module import centre_random_augmen
 from openfold3.tests.config import consts
 
 
+@pytest.mark.usefixtures("seeded_rng")
 class TestDiffusionLoss(unittest.TestCase):
     def setup_features(self):
         # Example: UNK UNK UNK ALA GLY/A A DT
@@ -96,6 +99,27 @@ class TestDiffusionLoss(unittest.TestCase):
         self.assertTrue(x_align.shape == (batch_size, n_atom, 3))
         self.assertTrue(torch.sum(torch.abs(x_align - x_gt) > 1e-5) == 0)
 
+    def test_weighted_rigid_align_ignores_masked_atoms(self):
+        # Masked-out atoms must not enter the centroid/covariance: with garbage
+        # at the masked positions the valid atoms must still recover x_gt.
+        k, g = 12, 6
+        theta = torch.tensor(0.7)
+        c, s = torch.cos(theta), torch.sin(theta)
+        rot = torch.tensor([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+        x_gt_valid = torch.randn(1, k, 3)
+        x_valid = x_gt_valid @ rot.T + torch.tensor([3.0, -1.0, 2.0])
+
+        x_gt = torch.cat([x_gt_valid, 1e3 * torch.randn(1, g, 3)], dim=1)
+        x = torch.cat([x_valid, 1e3 * torch.randn(1, g, 3)], dim=1)
+        mask = torch.cat([torch.ones(1, k), torch.zeros(1, g)], dim=1)
+
+        x_align = weighted_rigid_align(
+            x=x, x_gt=x_gt, w=torch.ones(1, k + g), atom_mask_gt=mask, eps=1e-8
+        )
+
+        assert_close(x_align[:, :k], x_gt_valid)
+
     def test_mse_loss(self):
         n_sample = 2
         dna_weight = 5
@@ -156,6 +180,38 @@ class TestDiffusionLoss(unittest.TestCase):
         self.assertTrue(loss.shape == (batch_size, n_sample))
         self.assertTrue((loss < 1e-5).all())
 
+    def test_bond_loss_value(self):
+        # Two coincident clusters of m single-atom polymer+ligand tokens make
+        # the bond mask all-true. Predicted cluster B is twice as far as the
+        # ground-truth B, so every cross-cluster pair has squared error exactly
+        # 1 while within-cluster pairs and the diagonal are 0; half the ordered
+        # pairs are cross-cluster, so the masked mean is exactly 0.5. The input
+        # is large enough that a less precise accumulator for the mask sum (e.g.
+        # bf16) would have a noticeable difference.
+        m = 175
+        n = 2 * m
+        x_gt = torch.zeros((1, n, 3))
+        x_gt[:, m:, 0] = 1.0
+        x = torch.zeros((1, n, 3))
+        x[:, m:, 0] = 2.0
+        batch = {
+            "token_mask": torch.ones((1, n)),
+            "num_atoms_per_token": torch.ones((1, n)),
+            "is_protein": torch.ones((1, n)),
+            "is_dna": torch.zeros((1, n)),
+            "is_rna": torch.zeros((1, n)),
+            "is_ligand": torch.ones((1, n)),
+            "token_bonds": torch.ones((1, n, n)),
+            "ground_truth": {
+                "atom_resolved_mask": torch.ones((1, n)),
+                "atom_positions": x_gt,
+            },
+        }
+
+        loss = bond_loss(x=x, batch=batch, eps=1e-8)
+
+        self.assertAlmostEqual(loss.item(), 0.5)
+
     def test_smooth_lddt_loss(self):
         n_sample = 2
 
@@ -192,6 +248,41 @@ class TestDiffusionLoss(unittest.TestCase):
 
         assert torch.equal(torch.nonzero(loss_masked), torch.nonzero(mostly_zeros_mask))
         assert torch.all(torch.not_equal(loss_masked, loss))
+
+    def test_smooth_lddt_loss_ignores_masked_atoms(self):
+        # Masked-out atoms must not affect the loss: adding extra atoms whose
+        # ground truth would count but whose prediction is wildly wrong (would
+        # drag the loss up markedly if they leaked), masked out, must give the
+        # same loss as not having them at all.
+        n = 10
+        extra = 5
+        x_gt = torch.randn(1, n + extra, 3)
+        x = torch.randn(1, n + extra, 3)
+        mask = torch.cat([torch.ones(1, n), torch.zeros(1, extra)], dim=1)
+
+        def run(positions_gt, positions, resolved_mask):
+            n_tok = positions_gt.shape[1]
+            batch = {
+                "token_mask": torch.ones((1, n_tok)),
+                "num_atoms_per_token": torch.ones((1, n_tok)),
+                "is_dna": torch.zeros((1, n_tok)),
+                "is_rna": torch.zeros((1, n_tok)),
+                "ground_truth": {
+                    "atom_resolved_mask": resolved_mask,
+                    "atom_positions": positions_gt,
+                },
+            }
+            return smooth_lddt_loss(
+                x=positions,
+                batch=batch,
+                loss_token_mask=torch.ones((1, n_tok)),
+                eps=1e-8,
+            )
+
+        loss_valid = run(x_gt[:, :n, :], x[:, :n, :], mask[:, :n])
+        loss_masked = run(x_gt, x, mask)
+
+        self.assertAlmostEqual(loss_masked.item(), loss_valid.item(), delta=1e-6)
 
     def _test_diffusion_loss(self, batch):
         n_sample = 2

--- a/openfold3/tests/test_distogram_loss.py
+++ b/openfold3/tests/test_distogram_loss.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import unittest
 
+import pytest
 import torch
 import torch.nn.functional as F
 
 from openfold3.core.loss.distogram import all_atom_distogram_loss
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
+from openfold3.tests.data_utils import atomized_single_atom_batch
 
 
+@pytest.mark.usefixtures("seeded_rng")
 class TestDistogramLoss(unittest.TestCase):
     def setup_features(self):
         # Example: UNK UNK UNK ALA GLY/A A DT
@@ -76,6 +80,23 @@ class TestDistogramLoss(unittest.TestCase):
         )
 
         self.assertTrue(l.shape == ())
+
+    def test_distogram_loss_zero_logits(self):
+        # Same idea as test_pde_loss_zero_logits
+        n_token, no_bins = 350, 8
+        batch = atomized_single_atom_batch(n_token)
+        logits = torch.zeros((1, n_token, n_token, no_bins))
+
+        loss, _ = all_atom_distogram_loss(
+            batch=batch,
+            logits=logits,
+            no_bins=no_bins,
+            bin_min=0,
+            bin_max=32,
+            eps=1e-8,
+        )
+
+        self.assertAlmostEqual(loss.item(), math.log(no_bins), delta=1e-6)
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/test_loss_utils.py
+++ b/openfold3/tests/test_loss_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pytest
+import torch
+
+from openfold3.core.loss.loss_utils import loss_masked_batch_mean
+
+
+@pytest.mark.usefixtures("seeded_rng")
+class TestLossUtils(unittest.TestCase):
+    def test_loss_masked_batch_mean_is_precise(self):
+        # Confirm we don't lose precision. The input is constructed such that if
+        # we used bfloat16 to sum the mask divisor, we would lose precision
+        # (because 50,000 is not precisely representable in bf16).
+        n = 50_000
+        value = 3.0
+        loss = torch.full((n, 1), value)
+        weight = torch.ones((n, 1))
+
+        result = loss_masked_batch_mean(
+            loss=loss, weight=weight, apply_weight=False, eps=1e-8
+        )
+
+        self.assertAlmostEqual(result.item(), value, delta=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Summary**

In a few loss computations, we sum over a mask. These sums get computed in i64 by default, which is a bit slow. Then when we add epsilon (and even if we didn't, when we use them as a divisor), they get converted to fp32. The precision loss of just doing this in fp32 in the first place is negligible.

The diffusion loss sums over all atoms showed up on a training profile I did on MI300X. I saw ~5% training step speedup with that change. I did a sweep for the same pattern elsewhere and updated those as well, as I think it's just a good practice, but those are smaller and didn't show up in the profile (OTOH because they're smaller, the fp32 will be bit-exact). I could revert those commits if you prefer.

**Changes**
- Change sums over boolean mask tensors used in loss denominators to use float32 when the result is immediately added to a float epsilon.
- Dropped mask sums that cancel entirely.

**Testing**
- Did some sanity checking here that torch.sum in fp32 doesn't lose significant precision vs using int64 and then casting.
- Did a training step starting from trained weights and confirmed no major disruption (cosine similarity >0.999, relative grad norm difference <1%)
- Unit tests for large edge case inputs


