### PR TITLE
feat: add openfold3-therock env for AMD APU / Strix Halo (gfx1151) support

### DIFF
--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -109,6 +109,8 @@ For AMD system installation: After installation, verify your ROCm environment is
 validate-openfold3-rocm
 ```
 
+> **AMD APUs / Strix Halo (`gfx1151`)**: the `rocm7.2` wheels above don't cover APUs. Use the `openfold3-therock` pixi environment instead (AMD TheRock nightly). See the [AMD ROCm inference docs](inference.md).
+
 (installation-environment-variables)=
 ### Environment variables
 

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -109,7 +109,7 @@ For AMD system installation: After installation, verify your ROCm environment is
 validate-openfold3-rocm
 ```
 
-> **AMD APUs / Strix Halo (`gfx1151`)**: the `rocm7.2` wheels above don't cover APUs. Use the `openfold3-therock` pixi environment instead (AMD TheRock nightly). See the [AMD ROCm inference docs](inference.md).
+> **AMD APUs / Strix Halo (`gfx1151`)**: the `rocm7.2` wheels above don't cover APUs. Use the `openfold3-therock` pixi environment instead (AMD TheRock, ROCm 7.14). See the [AMD ROCm inference docs](inference.md).
 
 (installation-environment-variables)=
 ### Environment variables

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -327,6 +327,22 @@ run_openfold predict \
 
 > **Note on first-run compilation**: Triton JIT-compiles kernels on first use and caches them to `~/.triton/cache`. The compilation is a one-time cost per unique sequence length per machine; subsequent runs at the same length incur no overhead.
 
+##### AMD APUs / Strix Halo (gfx1151) via TheRock nightly
+
+The default `openfold3-rocm7` environment uses the official `rocm7.2` PyTorch wheels, which do **not** cover AMD APUs such as Strix Halo (Ryzen AI Max+ 395, Radeon 8060S, `gfx1151`). For those, use the `openfold3-therock` pixi environment, which pulls PyTorch + Triton from AMD's [TheRock](https://github.com/ROCm/TheRock) nightly multi-arch index (`gfx1151` is release-ready per TheRock's `SUPPORTED_GPUS.md`).
+
+```bash
+pixi run -e openfold3-therock validate-openfold3-rocm
+```
+
+All Triton settings above apply unchanged; TheRock's Triton JITs to HIP for `gfx1151`.
+
+> **Version note**: TheRock version strings like `rocm7.13.0a...` / `rocm7.15.0a...` are **nightly build snapshots**, not released ROCm versions (the official line is 7.0 → 7.1 → 7.2). A higher number just means a more recent nightly, not a more qualified release. The exact build is pinned in `pixi.lock` for reproducibility; `pixi update` will move it. Keep `openfold3-rocm7` as the stable fallback.
+>
+> **Host requirement**: only the `amdgpu` kernel driver (`/dev/kfd`, `/dev/dri`) is needed. The ROCm userspace ships inside the torch wheel — no system `/opt/rocm` install required.
+
+For a different AMD GPU, change the `device-gfx1151` extra in the `pytorch-pypi-therock` feature (`pixi.toml`) to your target from TheRock's device table (e.g. `device-gfx1201`).
+
 ---
 
 (inference-cif-direct-templates)=

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -327,9 +327,9 @@ run_openfold predict \
 
 > **Note on first-run compilation**: Triton JIT-compiles kernels on first use and caches them to `~/.triton/cache`. The compilation is a one-time cost per unique sequence length per machine; subsequent runs at the same length incur no overhead.
 
-##### AMD APUs / Strix Halo (gfx1151) via TheRock nightly
+##### AMD APUs / Strix Halo (gfx1151) via TheRock
 
