### PR TITLE
ci: use spot aws runners

### DIFF
--- a/.github/workflows/ci-integration-test-conda-reusable.yml
+++ b/.github/workflows/ci-integration-test-conda-reusable.yml
@@ -41,7 +41,7 @@ jobs:
           echo "ami_id=$ami_id" >> "$GITHUB_OUTPUT"
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ${{ steps.resolve-ami.outputs.ami_id }}  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), resolved from SSM at runtime
           aws_instance_type: "g5.4xlarge" # A10G 64 GB 

--- a/.github/workflows/ci-integration-test-pixi-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-reusable.yml
@@ -42,7 +42,7 @@ jobs:
           echo "ami_id=$ami_id" >> "$GITHUB_OUTPUT"
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ${{ steps.resolve-ami.outputs.ami_id }}  # Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04), resolved from SSM at runtime
           aws_instance_type: "g5.4xlarge" # A10G 64 GB

--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge
+          aws_market_type: spot
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
           aws_tags: >-

--- a/.github/workflows/ci-test-conda-reusable.yml
+++ b/.github/workflows/ci-test-conda-reusable.yml
@@ -34,7 +34,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -35,7 +35,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: t3.2xlarge
+          aws_market_type: spot
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 200
           aws_tags: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.2.0
+        uses: omsf/start-aws-gha-runner@v1.3.0
         with:
           aws_image_id: ami-0754c6e75b3b97dcd  # Deep Learning AMI Neuron (Ubuntu 22.04)
           aws_instance_type: trn1.2xlarge


### PR DESCRIPTION
**Summary**

I don't know if this will work but i'm curious if we can switch to spot runners for our builders. 

**Changes**

- switch to `omsf/start-aws-gha-runner@v1.3.0` everywhere 
- switch to spot market for t3.2xlarge runs (these are probably v abundant) 

**Related Issues**

**Testing**

**Other Notes**
