### PR TITLE
Inference determinism: atom aggregation, feature seeding, and chunk-size reuse

### DIFF
--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -18,8 +18,11 @@ Inference class template for first inference pipeline prototype.
 
 import itertools
 import logging
+import random
 import traceback
+from contextlib import contextmanager
 
+import numpy as np
 import pandas as pd
 import torch
 from biotite.structure import AtomArray
@@ -70,6 +73,22 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _seeded_feature_creation(seed: int):
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
 
 
 @register_dataset
@@ -331,7 +350,8 @@ class InferenceDataset(Dataset):
         is_repeated_sample = bool(datapoint["repeated_sample"])
 
         try:
-            features = self.create_all_features(query)
+            with _seeded_feature_creation(int(seed)):
+                features = self.create_all_features(query)
             features["query_id"] = query_id
             features["seed"] = torch.tensor([seed])
             features["repeated_sample"] = torch.tensor(

--- a/openfold3/core/model/layers/sequence_local_atom_attention.py
+++ b/openfold3/core/model/layers/sequence_local_atom_attention.py
@@ -30,7 +30,9 @@ from openfold3.core.utils.atom_attention_block_utils import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
 )
 from openfold3.core.utils.checkpointing import checkpoint_section
 
@@ -542,16 +544,25 @@ class AtomAttentionEncoder(nn.Module):
 
         ql = ql * atom_mask.unsqueeze(-1)
 
