### PR TITLE
refactor: silence benign nvcc warning

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -336,6 +336,13 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   # Change torch extensions cache, used by deepspeed, to be isolated
   env.TORCH_EXTENSIONS_DIR = "$CONDA_PREFIX/caches/torch_extensions"
 
+  # Silence: "nvcc warning : incompatible redefinition for option 'compiler-bindir'".
+  # The conda cuda-nvcc activation prepends `-ccbin=$CXX` (…-c++) via NVCC_PREPEND_FLAGS,
+  # while torch's cpp_extension appends `-ccbin $CC` (…-cc) on the command line; torch's
+  # dedup guard can't see the prepended value, so nvcc gets two conflicting -ccbin. Align
+  # the prepend to $CC so both agree (no behaviour change: nvcc already used $CC last).
+  env.NVCC_PREPEND_FLAGS = "-ccbin=$CC"
+
 
 # --- CuEquivariance
 # https://developer.nvidia.com/cuequivariance#section-get-started


### PR DESCRIPTION
**Summary**

Removes the repeated nvcc warning : incompatible redefinition for option 'compiler-bindir' messages emitted when the DeepSpeed evoformer_attn CUDA extension is JIT-compiled (at first inference) in the CUDA pixi environments.

**Changes**

pixi.toml: in [feature.deepspeed-build.activation], set env.NVCC_PREPEND_FLAGS = "-ccbin=$CC" so the prepended -ccbin matches the one PyTorch injects. This is a no-op functionally — nvcc already used $CC (the last value) — it just stops the two from disagreeing.

**Related Issues**

**Testing**

**Other Notes**
