### PR TITLE
fix: make ColabFold MSA client robust to double-slash URL and unmappable template chains

### DIFF
--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -110,6 +110,13 @@ def query_colabfold_msa_server(
             is True, also returns a list of template paths for each sequence.
     """
 
+    # host_url may arrive as a pydantic Url (or a str). pydantic normalizes a bare
+    # authority to a trailing slash ("https://api.colabfold.com/"), so building request
+    # URLs as f"{host_url}/{endpoint}" would produce a double slash
+    # ("https://api.colabfold.com//ticket/msa"), which the server rejects with HTTP 400.
+    # Normalize to a plain string without a trailing slash so exactly one slash appears.
+    host_url = str(host_url).rstrip("/")
+
     submission_endpoint = "ticket/pair" if use_pairing else "ticket/msa"
 
     headers = {}
@@ -686,23 +693,34 @@ def remap_colabfold_template_chain_ids(
         for entry_id, l2a in label_to_author_maps.items()
     }
 
-    # Remap chain IDs
-    for top_n in per_rep.values():
+    # Remap chain IDs. Drop (rather than raise on) template hits whose author chain ID
+    # no longer maps to a label chain -- e.g. RCSB re-labeled the entry's author chains
+    # since pdb100 was built, so a pdb100 hit like "7t3m_J" references a chain that no
+    # longer exists. The rows are filtered alongside the remapped IDs so that the length
+    # of column 1 stays consistent with the DataFrame.
+    for rep_id, top_n in list(per_rep.items()):
         remapped_ids = []
+        keep_mask = []
         for template_id in top_n[1]:
             entry_id, author_chain_id = template_id.split("_")
 
             author_to_label = author_to_label_maps.get(entry_id, {})
             if author_chain_id not in author_to_label:
-                raise RuntimeError(
+                logger.warning(
                     f"Author chain {author_chain_id} not found in {entry_id}. "
-                    f"Available author chains: {sorted(author_to_label.keys())}"
+                    f"Available author chains: {sorted(author_to_label.keys())}. "
+                    "Dropping this template hit."
                 )
+                keep_mask.append(False)
+                continue
             label_chain_id = author_to_label[author_chain_id][0]
 
             remapped_ids.append(f"{entry_id}_{label_chain_id}")
+            keep_mask.append(True)
 
+        top_n = top_n[keep_mask].copy()
         top_n[1] = remapped_ids
+        per_rep[rep_id] = top_n
 
     return per_rep
 

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -17,10 +17,11 @@
 import json
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from pydantic_core import Url
 
 from openfold3.core.data.framework.data_module import DataModule, DataModuleConfig
 from openfold3.core.data.pipelines.preprocessing.template import (
@@ -34,6 +35,7 @@ from openfold3.core.data.tools.colabfold_msa_server import (
     collect_colabfold_msa_data,
     get_sequence_hash,
     preprocess_colabfold_msas,
+    query_colabfold_msa_server,
     remap_colabfold_template_chain_ids,
 )
 from openfold3.projects.of3_all_atom.config.dataset_config_components import MSASettings
@@ -160,15 +162,39 @@ class TestRemapColabfoldTemplateChainIds:
         assert remapped_ids[1] == "4pqx_A"
 
     @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
-    def test_unknown_author_chain_raises(self, _mock_fetch):
-        """When the author chain ID isn't in the API response, raise."""
-        with pytest.raises(RuntimeError, match="Author chain Z not found in 1rnb"):
-            remap_colabfold_template_chain_ids(
-                template_alignments=_make_m8_dataframe(["1rnb_Z"]),
-                m_with_templates={101},
-                rep_ids=["rep1"],
-                rep_id_to_m={"rep1": 101},
-            )
+    def test_unmappable_author_chain_is_dropped(self, _mock_fetch):
+        """A hit whose author chain isn't in the map is dropped, not raised."""
+        result = remap_colabfold_template_chain_ids(
+            template_alignments=_make_m8_dataframe(["1rnb_Z"]),
+            m_with_templates={101},
+            rep_ids=["rep1"],
+            rep_id_to_m={"rep1": 101},
+        )
+
+        assert "rep1" in result
+        assert result["rep1"][1].tolist() == []
+        assert len(result["rep1"]) == 0
+
+    @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
+    def test_unmappable_hit_dropped_mappable_kept(self, _mock_fetch):
+        """Unmappable hits are filtered out while mappable hits are remapped.
+
+        The dropped row must be removed from the DataFrame as well, so column 1
+        stays the same length as the frame.
+        """
+        result = remap_colabfold_template_chain_ids(
+            template_alignments=_make_m8_dataframe(["1rnb_Z", "1rnb_A", "4pqx_A"]),
+            m_with_templates={101},
+            rep_ids=["rep1"],
+            rep_id_to_m={"rep1": 101},
+        )
+
+        remapped = result["rep1"]
+        # 1rnb_Z is unmappable and dropped; the other two remain and are remapped.
+        assert remapped[1].tolist() == ["1rnb_B", "4pqx_A"]
+        assert len(remapped) == 2
+        # The e-value column (10) should still line up with the surviving rows.
+        assert len(remapped[10]) == len(remapped[1])
 
     def test_skips_rep_without_templates(self):
         """Rep IDs not in m_with_templates should be skipped (no fetch needed)."""
@@ -524,3 +550,71 @@ class TestMsaComputationSettings:
         assert "Output directory mismatch" in str(exc_info.value), (
             "Expected ValueError on output directory conflict"
         )
+
+
+class TestQueryUrlConstruction:
+    """The ColabFold host may carry a trailing slash (pydantic Url normalization).
+
+    Request URLs must still contain exactly one slash before the endpoint, otherwise
+    the server rejects the double-slash URL with HTTP 400.
+    """
+
+    @staticmethod
+    def _complete_post_response():
+        response = MagicMock()
+        response.json.return_value = {"status": "COMPLETE", "id": "jobid"}
+        return response
+
+    @patch("openfold3.core.data.tools.colabfold_msa_server.requests")
+    def test_submit_url_has_no_double_slash(self, mock_requests, tmp_path):
+        # A bare pydantic Url normalizes to a trailing slash: this is the bug trigger.
+        host = Url("https://dummy.url")
+        assert str(host).endswith("/")
+
+        prefix = tmp_path / "raw" / "main"
+        prefix.mkdir(parents=True, exist_ok=True)
+        # Pre-create the expected a3m so extraction/parsing runs without a real tarball.
+        (prefix / "uniref.a3m").write_text(">101\nSEQ\n")
+
+        mock_requests.post.return_value = self._complete_post_response()
+        mock_requests.get.return_value = MagicMock(content=b"")
+
+        query_colabfold_msa_server(
+            ["SEQ"],
+            prefix=prefix,
+            user_agent="test-agent",
+            use_templates=False,
+            use_pairing=False,
+            use_env=False,
+            host_url=host,
+        )
+
+        submit_url = mock_requests.post.call_args.args[0]
+        assert submit_url == "https://dummy.url/ticket/msa"
+        # No "//" after the scheme separator.
+        assert "//" not in submit_url.split("://", 1)[1]
+
+        download_url = mock_requests.get.call_args.args[0]
+        assert "//" not in download_url.split("://", 1)[1]
+
+    @patch("openfold3.core.data.tools.colabfold_msa_server.requests")
+    def test_submit_url_ok_for_plain_string_host(self, mock_requests, tmp_path):
+        prefix = tmp_path / "raw" / "main"
+        prefix.mkdir(parents=True, exist_ok=True)
+        (prefix / "uniref.a3m").write_text(">101\nSEQ\n")
+
+        mock_requests.post.return_value = self._complete_post_response()
+        mock_requests.get.return_value = MagicMock(content=b"")
+
+        query_colabfold_msa_server(
+            ["SEQ"],
+            prefix=prefix,
+            user_agent="test-agent",
+            use_templates=False,
+            use_pairing=False,
+            use_env=False,
+            host_url="https://api.colabfold.com",
+        )
+
+        submit_url = mock_requests.post.call_args.args[0]
+        assert submit_url == "https://api.colabfold.com/ticket/msa"


### PR DESCRIPTION
## Summary
Two independent robustness bugs in the ColabFold MSA client (`openfold3/core/data/tools/colabfold_msa_server.py`) cause hard failures during MSA preprocessing. Both are fixed here, each with a fail-verified test.

## Bug 1 — double-slash request URL → HTTP 400
On the pipeline path the host is a `pydantic_core.Url` (`MsaComputationSettings.server_url`, `ColabFoldQueryRunner.host_url`). Stringifying a bare-authority `Url` yields the spec-canonical trailing slash: `str(Url("https://api.colabfold.com")) == "https://api.colabfold.com/"`. The request URLs are built as `f"{host_url}/{endpoint}"`, so the pipeline path produces `https://api.colabfold.com//ticket/msa` (double slash), which the server rejects with `400 "invalid ID"`. Plain string-host callers were unaffected (no trailing slash), which is why this only surfaces via the settings/pipeline path.

Fix: normalize the host once at the top of `query_colabfold_msa_server` — `host_url = str(host_url).rstrip("/")`. This covers both `Url` and `str` inputs and all four join sites (submit / status / download / template).

## Bug 2 — one unmappable template chain aborts the whole job
`remap_colabfold_template_chain_ids` raises `RuntimeError` when a pdb100 template hit references an author chain absent from the RCSB author->label map (observed: `7t3m_J`; RCSB 7t3m exposes A/C/D/G/H/I). It runs inside `query_format_main` during MSA preprocessing, so a single stale template hit aborts the entire prediction — even when templates are disabled downstream.

Fix: skip-and-drop unmappable hits (with a warning) instead of raising, filtering the alignment rows so the remapped column stays row-aligned. Mappable hits are preserved.

## Tests
- Replaced `test_unknown_author_chain_raises` (asserted the old raise) with `test_unmappable_author_chain_is_dropped` and `test_unmappable_hit_dropped_mappable_kept`.
- Added `TestQueryUrlConstruction`: `Url` and `str` hosts both yield single-slash submit/download URLs.

All new tests fail on the pre-fix code and pass after. `ruff check` and `ruff format --check` are clean.

## Out of scope
Noticed but intentionally not changed here: in `submit`/`status`/`download`, `error_count = 0` is reset inside the retry `while True` loop, so the `if error_count > 5: raise` guard never fires (unbounded retry on persistent errors). Happy to send that as a separate focused PR.
