### PR TITLE
fix: unblock ci/cd with checkout@v7

### DIFF
--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -52,8 +52,9 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-        with: 
+        with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v4


### PR DESCRIPTION
**Summary**

Required by actions/checkout@v7 to check out fork PR code under pull_request_target. 

Safe here: public-repo fork runs are gated behind the 'safe-to-test' label (see ci-test.yml), so a maintainer reviews the diff before this trusted-context build runs.

Needed to unblock 
- https://github.com/aqlaboratory/openfold-3/pull/227
- https://github.com/aqlaboratory/openfold-3/pull/284

Both of which have the 'safe-to-test' label but the tests refuse to run

**Changes**

**Related Issues**

**Testing**

**Other Notes**
