### PR TITLE
ci: better tagging of GHA runners

### DIFF
--- a/.github/workflows/ci-integration-test-conda-reusable.yml
+++ b/.github/workflows/ci-integration-test-conda-reusable.yml
@@ -47,6 +47,19 @@ jobs:
           aws_instance_type: "g5.4xlarge" # A10G 64 GB 
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
+          aws_tags: >-
+            [
+              {"Key":"Name","Value":"of-gha-runner"},
+              {"Key":"Repository","Value":"${{ github.repository }}"},
+              {"Key":"Workflow","Value":"${{ github.workflow }}"},
+              {"Key":"RunId","Value":"${{ github.run_id }}"},
+              {"Key":"RunNumber","Value":"${{ github.run_number }}"},
+              {"Key":"RunAttempt","Value":"${{ github.run_attempt }}"},
+              {"Key":"Actor","Value":"${{ github.actor }}"},
+              {"Key":"EventName","Value":"${{ github.event_name }}"},
+              {"Key":"Ref","Value":"${{ github.ref_name }}"},
+              {"Key":"Sha","Value":"${{ github.sha }}"}
+            ]          
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/ci-integration-test-conda-reusable.yml
+++ b/.github/workflows/ci-integration-test-conda-reusable.yml
@@ -41,7 +41,7 @@ jobs:
           echo "ami_id=$ami_id" >> "$GITHUB_OUTPUT"
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ${{ steps.resolve-ami.outputs.ami_id }}  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), resolved from SSM at runtime
           aws_instance_type: "g5.4xlarge" # A10G 64 GB 

--- a/.github/workflows/ci-integration-test-pixi-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-reusable.yml
@@ -42,7 +42,7 @@ jobs:
           echo "ami_id=$ami_id" >> "$GITHUB_OUTPUT"
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ${{ steps.resolve-ami.outputs.ami_id }}  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), resolved from SSM at runtime
           aws_instance_type: "g5.4xlarge" # A10G 64 GB

--- a/.github/workflows/ci-integration-test-pixi-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-reusable.yml
@@ -48,6 +48,19 @@ jobs:
           aws_instance_type: "g5.4xlarge" # A10G 64 GB
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
+          aws_tags: >-
+            [
+              {"Key":"Name","Value":"of-gha-runner"},
+              {"Key":"Repository","Value":"${{ github.repository }}"},
+              {"Key":"Workflow","Value":"${{ github.workflow }}"},
+              {"Key":"RunId","Value":"${{ github.run_id }}"},
+              {"Key":"RunNumber","Value":"${{ github.run_number }}"},
+              {"Key":"RunAttempt","Value":"${{ github.run_attempt }}"},
+              {"Key":"Actor","Value":"${{ github.actor }}"},
+              {"Key":"EventName","Value":"${{ github.event_name }}"},
+              {"Key":"Ref","Value":"${{ github.ref_name }}"},
+              {"Key":"Sha","Value":"${{ github.sha }}"}
+            ]          
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge
+          aws_market_type: spot
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
           aws_tags: >-

--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -34,7 +34,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge

--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -40,6 +40,19 @@ jobs:
           aws_instance_type: t3.2xlarge
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
+          aws_tags: >-
+            [
+              {"Key":"Name","Value":"of-gha-runner"},
+              {"Key":"Repository","Value":"${{ github.repository }}"},
+              {"Key":"Workflow","Value":"${{ github.workflow }}"},
+              {"Key":"RunId","Value":"${{ github.run_id }}"},
+              {"Key":"RunNumber","Value":"${{ github.run_number }}"},
+              {"Key":"RunAttempt","Value":"${{ github.run_attempt }}"},
+              {"Key":"Actor","Value":"${{ github.actor }}"},
+              {"Key":"EventName","Value":"${{ github.event_name }}"},
+              {"Key":"Ref","Value":"${{ github.ref_name }}"},
+              {"Key":"Sha","Value":"${{ github.sha }}"}
+            ]          
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -35,7 +35,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -41,6 +41,19 @@ jobs:
           aws_instance_type: t3.2xlarge
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
+          aws_tags: >-
+            [
+              {"Key":"Name","Value":"of-gha-runner"},
+              {"Key":"Repository","Value":"${{ github.repository }}"},
+              {"Key":"Workflow","Value":"${{ github.workflow }}"},
+              {"Key":"RunId","Value":"${{ github.run_id }}"},
+              {"Key":"RunNumber","Value":"${{ github.run_number }}"},
+              {"Key":"RunAttempt","Value":"${{ github.run_attempt }}"},
+              {"Key":"Actor","Value":"${{ github.actor }}"},
+              {"Key":"EventName","Value":"${{ github.event_name }}"},
+              {"Key":"Ref","Value":"${{ github.ref_name }}"},
+              {"Key":"Sha","Value":"${{ github.sha }}"}
+            ]          
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge
+          aws_market_type: spot
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
           aws_tags: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,19 @@ jobs:
           aws_instance_type: trn1.2xlarge
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
+          aws_tags: >-
+            [
+              {"Key":"Name","Value":"of-gha-runner"},
+              {"Key":"Repository","Value":"${{ github.repository }}"},
+              {"Key":"Workflow","Value":"${{ github.workflow }}"},
+              {"Key":"RunId","Value":"${{ github.run_id }}"},
+              {"Key":"RunNumber","Value":"${{ github.run_number }}"},
+              {"Key":"RunAttempt","Value":"${{ github.run_attempt }}"},
+              {"Key":"Actor","Value":"${{ github.actor }}"},
+              {"Key":"EventName","Value":"${{ github.event_name }}"},
+              {"Key":"Ref","Value":"${{ github.ref_name }}"},
+              {"Key":"Sha","Value":"${{ github.sha }}"}
+            ]
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: trn1.2xlarge


### PR DESCRIPTION
**Summary**

Our runners currently run "nameless" so it's hard to identify them in the console. This PR changes this.

**Changes**

Found all places where we use `omsf/start-aws-gha-runner` and pass a battery of tags 

**Related Issues**

**Testing**

**Other Notes**