-        agg_args = (
-            batch["token_mask"],
-            batch["atom_to_token_index"],
-            atom_mask,
-            self.linear_q(ql),
-            -2,
-            "mean",
-        )
+        if not self.training and not torch.is_grad_enabled():
+            aggregate_fn = aggregate_atom_feat_to_tokens_segmented
+            agg_args = (
+                batch["num_atoms_per_token"],
+                atom_mask,
+                self.linear_q(ql),
+            )
+        else:
+            aggregate_fn = aggregate_atom_feat_to_tokens
+            agg_args = (
+                batch["token_mask"],
+                batch["atom_to_token_index"],
+                atom_mask,
+                self.linear_q(ql),
+                -2,
+                "mean",
+            )
         ai = checkpoint_section(
-            fn=aggregate_atom_feat_to_tokens,
+            fn=aggregate_fn,
             args=agg_args,
             apply_ckpt=self.ckpt_intermediate_steps,
             use_reentrant=self.use_reentrant,
@@ -674,11 +685,11 @@ class AtomAttentionDecoder(nn.Module):
         """
         # Broadcast per-token activations to atoms
         # [*, N_atom, c_atom]
-        ql = ql + broadcast_token_feat_to_atoms(
+        ql = ql + broadcast_token_feat_to_atoms_by_index(
             token_mask=batch["token_mask"],
-            num_atoms_per_token=batch["num_atoms_per_token"],
+            atom_to_token_index=batch["atom_to_token_index"],
+            atom_mask=batch["atom_mask"],
             token_feat=self.linear_q_in(ai),
-            token_dim=-2,
         )
 
         # Atom transformer

--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -114,6 +114,51 @@ def broadcast_token_feat_to_atoms(
     return atom_feat
 
 
+def _expand_to_batch(tensor: torch.Tensor, batch_dims: torch.Size) -> torch.Tensor:
+    while tensor.ndim - 1 < len(batch_dims):
+        tensor = tensor.unsqueeze(-2)
+    return tensor.expand(*batch_dims, tensor.shape[-1])
+
+
+def broadcast_token_feat_to_atoms_by_index(
+    token_mask: torch.Tensor,
+    atom_to_token_index: torch.Tensor,
+    atom_mask: torch.Tensor,
+    token_feat: torch.Tensor,
+) -> torch.Tensor:
+    """Gather token features onto atoms via ``atom_to_token_index``."""
+    batch_dims = token_feat.shape[:-2]
+    n_token, channels = token_feat.shape[-2:]
+    idx = _expand_to_batch(atom_to_token_index, batch_dims).clamp(0, n_token - 1)
+    idx = idx.long().unsqueeze(-1).expand(*idx.shape, channels)
+    token_mask = _expand_to_batch(token_mask, batch_dims).unsqueeze(-1)
+    atom_mask = _expand_to_batch(atom_mask, batch_dims).unsqueeze(-1)
+    return torch.gather(token_feat * token_mask, -2, idx) * atom_mask
+
+
+def aggregate_atom_feat_to_tokens_segmented(
+    num_atoms_per_token: torch.Tensor,
+    atom_mask: torch.Tensor,
+    atom_feat: torch.Tensor,
+    eps: float = 1e-9,
+) -> torch.Tensor:
+    """Deterministic mean-reduce of packed, token-sorted atoms."""
+    batch_dims = atom_feat.shape[:-2]
+    n_token = num_atoms_per_token.shape[-1]
+    atom_mask = _expand_to_batch(atom_mask, batch_dims)
+    lengths = _expand_to_batch(num_atoms_per_token, batch_dims).long()
+    lengths = torch.cat(
+        [lengths, atom_feat.shape[-2] - lengths.sum(dim=-1, keepdim=True)], dim=-1
+    )
+    token_feat = torch.segment_reduce(
+        atom_feat * atom_mask.unsqueeze(-1), "sum", lengths=lengths, axis=-2
+    )[..., :n_token, :]
+    counts = torch.segment_reduce(
+        atom_mask.to(atom_feat.dtype), "sum", lengths=lengths, axis=-1
+    )[..., :n_token]
+    return token_feat / (counts.unsqueeze(-1) + eps)
+
+
 def aggregate_atom_feat_to_tokens(
     token_mask: torch.Tensor,
     atom_to_token_index: torch.Tensor,

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -347,8 +347,9 @@ def chunk_layer(
 
 class ChunkSizeTuner:
     def __init__(self):
-        self.cached_chunk_size = None
-        self.cached_arg_data = None
+        # (arg_data, max_chunk_size, chunk_size) entries so alternating shapes
+        # and distinct max caps can reuse prior tunings.
+        self.cached_chunk_sizes: list[tuple[Any, int, int]] = []
 
     @staticmethod
     def _determine_favorable_chunk_size(fn, args, max_chunk_size):
@@ -410,19 +411,16 @@ class ChunkSizeTuner:
             return (a.shape, a.dtype.itemsize) if type(a) is torch.Tensor else a
 
         arg_data = tree_map(remove_tensors, args, object)
-        if self.cached_arg_data is not None:
-            # If args have changed shape/value, we need to re-tune
-            consistent = self._compare_arg_caches(self.cached_arg_data, arg_data)
-        else:
-            # Otherwise, we can reuse the precomputed value
-            consistent = False
+        for cached_arg_data, cached_max, cached_size in self.cached_chunk_sizes:
+            if cached_max == max_chunk_size and self._compare_arg_caches(
+                cached_arg_data, arg_data
+            ):
+                return cached_size
 
-        if not consistent:
-            self.cached_chunk_size = self._determine_favorable_chunk_size(
-                fn=representative_fn,
-                args=args,
-                max_chunk_size=max_chunk_size,
-            )
-            self.cached_arg_data = arg_data
-
-        return self.cached_chunk_size
+        chunk_size = self._determine_favorable_chunk_size(
+            fn=representative_fn,
+            args=args,
+            max_chunk_size=max_chunk_size,
+        )
+        self.cached_chunk_sizes.append((arg_data, max_chunk_size, chunk_size))
+        return chunk_size

--- a/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
+++ b/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
@@ -1,0 +1,73 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+
+import numpy as np
+
+from openfold3.core.data.framework.single_datasets.inference import (
+    InferenceDataset,
+    _seeded_feature_creation,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+LIGAND_QUERY = Query.model_validate(
+    {
+        "query_name": "ethanol",
+        "chains": [
+            {
+                "molecule_type": "ligand",
+                "chain_ids": "A",
+                "smiles": "CCO",
+            }
+        ],
+    }
+)
+
+
+def _reference_conformer_coords(seed: int) -> np.ndarray:
+    with _seeded_feature_creation(seed):
+        swrm = InferenceDataset.get_structure_with_ref_mols(LIGAND_QUERY)
+    return swrm.processed_reference_mols[0].mol.GetConformer().GetPositions()
+
+
+class TestInferenceFeatureSeeding(unittest.TestCase):
+    def test_same_seed_is_independent_of_global_rng(self):
+        for _ in range(100):
+            random.random()
+        first = _reference_conformer_coords(42)
+        for _ in range(100):
+            random.random()
+        second = _reference_conformer_coords(42)
+        np.testing.assert_allclose(first, second)
+
+    def test_different_seeds_can_differ(self):
+        first = _reference_conformer_coords(1)
+        second = _reference_conformer_coords(2)
+        self.assertFalse(np.allclose(first, second))
+
+    def test_restores_global_python_rng(self):
+        random.seed(7)
+        before = random.random()
+        with _seeded_feature_creation(999):
+            _reference_conformer_coords(999)
+        after = random.random()
+
+        random.seed(7)
+        expected_before = random.random()
+        expected_after = random.random()
+
+        self.assertEqual(before, expected_before)
+        self.assertEqual(after, expected_after)

--- a/openfold3/tests/test_atomize_utils.py
+++ b/openfold3/tests/test_atomize_utils.py
@@ -22,7 +22,9 @@ from openfold3.core.data.primitives.featurization.structure import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
     get_token_atom_index_offset,
     get_token_center_atoms,
     get_token_frame_atoms,
@@ -317,6 +319,21 @@ class TestBroadcastTokenFeatToAtoms(unittest.TestCase):
 
         self.assertTrue((atom_mask == gt_atom_mask).all())
 
+    def test_by_index_matches_repeat_interleave(self):
+        lengths = torch.tensor([[[2, 1, 3]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_mask = torch.ones(1, 1, 6)
+        atom_mask[..., 1] = 0
+        atom_index = create_atom_to_token_index(token_mask, lengths)
+        token_feat = torch.randn(1, 4, 3, 5)
+        expected = broadcast_token_feat_to_atoms(
+            token_mask, lengths, token_feat, -2
+        ) * atom_mask.unsqueeze(-1)
+        actual = broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+        torch.testing.assert_close(actual, expected)
+
 
 class TestAggregateAtomFeatToTokens(unittest.TestCase):
     def test_with_one_batch_dim(self):
@@ -426,6 +443,38 @@ class TestAggregateAtomFeatToTokens(unittest.TestCase):
         )
 
         self.assertTrue((torch.abs(token_feat - gt_token_feat) < 1e-5).all())
+
+
+class TestSegmentedAggregateAtomFeatToTokens(unittest.TestCase):
+    def test_matches_scatter_and_is_cuda_repeatable(self):
+        lengths = torch.tensor([[[3, 2, 1]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_index = torch.tensor([[[0, 0, 0, 1, 1, 2, 0]]])
+        atom_mask = torch.tensor([[[1, 1, 0, 1, 1, 1, 0]]], dtype=torch.float32)
+        atom_feat = torch.randn(1, 4, 7, 5)
+        expected = aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+        actual = aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+        torch.testing.assert_close(actual, expected)
+
+        if not torch.cuda.is_available():
+            return
+        lengths, atom_mask, atom_feat = (
+            t.cuda() for t in (lengths, atom_mask, atom_feat)
+        )
+        reference = aggregate_atom_feat_to_tokens_segmented(
+            lengths, atom_mask, atom_feat
+        )
+        for _ in range(16):
+            self.assertTrue(
+                torch.equal(
+                    aggregate_atom_feat_to_tokens_segmented(
+                        lengths, atom_mask, atom_feat
+                    ),
+                    reference,
+                )
+            )
 
 
 class TestGetTokenAtomIndex(unittest.TestCase):

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -415,3 +415,36 @@ class TestUtils(unittest.TestCase):
         self.assertNotEqual(
             first, second, "Chunk size should have been re-tuned for new arg count"
         )
+
+    def test_chunk_size_tuner_reuses_prior_shape_after_other_shapes(self):
+        tuner = ChunkSizeTuner()
+        calls = []
+
+        def fn(t, chunk_size):
+            calls.append(t.shape[-1])
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        a = (torch.zeros(2, 3, 16),)
+        b = (torch.zeros(2, 3, 128),)
+        first = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+        tuner.tune_chunk_size(fn, b, max_chunk_size=256)
+        tune_calls = len(calls)
+        reused = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+
+        self.assertEqual(reused, first)
+        self.assertEqual(len(calls), tune_calls)
+
+    def test_chunk_size_tuner_caches_max_chunk_size_separately(self):
+        tuner = ChunkSizeTuner()
+
+        def fn(t, chunk_size):
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        args = (torch.zeros(2, 3, 64),)
+        small = tuner.tune_chunk_size(fn, args, max_chunk_size=32)
+        large = tuner.tune_chunk_size(fn, args, max_chunk_size=256)
+        self.assertEqual(small, 32)
+        self.assertEqual(large, 64)
+        self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)

--- a/scripts/dev/bench_atom_transforms.py
+++ b/scripts/dev/bench_atom_transforms.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Microbenchmark atom broadcast/aggregation paths."""
+
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.utils.atomize_utils import (  # noqa: E402
+    aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
+    broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
+)
+
+
+def time_ms(fn, reps=100):
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) * 1000 / reps
+
+
+def main():
+    n_token, samples = 1264, 5
+    gen = torch.Generator().manual_seed(42)
+    lengths = torch.randint(4, 13, (1, n_token), generator=gen)
+    atom_index = torch.repeat_interleave(torch.arange(n_token), lengths[0])
+    n_atom = atom_index.numel()
+    lengths = lengths[:, None].cuda()
+    atom_index = atom_index.reshape(1, 1, n_atom).cuda()
+    token_mask = torch.ones(1, 1, n_token, device="cuda")
+    atom_mask = torch.ones(1, 1, n_atom, device="cuda")
+    token_feat = torch.randn(1, samples, n_token, 128, device="cuda")
+    atom_feat = torch.randn(1, samples, n_atom, 128, device="cuda")
+
+    def dynamic():
+        return broadcast_token_feat_to_atoms(token_mask, lengths, token_feat, -2)
+
+    def indexed():
+        return broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+
+    def atomic():
+        return aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+
+    def segmented():
+        return aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+
+    torch.testing.assert_close(indexed(), dynamic())
+    torch.testing.assert_close(segmented(), atomic(), rtol=1e-5, atol=1e-6)
+
+    d, i, a, s = (time_ms(fn) for fn in (dynamic, indexed, atomic, segmented))
+    print(torch.cuda.get_device_name())
+    print(f"broadcast {d:.3f}->{i:.3f} ms | aggregate {a:.3f}->{s:.3f} ms")
+    print(f"combined {(2 * d + a) / (2 * i + s):.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_determinism.py
+++ b/scripts/dev/check_determinism.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""Factorial repeatability check for foundation changes.
+
+Compares the impact of:
+1) per-datapoint feature seeding in InferenceDataset
+2) segmented atom aggregation in inference mode
+
+Each cell runs two retrievals/forwards with deliberate global RNG pollution
+between them and checks bitwise equality of input features and model outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import InferenceExperimentRunner  # noqa: E402
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+
+FEATURE_KEYS = (
+    "ref_pos",
+    "ref_mask",
+    "ref_element",
+    "ref_charge",
+    "ref_atom_name_chars",
+    "ref_space_uid",
+    "msa",
+    "msa_mask",
+)
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+)
+
+
+@dataclass(frozen=True)
+class PatchState:
+    feature_seeding: bool
+    segmented_atom_agg: bool
+
+    @property
+    def name(self) -> str:
+        feat = "seeded_features" if self.feature_seeding else "upstream_features"
+        agg = "segmented_agg" if self.segmented_atom_agg else "scatter_agg"
+        return f"{feat}+{agg}"
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def pollute_rng() -> None:
+    for _ in range(512):
+        random.random()
+    np.random.randn(16)
+    torch.randn(16)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def compare_tensor_dict(
+    first: dict[str, torch.Tensor], second: dict[str, torch.Tensor]
+) -> tuple[int, int, list[str]]:
+    keys = sorted(set(first) & set(second))
+    equal = 0
+    mismatches: list[str] = []
+    for key in keys:
+        a, b = first[key], second[key]
+        if a.shape != b.shape or a.dtype != b.dtype:
+            mismatches.append(f"{key}: shape/dtype differ")
+            continue
+        if torch.equal(a, b):
+            equal += 1
+        else:
+            max_diff = (a.float() - b.float()).abs().max().item()
+            mismatches.append(f"{key}: max_abs_diff={max_diff:.6g}")
+    return equal, len(keys), mismatches
+
+
+def apply_patches(state: PatchState) -> None:
+    import openfold3.core.data.framework.single_datasets.inference as inference_mod
+    import openfold3.core.model.layers.sequence_local_atom_attention as atom_attention
+
+    if not hasattr(inference_mod, "_CHECK_ORIGINAL_GETITEM"):
+        inference_mod._CHECK_ORIGINAL_GETITEM = inference_mod.InferenceDataset.__getitem__
+
+    original_getitem = inference_mod._CHECK_ORIGINAL_GETITEM
+
+    if state.feature_seeding:
+
+        def getitem(self, index):
+            return original_getitem(self, index)
+
+    else:
+
+        def getitem(self, index):
+            datapoint = self.datapoint_cache.iloc[index]
+            query_id = datapoint["query_id"]
+            query = self.query_cache[query_id]
+            seed = datapoint["seed"]
+            is_repeated_sample = bool(datapoint["repeated_sample"])
+            try:
+                features = self.create_all_features(query)
+                features["query_id"] = query_id
+                features["seed"] = torch.tensor([seed])
+                features["repeated_sample"] = torch.tensor(
+                    [is_repeated_sample], dtype=torch.bool
+                )
+                features["valid_sample"] = torch.tensor([True], dtype=torch.bool)
+                return features
+            except Exception as exc:
+                import traceback
+
+                inference_mod.logger.warning(
+                    f"Failed to process {query_id}: {type(exc).__name__}\n"
+                    f"{traceback.format_exc()}"
+                )
+                return {
+                    "query_id": query_id,
+                    "repeated_sample": torch.tensor(
+                        [is_repeated_sample], dtype=torch.bool
+                    ),
+                    "valid_sample": torch.tensor([False], dtype=torch.bool),
+                }
+
+    inference_mod.InferenceDataset.__getitem__ = getitem
+
+    if not hasattr(atom_attention, "_CHECK_ORIGINAL_ENCODER_FORWARD"):
+        atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD = (
+            atom_attention.AtomAttentionEncoder.forward
+        )
+
+    original_encoder_forward = atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD
+
+    if state.segmented_atom_agg:
+        atom_attention.AtomAttentionEncoder.forward = original_encoder_forward
+    else:
+
+        def encoder_forward_with_scatter(self, *args, **kwargs):
+            was_training = self.training
+            self.training = True
+            try:
+                return original_encoder_forward(self, *args, **kwargs)
+            finally:
+                self.training = was_training
+
+        atom_attention.AtomAttentionEncoder.forward = encoder_forward_with_scatter
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to("cuda"), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def capture_features(batch: dict) -> dict[str, torch.Tensor]:
+    return {k: batch[k].detach().clone() for k in FEATURE_KEYS if k in batch}
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().clone()
+                break
+    return captured
+
+
+def run_forward(runner: InferenceExperimentRunner, batch: dict) -> dict:
+    module = runner.lightning_module.to("cuda").eval()
+    seed_everything(int(batch["seed"][0].item()))
+    with torch.inference_mode():
+        return module(batch)
+
+
+def check_configuration(
+    state: PatchState,
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> dict:
+    apply_patches(state)
+    runner = build_runner(query_json, runner_yaml, seed)
+
+    pollute_rng()
+    features_a = capture_features(get_batch(runner))
+
+    pollute_rng()
+    features_b = capture_features(get_batch(runner))
+
+    feat_equal, feat_total, feat_mismatches = compare_tensor_dict(
+        features_a, features_b
+    )
+
+    # Model repeats use the same batch and the same predict_step reseed contract.
+    pollute_rng()
+    seed_everything(seed)
+    batch = get_batch(runner)
+    outputs_a = capture_outputs(run_forward(runner, batch))
+
+    pollute_rng()
+    seed_everything(seed)
+    outputs_b = capture_outputs(run_forward(runner, batch))
+
+    out_equal, out_total, out_mismatches = compare_tensor_dict(outputs_a, outputs_b)
+
+    return {
+        "configuration": state.name,
+        "feature_seeding": state.feature_seeding,
+        "segmented_atom_agg": state.segmented_atom_agg,
+        "features": {
+            "bitwise_equal_keys": feat_equal,
+            "total_keys": feat_total,
+            "all_bitwise_equal": feat_equal == feat_total and not feat_mismatches,
+            "ref_pos_bitwise_equal": bool(
+                torch.equal(features_a["ref_pos"], features_b["ref_pos"])
+            ),
+            "mismatches": feat_mismatches,
+        },
+        "outputs": {
+            "bitwise_equal_keys": out_equal,
+            "total_keys": out_total,
+            "all_bitwise_equal": out_equal == out_total and not out_mismatches,
+            "atom_positions_predicted_bitwise_equal": bool(
+                torch.equal(
+                    outputs_a["atom_positions_predicted"],
+                    outputs_b["atom_positions_predicted"],
+                )
+            ),
+            "mismatches": out_mismatches,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query-json",
+        type=Path,
+        default=Path(
+            "examples/example_inference_inputs/query_single_protein_single_ligand.json"
+        ),
+    )
+    parser.add_argument(
+        "--runner-yaml",
+        type=Path,
+        default=Path("examples/example_runner_yamls/smoke_inference.yml"),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.use_deterministic_algorithms(False)
+
+    configs = [
+        PatchState(feature_seeding=False, segmented_atom_agg=False),
+        PatchState(feature_seeding=True, segmented_atom_agg=False),
+        PatchState(feature_seeding=False, segmented_atom_agg=True),
+        PatchState(feature_seeding=True, segmented_atom_agg=True),
+    ]
+
+    results = [
+        check_configuration(cfg, args.query_json, args.runner_yaml, args.seed)
+        for cfg in configs
+    ]
+    print(json.dumps(results, indent=2))
+
+    print(
+        textwrap.dedent(
+            f"""
+            Matrix (production math, seed={args.seed}):
+            - feature repeats: global RNG polluted before each featurization, no pre-seed
+            - output repeats: same batch, predict_step-style reseed before each forward
+
+            configuration                         | features equal | outputs equal
+            --------------------------------------|----------------|---------------
+            """
+        ).rstrip()
+    )
+    for row in results:
+        print(
+            f"{row['configuration']:<37} | "
+            f"{str(row['features']['all_bitwise_equal']):<14} | "
+            f"{str(row['outputs']['all_bitwise_equal'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

First PR in a planned breakdown of [#318](https://github.com/aqlaboratory/openfold-3/pull/318). This lands only the inference-determinism and chunk-reuse foundation.

### Why current inference can disagree across identical runs

Two independent sources of nondeterminism show up even with a fixed sample seed and production math (TF32 on):

1. **Feature creation RNG.** On-the-fly features such as ligand conformers draw from ambient Python / NumPy / Torch RNG. Upstream does not pin that RNG to the datapoint `seed` during featurization, so the same query can produce different `ref_pos` (and related features) depending on prior process state.
2. **CUDA atom→token aggregation.** Inference aggregation uses `scatter_add_`, whose CUDA atomic reductions are not order-stable. Small differences are amplified through diffusion and can change the final pose.

These are independent: seeding features alone does not make model outputs repeatable under scatter aggregation, and segmented aggregation alone does not make ligand features repeatable under polluted ambient RNG.

### What this PR changes

- Scope feature creation to each datapoint's `seed` (save/restore Python, NumPy, and CPU Torch RNG) so conformers and other feature RNG no longer depend on ambient process state
- Use packed `segment_reduce` for atom→token aggregation in inference / no-grad, keeping `scatter_add_` for training/autograd
- Use indexed token→atom broadcast in the atom decoder
- Cache `ChunkSizeTuner` results per argument shape and max chunk size so alternating targets reuse prior probes instead of retuning every revisit