### PR TITLE
Changes openfold3 inference defaults to not use deepspeed

### DIFF
--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -113,7 +113,7 @@ model_config = mlc.ConfigDict(
                 "eval": {
                     "chunk_size": None,
                     "tune_chunk_size": tune_chunk_size,
-                    "use_deepspeed_evo_attention": not _is_rocm,
+                    "use_deepspeed_evo_attention": False,
                     "use_cueq_triangle_kernels": False,
                     "use_triton_triangle_kernels": _is_rocm,
                     "use_lma": False,

--- a/openfold3/tests/test_inference_full.py
+++ b/openfold3/tests/test_inference_full.py
@@ -43,7 +43,6 @@ from openfold3.tests.compare_utils import skip_unless_cuda_available
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
-
 protein_only_query = InferenceQuerySet.model_validate(
     {
         "queries": {
@@ -86,11 +85,6 @@ inference_test_yaml_str = textwrap.dedent("""\
       presets:
         - predict
         - low_mem
-      custom:
-        settings:
-          memory:
-            eval:
-              use_deepspeed_evo_attention: false
     """)
 
 


### PR DESCRIPTION
**Summary**
Fixes an issue where default settings for inference still uses the deepspeed kernel. The fix is to change the default settings for inference to not use the deepspeed kernel, which was omitted from the [original 0.4.2 release candidate](https://github.com/aqlaboratory/openfold-3/pull/277)

Also fixes a bug with inference integration test where deepspeed settings were hard coded to be False, which is how this error was overlooked in testing.

**Changes**
- Updates model defaults for inference
- Updates `openfold3/tests/test_inference_full.py` to remove manual deepspeed settings
- Tagged with release 0.4.3

**Related Issues**

**Testing**
-[x] Test default inference settings e.g. `run_openfold predict --query-json=query_ubiqutiin.json` works with new installation
-[x] Test that `test_inference_full.py` breaks when the deepspeed manual settings are removed and the defaults in `model_config.json` are not updated.

**Other Notes**