-The default `openfold3-rocm7` environment uses the official `rocm7.2` PyTorch wheels, which do **not** cover AMD APUs such as Strix Halo (Ryzen AI Max+ 395, Radeon 8060S, `gfx1151`). For those, use the `openfold3-therock` pixi environment, which pulls PyTorch + Triton from AMD's [TheRock](https://github.com/ROCm/TheRock) nightly multi-arch index (`gfx1151` is release-ready per TheRock's `SUPPORTED_GPUS.md`).
+The default `openfold3-rocm7` environment uses the official `rocm7.2` PyTorch wheels, which do **not** cover AMD APUs such as Strix Halo (Ryzen AI Max+ 395, Radeon 8060S, `gfx1151`). For those, use the `openfold3-therock` pixi environment, which pulls PyTorch + Triton from AMD's [TheRock](https://github.com/ROCm/TheRock) multi-arch index (`gfx1151` is release-ready per TheRock's `SUPPORTED_GPUS.md`).
 
 ```bash
 pixi run -e openfold3-therock validate-openfold3-rocm
@@ -337,7 +337,7 @@ pixi run -e openfold3-therock validate-openfold3-rocm
 
 All Triton settings above apply unchanged; TheRock's Triton JITs to HIP for `gfx1151`.
 
-> **Version note**: TheRock version strings like `rocm7.13.0a...` / `rocm7.15.0a...` are **nightly build snapshots**, not released ROCm versions (the official line is 7.0 → 7.1 → 7.2). A higher number just means a more recent nightly, not a more qualified release. The exact build is pinned in `pixi.lock` for reproducibility; `pixi update` will move it. Keep `openfold3-rocm7` as the stable fallback.
+> **Version note**: ROCm 7.14 is AMD's production release built on TheRock, and it officially supports `gfx1151`. However, `gfx1151` wheels are currently published **only** to TheRock's multi-arch index and are still prerelease-tagged (`+rocm7.14.0a<date>`) — there is no PyPI/conda-forge/stable wheel yet. This env therefore pins one dated 7.14-line build (`torch 2.12.0+rocm7.14.0a20260624`) for reproducibility rather than tracking the nightly tip; bump the version and date together in `pixi.toml` to move it. Treat this as an opt-in developer env for validating the prerelease 7.14 path, not a CI/production dependency. Keep `openfold3-rocm7` as the stable fallback.
 >
 > **Host requirement**: only the `amdgpu` kernel driver (`/dev/kfd`, `/dev/dri`) is needed. The ROCm userspace ships inside the torch wheel — no system `/opt/rocm` install required.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -6676,17 +6676,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx115x-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx11-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
       - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/mpmath-1.3.0-py3-none-any.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.15.0a20260717.tar.gz
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.14.0a20260624.tar.gz
       - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.15.0a20260717-py3-none-linux_x86_64.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.15.0a20260717-py3-none-linux_x86_64.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.15.0a20260717-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.14.0a20260624-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.14.0a20260624-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.14.0a20260624-py3-none-linux_x86_64.whl
       - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/sympy-1.14.0-py3-none-any.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
-      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.8.0%2Bgit43422b04.rocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.7.0%2Bgitb4e20bbe.rocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/hhsuite-3.3.0-h503566f_15.tar.bz2
   sha256: 1d7a96783862071c92102bb959a479e04dd25eccebabcadc5d3f18bd8070a67f
@@ -11415,7 +11415,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/msgpack?source=compressed-mapping
+  - pkg:pypi/msgpack?source=hash-mapping
   run_exports: {}
   size: 112798
   timestamp: 1782460772873
@@ -30322,19 +30322,19 @@ packages:
   requires_dist:
   - typing-extensions>=4.1.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx11-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
+  name: amd-torch-device-gfx11
+  version: 2.12.0+rocm7.14.0a20260624
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - torch==2.12.0+rocm7.14.0a20260624
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
   name: amd-torch-device-gfx1151
-  version: 2.14.0a0+rocm7.15.0a20260717
+  version: 2.12.0+rocm7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
   requires_dist:
-  - torch==2.14.0a0+rocm7.15.0a20260717
-  - rocm-sdk-device-gfx1151==7.15.0a20260717
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx115x-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
-  name: amd-torch-device-gfx115x
-  version: 2.14.0a0+rocm7.15.0a20260717
-  index: https://rocm.nightlies.amd.com/whl-multi-arch/
-  requires_dist:
-  - torch==2.14.0a0+rocm7.15.0a20260717
+  - torch==2.12.0+rocm7.14.0a20260624
+  - rocm-sdk-device-gfx1151==7.14.0a20260624
 - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/mpmath-1.3.0-py3-none-any.whl
   name: mpmath
   version: 1.3.0
@@ -30348,71 +30348,69 @@ packages:
   - sphinx ; extra == 'docs'
   - gmpy2>=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
   - pytest>=4.6 ; extra == 'tests'
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.15.0a20260717.tar.gz
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.14.0a20260624.tar.gz
   name: rocm
-  version: 7.15.0a20260717
+  version: 7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
   requires_dist:
-  - rocm==7.15.0a20260717
-  - rocm-sdk-core==7.15.0a20260717
-  - rocm-sdk-libraries==7.15.0a20260717 ; extra == 'libraries'
-  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device'
-  - rocm-sdk-devel==7.15.0a20260717 ; extra == 'devel'
-  - rocm-profiler==7.15.0a20260717 ; extra == 'profiler'
-  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device-gfx1010'
-  - rocm-sdk-device-gfx1011==7.15.0a20260717 ; extra == 'device-gfx1011'
-  - rocm-sdk-device-gfx1012==7.15.0a20260717 ; extra == 'device-gfx1012'
-  - rocm-sdk-device-gfx1030==7.15.0a20260717 ; extra == 'device-gfx1030'
-  - rocm-sdk-device-gfx1031==7.15.0a20260717 ; extra == 'device-gfx1031'
-  - rocm-sdk-device-gfx1032==7.15.0a20260717 ; extra == 'device-gfx1032'
-  - rocm-sdk-device-gfx1033==7.15.0a20260717 ; extra == 'device-gfx1033'
-  - rocm-sdk-device-gfx1034==7.15.0a20260717 ; extra == 'device-gfx1034'
-  - rocm-sdk-device-gfx1035==7.15.0a20260717 ; extra == 'device-gfx1035'
-  - rocm-sdk-device-gfx1036==7.15.0a20260717 ; extra == 'device-gfx1036'
-  - rocm-sdk-device-gfx1100==7.15.0a20260717 ; extra == 'device-gfx1100'
-  - rocm-sdk-device-gfx1101==7.15.0a20260717 ; extra == 'device-gfx1101'
-  - rocm-sdk-device-gfx1102==7.15.0a20260717 ; extra == 'device-gfx1102'
-  - rocm-sdk-device-gfx1103==7.15.0a20260717 ; extra == 'device-gfx1103'
-  - rocm-sdk-device-gfx1150==7.15.0a20260717 ; extra == 'device-gfx1150'
-  - rocm-sdk-device-gfx1151==7.15.0a20260717 ; extra == 'device-gfx1151'
-  - rocm-sdk-device-gfx1152==7.15.0a20260717 ; extra == 'device-gfx1152'
-  - rocm-sdk-device-gfx1153==7.15.0a20260717 ; extra == 'device-gfx1153'
-  - rocm-sdk-device-gfx1200==7.15.0a20260717 ; extra == 'device-gfx1200'
-  - rocm-sdk-device-gfx1201==7.15.0a20260717 ; extra == 'device-gfx1201'
-  - rocm-sdk-device-gfx1250==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx1250'
-  - rocm-sdk-device-gfx900==7.15.0a20260717 ; extra == 'device-gfx900'
-  - rocm-sdk-device-gfx906==7.15.0a20260717 ; extra == 'device-gfx906'
-  - rocm-sdk-device-gfx908==7.15.0a20260717 ; extra == 'device-gfx908'
-  - rocm-sdk-device-gfx90a==7.15.0a20260717 ; extra == 'device-gfx90a'
-  - rocm-sdk-device-gfx942==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx942'
-  - rocm-sdk-device-gfx950==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx950'
-  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1011==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1012==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1030==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1031==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1032==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1033==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1034==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1035==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1036==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1100==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1101==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1102==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1103==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1150==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1151==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1152==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1153==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1200==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1201==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx1250==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
-  - rocm-sdk-device-gfx900==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx906==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx908==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx90a==7.15.0a20260717 ; extra == 'device-all'
-  - rocm-sdk-device-gfx942==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
-  - rocm-sdk-device-gfx950==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
+  - rocm==7.14.0a20260624
+  - rocm-sdk-core==7.14.0a20260624
+  - rocm-sdk-libraries==7.14.0a20260624 ; extra == 'libraries'
+  - rocm-sdk-device-gfx1010==7.14.0a20260624 ; extra == 'device'
+  - rocm-sdk-devel==7.14.0a20260624 ; extra == 'devel'
+  - rocm-profiler==7.14.0a20260624 ; extra == 'profiler'
+  - rocm-sdk-device-gfx1010==7.14.0a20260624 ; extra == 'device-gfx1010'
+  - rocm-sdk-device-gfx1011==7.14.0a20260624 ; extra == 'device-gfx1011'
+  - rocm-sdk-device-gfx1012==7.14.0a20260624 ; extra == 'device-gfx1012'
+  - rocm-sdk-device-gfx1030==7.14.0a20260624 ; extra == 'device-gfx1030'
+  - rocm-sdk-device-gfx1031==7.14.0a20260624 ; extra == 'device-gfx1031'
+  - rocm-sdk-device-gfx1032==7.14.0a20260624 ; extra == 'device-gfx1032'
+  - rocm-sdk-device-gfx1033==7.14.0a20260624 ; extra == 'device-gfx1033'
+  - rocm-sdk-device-gfx1034==7.14.0a20260624 ; extra == 'device-gfx1034'
+  - rocm-sdk-device-gfx1035==7.14.0a20260624 ; extra == 'device-gfx1035'
+  - rocm-sdk-device-gfx1036==7.14.0a20260624 ; extra == 'device-gfx1036'
+  - rocm-sdk-device-gfx1100==7.14.0a20260624 ; extra == 'device-gfx1100'
+  - rocm-sdk-device-gfx1101==7.14.0a20260624 ; extra == 'device-gfx1101'
+  - rocm-sdk-device-gfx1102==7.14.0a20260624 ; extra == 'device-gfx1102'
+  - rocm-sdk-device-gfx1103==7.14.0a20260624 ; extra == 'device-gfx1103'
+  - rocm-sdk-device-gfx1150==7.14.0a20260624 ; extra == 'device-gfx1150'
+  - rocm-sdk-device-gfx1151==7.14.0a20260624 ; extra == 'device-gfx1151'
+  - rocm-sdk-device-gfx1152==7.14.0a20260624 ; extra == 'device-gfx1152'
+  - rocm-sdk-device-gfx1153==7.14.0a20260624 ; extra == 'device-gfx1153'
+  - rocm-sdk-device-gfx1200==7.14.0a20260624 ; extra == 'device-gfx1200'
+  - rocm-sdk-device-gfx1201==7.14.0a20260624 ; extra == 'device-gfx1201'
+  - rocm-sdk-device-gfx900==7.14.0a20260624 ; extra == 'device-gfx900'
+  - rocm-sdk-device-gfx906==7.14.0a20260624 ; extra == 'device-gfx906'
+  - rocm-sdk-device-gfx908==7.14.0a20260624 ; extra == 'device-gfx908'
+  - rocm-sdk-device-gfx90a==7.14.0a20260624 ; extra == 'device-gfx90a'
+  - rocm-sdk-device-gfx942==7.14.0a20260624 ; sys_platform == 'linux' and extra == 'device-gfx942'
+  - rocm-sdk-device-gfx950==7.14.0a20260624 ; sys_platform == 'linux' and extra == 'device-gfx950'
+  - rocm-sdk-device-gfx1010==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1011==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1012==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1030==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1031==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1032==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1033==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1034==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1035==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1036==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1100==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1101==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1102==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1103==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1150==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1151==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1152==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1153==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1200==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1201==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx900==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx906==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx908==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx90a==7.14.0a20260624 ; extra == 'device-all'
+  - rocm-sdk-device-gfx942==7.14.0a20260624 ; sys_platform == 'linux' and extra == 'device-all'
+  - rocm-sdk-device-gfx950==7.14.0a20260624 ; sys_platform == 'linux' and extra == 'device-all'
 - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl
   name: rocm-bootstrap
   version: 0.1.0
@@ -30420,19 +30418,19 @@ packages:
   requires_dist:
   - pytest ; extra == 'dev'
   requires_python: '>=3.10'
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.15.0a20260717-py3-none-linux_x86_64.whl
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.14.0a20260624-py3-none-linux_x86_64.whl
   name: rocm-sdk-core
-  version: 7.15.0a20260717
+  version: 7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.15.0a20260717-py3-none-linux_x86_64.whl
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.14.0a20260624-py3-none-linux_x86_64.whl
   name: rocm-sdk-device-gfx1151
-  version: 7.15.0a20260717
+  version: 7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
   requires_dist:
-  - rocm-sdk-libraries==7.15.0a20260717
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.15.0a20260717-py3-none-linux_x86_64.whl
+  - rocm-sdk-libraries==7.14.0a20260624
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.14.0a20260624-py3-none-linux_x86_64.whl
   name: rocm-sdk-libraries
-  version: 7.15.0a20260717
+  version: 7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
 - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/sympy-1.14.0-py3-none-any.whl
   name: sympy
@@ -30443,94 +30441,106 @@ packages:
   - pytest>=7.1.0 ; extra == 'dev'
   - hypothesis>=6.70.0 ; extra == 'dev'
   requires_python: '>=3.9'
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.12.0%2Brocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
   name: torch
-  version: 2.14.0a0+rocm7.15.0a20260717
+  version: 2.12.0+rocm7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
   requires_dist:
   - filelock
   - typing-extensions>=4.10.0
-  - setuptools>=77.0.3
+  - setuptools<82
   - sympy>=1.13.3
   - networkx>=2.5.1
   - jinja2
   - fsspec>=0.8.5
-  - rocm[libraries]==7.15.0a20260717
-  - triton==3.8.0+git43422b04.rocm7.15.0a20260717
+  - rocm[libraries]==7.14.0a20260624
+  - triton==3.7.0+gitb4e20bbe.rocm7.14.0a20260624
   - optree>=0.13.0 ; extra == 'optree'
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - pyyaml ; extra == 'pyyaml'
   - rocm-bootstrap
-  - amd-torch-device-gfx1010==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1010'
-  - amd-torch-device-gfx1011==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1011'
-  - amd-torch-device-gfx1012==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1012'
-  - amd-torch-device-gfx1030==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1030'
-  - amd-torch-device-gfx1031==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1031'
-  - amd-torch-device-gfx1032==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1032'
-  - amd-torch-device-gfx1033==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1033'
-  - amd-torch-device-gfx1034==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1034'
-  - amd-torch-device-gfx1035==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1035'
-  - amd-torch-device-gfx1036==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1036'
-  - amd-torch-device-gfx1100==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1100'
-  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1100'
-  - amd-torch-device-gfx1101==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1101'
-  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1101'
-  - amd-torch-device-gfx1102==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1102'
-  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1102'
-  - amd-torch-device-gfx1103==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1103'
-  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1103'
-  - amd-torch-device-gfx1150==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1150'
-  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1150'
-  - amd-torch-device-gfx1151==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1151'
-  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1151'
-  - amd-torch-device-gfx1152==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1152'
-  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1152'
-  - amd-torch-device-gfx1153==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1153'
-  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1153'
-  - amd-torch-device-gfx1200==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1200'
-  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1200'
-  - amd-torch-device-gfx1201==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1201'
-  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1201'
-  - amd-torch-device-gfx900==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx900'
-  - amd-torch-device-gfx906==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx906'
-  - amd-torch-device-gfx908==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx908'
-  - amd-torch-device-gfx90a==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx90a'
-  - amd-torch-device-gfx942==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx942'
-  - amd-torch-device-gfx950==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx950'
-  - amd-torch-device-gfx1010==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1011==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1012==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1030==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1031==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1032==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1033==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1034==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1035==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1036==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1100==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1101==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1102==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1103==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1150==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1151==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1152==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1153==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1200==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx1201==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx900==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx906==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx908==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx90a==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx942==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
-  - amd-torch-device-gfx950==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1010==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1010'
+  - amd-torch-device-gfx1011==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1011'
+  - amd-torch-device-gfx1012==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1012'
+  - amd-torch-device-gfx1030==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1030'
+  - amd-torch-device-gfx1031==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1031'
+  - amd-torch-device-gfx1032==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1032'
+  - amd-torch-device-gfx1033==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1033'
+  - amd-torch-device-gfx1034==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1034'
+  - amd-torch-device-gfx1035==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1035'
+  - amd-torch-device-gfx1036==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1036'
+  - amd-torch-device-gfx1100==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1100'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1100'
+  - amd-torch-device-gfx1101==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1101'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1101'
+  - amd-torch-device-gfx1102==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1102'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1102'
+  - amd-torch-device-gfx1103==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1103'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1103'
+  - amd-torch-device-gfx1150==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1150'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1150'
+  - amd-torch-device-gfx1151==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1151'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1151'
+  - amd-torch-device-gfx1152==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1152'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1152'
+  - amd-torch-device-gfx1153==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1153'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1153'
+  - amd-torch-device-gfx1200==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1200'
+  - amd-torch-device-gfx12-0==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1200'
+  - amd-torch-device-gfx1201==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1201'
+  - amd-torch-device-gfx12-0==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx1201'
+  - amd-torch-device-gfx900==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx900'
+  - amd-torch-device-gfx906==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx906'
+  - amd-torch-device-gfx908==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx908'
+  - amd-torch-device-gfx90a==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx90a'
+  - amd-torch-device-gfx942==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx942'
+  - amd-torch-device-gfx950==2.12.0+rocm7.14.0a20260624 ; extra == 'device-gfx950'
+  - amd-torch-device-gfx1010==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1011==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1012==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1030==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1031==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1032==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1033==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1034==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1035==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1036==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx11==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1100==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1101==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1102==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1103==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1150==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1151==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1152==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1153==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx12-0==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1200==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx1201==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx900==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx906==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx908==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx90a==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx942==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
+  - amd-torch-device-gfx950==2.12.0+rocm7.14.0a20260624 ; extra == 'device-all'
   requires_python: '>=3.10'
-- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.8.0%2Bgit43422b04.rocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.7.0%2Bgitb4e20bbe.rocm7.14.0a20260624-cp313-cp313-linux_x86_64.whl
   name: triton
-  version: 3.8.0+git43422b04.rocm7.15.0a20260717
+  version: 3.7.0+gitb4e20bbe.rocm7.14.0a20260624
   index: https://rocm.nightlies.amd.com/whl-multi-arch/
   requires_dist:
   - importlib-metadata ; python_full_version < '3.10'
+  - cmake>=3.20,<4.0 ; extra == 'build'
+  - lit ; extra == 'build'
+  - autopep8 ; extra == 'tests'
+  - isort ; extra == 'tests'
+  - numpy ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-forked ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  - scipy>=1.7.1 ; extra == 'tests'
+  - llnl-hatchet ; extra == 'tests'
+  - matplotlib ; extra == 'tutorials'
+  - pandas ; extra == 'tutorials'
+  - tabulate ; extra == 'tutorials'
   requires_python: '>=3.10,<3.15'

--- a/pixi.lock
+++ b/pixi.lock
@@ -6387,69 +6387,81 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      p1:
+  openfold3-therock:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    indexes:
+    - https://pypi.org/simple
+    - https://rocm.nightlies.amd.com/whl-multi-arch/
+    options:
+      pypi-prerelease-mode: allow
+    packages:
+      linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/hhsuite-3.3.0-h503566f_15.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/linux-64/hmmer-3.4-hb6cb901_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aria2-1.37.0-h4b33fff_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.0-h9b893ba_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h692f434_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-hc1936db_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.35.14-py314h9e666f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.32.2-py314h7d485c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotite-1.7.1-py314hdff1159_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotraj-1.2.2-py314h42812f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h2aa3ae6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h720e601_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h6ffeea8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h38ae05a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.27.3-h6f4d18d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h21f4ec5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.8-h46fcd08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h720e601_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.1-py313hd5f5364_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.35.0-py313h57d1877_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py313h18e8e13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotite-1.7.1-py313h0aaa388_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotraj-1.2.2-py313h5d5ffb9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py313hf159716_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py313hf46b229_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py314h67df5f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py313hc8edb43_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.2-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py314hdafbbf9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py313h78bf25f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h235f0fe_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gemmi-0.7.5-py314h2920e28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gemmi-0.7.5-py313hbaa079c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.3-py314h42812f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.3-py313h5d5ffb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kalign-python-3.6.0-py314h118ebf0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kalign-python-3.6.0-py313h92f78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py313hc8edb43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py314h3a4f467_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py313hfaae9d9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
@@ -6470,7 +6482,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
@@ -6494,45 +6506,44 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py314had63eae_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.0.0-hecca717_915.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py313h6c470cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_243.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py314h97ea11e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313hc8edb43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py314h2b28147_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.0.0-ha770c72_915.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py313hf6604e3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.1.0-ha770c72_243.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-4.1.6-hc5af2df_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py313hbfd7664_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.35.1-py314h8f612e1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py313h80991f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.35.1-py313h098d647_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py314h9cd037b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-lmdb-2.2.1-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py313h3f29d12_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-lmdb-2.3.0-py313h54dd161_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py313h66a1ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.22-h462bb3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.28.0-py314h2e6c369_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.28.0-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -6549,14 +6560,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.39-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.39-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.50-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -6564,25 +6574,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.30.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.63.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.3.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/func_timeout-4.3.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/furo-2025.12.19-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.52-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ijson-3.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ijson-3.5.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
@@ -6621,14 +6630,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-vcr-1.0.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reportlab-5.0.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rlpycairo-0.4.0-pyh6c17108_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.64.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
@@ -6644,317 +6653,40 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.4-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/vcrpy-8.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/vcrpy-8.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
-      - pypi: https://download-r2.pytorch.org/whl/rocm7.2/torch-2.12.1%2Brocm7.2-cp314-cp314-manylinux_2_28_x86_64.whl
-      - pypi: https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp314-cp314-linux_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/53/d81269aaafccea0d33396c03035de997b743f11e648e6e27a0df99c72980/yarl-1.24.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      p3:
-      - conda: https://conda.anaconda.org/bioconda/linux-64/hhsuite-3.3.0-h503566f_15.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/linux-64/hmmer-3.4-hb6cb901_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aria2-1.37.0-h4b33fff_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.0-h9b893ba_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h692f434_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-hc1936db_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.35.14-py314h9e666f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.32.2-py314h7d485c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotite-1.7.1-py314hdff1159_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/biotraj-1.2.2-py314h42812f9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py314h67df5f8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py314hdafbbf9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h235f0fe_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gemmi-0.7.5-py314h2920e28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.3-py314h42812f9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kalign-python-3.6.0-py314h118ebf0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py314h3a4f467_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.10.5-h6406941_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkit-2025.09.6-h4dfd318_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py314had63eae_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.0.0-hecca717_915.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py314h97ea11e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py314h2b28147_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.0.0-ha770c72_915.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-4.1.6-hc5af2df_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.35.1-py314h8f612e1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py314h9cd037b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-lmdb-2.2.1-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.28.0-py314h2e6c369_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.16-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.39-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.39-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.63.0-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/func_timeout-4.3.5-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/furo-2025.12.19-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ijson-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_119.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_119.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/memory_profiler-0.61.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ml-collections-1.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/myst-parser-3.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pdbeccdutils-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-datadir-1.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-regressions-2.11.0-pyhc455866_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-vcr-1.0.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/reportlab-5.0.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rlpycairo-0.4.0-pyh6c17108_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.64.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.3.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-basic-ng-1.0.0b2-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/vcrpy-8.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: ./
-      - pypi: https://download-r2.pytorch.org/whl/rocm7.2/torch-2.12.1%2Brocm7.2-cp314-cp314-manylinux_2_28_x86_64.whl
-      - pypi: https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp314-cp314-linux_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/53/d81269aaafccea0d33396c03035de997b743f11e648e6e27a0df99c72980/yarl-1.24.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx115x-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.15.0a20260717.tar.gz
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.15.0a20260717-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.15.0a20260717-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.15.0a20260717-py3-none-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+      - pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.8.0%2Bgit43422b04.rocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/hhsuite-3.3.0-h503566f_15.tar.bz2
   sha256: 1d7a96783862071c92102bb959a479e04dd25eccebabcadc5d3f18bd8070a67f
@@ -7289,6 +7021,25 @@ packages:
     - aws-c-auth >=0.10.1,<0.10.2.0a0
   size: 134427
   timestamp: 1777489423676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
+  sha256: 845fe32ee750d4a4d3efdb1d95a8c29c3388e3ea9787b77341ec4abe4e198b11
+  md5: 4347d5ffdf34adf9c5edd10837727d96
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-sdkutils >=0.2.7,<0.2.8.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.4,<0.10.5.0a0
+  size: 135073
+  timestamp: 1784086842394
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
   sha256: f21d648349a318f4ae457ea5403d542ba6c0e0343b8642038523dd612b2a5064
   md5: 3c3d02681058c3d206b562b2e3bc337f
@@ -7305,6 +7056,22 @@ packages:
     - aws-c-cal >=0.9.13,<0.9.14.0a0
   size: 56230
   timestamp: 1764593147526
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h2aa3ae6_4.conda
+  sha256: a67c944be1728f576c02fe8f28b0cbb78b5353415075db3da4ef71bc9dd8c00c
+  md5: 9c6072e7b882d35ac956c07e493d6a9e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 56752
+  timestamp: 1784043396713
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
   sha256: 926a5b9de0a586e88669d81de717c8dd3218c51ce55658e8a16af7e7fe87c833
   md5: e36ad70a7e0b48f091ed6902f04c23b8
@@ -7319,6 +7086,35 @@ packages:
     - aws-c-common >=0.12.6,<0.12.7.0a0
   size: 239605
   timestamp: 1763585595898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.2-hb03c661_0.conda
+  sha256: 701398f1c9978c41e93cb0947869a66b7f8004e9d6e548d63d11aedae83cfb02
+  md5: f3e0b2e044485ae90d4a59c77e7a0182
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.2,<0.14.3.0a0
+  size: 246263
+  timestamp: 1783637234072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h720e601_4.conda
+  sha256: 8e0a5513cfc42df8bd16adbd8e83a37d3ca89b8e04cb20eb04eb177bbbfea365
+  md5: c9be3f5854f349ae77a1a174b59e11a8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 22301
+  timestamp: 1784042853709
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
   sha256: 1838bdc077b77168416801f4715335b65e9223f83641a2c28644f8acd8f9db0e
   md5: f16f498641c9e05b645fe65902df661a
@@ -7352,6 +7148,24 @@ packages:
     - aws-c-event-stream >=0.7.0,<0.7.1.0a0
   size: 59054
   timestamp: 1774479894768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h6ffeea8_4.conda
+  sha256: b1f35f7b7a5e745e2d56cf93212770bb56f5207fa9f0e38f98b0c05a1b898a90
+  md5: 204d1e8d60c3ae839bd1898e4c7742c8
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  size: 59633
+  timestamp: 1784075699558
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
   sha256: 38cfc8894db6729770ac18f900296c3f7c20f349a5586a8d8e1a62571fce61d5
   md5: 77f70a9ab785a146dbf66fba00131403
@@ -7370,6 +7184,24 @@ packages:
     - aws-c-http >=0.10.13,<0.10.14.0a0
   size: 225826
   timestamp: 1774488399486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h38ae05a_4.conda
+  sha256: 4b939b4a76a11c9ec50c891ae9bf232da8dcaf8797701df1e79ae51c988be2d4
+  md5: 97f2799ae6ff7b6f52dfa321fef9676b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 231294
+  timestamp: 1784075685646
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h692f434_1.conda
   sha256: e3e33031d641864128ab11f9b8585ad5beb82fa988fe833bb0767dd01878a371
   md5: 14260392d0b491c537b5e26e9a506fff
@@ -7387,6 +7219,23 @@ packages:
     - aws-c-io >=0.26.3,<0.26.4.0a0
   size: 181583
   timestamp: 1777471132287
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.27.3-h6f4d18d_1.conda
+  sha256: 94c32ca672ce290e250aea1cfb92582cca4658bdc3ec7cb1ceef254f34451595
+  md5: bd19b685b88557830f1a617a6d404eb2
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - s2n >=1.7.5,<1.7.6.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-io >=0.27.3,<0.27.4.0a0
+  size: 183100
+  timestamp: 1784054829913
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-hc1936db_2.conda
   sha256: 236ab4138ff4600f95903d2da94125df78577055f6687afa8806db0f6ed2e1a8
   md5: 9120bc47b6f837f3cea90928c3e9a8fa
@@ -7404,6 +7253,23 @@ packages:
     - aws-c-mqtt >=0.15.2,<0.15.3.0a0
   size: 221638
   timestamp: 1777488145895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h21f4ec5_2.conda
+  sha256: 0252f072e2f493f8348575938c69b48b2799f29f0489c4ad2c5a919ab7e3d02e
+  md5: 9728195c2f600ef427a1964ee193e707
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 224933
+  timestamp: 1784087527918
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
   sha256: 4cecb4d595b7cf558087c37b8131cae5204b2c64d75f6b951dc3731d3f872bb8
   md5: 50ae8372984b8b98e056ac8f6b70ab29
@@ -7425,6 +7291,27 @@ packages:
     - aws-c-s3 >=0.12.2,<0.12.3.0a0
   size: 152657
   timestamp: 1777824812393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.8-h46fcd08_1.conda
+  sha256: a423bffbb0e6cacb5e2a0861b918ba3180e5132509afb1faf225ee9f0ec8f981
+  md5: 706aa99414d18db5b23475b45cc93a0b
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - openssl >=3.5.7,<4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-auth >=0.10.4,<0.10.5.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.8,<0.12.9.0a0
+  size: 156174
+  timestamp: 1784100985258
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
   sha256: 9d62c5029f6f8219368a8665f0a549da572dc777f52413b7d75609cacdbc02cc
   md5: c7e3e08b7b1b285524ab9d74162ce40b
@@ -7440,6 +7327,36 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 59383
   timestamp: 1764610113765
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h720e601_2.conda
+  sha256: e419e179e04021fc680d98af23fac4b4c2369cea61171087e57a734e968dd9bd
+  md5: 816f62fa82532118ebb2398382090945
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.7,<0.2.8.0a0
+  size: 68515
+  timestamp: 1784044260935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
+  sha256: 6cc8617854a43040291dea791fe111ba408e7a5bbd9ee9e5a99375da7a16846b
+  md5: 24ee781effc5779206a80139323c9caf
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 101904
+  timestamp: 1784044248506
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
   sha256: 09472dd5fa4473cffd44741ee4c1112f2c76d7168d1343de53c2ad283dc1efa6
   md5: f8e1bcc5c7d839c5882e94498791be08
@@ -7499,6 +7416,29 @@ packages:
   run_exports: {}
   size: 15609559
   timestamp: 1783119682259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.1-py313hd5f5364_0.conda
+  sha256: 04f541ec15c69a095b7650217b80535158747f21d88ed6a94123c6c6bfbb12f8
+  md5: baa08979dda4358ed39677deb9245db5
+  depends:
+  - python
+  - colorama >=0.2.5,<0.4.7
+  - docutils >=0.10,<0.20
+  - ruamel.yaml >=0.15.0,<=0.19.1
+  - ruamel.yaml.clib >=0.2.0,<=0.2.15
+  - prompt-toolkit >=3.0.24,<3.0.52
+  - distro >=1.5.0,<1.9.0
+  - awscrt ==0.35.0
+  - python-dateutil >=2.1,<=2.9.0
+  - jmespath >=0.7.1,<1.1.0
+  - urllib3 >=1.25.4,<=2.6.3
+  - wcwidth <0.3.0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/awscli?source=hash-mapping
+  run_exports: {}
+  size: 15680874
+  timestamp: 1784273083238
 - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.32.2-py313h15cf2f3_0.conda
   sha256: 27a052c103075742f40ebdb3d861e45eeb27544702354df0f7cd6a34d82b55a2
   md5: 3cd9e9c79309e5dbef6c3ff093a4d66e
@@ -7547,6 +7487,31 @@ packages:
   run_exports: {}
   size: 297464
   timestamp: 1778345775153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.35.0-py313h57d1877_0.conda
+  sha256: 207648d25951b45d5ef93605f25c2559428d3cf23fa16f062d106d3ff00f5e88
+  md5: 61c60909bc3a4c2da7373166a3429918
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - python_abi 3.13.* *_cp313
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - s2n >=1.7.5,<1.7.6.0a0
+  - aws-c-s3 >=0.12.8,<0.12.9.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  - aws-c-io >=0.27.3,<0.27.4.0a0
+  - aws-c-common >=0.14.2,<0.14.3.0a0
+  - aws-c-auth >=0.10.4,<0.10.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/awscrt?source=hash-mapping
+  run_exports: {}
+  size: 301021
+  timestamp: 1784127688312
 - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py313h18e8e13_0.conda
   sha256: d7aca2b34335035ef80eaaebff4e5a0ae524b6f3792a82a144d38c4a81f42916
   md5: fbc7d3707f09cae6648e6eb1b6203a5c
@@ -7557,6 +7522,8 @@ packages:
   - python_abi 3.13.* *_cp313
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=compressed-mapping
   run_exports: {}
   size: 242845
   timestamp: 1781450812380
@@ -7571,6 +7538,17 @@ packages:
   run_exports: {}
   size: 35436
   timestamp: 1774197482571
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+  sha256: 659c367ef49df7741749a2ad240b007d7df51b4f210505a78543deafb001e44c
+  md5: e8452fe381cac5fff20563a07722dfa5
+  depends:
+  - binutils_impl_linux-64 >=2.46.1,<2.46.2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 35399
+  timestamp: 1784214547142
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
   sha256: 0a7d405064f53b9d91d92515f1460f7906ee5e8523f3cd8973430e81219f4917
   md5: 8165352fdce2d2025bf884dc0ee85700
@@ -7584,6 +7562,19 @@ packages:
   run_exports: {}
   size: 3661455
   timestamp: 1774197460085
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+  sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+  md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+  depends:
+  - ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 3713752
+  timestamp: 1784214522814
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
   sha256: 78a58d523d072b7f8e591b8f8572822e044b31764ed7e8d170392e7bc6d58339
   md5: 2a307a17309d358c9b42afdd3199ddcc
@@ -7595,6 +7586,17 @@ packages:
   run_exports: {}
   size: 36304
   timestamp: 1774197485247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+  sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+  md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+  depends:
+  - binutils_impl_linux-64 2.46.1 default_hfdba357_102
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 36337
+  timestamp: 1784214551894
 - conda: https://conda.anaconda.org/conda-forge/linux-64/biopython-1.87-py313h07c4f96_0.conda
   sha256: a64c51971e8f9f4bf58c6fd6f3c91cd558ad20ac093779aac3d66a39052f0aab
   md5: 7a1c1b14a788418843ff0454027502da
@@ -7608,6 +7610,30 @@ packages:
   run_exports: {}
   size: 3314508
   timestamp: 1774882194746
+- conda: https://conda.anaconda.org/conda-forge/linux-64/biotite-1.7.1-py313h0aaa388_0.conda
+  sha256: 116c48b4a898d565dd0a207404e2e89e2041126a908d417876d034d0e2a01b8d
+  md5: c13bb9f96da564b7d11d0c7650a9ec55
+  depends:
+  - python
+  - biotraj >=1.0,<2.0
+  - requests >=2.12
+  - numpy >=1.26,<2.4
+  - msgpack-python
+  - networkx >=2.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
+  constrains:
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/biotite?source=hash-mapping
+  run_exports: {}
+  size: 58815835
+  timestamp: 1782310626271
 - conda: https://conda.anaconda.org/conda-forge/linux-64/biotite-1.7.1-py314hdff1159_0.conda
   sha256: 5b145fd7867a539f3b86d8a2930ae36f1554d4047326ef57d6d0a1e2b6302cdd
   md5: 20cc8de876e38e96d6e53133c4d27c6b
@@ -7632,6 +7658,24 @@ packages:
   run_exports: {}
   size: 58985162
   timestamp: 1782310635783
+- conda: https://conda.anaconda.org/conda-forge/linux-64/biotraj-1.2.2-py313h5d5ffb9_2.conda
+  sha256: 981fa8b0332cf4413a83321cc7317be2d8bdc43afc381d31372d6e0d224cce17
+  md5: 56143f8e7e65fd01b2a35ec0a88d8172
+  depends:
+  - python
+  - numpy >=1.26
+  - scipy >=1.13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python_abi 3.13.* *_cp313
+  license: LGPL-2.1-only
+  purls:
+  - pkg:pypi/biotraj?source=hash-mapping
+  run_exports: {}
+  size: 3815491
+  timestamp: 1767272676184
 - conda: https://conda.anaconda.org/conda-forge/linux-64/biotraj-1.2.2-py314h42812f9_2.conda
   sha256: 2ca9cb1fb2f35b6066b543fe9d6a59219eac12c1a82a7d1ba89b8301fc1491ee
   md5: 1fed0515b9bf438f2e8d5dde9d052981
@@ -7696,6 +7740,8 @@ packages:
   - libbrotlicommon 1.2.0 hb03c661_1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
   run_exports: {}
   size: 367721
   timestamp: 1764017371123
@@ -7745,6 +7791,20 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 207882
   timestamp: 1765214722852
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+  sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+  md5: 6130ad6705adc993b5d8482b7f66e01f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 210929
+  timestamp: 1784091008551
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
   sha256: 8e7a40f16400d7839c82581410aa05c1f8324a693c9d50079f8c50dc9fb241f0
   md5: abd85120de1187b0d1ec305c2173c71b
@@ -7821,6 +7881,23 @@ packages:
   run_exports: {}
   size: 300271
   timestamp: 1761203085220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py313hf46b229_0.conda
+  sha256: 8f8ee27b9f450fb2a2b568356d19c812ec4a511fe6f2042c1f0a04f2fa425fb9
+  md5: 575efaa378a66d0f2c6891092267edf7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 304647
+  timestamp: 1783424174920
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.13-h4d16d09_1.conda
   sha256: 200da7fefacb1a196dd7b4b6f45106cebe017042b1491e2b27c7cc833beed8ea
   md5: 5f68e67b2b9463501260e731e2999dec
@@ -7960,6 +8037,23 @@ packages:
   run_exports: {}
   size: 31751
   timestamp: 1778268677594
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py313hc8edb43_4.conda
+  sha256: 7f86eb205d2d7fcf2c82654a08c6a240623ac34cb406206b4b1f1afa5cda8e49
+  md5: 33639459bc29437315d4bff9ed5bc7a7
+  depends:
+  - numpy >=1.25
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/contourpy?source=hash-mapping
+  run_exports: {}
+  size: 321850
+  timestamp: 1769155964333
 - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
   sha256: b0314a7f1fb4a294b1a8bcf5481d4a8d9412a9fee23b7e3f93fb10e4d504f2cc
   md5: 95bede9cdb7a30a4b611223d52a01aa4
@@ -7993,6 +8087,22 @@ packages:
   run_exports: {}
   size: 419778
   timestamp: 1783019185319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.2-py313h3dea7bd_0.conda
+  sha256: 83ae7eb4af7533369cd373320be5973de018b5dee01a43c42c06bf5a773ca306
+  md5: 0ca456463b87657599aecdb9c664b3d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/coverage?source=compressed-mapping
+  run_exports: {}
+  size: 402264
+  timestamp: 1784150199793
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cccl-12.9.27-ha770c72_0.conda
   sha256: 501d37608d6f2fa5eff6270d782fd84cd3a8375aff23548dd16a1eae5149b176
   md5: 6ffab2fb624588d718aeb81f8dd38c8a
@@ -8780,6 +8890,8 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  purls:
+  - pkg:pypi/docutils?source=hash-mapping
   run_exports: {}
   size: 901056
   timestamp: 1755942635216
@@ -8841,6 +8953,23 @@ packages:
     - fonts-conda-ecosystem
   size: 281880
   timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py313h3dea7bd_0.conda
+  sha256: e0029a390d7aef29bd6e7c12a3759f5e0b989930b5781e544ca9bac0abcd8442
+  md5: ae83c999b4cfc4c171ce88b99c8b43cc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fonttools?source=hash-mapping
+  run_exports: {}
+  size: 2995315
+  timestamp: 1778770432258
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
   sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
   md5: 8462b5322567212beeb025f3519fb3e2
@@ -8913,6 +9042,25 @@ packages:
     - libgcc >=14
   size: 29324
   timestamp: 1781279939286
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gemmi-0.7.5-py313hbaa079c_0.conda
+  sha256: 10ac77aa3cd42b193d003bdc7f64c1d32dba8e4ecefc18d9f78cab94a0237984
+  md5: 895c5a768147a9d479351bf75b641bf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zlib-ng >=2.3.3,<2.4.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  purls:
+  - pkg:pypi/gemmi?source=hash-mapping
+  run_exports:
+    weak:
+    - gemmi >=0.7.5,<0.7.6.0a0
+  size: 4326665
+  timestamp: 1772446412986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gemmi-0.7.5-py314h2920e28_0.conda
   sha256: 845550119273b0d48d61c81f11ed5c5a2967205b3565792bea6bc001bc4836fa
   md5: 0bc57ccee14e5cbe203c3c46a5b1362b
@@ -8989,6 +9137,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=compressed-mapping
   run_exports: {}
   size: 267125
   timestamp: 1782524630615
@@ -9094,6 +9244,22 @@ packages:
   run_exports: {}
   size: 54664
   timestamp: 1757685467253
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kalign-python-3.6.0-py313h92f78c6_0.conda
+  sha256: 7c2bb87965a3cc22bee35c89cdfeed66f3057797b7f4c12fcebfe95e6ac992b5
+  md5: 4982ca96d8c30ccae5c90ff679137d20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/kalign-python?source=hash-mapping
+  run_exports: {}
+  size: 368599
+  timestamp: 1778955701574
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kalign-python-3.6.0-py314h118ebf0_0.conda
   sha256: f7c942bcb2702ea930a74011f525376f6982c04c2020868d53e642b42e5041bd
   md5: c4aa8cc97a29ee2454435068531a9219
@@ -9123,6 +9289,22 @@ packages:
     - keyutils >=1.6.3,<2.0a0
   size: 134088
   timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py313hc8edb43_0.conda
+  sha256: 0447d2901639f295989c5ccba7b1c367ed78b216e0d2705327a8c8a87a31177e
+  md5: b81883b9dbf5069821c2fb09a8ba1407
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/kiwisolver?source=hash-mapping
+  run_exports: {}
+  size: 76911
+  timestamp: 1773067054809
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
   sha256: e3488ea4a336f29e57de8f282bf40c0505cfc482e03004615e694b48e7d9c79f
   md5: 7397e418cab519b8d789936cf2dde6f6
@@ -9188,6 +9370,20 @@ packages:
   run_exports: {}
   size: 728002
   timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275
@@ -9316,6 +9512,24 @@ packages:
   run_exports: {}
   size: 3151820
   timestamp: 1766348212857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py313hfaae9d9_5.conda
+  sha256: 17cf7433f9b4d9112aa5555a1ceb44f92523775e176a74da95d13c227151bb1b
+  md5: 70972ce69d695861812bcc1284849286
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - boost <0.0a0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  purls: []
+  run_exports: {}
+  size: 124034
+  timestamp: 1766348701781
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py314h3a4f467_5.conda
   sha256: 33e3bc248d730b8c2950c30cda78b10c4dcd492ceafc7067dd507cdb1769758d
   md5: 3df01e5c27e70b0cee2408438514b703
@@ -10193,6 +10407,21 @@ packages:
     - libjpeg-turbo >=3.1.4.1,<4.0a0
   size: 633831
   timestamp: 1775962768273
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+  sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+  md5: 466badda5536d85ddc63ee9404f29735
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.2.0,<4.0a0
+  size: 652868
+  timestamp: 1783731886811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
   build_number: 8
   sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
@@ -11014,6 +11243,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
   run_exports: {}
   size: 26100
   timestamp: 1772445154165
@@ -11034,6 +11265,38 @@ packages:
   run_exports: {}
   size: 27424
   timestamp: 1772445227915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py313h6c470cf_1.conda
+  sha256: e6335a7fcb1cc9c6dd0aae18bed34080764dda4486c314505536e84e38fde69b
+  md5: 1a3cd18fa2cfd6048c4e052ff9d9ff26
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libraqm >=0.10.5,<0.11.0a0
+  - libstdcxx >=14
+  - numpy >=1.23
+  - numpy >=1.25,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.13.* *_cp313
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/matplotlib?source=compressed-mapping
+  run_exports: {}
+  size: 8974852
+  timestamp: 1782829528425
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.0-py314had63eae_1.conda
   sha256: 666a19f61a40c5936bd0f07965b159ced727256fa7e2a4ff9dd5f0146aad86f1
   md5: 5866f3034ce42e8d512e7640f43270fd
@@ -11084,6 +11347,24 @@ packages:
   run_exports: {}
   size: 143201396
   timestamp: 1781016571972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_243.conda
+  sha256: c68967a13488684d87fb7ac77b73c6f3f825f2da403707a14e75374c0ce3629f
+  md5: cef284d6d9fe0caf11638f5f0e4f9a64
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=22.1.8
+  - onemkl-license 2026.1.0 ha770c72_243
+  - tbb >=2023.0.0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 143101973
+  timestamp: 1783700248990
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
   sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
   md5: 770d00bf57b5599c4544d61b61d8c6c6
@@ -11122,6 +11403,22 @@ packages:
   purls: []
   run_exports: {}
   size: 4204
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313hc8edb43_1.conda
+  sha256: 6bc2690c67ba7354affa0498a68998fad8f66759c287706e7ff42c2242e14ccb
+  md5: edd7c461f72756bd3829f836e107c488
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/msgpack?source=compressed-mapping
+  run_exports: {}
+  size: 112798
+  timestamp: 1782460772873
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py314h97ea11e_1.conda
   sha256: f33032ef3dcb8759309e8a55b0cb989e377ce315122bb86b00c0adbcf6665abf
   md5: 1c8698b2012012806ec17a062bb9f339
@@ -11196,6 +11493,29 @@ packages:
   run_exports: {}
   size: 186323
   timestamp: 1763688260928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py313hf6604e3_1.conda
+  sha256: 2f8aff2a17e4d43012e9863ef4392e6d5de3ae9da0c3e322831f8c5c3d86df71
+  md5: dce261869f78ba9b81b9091b084d328d
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  run_exports:
+    weak:
+    - numpy >=1.23,<3
+  size: 8919234
+  timestamp: 1766383469748
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py314h2b28147_1.conda
   sha256: 81425306df4f0ddba159e80c8d91323a34df335079ca93a194201e57b337231c
   md5: ab17cb5f388fa17c08937cb9cc24e7b6
@@ -11264,6 +11584,15 @@ packages:
   run_exports: {}
   size: 39966
   timestamp: 1781016460562
+- conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.1.0-ha770c72_243.conda
+  sha256: b560b1106416b7df0041144aad3842e8783e22c70418a46cbcc90fe67a96b229
+  md5: 2617b8e56c82fe48be8951e7794f08bc
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 39889
+  timestamp: 1783700145236
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
   md5: 11b3379b191f63139e29c0d19dee24cd
@@ -11407,6 +11736,64 @@ packages:
   run_exports: {}
   size: 14912799
   timestamp: 1764615091147
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py313hbfd7664_0.conda
+  sha256: a02d58327a57eb2f149c040b31c758fc6acea7c6aa5cb09b40b146eb6ed637d9
+  md5: 70d4dd67877354f6912af31177cb1117
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandas?source=compressed-mapping
+  run_exports: {}
+  size: 15001668
+  timestamp: 1778602610159
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
   sha256: 8e4b161f3f7fbdf17f842b518ff3794b6af9378a90d095719d7153360d126dc1
   md5: bc2e1390314b1269e66fb1966fbcae5d
@@ -11497,6 +11884,30 @@ packages:
     - perl >=5.32.1,<6.0a0 *_perl5
   size: 13344463
   timestamp: 1703310653947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py313h80991f8_0.conda
+  sha256: cb3e51a639d19e04d0ea197ff6f6805a40eeef92d762642f28fa1cd1d25f672a
+  md5: 730e462e7e141813192b606cf07ebdd0
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - lcms2 >=2.19.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - tk >=8.6.13,<8.7.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - python_abi 3.13.* *_cp313
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  license: HPND
+  purls:
+  - pkg:pypi/pillow?source=compressed-mapping
+  run_exports: {}
+  size: 1077037
+  timestamp: 1782912080163
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
   sha256: bcab128df8980514061a78b9c67f5004954048f584da20df8c5a78de9e3f5abb
   md5: 233e62a8eb894b79b5c93f4f8dec4dcd
@@ -11537,6 +11948,20 @@ packages:
     - pixman >=0.46.4,<1.0a0
   size: 450960
   timestamp: 1754665235234
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+  sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+  md5: 7cd77fef4da3e1ca9484394616cb71f1
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  purls: []
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
+  size: 376220
+  timestamp: 1784286827180
 - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py314h61e7c5f_2.conda
   sha256: ceed4e3b1d13b0f200afbf01f7e314111cce85e116b8db512ff940571ba64104
   md5: 418826d23f3fa6354700b4f31c5b87ba
@@ -11558,6 +11983,27 @@ packages:
   run_exports: {}
   size: 491842
   timestamp: 1773265994654
+- conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.35.1-py313h098d647_1.conda
+  sha256: de6fcd9425f283d54c5b890d0faacb68af90a993f831692a53b6bb49cf8b2a0a
+  md5: 983a0c489bb61bdf6f752784913fd4bd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260526.0,<20260527.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 7.35.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/protobuf?source=hash-mapping
+  run_exports: {}
+  size: 491577
+  timestamp: 1781356299811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.35.1-py314h8f612e1_1.conda
   sha256: d0497d95a3ea807d17d906bd787eee373f23c8af244ea204056a4efd2acd0756
   md5: 3557e8b001473ee4613805d2a1d93a5e
@@ -11589,6 +12035,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   run_exports: {}
   size: 228663
   timestamp: 1769678153829
@@ -11632,6 +12080,23 @@ packages:
   run_exports: {}
   size: 228171
   timestamp: 1757853258550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py313h3f29d12_1.conda
+  sha256: 282f1bb7996ff55a3de70771e37a100da95743d5a574e16f0d8e60ed8449ad9f
+  md5: 4bc473b93f2304acb6eb291c92fa3dc5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-2.1-only OR MPL-1.1
+  purls:
+  - pkg:pypi/pycairo?source=hash-mapping
+  run_exports: {}
+  size: 118064
+  timestamp: 1770726348986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py314h9cd037b_1.conda
   sha256: d325468144ce190d0f162a62e2e93dc23ddb5d68bb16764bd6f541c3a9430c26
   md5: 2bec2eaba61461dd0d0ebeaff47a5c7d
@@ -11662,6 +12127,8 @@ packages:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
   run_exports: {}
   size: 1893749
   timestamp: 1778084222642
@@ -11706,6 +12173,7 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   license: Python-2.0
+  purls: []
   run_exports:
     weak:
     - python_abi 3.13.* *_cp313
@@ -11761,6 +12229,20 @@ packages:
   run_exports: {}
   size: 206679
   timestamp: 1780630652883
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-lmdb-2.3.0-py313h54dd161_0.conda
+  sha256: fbcda02f0a6f30e2de0e0f5a69688684aac76c8ffaf2bb7b3368b842ccbc4b1b
+  md5: 1e3cd4aaf820ed55d4acfe6dc7acfd08
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: OLDAP-2.8
+  purls:
+  - pkg:pypi/lmdb?source=hash-mapping
+  run_exports: {}
+  size: 215062
+  timestamp: 1784229007296
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py314_hfa65069_305.conda
   sha256: bff8f588459f25859f7d932482fedd5a3dba5641eef79b8d38129cf5e2ee40f2
   md5: 37ae3822370f0ec41ed7492388b3fb13
@@ -12091,6 +12573,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   run_exports: {}
   size: 201616
   timestamp: 1770223543730
@@ -12124,6 +12608,36 @@ packages:
     - qhull >=2020.2,<2020.3.0a0
   size: 552937
   timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py313h66a1ddb_1.conda
+  sha256: ab3f768f83a8a1b73d6b2da4f9452074b13faaebc077a0abac91cfe00329b914
+  md5: c314bf18262cfb441a219ae1fa5bcef3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
+  - libgcc >=14
+  - libpq >=18.3,<19.0a0
+  - librdkit 2025.09.6 h4dfd318_1
+  - libstdcxx >=14
+  - matplotlib-base
+  - numpy >=1.23,<3
+  - pandas
+  - pillow
+  - pycairo
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - reportlab
+  - sqlalchemy
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/rdkit?source=hash-mapping
+  run_exports: {}
+  size: 20224406
+  timestamp: 1773046759514
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
   sha256: 88ac82e7a4cd70b93a30029f20d5415b7c21cc8abd99f097245ff7bbb91b515c
   md5: 0df58bdf9a687ec8d0075885b0e43f0f
@@ -12212,6 +12726,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
   run_exports: {}
   size: 149946
   timestamp: 1766159512977
@@ -12247,6 +12763,22 @@ packages:
   run_exports: {}
   size: 9342178
   timestamp: 1782428525856
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.22-h462bb3b_0.conda
+  noarch: python
+  sha256: 2002c7869a95ed94b03303a033fcc24b608597bdd01c8f01d90c47175616edb9
+  md5: ad7d8b2d37a1098a04ddd8b34b962481
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  purls:
+  - pkg:pypi/ruff?source=compressed-mapping
+  run_exports: {}
+  size: 9333318
+  timestamp: 1784237314764
 - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
   sha256: 856866fd519b812db3e092aba308248dd87b5c308186fcffe593f309373ae94c
   md5: 3f578c7d2b0bb52469340e4060d48d94
@@ -12262,6 +12794,45 @@ packages:
     - s2n >=1.7.2,<1.7.3.0a0
   size: 387306
   timestamp: 1777466173323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+  sha256: 7369ac21f3561e2203f5b1600ef0671270057380783ca4b9e15f679ba25db575
+  md5: fa1c00d999e83ec20173c9775f71a1f1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - s2n >=1.7.5,<1.7.6.0a0
+  size: 392607
+  timestamp: 1783164766248
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+  sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
+  md5: a32f88181ff9a3451c71be1f17a7c799
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=compressed-mapping
+  run_exports: {}
+  size: 17171066
+  timestamp: 1781912954186
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
   sha256: 85503102237f8515ab92319fc14609e894ac9e95e3a1398b0c49db1f9ee50877
   md5: 62c390c1f8f51240f1ebc7ba782669ad
@@ -12313,6 +12884,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
   run_exports: {}
   size: 3852066
   timestamp: 1781547880247
@@ -12364,6 +12937,23 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3301196
   timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
 - conda: https://conda.anaconda.org/conda-forge/linux-64/triton-3.6.0-cuda129py314h2b49ec1_2.conda
   sha256: da5243c7f03e5dd5162f5434bbaa0b4a59f29f28dd0eaeb73cdc84d963ad4f6a
   md5: ec39e29cc9ed8706e5eabce88a271d9c
@@ -12464,6 +13054,23 @@ packages:
   run_exports: {}
   size: 40376689
   timestamp: 1781881965775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
+  sha256: 7f2e4f38e57c17858c644259a1be868d6e98780239fd93bfa057cb5cfc24a928
+  md5: cb423e0853b3dde2b3738db4dedf5ba2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  run_exports: {}
+  size: 14910
+  timestamp: 1769438729201
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
   sha256: c84034056dc938c853e4f61e72e5bd37e2ec91927a661fb9762f678cbea52d43
   md5: 5d3c008e54c7f49592fca9c32896a76f
@@ -12496,6 +13103,34 @@ packages:
   run_exports: {}
   size: 409562
   timestamp: 1770909102180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.28.0-py313h843e2db_0.conda
+  sha256: e102c975acc0b827a1d30ffa32000f4a06a4cd3e9b5d6246808c0c3f7869c916
+  md5: 0fe4b56ce6d6eaa82396d4eff5728694
+  depends:
+  - packaging
+  - pydantic >=2.6,<3
+  - python
+  - click >=8.2.0
+  - gitpython >=1.0.0,!=3.1.29
+  - platformdirs
+  - protobuf >4.21.0,!=5.28.0,!=5.29.0,<8
+  - pyyaml
+  - requests >=2.0.0,<3
+  - sentry-sdk >=2.0.0
+  - typing_extensions >=4.8,<5
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - __glibc >=2.17
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wandb?source=hash-mapping
+  run_exports: {}
+  size: 24823847
+  timestamp: 1782231034092
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.28.0-py314h2e6c369_0.conda
   sha256: 73473980e6fa97806c2ca4f4718945be75c507d234ea54ebe416128a520b3be4
   md5: 592b83c78e5d8111348266149bf11096
@@ -12537,6 +13172,21 @@ packages:
   run_exports: {}
   size: 64865
   timestamp: 1756851811052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
+  sha256: 234b4888d4303c29f839408345f52194078716a369680920af09f6a8fef803a9
+  md5: d6f92eb04d026a9e5b9c5d52c8cd65d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  run_exports: {}
+  size: 117401
+  timestamp: 1782133645625
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
   sha256: f2789ff73f60f3b740629146a64f778bbf40e26900978cb632180878a496423c
   md5: e1e275654a6c998b7357606f5da46af7
@@ -17785,6 +18435,21 @@ packages:
   run_exports: {}
   size: 89223
   timestamp: 1783155090442
+- conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.50-pyhd8ed1ab_0.conda
+  sha256: f79217bbab919c4e2508e838d7604ebbd34557daad3b0fd4eb3a6740447195b2
+  md5: cd1b32fc2fae046905da2e8fed40ec90
+  depends:
+  - botocore >=1.43.50,<1.44.0
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - s3transfer >=0.19.0,<0.20.0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/boto3?source=compressed-mapping
+  run_exports: {}
+  size: 88508
+  timestamp: 1784289011251
 - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.39-pyhd8ed1ab_0.conda
   sha256: 720a5c5a3c83840ec79b167ddf67a3b382e9af966ac9a2babaf359c77f3700c3
   md5: 86405728dad2cb65223e5c96a64952af
@@ -17800,6 +18465,21 @@ packages:
   run_exports: {}
   size: 8749870
   timestamp: 1783119864337
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.50-pyhd8ed1ab_0.conda
+  sha256: 4c294a5ab7aeae8755224a8bb39eab034dab924bf075a5a930fbb1130a27f67d
+  md5: 4e260740ede31e3a099de6001253f078
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/botocore?source=compressed-mapping
+  run_exports: {}
+  size: 8800570
+  timestamp: 1784272609753
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
   md5: a9965dd99f683c5f444428f896635716
@@ -17845,6 +18525,18 @@ packages:
   run_exports: {}
   size: 58872
   timestamp: 1775127203018
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+  sha256: 8d8813ef655b4e75e4fb897abd83ad548882efad7b4e836b021b797f42780799
+  md5: d154b40b109e503430979e8a8d099eaf
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=compressed-mapping
+  run_exports: {}
+  size: 61418
+  timestamp: 1783505332569
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
   sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
   md5: 2c4bd6aeb90bb157456841c3270a0d92
@@ -18532,6 +19224,17 @@ packages:
   run_exports: {}
   size: 38993
   timestamp: 1783063554943
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.30.2-pyhd8ed1ab_0.conda
+  sha256: 6ce888c8d597af7aba41e5a48b8fcc86fba072a97297d39f821968297b27d497
+  md5: 0c38ae0295ee197e7f26675f34e173c4
+  depends:
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=compressed-mapping
+  run_exports: {}
+  size: 74480
+  timestamp: 1784269447478
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -18691,6 +19394,20 @@ packages:
   run_exports: {}
   size: 162193
   timestamp: 1778065820061
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.52-pyhd8ed1ab_0.conda
+  sha256: d3b01f5ba797df68dd680cea943a0aad0dc23b2a5b53a60e5b2b816a1d17c047
+  md5: f3f5111c75b5d06a9d8abc849180f2fe
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.10
+  - typing_extensions >=3.10.0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/gitpython?source=hash-mapping
+  run_exports: {}
+  size: 164773
+  timestamp: 1784209954001
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -18791,6 +19508,19 @@ packages:
   run_exports: {}
   size: 32710
   timestamp: 1771983049252
+- conda: https://conda.anaconda.org/conda-forge/noarch/ijson-3.5.1-pyhcf101f3_1.conda
+  sha256: 3c55b1b9f53e15714354324a33e219454ed62f8df202dd7552159723d986b4ef
+  md5: f9c4de829f497cb3f6848aef322228d0
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/ijson?source=hash-mapping
+  run_exports: {}
+  size: 33466
+  timestamp: 1783433147816
 - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
   sha256: 5a047f9eac290e679b4e6f6f4cbfcc5acdfbf031a4f06824d4ddb590cdbb850b
   md5: 92617c2ba2847cca7a6ed813b6f4ab79
@@ -19664,6 +20394,21 @@ packages:
   run_exports: {}
   size: 35503
   timestamp: 1783111064496
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.4-pyhcf101f3_0.conda
+  sha256: 9384ca69570af20fd91f2b0b659cdcbcba4ce5ced2a08c6dd234b13a6cd80411
+  md5: 1b77c69c18f649eb348bafedb277fecb
+  depends:
+  - python >=3.10
+  - filelock >=3.15.4
+  - platformdirs <5,>=4.3.6
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/python-discovery?source=hash-mapping
+  run_exports: {}
+  size: 35789
+  timestamp: 1783599318259
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
   md5: 23029aae904a2ba587daba708208012f
@@ -19693,6 +20438,7 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   run_exports: {}
   size: 7002
   timestamp: 1752805902938
@@ -19845,6 +20591,19 @@ packages:
   run_exports: {}
   size: 73916
   timestamp: 1781693053515
+- conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 9b3691f28b0b7168681e4f008408ea457ae47ac748c32ac81698f342c6b1dfbe
+  md5: 8fba8b24622821515617fb5cfd876ed5
+  depends:
+  - botocore >=1.37.4,<2.0a.0
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/s3transfer?source=compressed-mapping
+  run_exports: {}
+  size: 73972
+  timestamp: 1783769377417
 - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.64.0-pyhd8ed1ab_0.conda
   sha256: de2517f2a4cf06cf3ac6ff35ad54b98e7b73d3c51561ab013a2c59a15efb6dc6
   md5: 867c1f7e2ffd6ac557f50da25a2b6aed
@@ -19859,6 +20618,20 @@ packages:
   run_exports: {}
   size: 313685
   timestamp: 1782821797845
+- conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.66.0-pyhd8ed1ab_0.conda
+  sha256: d51ab84b1e7c35c325f64522d13b4b86d98ff7b388155615de31076c8d979813
+  md5: 3d69c13543e4ec1d70fc44d93c617e8d
+  depends:
+  - certifi
+  - python >=3.10
+  - urllib3 >=1.25.7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/sentry-sdk?source=compressed-mapping
+  run_exports: {}
+  size: 318060
+  timestamp: 1784223463013
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
   sha256: 6ecf738d5590bf228f09c4ecd1ea91d811f8e0bd9acdef341bc4d6c36beb13a3
   md5: d629a398d7bf872f9ed7b27ab959de15
@@ -20247,6 +21020,22 @@ packages:
   run_exports: {}
   size: 94965
   timestamp: 1781741268338
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.4-pyh8f84b5b_0.conda
+  sha256: 1964320e89c00a531705449187f4b8ed85f935c73f13ba55de3a6b35b05443fa
+  md5: 54772f97dc361b1659ef0b34d71d39b4
+  depends:
+  - python >=3.10
+  - __unix
+  - python
+  constrains:
+  - envwrap >=0.2
+  - ipywidgets >=6.0
+  license: MPL-2.0 and MIT
+  purls:
+  - pkg:pypi/tqdm?source=compressed-mapping
+  run_exports: {}
+  size: 681697
+  timestamp: 1783440211093
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -20318,6 +21107,14 @@ packages:
   run_exports: {}
   size: 119135
   timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  purls: []
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640
 - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.9.3-pyhd8ed1ab_0.conda
   sha256: 33afef3f9b2e3b73254a9401cf7a101632ac74f704fdf7e744ca896720797caa
   md5: 04429efde19509f6672b9f9434676ae9
@@ -20358,6 +21155,20 @@ packages:
   run_exports: {}
   size: 43340
   timestamp: 1781729813650
+- conda: https://conda.anaconda.org/conda-forge/noarch/vcrpy-8.3.0-pyhd8ed1ab_0.conda
+  sha256: 71a8c59f1f1872744bcaf9eb6ac5030e8b80329150dcdefdff835f5c823bb257
+  md5: 8222a182f349bb5a6b3dd1dda51c0aaa
+  depends:
+  - python >=3.10
+  - pyyaml
+  - wrapt
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/vcrpy?source=hash-mapping
+  run_exports: {}
+  size: 44492
+  timestamp: 1783381851939
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.1-pyhcf101f3_0.conda
   sha256: 0a7b0a2ada7ad719f9d4f8874eb10911e1fcfdecefc86456105eb806ebd60ac4
   md5: e449fb99b714be1e13fa5564dacd1af5
@@ -20377,6 +21188,25 @@ packages:
   run_exports: {}
   size: 3111990
   timestamp: 1781651033074
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.6.1-pyhcf101f3_0.conda
+  sha256: a3a78b98b620dde6908361318e8b8c25541c51078beb3aa8c98b3b9c51e530bb
+  md5: d88ad67ad6d55077bd1751736f3e84c1
+  depends:
+  - python >=3.10
+  - distlib >=0.3.7,<1
+  - filelock <4,>=3.24.2
+  - importlib-metadata >=6.6
+  - platformdirs >=3.9.1,<5
+  - python-discovery >=1.4.2
+  - typing_extensions >=4.13.2
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=hash-mapping
+  run_exports: {}
+  size: 3271213
+  timestamp: 1783721909186
 - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   md5: 7e1e5ff31239f9cd5855714df8a3783d
@@ -27840,6 +28670,11 @@ packages:
   requires_dist:
   - nvidia-nvjitlink
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: propcache
+  version: 0.5.2
+  sha256: 4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8d/27/b19d776f6082e2fedbc8dc532824c3d2bc0b39ef7421370e0d9907f50c7f/cuequivariance_ops_torch_cu13-0.10.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
   name: cuequivariance-ops-torch-cu13
   version: 0.10.0
@@ -28038,6 +28873,25 @@ packages:
   - tensorrt-cu13 ; extra == 'plugins'
   - polygraphy ; extra == 'plugins'
   - cuda-bindings ; extra == 'plugins'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: aiohttp
+  version: 3.14.1
+  sha256: faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451
+  requires_dist:
+  - aiohappyeyeballs>=2.5.0
+  - aiosignal>=1.4.0
+  - async-timeout>=4.0,<6.0 ; python_full_version < '3.11'
+  - attrs>=17.3.0
+  - frozenlist>=1.1.1
+  - multidict>=4.5,<7.0
+  - propcache>=0.2.0
+  - typing-extensions>=4.4 ; python_full_version < '3.13'
+  - yarl>=1.17.0,<2.0
+  - aiodns>=3.3.0 ; sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+  - brotli>=1.2 ; platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+  - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
+  - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
   name: pytest-cov
@@ -28432,6 +29286,13 @@ packages:
   - xlsxwriter>=3.2.0 ; extra == 'all'
   - zstandard>=0.23.0 ; extra == 'all'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: multidict
+  version: 6.7.1
+  sha256: 9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429
+  requires_dist:
+  - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/b0/c9/faa051848450109c83d29c7b1d5871deea4a33aacbb8bacccb7b0e5460b8/rdkit-2025.9.6-cp314-cp314-manylinux_2_28_x86_64.whl
   name: rdkit
   version: 2025.9.6
@@ -28905,6 +29766,11 @@ packages:
   - cuda-toolkit==13.* ; extra == 'all'
   - nvidia-cudla==13.* ; platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'all'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: frozenlist
+  version: 1.8.0
+  sha256: fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d7/3b/2abcc7f47e955a8cb45a6378ec69cd8ed2dcb3d14ceb67717dea020a794a/boto3-1.43.40-py3-none-any.whl
   name: boto3
   version: 1.43.40
@@ -29041,6 +29907,15 @@ packages:
   version: 2.2.1
   sha256: a303e0c9d2e187e0304497ad3bb361d1ac359b55ce929d1aca2caec06582c134
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: yarl
+  version: 1.24.2
+  sha256: 91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
   name: packaging
   version: '26.2'
@@ -29447,3 +30322,215 @@ packages:
   requires_dist:
   - typing-extensions>=4.1.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1151-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+  name: amd-torch-device-gfx1151
+  version: 2.14.0a0+rocm7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - torch==2.14.0a0+rocm7.15.0a20260717
+  - rocm-sdk-device-gfx1151==7.15.0a20260717
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx115x-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+  name: amd-torch-device-gfx115x
+  version: 2.14.0a0+rocm7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - torch==2.14.0a0+rocm7.15.0a20260717
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/mpmath-1.3.0-py3-none-any.whl
+  name: mpmath
+  version: 1.3.0
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - pytest>=4.6 ; extra == 'develop'
+  - pycodestyle ; extra == 'develop'
+  - pytest-cov ; extra == 'develop'
+  - codecov ; extra == 'develop'
+  - wheel ; extra == 'develop'
+  - sphinx ; extra == 'docs'
+  - gmpy2>=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
+  - pytest>=4.6 ; extra == 'tests'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.15.0a20260717.tar.gz
+  name: rocm
+  version: 7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - rocm==7.15.0a20260717
+  - rocm-sdk-core==7.15.0a20260717
+  - rocm-sdk-libraries==7.15.0a20260717 ; extra == 'libraries'
+  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device'
+  - rocm-sdk-devel==7.15.0a20260717 ; extra == 'devel'
+  - rocm-profiler==7.15.0a20260717 ; extra == 'profiler'
+  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device-gfx1010'
+  - rocm-sdk-device-gfx1011==7.15.0a20260717 ; extra == 'device-gfx1011'
+  - rocm-sdk-device-gfx1012==7.15.0a20260717 ; extra == 'device-gfx1012'
+  - rocm-sdk-device-gfx1030==7.15.0a20260717 ; extra == 'device-gfx1030'
+  - rocm-sdk-device-gfx1031==7.15.0a20260717 ; extra == 'device-gfx1031'
+  - rocm-sdk-device-gfx1032==7.15.0a20260717 ; extra == 'device-gfx1032'
+  - rocm-sdk-device-gfx1033==7.15.0a20260717 ; extra == 'device-gfx1033'
+  - rocm-sdk-device-gfx1034==7.15.0a20260717 ; extra == 'device-gfx1034'
+  - rocm-sdk-device-gfx1035==7.15.0a20260717 ; extra == 'device-gfx1035'
+  - rocm-sdk-device-gfx1036==7.15.0a20260717 ; extra == 'device-gfx1036'
+  - rocm-sdk-device-gfx1100==7.15.0a20260717 ; extra == 'device-gfx1100'
+  - rocm-sdk-device-gfx1101==7.15.0a20260717 ; extra == 'device-gfx1101'
+  - rocm-sdk-device-gfx1102==7.15.0a20260717 ; extra == 'device-gfx1102'
+  - rocm-sdk-device-gfx1103==7.15.0a20260717 ; extra == 'device-gfx1103'
+  - rocm-sdk-device-gfx1150==7.15.0a20260717 ; extra == 'device-gfx1150'
+  - rocm-sdk-device-gfx1151==7.15.0a20260717 ; extra == 'device-gfx1151'
+  - rocm-sdk-device-gfx1152==7.15.0a20260717 ; extra == 'device-gfx1152'
+  - rocm-sdk-device-gfx1153==7.15.0a20260717 ; extra == 'device-gfx1153'
+  - rocm-sdk-device-gfx1200==7.15.0a20260717 ; extra == 'device-gfx1200'
+  - rocm-sdk-device-gfx1201==7.15.0a20260717 ; extra == 'device-gfx1201'
+  - rocm-sdk-device-gfx1250==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx1250'
+  - rocm-sdk-device-gfx900==7.15.0a20260717 ; extra == 'device-gfx900'
+  - rocm-sdk-device-gfx906==7.15.0a20260717 ; extra == 'device-gfx906'
+  - rocm-sdk-device-gfx908==7.15.0a20260717 ; extra == 'device-gfx908'
+  - rocm-sdk-device-gfx90a==7.15.0a20260717 ; extra == 'device-gfx90a'
+  - rocm-sdk-device-gfx942==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx942'
+  - rocm-sdk-device-gfx950==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-gfx950'
+  - rocm-sdk-device-gfx1010==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1011==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1012==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1030==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1031==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1032==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1033==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1034==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1035==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1036==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1100==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1101==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1102==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1103==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1150==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1151==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1152==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1153==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1200==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1201==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx1250==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
+  - rocm-sdk-device-gfx900==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx906==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx908==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx90a==7.15.0a20260717 ; extra == 'device-all'
+  - rocm-sdk-device-gfx942==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
+  - rocm-sdk-device-gfx950==7.15.0a20260717 ; sys_platform == 'linux' and extra == 'device-all'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl
+  name: rocm-bootstrap
+  version: 0.1.0
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - pytest ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.15.0a20260717-py3-none-linux_x86_64.whl
+  name: rocm-sdk-core
+  version: 7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1151-7.15.0a20260717-py3-none-linux_x86_64.whl
+  name: rocm-sdk-device-gfx1151
+  version: 7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - rocm-sdk-libraries==7.15.0a20260717
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.15.0a20260717-py3-none-linux_x86_64.whl
+  name: rocm-sdk-libraries
+  version: 7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/sympy-1.14.0-py3-none-any.whl
+  name: sympy
+  version: 1.14.0
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - mpmath>=1.1.0,<1.4
+  - pytest>=7.1.0 ; extra == 'dev'
+  - hypothesis>=6.70.0 ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.14.0a0%2Brocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+  name: torch
+  version: 2.14.0a0+rocm7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - filelock
+  - typing-extensions>=4.10.0
+  - setuptools>=77.0.3
+  - sympy>=1.13.3
+  - networkx>=2.5.1
+  - jinja2
+  - fsspec>=0.8.5
+  - rocm[libraries]==7.15.0a20260717
+  - triton==3.8.0+git43422b04.rocm7.15.0a20260717
+  - optree>=0.13.0 ; extra == 'optree'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - pyyaml ; extra == 'pyyaml'
+  - rocm-bootstrap
+  - amd-torch-device-gfx1010==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1010'
+  - amd-torch-device-gfx1011==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1011'
+  - amd-torch-device-gfx1012==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1012'
+  - amd-torch-device-gfx1030==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1030'
+  - amd-torch-device-gfx1031==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1031'
+  - amd-torch-device-gfx1032==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1032'
+  - amd-torch-device-gfx1033==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1033'
+  - amd-torch-device-gfx1034==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1034'
+  - amd-torch-device-gfx1035==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1035'
+  - amd-torch-device-gfx1036==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1036'
+  - amd-torch-device-gfx1100==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1100'
+  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1100'
+  - amd-torch-device-gfx1101==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1101'
+  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1101'
+  - amd-torch-device-gfx1102==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1102'
+  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1102'
+  - amd-torch-device-gfx1103==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1103'
+  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1103'
+  - amd-torch-device-gfx1150==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1150'
+  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1150'
+  - amd-torch-device-gfx1151==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1151'
+  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1151'
+  - amd-torch-device-gfx1152==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1152'
+  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1152'
+  - amd-torch-device-gfx1153==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1153'
+  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1153'
+  - amd-torch-device-gfx1200==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1200'
+  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1200'
+  - amd-torch-device-gfx1201==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1201'
+  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx1201'
+  - amd-torch-device-gfx900==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx900'
+  - amd-torch-device-gfx906==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx906'
+  - amd-torch-device-gfx908==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx908'
+  - amd-torch-device-gfx90a==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx90a'
+  - amd-torch-device-gfx942==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx942'
+  - amd-torch-device-gfx950==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-gfx950'
+  - amd-torch-device-gfx1010==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1011==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1012==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1030==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1031==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1032==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1033==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1034==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1035==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1036==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1100==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1101==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1102==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1103==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx110x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1150==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1151==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1152==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1153==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx115x==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx12-0==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1200==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx1201==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx900==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx906==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx908==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx90a==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx942==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  - amd-torch-device-gfx950==2.14.0a0+rocm7.15.0a20260717 ; extra == 'device-all'
+  requires_python: '>=3.10'
+- pypi: https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.8.0%2Bgit43422b04.rocm7.15.0a20260717-cp313-cp313-linux_x86_64.whl
+  name: triton
+  version: 3.8.0+git43422b04.rocm7.15.0a20260717
+  index: https://rocm.nightlies.amd.com/whl-multi-arch/
+  requires_dist:
+  - importlib-metadata ; python_full_version < '3.10'
+  requires_python: '>=3.10,<3.15'

--- a/pixi.toml
+++ b/pixi.toml
@@ -302,15 +302,19 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   torch = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
   triton-rocm = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
 
-# AMD GPU support via TheRock nightly wheels. Adds gfx1151 (Strix Halo) support,
-# which the official rocm7.2 wheels (openfold3-rocm7) lack. Nightly/prerelease,
-# pinned in pixi.lock; keep openfold3-rocm7 as the stable fallback.
+# AMD GPU support via TheRock (AMD's production build system as of ROCm 7.14).
+# Adds gfx1151 (Strix Halo) support, which the official rocm7.2 wheels
+# (openfold3-rocm7) lack. gfx1151 wheels are only published to TheRock's
+# multi-arch index and are still prerelease-tagged (+rocmX.Y.0a<date>); there is
+# no PyPI/conda-forge/stable wheel yet. We pin one dated 7.14-line build for
+# reproducibility. Keep openfold3-rocm7 as the stable fallback for other AMD GPUs.
 [feature.pytorch-pypi-therock]
 
   platforms = ["linux-64"]
 
   [feature.pytorch-pypi-therock.pypi-options]
-  # Nightly wheels (incl. transitive rocm-sdk-*) need a global prerelease allow.
+  # TheRock wheels (incl. transitive rocm-sdk-*) carry a prerelease tag, so pip
+  # needs a global prerelease allow even though we pin an exact version below.
   prerelease-mode = "allow"
   # torch's exact rocm[libraries]/device pins live here too, so make it an index.
   extra-index-urls = ["https://rocm.nightlies.amd.com/whl-multi-arch/"]
@@ -323,8 +327,10 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   cxx-compiler = "*"
 
   [feature.pytorch-pypi-therock.pypi-dependencies]
+  # Pinned to the latest ROCm 7.14-line build (torch 2.12 is AMD's top validated
+  # PyTorch for 7.14). Bump the version/date together to move the pin.
   # Change device-gfx1151 to retarget another AMD GPU.
-  torch = { version = "*", extras = ["device-gfx1151"] }
+  torch = { version = "==2.12.0+rocm7.14.0a20260624", extras = ["device-gfx1151"] }
   triton = "*"
 
 [feature.cuda12]

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,6 +23,7 @@
 #                                                     keeping the environments as sane and consistent as possible
 #                                                     (useful if requiring deps not yet in conda-forge)
 #   - openfold3-rocm7: environment for AMD GPU support with ROCm 7.x (linux-64 only at the moment)
+#   - openfold3-therock: AMD GPU support via TheRock nightly wheels, adds APU/Strix Halo (gfx1151) support (linux-64 only)
 #   - openfold3-msa: environment for OpenFold3 style MSA generation (with snakemake, hmmer, and hhsuite)
 #
 # The current environments pass all inference tests available in each platform.
@@ -161,6 +162,14 @@ openfold3-rocm7 = { no-default-feature = true, features = [
     "openfold3-editable",
     "tests",
 ] }
+openfold3-therock = { no-default-feature = true, features = [
+    "python",
+    "openfold3-cpu",
+    "pytorch-pypi-therock",
+    "not-in-pypi",
+    "openfold3-editable",
+    "tests",
+] }
 openfold3-msa = { no-default-feature = true, features = [
     "openfold3-msa",
 ] }
@@ -292,6 +301,39 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   [feature.pytorch-pypi-rocm7.pypi-dependencies]
   torch = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
   triton-rocm = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
+
+# ROCm via AMD's TheRock nightly multi-arch index. This is the only path with
+# gfx1151 (Strix Halo / Ryzen AI Max+ 395) support - release-ready per TheRock's
+# SUPPORTED_GPUS.md, unlike the official rocm7.2 wheels used by openfold3-rocm7.
+# Unified multi-arch index + a [device-*] pip extra picks the GPU; the triton
+# package is named `triton` here (not `triton-rocm`), and torch bundles its own
+# ROCm libs (rocm-sdk-*), so no system /opt/rocm is required.
+# N.B. these are nightly (prerelease) wheels pinned in pixi.lock; keep
+# openfold3-rocm7 as the stable fallback. Retarget by changing device-gfx1151.
+[feature.pytorch-pypi-therock]
+
+  platforms = ["linux-64"]
+
+  [feature.pytorch-pypi-therock.pypi-options]
+  # TheRock only publishes nightly (prerelease) wheels, including transitive
+  # rocm-sdk-* deps, so a global allow is required (per-dep specs don't cover them).
+  prerelease-mode = "allow"
+  # torch pins exact rocm[libraries]==<nightly> and amd-torch-device-gfx1151, which
+  # live on the same index. Make it an extra index so those transitive deps resolve.
+  extra-index-urls = ["https://rocm.nightlies.amd.com/whl-multi-arch/"]
+  index-strategy = "unsafe-best-match"
+
+  [feature.pytorch-pypi-therock.dependencies]
+  # cp314 has no TheRock wheels; cap at 3.13.
+  python = ">=3.12,<3.14"
+  setuptools = "<82"
+  # Triton JIT-compiles its launcher stub with a host C compiler at runtime.
+  c-compiler = "*"
+  cxx-compiler = "*"
+
+  [feature.pytorch-pypi-therock.pypi-dependencies]
+  torch = { version = "*", extras = ["device-gfx1151"] }
+  triton = "*"
 
 [feature.cuda12]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -302,21 +302,14 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   torch = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
   triton-rocm = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
 
-# AMD GPU support via TheRock (AMD's production build system as of ROCm 7.14).
-# Adds gfx1151 (Strix Halo) support, which the official rocm7.2 wheels
-# (openfold3-rocm7) lack. gfx1151 wheels are only published to TheRock's
-# multi-arch index and are still prerelease-tagged (+rocmX.Y.0a<date>); there is
-# no PyPI/conda-forge/stable wheel yet. We pin one dated 7.14-line build for
-# reproducibility. Keep openfold3-rocm7 as the stable fallback for other AMD GPUs.
+# gfx1151 (Strix Halo) support via AMD TheRock, which the official rocm7.2
+# wheels (openfold3-rocm7) lack. Prerelease-only; details in inference.md.
 [feature.pytorch-pypi-therock]
 
   platforms = ["linux-64"]
 
   [feature.pytorch-pypi-therock.pypi-options]
-  # TheRock wheels (incl. transitive rocm-sdk-*) carry a prerelease tag, so pip
-  # needs a global prerelease allow even though we pin an exact version below.
-  prerelease-mode = "allow"
-  # torch's exact rocm[libraries]/device pins live here too, so make it an index.
+  prerelease-mode = "allow"  # TheRock wheels + transitive rocm-sdk-* are prerelease-tagged
   extra-index-urls = ["https://rocm.nightlies.amd.com/whl-multi-arch/"]
   index-strategy = "unsafe-best-match"
 
@@ -327,9 +320,7 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   cxx-compiler = "*"
 
   [feature.pytorch-pypi-therock.pypi-dependencies]
-  # Pinned to the latest ROCm 7.14-line build (torch 2.12 is AMD's top validated
-  # PyTorch for 7.14). Bump the version/date together to move the pin.
-  # Change device-gfx1151 to retarget another AMD GPU.
+  # Pinned to a dated 7.14 build; bump version+date together. device-gfx1151 sets the GPU.
   torch = { version = "==2.12.0+rocm7.14.0a20260624", extras = ["device-gfx1151"] }
   triton = "*"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -302,36 +302,28 @@ torch = { version = "*", index = "https://download.pytorch.org/whl/cu130" }
   torch = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
   triton-rocm = { version = "*", index = "https://download.pytorch.org/whl/rocm7.2" }
 
-# ROCm via AMD's TheRock nightly multi-arch index. This is the only path with
-# gfx1151 (Strix Halo / Ryzen AI Max+ 395) support - release-ready per TheRock's
-# SUPPORTED_GPUS.md, unlike the official rocm7.2 wheels used by openfold3-rocm7.
-# Unified multi-arch index + a [device-*] pip extra picks the GPU; the triton
-# package is named `triton` here (not `triton-rocm`), and torch bundles its own
-# ROCm libs (rocm-sdk-*), so no system /opt/rocm is required.
-# N.B. these are nightly (prerelease) wheels pinned in pixi.lock; keep
-# openfold3-rocm7 as the stable fallback. Retarget by changing device-gfx1151.
+# AMD GPU support via TheRock nightly wheels. Adds gfx1151 (Strix Halo) support,
+# which the official rocm7.2 wheels (openfold3-rocm7) lack. Nightly/prerelease,
+# pinned in pixi.lock; keep openfold3-rocm7 as the stable fallback.
 [feature.pytorch-pypi-therock]
 
   platforms = ["linux-64"]
 
   [feature.pytorch-pypi-therock.pypi-options]
-  # TheRock only publishes nightly (prerelease) wheels, including transitive
-  # rocm-sdk-* deps, so a global allow is required (per-dep specs don't cover them).
+  # Nightly wheels (incl. transitive rocm-sdk-*) need a global prerelease allow.
   prerelease-mode = "allow"
-  # torch pins exact rocm[libraries]==<nightly> and amd-torch-device-gfx1151, which
-  # live on the same index. Make it an extra index so those transitive deps resolve.
+  # torch's exact rocm[libraries]/device pins live here too, so make it an index.
   extra-index-urls = ["https://rocm.nightlies.amd.com/whl-multi-arch/"]
   index-strategy = "unsafe-best-match"
 
   [feature.pytorch-pypi-therock.dependencies]
-  # cp314 has no TheRock wheels; cap at 3.13.
-  python = ">=3.12,<3.14"
+  python = ">=3.12,<3.14"  # no cp314 wheels yet
   setuptools = "<82"
-  # Triton JIT-compiles its launcher stub with a host C compiler at runtime.
-  c-compiler = "*"
+  c-compiler = "*"  # Triton JIT needs a host compiler at runtime
   cxx-compiler = "*"
 
   [feature.pytorch-pypi-therock.pypi-dependencies]
+  # Change device-gfx1151 to retarget another AMD GPU.
   torch = { version = "*", extras = ["device-gfx1151"] }
   triton = "*"
 


### PR DESCRIPTION
## What

Adds an `openfold3-therock` pixi environment that provides ROCm PyTorch +
Triton via AMD's [TheRock](https://github.com/ROCm/TheRock) nightly multi-arch
index, enabling AMD APUs — notably Strix Halo (Ryzen AI Max+ 395 / Radeon
8060S, `gfx1151`).

## Why

The existing `openfold3-rocm7` env uses the official `rocm7.2` wheels, which
do not cover `gfx1151`. In TheRock, `gfx1151` is release-ready
(SUPPORTED_GPUS.md). This slots into the existing Triton kernel path — no code
changes, only a new pixi feature/env + lock and docs.

## Verification

`validate-openfold3-rocm` passes on real gfx1151 hardware, including the
Triton evoformer kernel load:

- torch 2.14.0a0+rocm7.15.0a..., HIP 7.15.0
- GPU visible: AMD Radeon 8060S Graphics
- Triton backend HIP, evoformer kernel loaded

End-to-end inference also verified on the same hardware — `run_openfold
predict` with the `triton.yml` preset on ubiquitin (76 residues):

- Successful queries: 1, failed: 0 (~32s forward pass)
- 5 diffusion samples, valid CIF output (601 atoms each) + confidence JSONs
- Triton kernels only (DeepSpeed / cuEquivariance disabled)

One benign warning is emitted: `CK GEMM on an unsupported architecture!
Cannot set blas backend to CK` — ROCm's Composable Kernel GEMM isn't tuned for
gfx1151, so it falls back to rocBLAS. Output is correct; this is a perf note,
not an error.

## Caveats

- **Nightly wheels.** The TheRock multi-arch wheel index currently publishes
  only prerelease (`a<date>`) builds; the exact version is pinned in
  `pixi.lock`. `openfold3-rocm7` stays as the stable path.
- **Version context.** TheRock's 7.9–7.13 preview train is complete; ROCm 7.14
  is AMD's first production TheRock release and lists gfx1151 as a supported
  arch. However, 7.14 currently ships as OS packages / tarballs, not as a
  pinnable PyTorch wheel — so a stable-wheel repin is a **follow-up** once one
  is published. Until then the pinned nightly is the working path.
- Consider gating any CI for this env as experimental, given nightly drift.
- linux-64 only; Python capped `<3.14` (no cp314 wheels yet).

## Note on the `pixi.lock` diff

The lock diff is large (~1800 lines) but **additive only**. `pixi.lock` is
shared by all environments, so adding one env re-serializes the file and
reorders existing package references — hence the noisy removed/added lines.

Verified no existing environment is affected:
- No packages removed (unique packages 1412 → 1489; the +77 are all for
  `openfold3-therock`).
- Environment list is unchanged plus the one new `openfold3-therock`.
- Existing envs (`cpu`, `cuda12/13`, `*-pypi`, `msa`, `rocm7`) resolve to the
  same packages/versions/hashes as before — no re-solve, no drift.

## Note / questions (first contribution)

This is my first contribution here, opened as a **draft** to get direction
before polishing. I'd appreciate guidance on:

1. **Is TheRock the approach you want** for APU support, or would you prefer to
   wait for gfx1151 in the official PyTorch ROCm wheels?
2. **How should the nightly be handled in CI** — skip it, run it non-blocking,
   or add a self-hosted gfx1151 runner (mirroring the existing amd-gpu setup in
   #280)?
3. Any preference on **where the docs live** (I put them in `inference.md` +
   `Installation.md`) and on the `pixi.lock` diff size for a nightly env?

Happy to adjust naming, structure, or split docs/config into separate PRs.

---

*Note: this work was done with AI-assisted tooling; all changes were
reviewed and verified on real gfx1151 hardware before submitting.*
