### PR TITLE
Reduce inference peak memory with chunking and fine-grained lifecycle control

### DIFF
--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -18,8 +18,11 @@ Inference class template for first inference pipeline prototype.
 
 import itertools
 import logging
+import random
 import traceback
+from contextlib import contextmanager
 
+import numpy as np
 import pandas as pd
 import torch
 from biotite.structure import AtomArray
@@ -70,6 +73,22 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _seeded_feature_creation(seed: int):
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
 
 
 @register_dataset
@@ -331,7 +350,8 @@ class InferenceDataset(Dataset):
         is_repeated_sample = bool(datapoint["repeated_sample"])
 
         try:
-            features = self.create_all_features(query)
+            with _seeded_feature_creation(int(seed)):
+                features = self.create_all_features(query)
             features["query_id"] = query_id
             features["seed"] = torch.tensor([seed])
             features["repeated_sample"] = torch.tensor(

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -173,6 +173,7 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         si_input = si_input.detach().clone()
         si = si.detach().clone()
         zij = zij.detach().clone()
+        del output["zij_trunk"]
         atom_positions_predicted = atom_positions_predicted.detach().clone()
 
         token_mask = batch["token_mask"]

--- a/openfold3/core/model/latent/base_blocks.py
+++ b/openfold3/core/model/latent/base_blocks.py
@@ -40,6 +40,7 @@ from openfold3.core.model.layers.triangular_multiplicative_update import (
 )
 from openfold3.core.model.primitives import DropoutRowwise
 from openfold3.core.model.utils import assert_sole_holder
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -315,20 +316,25 @@ class PairBlock(nn.Module):
         use_triton_triangle_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the outgoing and incoming triangular multiplicative updates."""
-        inplace_safe = inplace_safe and (not use_cueq_triangle_kernels)
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        use_cueq_trimul = use_cueq_triangle_kernels and not chunked_trimul
+        # cuEq supersedes inplace_safe unless a trimul chunk cap forces eager.
+        inplace_safe = inplace_safe and (not use_cueq_trimul)
         ## VS: having both inplace_safe and use_cueq_triangle_kernels set to
         ## true causes `z = z + self.ps_dropout_row_layer(tmu_update)` below
         ## to be skipped, as this is the expected output of tri_mult w/ inplace
         ## safe, creating an error. So disable inplace_safe if
         ## use_cueq_triangle_kernels is true. Ideally could be refactored to use
         ## _add_with_inplace=False, then wrap with add as done elsewhere
+        inplace_chunk_size = trimul_chunk_cap() if chunked_trimul else 256
         tmu_update = self.tri_mul_out(
             z,
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)
@@ -345,8 +351,9 @@ class PairBlock(nn.Module):
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)

--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -28,7 +28,11 @@ import torch
 from torch import nn
 
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 
 
 # TODO: Rename to CheckpointStack and generalize any kind of block (i.e. remove
@@ -141,6 +145,10 @@ class MSAStack(nn.Module, ABC):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -28,7 +28,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.layers.attention_pair_bias import AttentionPairBias
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -384,6 +388,10 @@ class PairFormerStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -42,6 +42,25 @@ from openfold3.core.utils.chunk_utils import (
 )
 from openfold3.core.utils.tensor_utils import add
 
+_TEMPLATE_DIM_BY_KEY = {
+    "template_restype": -3,
+    "template_pseudo_beta_mask": -2,
+    "template_backbone_frame_mask": -2,
+    "template_distogram": -4,
+    "template_unit_vector": -4,
+}
+
+
+def _slice_template_feature(k: str, x: torch.Tensor, idx: int) -> torch.Tensor:
+    """Return one template while preserving the singleton template dimension."""
+    template_dim = _TEMPLATE_DIM_BY_KEY.get(k)
+    if template_dim is None:
+        return x
+
+    slices = [slice(None)] * x.dim()
+    slices[template_dim] = slice(idx, idx + 1)
+    return x[tuple(slices)]
+
 
 # TODO: Make arguments match PairBlock
 class TemplatePairBlock(PairBlock):
@@ -590,6 +609,60 @@ class TemplateEmbedderAllAtom(nn.Module):
 
         return t_out.to(device=out_device)
 
+    def _forward_streaming(
+        self,
+        batch: dict,
+        z: torch.Tensor,
+        pair_mask: torch.Tensor,
+        chunk_size: int | None = None,
+        _mask_trans: bool = True,
+        use_deepspeed_evo_attention: bool = False,
+        use_cueq_triangle_kernels: bool = False,
+        use_triton_triangle_kernels: bool = False,
+        use_lma: bool = False,
+        inplace_safe: bool = False,
+    ) -> torch.Tensor:
+        """Process templates one-at-a-time and accumulate their stack outputs."""
+        n_templ = batch["template_restype"].shape[-3]
+        pair_mask = pair_mask[..., None, :, :].to(dtype=z.dtype)
+        t_sum = None
+
+        for i in range(n_templ):
+            batch_templ = {
+                k: (
+                    _slice_template_feature(k, v, i)
+                    if isinstance(v, torch.Tensor) and k.startswith("template_")
+                    else v
+                )
+                for k, v in batch.items()
+            }
+
+            t = self.template_pair_embedder(batch=batch_templ, z=z)
+            batch_templ.pop("template_distogram", None)
+            batch_templ.pop("template_unit_vector", None)
+
+            t = self.template_pair_stack(
+                t,
+                pair_mask,
+                chunk_size=chunk_size,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+                _mask_trans=_mask_trans,
+            )
+
+            t = t.squeeze(-4)
+            if t_sum is None:
+                t_sum = t
+            else:
+                t_sum.add_(t)
+            del t
+
+        assert t_sum is not None
+        return t_sum / n_templ
+
     def _forward(
         self,
         batch: dict,
@@ -668,8 +741,30 @@ class TemplateEmbedderAllAtom(nn.Module):
                 [*, N_token, N_token, C_z] Template embedding
         """
         n_templ = batch["template_restype"].shape[-3]
+        template_sum_done = False
+        can_stream = (
+            inplace_safe
+            and not self.training
+            and not torch.is_grad_enabled()
+            and not offload_inference
+            and n_templ > 1
+        )
 
-        if offload_inference:
+        if can_stream:
+            t = self._forward_streaming(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=chunk_size,
+                _mask_trans=True,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+            )
+            template_sum_done = True
+        elif offload_inference:
             t = self._forward_offload(
                 batch=batch,
                 z=z,
@@ -696,8 +791,10 @@ class TemplateEmbedderAllAtom(nn.Module):
                 inplace_safe=inplace_safe,
             )
 
+        if not template_sum_done:
+            t = torch.sum(t, dim=-4) / n_templ
+
         # [*, N_token, N_token, C_z]
-        t = torch.sum(t, dim=-4) / n_templ
         t = torch.nn.functional.relu(t)
         t = self.linear_t(t)
 

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -35,7 +35,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -395,6 +399,10 @@ class TemplatePairStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=t.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/layers/diffusion_conditioning.py
+++ b/openfold3/core/model/layers/diffusion_conditioning.py
@@ -21,7 +21,10 @@ from openfold3.core.model.feature_embedders.input_embedders import FourierEmbedd
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.model.primitives.linear import Linear
 from openfold3.core.model.primitives.normalization import LayerNorm
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+)
 from openfold3.core.utils.relpos import relpos_complex
 
 
@@ -29,6 +32,8 @@ class DiffusionConditioning(nn.Module):
     """
     Implements AF3 Algorithm 21.
     """
+
+    _EMBED_ZIJ_CHUNK_ROWS: int = 128
 
     def __init__(
         self,
@@ -130,6 +135,53 @@ class DiffusionConditioning(nn.Module):
         if tune_chunk_size:
             self.chunk_size_tuner = ChunkSizeTuner()
 
+    def _embed_zij(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        if not torch.is_grad_enabled():
+            return self._embed_zij_chunked(batch, zij_trunk)
+
+        relpos_zij = relpos_complex(
+            batch=batch,
+            max_relative_idx=self.max_relative_idx,
+            max_relative_chain=self.max_relative_chain,
+        ).to(dtype=zij_trunk.dtype)
+
+        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
+        return self.linear_z(self.layer_norm_z(zij))
+
+    def _embed_zij_chunked(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        """Row-chunked LN/linear over trunk pair + relpos (channel-wise LN)."""
+        n_token = zij_trunk.shape[-3]
+        chunk = self._EMBED_ZIJ_CHUNK_ROWS
+        out = torch.empty(
+            *zij_trunk.shape[:-1],
+            self.c_z,
+            dtype=zij_trunk.dtype,
+            device=zij_trunk.device,
+        )
+        for i in range(0, n_token, chunk):
+            row_slice = slice(i, min(i + chunk, n_token))
+            relpos_chunk = relpos_complex(
+                batch=batch,
+                max_relative_idx=self.max_relative_idx,
+                max_relative_chain=self.max_relative_chain,
+                row_slice=row_slice,
+            ).to(dtype=zij_trunk.dtype)
+            cat_chunk = torch.cat(
+                [zij_trunk[..., row_slice, :, :], relpos_chunk], dim=-1
+            )
+            del relpos_chunk
+            out[..., row_slice, :, :] = self.linear_z(self.layer_norm_z(cat_chunk))
+            del cat_chunk
+        return out
+
     def _embed_trunk_inputs(
         self,
         batch: dict,
@@ -139,14 +191,7 @@ class DiffusionConditioning(nn.Module):
         zij_trunk: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Pair conditioning
-        relpos_zij = relpos_complex(
-            batch=batch,
-            max_relative_idx=self.max_relative_idx,
-            max_relative_chain=self.max_relative_chain,
-        ).to(dtype=zij_trunk.dtype)
-
-        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
-        zij = self.linear_z(self.layer_norm_z(zij))
+        zij = self._embed_zij(batch=batch, zij_trunk=zij_trunk)
 
         # Single conditioning
         si = torch.cat([si_trunk, si_input], dim=-1)
@@ -198,6 +243,8 @@ class DiffusionConditioning(nn.Module):
                 ),
                 max_chunk_size=chunk_size,
             )
+
+        chunk_size = apply_transition_chunk_cap(chunk_size)
 
         si, zij = self._forward(
             si=si, zij=zij, token_mask=token_mask, chunk_size=chunk_size

--- a/openfold3/core/model/layers/sequence_local_atom_attention.py
+++ b/openfold3/core/model/layers/sequence_local_atom_attention.py
@@ -30,7 +30,9 @@ from openfold3.core.utils.atom_attention_block_utils import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
 )
 from openfold3.core.utils.checkpointing import checkpoint_section
 
@@ -542,16 +544,25 @@ class AtomAttentionEncoder(nn.Module):
 
         ql = ql * atom_mask.unsqueeze(-1)
 
-        agg_args = (
-            batch["token_mask"],
-            batch["atom_to_token_index"],
-            atom_mask,
-            self.linear_q(ql),
-            -2,
-            "mean",
-        )
+        if not self.training and not torch.is_grad_enabled():
+            aggregate_fn = aggregate_atom_feat_to_tokens_segmented
+            agg_args = (
+                batch["num_atoms_per_token"],
+                atom_mask,
+                self.linear_q(ql),
+            )
+        else:
+            aggregate_fn = aggregate_atom_feat_to_tokens
+            agg_args = (
+                batch["token_mask"],
+                batch["atom_to_token_index"],
+                atom_mask,
+                self.linear_q(ql),
+                -2,
+                "mean",
+            )
         ai = checkpoint_section(
-            fn=aggregate_atom_feat_to_tokens,
+            fn=aggregate_fn,
             args=agg_args,
             apply_ckpt=self.ckpt_intermediate_steps,
             use_reentrant=self.use_reentrant,
@@ -674,11 +685,11 @@ class AtomAttentionDecoder(nn.Module):
         """
         # Broadcast per-token activations to atoms
         # [*, N_atom, c_atom]
-        ql = ql + broadcast_token_feat_to_atoms(
+        ql = ql + broadcast_token_feat_to_atoms_by_index(
             token_mask=batch["token_mask"],
-            num_atoms_per_token=batch["num_atoms_per_token"],
+            atom_to_token_index=batch["atom_to_token_index"],
+            atom_mask=batch["atom_mask"],
             token_feat=self.linear_q_in(ai),
-            token_dim=-2,
         )
 
         # Atom transformer

--- a/openfold3/core/model/layers/triangular_multiplicative_update.py
+++ b/openfold3/core/model/layers/triangular_multiplicative_update.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 import openfold3.core.config.default_linear_init_config as lin_init
 from openfold3.core.kernels.cueq_utils import is_cuequivariance_available
 from openfold3.core.model.primitives import LayerNorm, Linear
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import permute_final_dims
 
 if is_cuequivariance_available():
@@ -1117,8 +1118,9 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
         ## NOTE: valid for inplace safe and use_cueq_triangle_kernels to be enabled
         ## inplace safe is used across the codebase and so should not
         ## be disabled. So if use_cueq_triangle_kernels is True, it will always
-        ## supersede inplace_safe
-        if use_cueq_triangle_kernels:
+        ## supersede inplace_safe unless a trimul chunk cap forces eager.
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        if use_cueq_triangle_kernels and not chunked_trimul:
             ## VS: The cuequivariance kernel is based on the boltz implementation
             ## of triangle multiplicative update, which fuses the linear_*_p
             ## projections into a single layer (similarly for linear_*_g).
@@ -1149,10 +1151,11 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             return x
 
         if inplace_safe:
+            chunk_size = trimul_chunk_cap() if chunked_trimul else _inplace_chunk_size
             x = self._inference_forward(
                 z,
                 mask,
-                inplace_chunk_size=_inplace_chunk_size,
+                inplace_chunk_size=chunk_size,
                 with_add=_add_with_inplace,
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
             )

--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -114,6 +114,51 @@ def broadcast_token_feat_to_atoms(
     return atom_feat
 
 
+def _expand_to_batch(tensor: torch.Tensor, batch_dims: torch.Size) -> torch.Tensor:
+    while tensor.ndim - 1 < len(batch_dims):
+        tensor = tensor.unsqueeze(-2)
+    return tensor.expand(*batch_dims, tensor.shape[-1])
+
+
+def broadcast_token_feat_to_atoms_by_index(
+    token_mask: torch.Tensor,
+    atom_to_token_index: torch.Tensor,
+    atom_mask: torch.Tensor,
+    token_feat: torch.Tensor,
+) -> torch.Tensor:
+    """Gather token features onto atoms via ``atom_to_token_index``."""
+    batch_dims = token_feat.shape[:-2]
+    n_token, channels = token_feat.shape[-2:]
+    idx = _expand_to_batch(atom_to_token_index, batch_dims).clamp(0, n_token - 1)
+    idx = idx.long().unsqueeze(-1).expand(*idx.shape, channels)
+    token_mask = _expand_to_batch(token_mask, batch_dims).unsqueeze(-1)
+    atom_mask = _expand_to_batch(atom_mask, batch_dims).unsqueeze(-1)
+    return torch.gather(token_feat * token_mask, -2, idx) * atom_mask
+
+
+def aggregate_atom_feat_to_tokens_segmented(
+    num_atoms_per_token: torch.Tensor,
+    atom_mask: torch.Tensor,
+    atom_feat: torch.Tensor,
+    eps: float = 1e-9,
+) -> torch.Tensor:
+    """Deterministic mean-reduce of packed, token-sorted atoms."""
+    batch_dims = atom_feat.shape[:-2]
+    n_token = num_atoms_per_token.shape[-1]
+    atom_mask = _expand_to_batch(atom_mask, batch_dims)
+    lengths = _expand_to_batch(num_atoms_per_token, batch_dims).long()
+    lengths = torch.cat(
+        [lengths, atom_feat.shape[-2] - lengths.sum(dim=-1, keepdim=True)], dim=-1
+    )
+    token_feat = torch.segment_reduce(
+        atom_feat * atom_mask.unsqueeze(-1), "sum", lengths=lengths, axis=-2
+    )[..., :n_token, :]
+    counts = torch.segment_reduce(
+        atom_mask.to(atom_feat.dtype), "sum", lengths=lengths, axis=-1
+    )[..., :n_token]
+    return token_feat / (counts.unsqueeze(-1) + eps)
+
+
 def aggregate_atom_feat_to_tokens(
     token_mask: torch.Tensor,
     atom_to_token_index: torch.Tensor,

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -14,6 +14,7 @@
 
 import logging
 import math
+import os
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
@@ -24,6 +25,57 @@ from openfold3.core.utils.tensor_utils import (
     tensor_tree_map,
     tree_map,
 )
+
+
+def _positive_env_int(name: str) -> int | None:
+    """Parse a positive int env var; unset/invalid -> None."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        val = int(raw)
+    except ValueError:
+        return None
+    return val if val > 0 else None
+
+
+def triangle_attn_chunk_cap() -> int | None:
+    """Optional row cap for triangle attention (``OPENFOLD3_TRI_ATTN_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRI_ATTN_CHUNK_CAP")
+
+
+def apply_triangle_attn_chunk_cap(
+    attn_chunk: int,
+    n_tokens: int | None = None,
+) -> int:
+    """Cap triangle-attention rows; no-op when ``n_tokens <= cap``."""
+    cap = triangle_attn_chunk_cap()
+    if cap is None:
+        return attn_chunk
+    if n_tokens is not None and n_tokens <= cap:
+        return attn_chunk
+    return min(attn_chunk, cap)
+
+
+def trimul_chunk_cap() -> int | None:
+    """Optional row chunk for trimul (``OPENFOLD3_TRIMUL_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRIMUL_CHUNK_CAP")
+
+
+def use_chunked_trimul(inplace_safe: bool) -> bool:
+    """Use eager chunked trimul instead of cuEq when a cap is set."""
+    return inplace_safe and trimul_chunk_cap() is not None
+
+
+def transition_chunk_cap() -> int | None:
+    """Optional cap for transition/OPM chunk size (``OPENFOLD3_TRANSITION_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRANSITION_CHUNK_CAP")
+
+
+def apply_transition_chunk_cap(chunk_size: int) -> int:
+    """Apply ``OPENFOLD3_TRANSITION_CHUNK_CAP`` after chunk-size tuning."""
+    cap = transition_chunk_cap()
+    return chunk_size if cap is None else min(chunk_size, cap)
 
 
 def _fetch_dims(tree):

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -347,8 +347,9 @@ def chunk_layer(
 
 class ChunkSizeTuner:
     def __init__(self):
-        self.cached_chunk_size = None
-        self.cached_arg_data = None
+        # (arg_data, max_chunk_size, chunk_size) entries so alternating shapes
+        # and distinct max caps can reuse prior tunings.
+        self.cached_chunk_sizes: list[tuple[Any, int, int]] = []
 
     @staticmethod
     def _determine_favorable_chunk_size(fn, args, max_chunk_size):
@@ -410,19 +411,16 @@ class ChunkSizeTuner:
             return (a.shape, a.dtype.itemsize) if type(a) is torch.Tensor else a
 
         arg_data = tree_map(remove_tensors, args, object)
-        if self.cached_arg_data is not None:
-            # If args have changed shape/value, we need to re-tune
-            consistent = self._compare_arg_caches(self.cached_arg_data, arg_data)
-        else:
-            # Otherwise, we can reuse the precomputed value
-            consistent = False
+        for cached_arg_data, cached_max, cached_size in self.cached_chunk_sizes:
+            if cached_max == max_chunk_size and self._compare_arg_caches(
+                cached_arg_data, arg_data
+            ):
+                return cached_size
 
-        if not consistent:
-            self.cached_chunk_size = self._determine_favorable_chunk_size(
-                fn=representative_fn,
-                args=args,
-                max_chunk_size=max_chunk_size,
-            )
-            self.cached_arg_data = arg_data
-
-        return self.cached_chunk_size
+        chunk_size = self._determine_favorable_chunk_size(
+            fn=representative_fn,
+            args=args,
+            max_chunk_size=max_chunk_size,
+        )
+        self.cached_chunk_sizes.append((arg_data, max_chunk_size, chunk_size))
+        return chunk_size

--- a/openfold3/core/utils/relpos.py
+++ b/openfold3/core/utils/relpos.py
@@ -18,7 +18,10 @@ from openfold3.core.utils.tensor_utils import binned_one_hot
 
 
 def relpos_complex(
-    batch: dict, max_relative_idx: int, max_relative_chain: int
+    batch: dict,
+    max_relative_idx: int,
+    max_relative_chain: int,
+    row_slice: slice | None = None,
 ) -> torch.Tensor:
     """
     Args:
@@ -28,16 +31,37 @@ def relpos_complex(
             Maximum relative position and token indices clipped
         max_relative_chain:
             Maximum relative chain indices clipped
+        row_slice:
+            Optional slice over the first spatial dimension (rows of the pair
+            tensor). When provided, returns ``[*, chunk, N_token, C]`` instead
+            of ``[*, N_token, N_token, C]``. Used by the chunked diffusion
+            conditioning path to avoid materializing the full ``[N, N, 139]``
+            relpos tensor.
 
     Returns:
-        [*, N_token, N_token, C_z] Relative position embedding
+        [*, N_token, N_token, C_z] Relative position embedding (or
+        [*, chunk, N_token, C_z] when row_slice is given)
     """
     res_idx = batch["residue_index"]
     asym_id = batch["asym_id"]
     entity_id = batch["entity_id"]
-    same_chain = asym_id[..., None] == asym_id[..., None, :]
-    same_res = res_idx[..., None] == res_idx[..., None, :]
-    same_entity = entity_id[..., None] == entity_id[..., None, :]
+
+    if row_slice is not None:
+        row_asym = asym_id[..., row_slice, None]
+        col_asym = asym_id[..., None, :]
+        same_chain = row_asym == col_asym
+
+        row_res = res_idx[..., row_slice, None]
+        col_res = res_idx[..., None, :]
+        same_res = row_res == col_res
+
+        row_entity = entity_id[..., row_slice, None]
+        col_entity = entity_id[..., None, :]
+        same_entity = row_entity == col_entity
+    else:
+        same_chain = asym_id[..., None] == asym_id[..., None, :]
+        same_res = res_idx[..., None] == res_idx[..., None, :]
+        same_entity = entity_id[..., None] == entity_id[..., None, :]
 
     def relpos(
         pos: torch.Tensor, condition: torch.BoolTensor, rel_clip_idx: int
@@ -54,7 +78,10 @@ def relpos_complex(
             rel_pos:
                 [*, N_token, N_token, 2 * rel_clip_idx + 2] Relative position embedding
         """
-        offset = pos[..., None] - pos[..., None, :]
+        if row_slice is not None:
+            offset = pos[..., row_slice, None] - pos[..., None, :]
+        else:
+            offset = pos[..., None] - pos[..., None, :]
         clipped_offset = torch.clamp(offset + rel_clip_idx, min=0, max=2 * rel_clip_idx)
         final_offset = torch.where(
             condition,

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -329,6 +329,7 @@ class OpenFold3(nn.Module):
         si_trunk: torch.Tensor,
         zij_trunk: torch.Tensor,
         inplace_safe: bool = False,
+        zij_release: list | None = None,
     ) -> dict:
         """
         Mini diffusion rollout described in section 4.1.
@@ -345,6 +346,8 @@ class OpenFold3(nn.Module):
                 [*, N_token, N_token, C_z] Pair representation output from model trunk
             inplace_safe:
                 Whether inplace operations can be performed
+            zij_release:
+                Optional owned trunk-pair slot cleared before confidence.
 
         Returns:
             Output dictionary containing the predicted trunk embeddings,
@@ -413,8 +416,11 @@ class OpenFold3(nn.Module):
             "zij_trunk": zij_trunk,
             "atom_positions_predicted": atom_positions_predicted,
         }
+        del zij_trunk
+        if zij_release is not None:
+            zij_release[0] = None
 
-        cast_dtype = torch.float32 if self.training else si_trunk.dtype
+        cast_dtype = torch.float32 if self.training else output["si_trunk"].dtype
         with torch.amp.autocast(device_type="cuda", dtype=cast_dtype):
             # Compute confidence logits
             output.update(
@@ -671,13 +677,19 @@ class OpenFold3(nn.Module):
         batch = tensor_tree_map(lambda t: t.unsqueeze(1), batch)
         batch["ref_space_uid_to_perm"] = ref_space_uid_to_perm
 
+        retain_trunk_pair = self.training or "ground_truth" in batch
+        zij_release = None if retain_trunk_pair else [zij_trunk]
+        if zij_release is not None:
+            del zij_trunk
+
         # Mini rollout
         rollout_output = self._rollout(
             batch=batch,
             si_input=si_input,
             si_trunk=si_trunk,
-            zij_trunk=zij_trunk,
+            zij_trunk=(zij_trunk if retain_trunk_pair else zij_release[0]),
             inplace_safe=inplace_safe,
+            zij_release=zij_release,
         )
 
         output.update(rollout_output)

--- a/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
+++ b/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
@@ -1,0 +1,73 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+
+import numpy as np
+
+from openfold3.core.data.framework.single_datasets.inference import (
+    InferenceDataset,
+    _seeded_feature_creation,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+LIGAND_QUERY = Query.model_validate(
+    {
+        "query_name": "ethanol",
+        "chains": [
+            {
+                "molecule_type": "ligand",
+                "chain_ids": "A",
+                "smiles": "CCO",
+            }
+        ],
+    }
+)
+
+
+def _reference_conformer_coords(seed: int) -> np.ndarray:
+    with _seeded_feature_creation(seed):
+        swrm = InferenceDataset.get_structure_with_ref_mols(LIGAND_QUERY)
+    return swrm.processed_reference_mols[0].mol.GetConformer().GetPositions()
+
+
+class TestInferenceFeatureSeeding(unittest.TestCase):
+    def test_same_seed_is_independent_of_global_rng(self):
+        for _ in range(100):
+            random.random()
+        first = _reference_conformer_coords(42)
+        for _ in range(100):
+            random.random()
+        second = _reference_conformer_coords(42)
+        np.testing.assert_allclose(first, second)
+
+    def test_different_seeds_can_differ(self):
+        first = _reference_conformer_coords(1)
+        second = _reference_conformer_coords(2)
+        self.assertFalse(np.allclose(first, second))
+
+    def test_restores_global_python_rng(self):
+        random.seed(7)
+        before = random.random()
+        with _seeded_feature_creation(999):
+            _reference_conformer_coords(999)
+        after = random.random()
+
+        random.seed(7)
+        expected_before = random.random()
+        expected_after = random.random()
+
+        self.assertEqual(before, expected_before)
+        self.assertEqual(after, expected_after)

--- a/openfold3/tests/core/model/latent/test_template_module.py
+++ b/openfold3/tests/core/model/latent/test_template_module.py
@@ -54,6 +54,58 @@ class TestTemplateEmbedderAllAtom(unittest.TestCase):
 
         self.assertTrue(t.shape == (batch_size, n_token, n_token, c_in))
 
+    def test_streaming_matches_full_batch(self):
+        batch_size = 1
+        n_templ = 3
+        n_token = 8
+
+        of3_proj_entry = OF3ProjectEntry()
+        of3_config = of3_proj_entry.get_model_config_with_presets()
+        c_in = of3_config.architecture.template.template_pair_embedder.c_in
+        embedder = TemplateEmbedderAllAtom(of3_config.architecture.template)
+        embedder.eval()
+
+        torch.manual_seed(0)
+        batch = {
+            "token_mask": torch.ones((batch_size, n_token)),
+            "asym_id": torch.ones((batch_size, n_token)),
+            "template_restype": torch.randn((batch_size, n_templ, n_token, 32)),
+            "template_pseudo_beta_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_backbone_frame_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_distogram": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 39)
+            ),
+            "template_unit_vector": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 3)
+            ),
+        }
+        z = torch.randn((batch_size, n_token, n_token, c_in))
+        pair_mask = torch.ones((batch_size, n_token, n_token))
+
+        with torch.inference_mode():
+            t_stream = embedder(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = embedder._forward(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = torch.sum(t_full, dim=-4) / n_templ
+            t_full = torch.nn.functional.relu(t_full)
+            t_full = embedder.linear_t(t_full)
+
+        self.assertTrue(
+            torch.allclose(t_stream, t_full, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(t_stream - t_full).abs().max().item():.3e}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/test_atomize_utils.py
+++ b/openfold3/tests/test_atomize_utils.py
@@ -22,7 +22,9 @@ from openfold3.core.data.primitives.featurization.structure import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
     get_token_atom_index_offset,
     get_token_center_atoms,
     get_token_frame_atoms,
@@ -317,6 +319,21 @@ class TestBroadcastTokenFeatToAtoms(unittest.TestCase):
 
         self.assertTrue((atom_mask == gt_atom_mask).all())
 
+    def test_by_index_matches_repeat_interleave(self):
+        lengths = torch.tensor([[[2, 1, 3]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_mask = torch.ones(1, 1, 6)
+        atom_mask[..., 1] = 0
+        atom_index = create_atom_to_token_index(token_mask, lengths)
+        token_feat = torch.randn(1, 4, 3, 5)
+        expected = broadcast_token_feat_to_atoms(
+            token_mask, lengths, token_feat, -2
+        ) * atom_mask.unsqueeze(-1)
+        actual = broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+        torch.testing.assert_close(actual, expected)
+
 
 class TestAggregateAtomFeatToTokens(unittest.TestCase):
     def test_with_one_batch_dim(self):
@@ -426,6 +443,38 @@ class TestAggregateAtomFeatToTokens(unittest.TestCase):
         )
 
         self.assertTrue((torch.abs(token_feat - gt_token_feat) < 1e-5).all())
+
+
+class TestSegmentedAggregateAtomFeatToTokens(unittest.TestCase):
+    def test_matches_scatter_and_is_cuda_repeatable(self):
+        lengths = torch.tensor([[[3, 2, 1]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_index = torch.tensor([[[0, 0, 0, 1, 1, 2, 0]]])
+        atom_mask = torch.tensor([[[1, 1, 0, 1, 1, 1, 0]]], dtype=torch.float32)
+        atom_feat = torch.randn(1, 4, 7, 5)
+        expected = aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+        actual = aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+        torch.testing.assert_close(actual, expected)
+
+        if not torch.cuda.is_available():
+            return
+        lengths, atom_mask, atom_feat = (
+            t.cuda() for t in (lengths, atom_mask, atom_feat)
+        )
+        reference = aggregate_atom_feat_to_tokens_segmented(
+            lengths, atom_mask, atom_feat
+        )
+        for _ in range(16):
+            self.assertTrue(
+                torch.equal(
+                    aggregate_atom_feat_to_tokens_segmented(
+                        lengths, atom_mask, atom_feat
+                    ),
+                    reference,
+                )
+            )
 
 
 class TestGetTokenAtomIndex(unittest.TestCase):

--- a/openfold3/tests/test_diffusion_conditioning.py
+++ b/openfold3/tests/test_diffusion_conditioning.py
@@ -17,11 +17,22 @@ import unittest
 import torch
 
 from openfold3.core.model.layers.diffusion_conditioning import DiffusionConditioning
+from openfold3.core.utils.relpos import relpos_complex
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
 
 
 class TestDiffusionConditioning(unittest.TestCase):
+    def _batch(self, batch_size: int, n_token: int) -> dict:
+        return {
+            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "token_mask": torch.ones((batch_size, n_token)),
+            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "sym_id": torch.zeros((batch_size, n_token)),
+            "asym_id": torch.zeros((batch_size, n_token)),
+            "entity_id": torch.zeros((batch_size, n_token)),
+        }
+
     def test_without_n_sample_channel(self):
         batch_size = consts.batch_size
         n_token = consts.n_res
@@ -45,14 +56,7 @@ class TestDiffusionConditioning(unittest.TestCase):
             -1.2 + 1.5 * torch.randn(batch_size, device=si_trunk.device)
         )
 
-        batch = {
-            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "token_mask": torch.ones((batch_size, n_token)),
-            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "sym_id": torch.zeros((batch_size, n_token)),
-            "asym_id": torch.zeros((batch_size, n_token)),
-            "entity_id": torch.zeros((batch_size, n_token)),
-        }
+        batch = self._batch(batch_size, n_token)
 
         si, zij = dc(
             batch=batch,
@@ -65,6 +69,53 @@ class TestDiffusionConditioning(unittest.TestCase):
 
         self.assertTrue(si.shape == (batch_size, n_token, c_s))
         self.assertTrue(zij.shape == (batch_size, n_token, n_token, c_z))
+
+    def test_relpos_row_slice_matches_full(self):
+        batch_size = 2
+        n_token = 17
+        batch = self._batch(batch_size, n_token)
+        full = relpos_complex(batch, max_relative_idx=32, max_relative_chain=2)
+        chunk = 5
+        parts = [
+            relpos_complex(
+                batch,
+                max_relative_idx=32,
+                max_relative_chain=2,
+                row_slice=slice(i, min(i + chunk, n_token)),
+            )
+            for i in range(0, n_token, chunk)
+        ]
+        rebuilt = torch.cat(parts, dim=-3)
+        self.assertTrue(torch.equal(rebuilt, full))
+
+    def test_chunked_pair_embed_matches_eager(self):
+        batch_size = 1
+        n_token = 37
+        c_s_input = consts.c_s + 65
+        c_s = consts.c_s
+        c_z = consts.c_z
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        diff_cond_config = config.architecture.diffusion_module.diffusion_conditioning
+        diff_cond_config.update({"c_s": c_s, "c_s_input": c_s_input, "c_z": c_z})
+        dc = DiffusionConditioning(**diff_cond_config)
+        dc.eval()
+
+        torch.manual_seed(0)
+        batch = self._batch(batch_size, n_token)
+        zij_trunk = torch.randn(batch_size, n_token, n_token, c_z)
+
+        with torch.no_grad():
+            zij_chunked = dc._embed_zij_chunked(batch, zij_trunk)
+        # Eager path is taken when gradients are enabled.
+        with torch.enable_grad():
+            zij_eager = dc._embed_zij(batch, zij_trunk.detach())
+
+        self.assertTrue(
+            torch.allclose(zij_chunked, zij_eager, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(zij_chunked - zij_eager).abs().max().item():.3e}",
+        )
 
     def test_with_different_schedule(self):
         batch_size = consts.batch_size

--- a/openfold3/tests/test_heads.py
+++ b/openfold3/tests/test_heads.py
@@ -412,6 +412,47 @@ class TestAuxiliaryHeadsAllAtom(unittest.TestCase):
             aux_out["experimentally_resolved_logits"].shape, expected_shape_exp_res
         )
 
+    def test_releases_trunk_pair_after_confidence_clone(self):
+        batch_size = consts.batch_size
+        n_token = consts.n_res
+        n_msa = 10
+        n_templ = 3
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        batch = random_of3_features(
+            batch_size=batch_size, n_token=n_token, n_msa=n_msa, n_templ=n_templ
+        )
+        n_atom = torch.max(batch["num_atoms_per_token"].sum(dim=-1)).int().item()
+
+        heads_config = config.architecture.heads
+        heads_config.pae.enabled = True
+        aux_head = AuxiliaryHeadsAllAtom(heads_config).eval()
+        initialize_model_weights(aux_head)
+
+        outputs = {
+            "si_trunk": torch.ones(
+                batch_size, n_token, config.architecture.shared.c_s
+            ),
+            "zij_trunk": torch.ones(
+                batch_size, n_token, n_token, config.architecture.shared.c_z
+            ),
+            "atom_positions_predicted": torch.randn(batch_size, n_atom, 3),
+        }
+
+        with torch.inference_mode():
+            aux_head(
+                batch,
+                torch.ones(
+                    batch_size, n_token, config.architecture.shared.c_s_input
+                ),
+                outputs,
+                use_zij_trunk_embedding=True,
+                chunk_size=4,
+            )
+
+        self.assertNotIn("zij_trunk", outputs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -415,3 +415,36 @@ class TestUtils(unittest.TestCase):
         self.assertNotEqual(
             first, second, "Chunk size should have been re-tuned for new arg count"
         )
+
+    def test_chunk_size_tuner_reuses_prior_shape_after_other_shapes(self):
+        tuner = ChunkSizeTuner()
+        calls = []
+
+        def fn(t, chunk_size):
+            calls.append(t.shape[-1])
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        a = (torch.zeros(2, 3, 16),)
+        b = (torch.zeros(2, 3, 128),)
+        first = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+        tuner.tune_chunk_size(fn, b, max_chunk_size=256)
+        tune_calls = len(calls)
+        reused = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+
+        self.assertEqual(reused, first)
+        self.assertEqual(len(calls), tune_calls)
+
+    def test_chunk_size_tuner_caches_max_chunk_size_separately(self):
+        tuner = ChunkSizeTuner()
+
+        def fn(t, chunk_size):
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        args = (torch.zeros(2, 3, 64),)
+        small = tuner.tune_chunk_size(fn, args, max_chunk_size=32)
+        large = tuner.tune_chunk_size(fn, args, max_chunk_size=256)
+        self.assertEqual(small, 32)
+        self.assertEqual(large, 64)
+        self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -13,12 +13,23 @@
 # limitations under the License.
 
 import math
+import os
 import unittest
 
 import torch
 
 from openfold3.core.model.primitives import Linear
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner, _chunk_slice, chunk_layer
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    _chunk_slice,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+    chunk_layer,
+    transition_chunk_cap,
+    triangle_attn_chunk_cap,
+    trimul_chunk_cap,
+    use_chunked_trimul,
+)
 from openfold3.core.utils.rigid_utils import (
     Rigid,
     Rotation,
@@ -448,3 +459,79 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(small, 32)
         self.assertEqual(large, 64)
         self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)
+
+    def test_triangle_attn_chunk_cap_env(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(triangle_attn_chunk_cap())
+
+            os.environ[key] = "64"
+            self.assertEqual(triangle_attn_chunk_cap(), 64)
+
+            os.environ[key] = "bad"
+            self.assertIsNone(triangle_attn_chunk_cap())
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_apply_triangle_attn_chunk_cap(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ[key] = "128"
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 128
+            )
+            # Cap cannot shrink the working set when N already fits.
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=76), 1024
+            )
+            os.environ.pop(key, None)
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 1024
+            )
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_trimul_chunk_cap_selects_chunked_eager_path(self):
+        key = "OPENFOLD3_TRIMUL_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(trimul_chunk_cap())
+            self.assertFalse(use_chunked_trimul(inplace_safe=True))
+
+            os.environ[key] = "128"
+            self.assertEqual(trimul_chunk_cap(), 128)
+            self.assertTrue(use_chunked_trimul(inplace_safe=True))
+            self.assertFalse(use_chunked_trim(inplace_safe=False))
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_transition_chunk_cap_env(self):
+        key = "OPENFOLD3_TRANSITION_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(transition_chunk_cap())
+            self.assertEqual(apply_transition_chunk_cap(1024), 1024)
+
+            os.environ[key] = "128"
+            self.assertEqual(transition_chunk_cap(), 128)
+            self.assertEqual(apply_transition_chunk_cap(1024), 128)
+            self.assertEqual(apply_transition_chunk_cap(64), 64)
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old

--- a/scripts/dev/bench_atom_transforms.py
+++ b/scripts/dev/bench_atom_transforms.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Microbenchmark atom broadcast/aggregation paths."""
+
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.utils.atomize_utils import (  # noqa: E402
+    aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
+    broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
+)
+
+
+def time_ms(fn, reps=100):
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) * 1000 / reps
+
+
+def main():
+    n_token, samples = 1264, 5
+    gen = torch.Generator().manual_seed(42)
+    lengths = torch.randint(4, 13, (1, n_token), generator=gen)
+    atom_index = torch.repeat_interleave(torch.arange(n_token), lengths[0])
+    n_atom = atom_index.numel()
+    lengths = lengths[:, None].cuda()
+    atom_index = atom_index.reshape(1, 1, n_atom).cuda()
+    token_mask = torch.ones(1, 1, n_token, device="cuda")
+    atom_mask = torch.ones(1, 1, n_atom, device="cuda")
+    token_feat = torch.randn(1, samples, n_token, 128, device="cuda")
+    atom_feat = torch.randn(1, samples, n_atom, 128, device="cuda")
+
+    def dynamic():
+        return broadcast_token_feat_to_atoms(token_mask, lengths, token_feat, -2)
+
+    def indexed():
+        return broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+
+    def atomic():
+        return aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+
+    def segmented():
+        return aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+
+    torch.testing.assert_close(indexed(), dynamic())
+    torch.testing.assert_close(segmented(), atomic(), rtol=1e-5, atol=1e-6)
+
+    d, i, a, s = (time_ms(fn) for fn in (dynamic, indexed, atomic, segmented))
+    print(torch.cuda.get_device_name())
+    print(f"broadcast {d:.3f}->{i:.3f} ms | aggregate {a:.3f}->{s:.3f} ms")
+    print(f"combined {(2 * d + a) / (2 * i + s):.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_determinism.py
+++ b/scripts/dev/check_determinism.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""Factorial repeatability check for foundation changes.
+
+Compares the impact of:
+1) per-datapoint feature seeding in InferenceDataset
+2) segmented atom aggregation in inference mode
+
+Each cell runs two retrievals/forwards with deliberate global RNG pollution
+between them and checks bitwise equality of input features and model outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import InferenceExperimentRunner  # noqa: E402
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+
+FEATURE_KEYS = (
+    "ref_pos",
+    "ref_mask",
+    "ref_element",
+    "ref_charge",
+    "ref_atom_name_chars",
+    "ref_space_uid",
+    "msa",
+    "msa_mask",
+)
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+)
+
+
+@dataclass(frozen=True)
+class PatchState:
+    feature_seeding: bool
+    segmented_atom_agg: bool
+
+    @property
+    def name(self) -> str:
+        feat = "seeded_features" if self.feature_seeding else "upstream_features"
+        agg = "segmented_agg" if self.segmented_atom_agg else "scatter_agg"
+        return f"{feat}+{agg}"
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def pollute_rng() -> None:
+    for _ in range(512):
+        random.random()
+    np.random.randn(16)
+    torch.randn(16)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def compare_tensor_dict(
+    first: dict[str, torch.Tensor], second: dict[str, torch.Tensor]
+) -> tuple[int, int, list[str]]:
+    keys = sorted(set(first) & set(second))
+    equal = 0
+    mismatches: list[str] = []
+    for key in keys:
+        a, b = first[key], second[key]
+        if a.shape != b.shape or a.dtype != b.dtype:
+            mismatches.append(f"{key}: shape/dtype differ")
+            continue
+        if torch.equal(a, b):
+            equal += 1
+        else:
+            max_diff = (a.float() - b.float()).abs().max().item()
+            mismatches.append(f"{key}: max_abs_diff={max_diff:.6g}")
+    return equal, len(keys), mismatches
+
+
+def apply_patches(state: PatchState) -> None:
+    import openfold3.core.data.framework.single_datasets.inference as inference_mod
+    import openfold3.core.model.layers.sequence_local_atom_attention as atom_attention
+
+    if not hasattr(inference_mod, "_CHECK_ORIGINAL_GETITEM"):
+        inference_mod._CHECK_ORIGINAL_GETITEM = inference_mod.InferenceDataset.__getitem__
+
+    original_getitem = inference_mod._CHECK_ORIGINAL_GETITEM
+
+    if state.feature_seeding:
+
+        def getitem(self, index):
+            return original_getitem(self, index)
+
+    else:
+
+        def getitem(self, index):
+            datapoint = self.datapoint_cache.iloc[index]
+            query_id = datapoint["query_id"]
+            query = self.query_cache[query_id]
+            seed = datapoint["seed"]
+            is_repeated_sample = bool(datapoint["repeated_sample"])
+            try:
+                features = self.create_all_features(query)
+                features["query_id"] = query_id
+                features["seed"] = torch.tensor([seed])
+                features["repeated_sample"] = torch.tensor(
+                    [is_repeated_sample], dtype=torch.bool
+                )
+                features["valid_sample"] = torch.tensor([True], dtype=torch.bool)
+                return features
+            except Exception as exc:
+                import traceback
+
+                inference_mod.logger.warning(
+                    f"Failed to process {query_id}: {type(exc).__name__}\n"
+                    f"{traceback.format_exc()}"
+                )
+                return {
+                    "query_id": query_id,
+                    "repeated_sample": torch.tensor(
+                        [is_repeated_sample], dtype=torch.bool
+                    ),
+                    "valid_sample": torch.tensor([False], dtype=torch.bool),
+                }
+
+    inference_mod.InferenceDataset.__getitem__ = getitem
+
+    if not hasattr(atom_attention, "_CHECK_ORIGINAL_ENCODER_FORWARD"):
+        atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD = (
+            atom_attention.AtomAttentionEncoder.forward
+        )
+
+    original_encoder_forward = atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD
+
+    if state.segmented_atom_agg:
+        atom_attention.AtomAttentionEncoder.forward = original_encoder_forward
+    else:
+
+        def encoder_forward_with_scatter(self, *args, **kwargs):
+            was_training = self.training
+            self.training = True
+            try:
+                return original_encoder_forward(self, *args, **kwargs)
+            finally:
+                self.training = was_training
+
+        atom_attention.AtomAttentionEncoder.forward = encoder_forward_with_scatter
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to("cuda"), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def capture_features(batch: dict) -> dict[str, torch.Tensor]:
+    return {k: batch[k].detach().clone() for k in FEATURE_KEYS if k in batch}
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().clone()
+                break
+    return captured
+
+
+def run_forward(runner: InferenceExperimentRunner, batch: dict) -> dict:
+    module = runner.lightning_module.to("cuda").eval()
+    seed_everything(int(batch["seed"][0].item()))
+    with torch.inference_mode():
+        return module(batch)
+
+
+def check_configuration(
+    state: PatchState,
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> dict:
+    apply_patches(state)
+    runner = build_runner(query_json, runner_yaml, seed)
+
+    pollute_rng()
+    features_a = capture_features(get_batch(runner))
+
+    pollute_rng()
+    features_b = capture_features(get_batch(runner))
+
+    feat_equal, feat_total, feat_mismatches = compare_tensor_dict(
+        features_a, features_b
+    )
+
+    # Model repeats use the same batch and the same predict_step reseed contract.
+    pollute_rng()
+    seed_everything(seed)
+    batch = get_batch(runner)
+    outputs_a = capture_outputs(run_forward(runner, batch))
+
+    pollute_rng()
+    seed_everything(seed)
+    outputs_b = capture_outputs(run_forward(runner, batch))
+
+    out_equal, out_total, out_mismatches = compare_tensor_dict(outputs_a, outputs_b)
+
+    return {
+        "configuration": state.name,
+        "feature_seeding": state.feature_seeding,
+        "segmented_atom_agg": state.segmented_atom_agg,
+        "features": {
+            "bitwise_equal_keys": feat_equal,
+            "total_keys": feat_total,
+            "all_bitwise_equal": feat_equal == feat_total and not feat_mismatches,
+            "ref_pos_bitwise_equal": bool(
+                torch.equal(features_a["ref_pos"], features_b["ref_pos"])
+            ),
+            "mismatches": feat_mismatches,
+        },
+        "outputs": {
+            "bitwise_equal_keys": out_equal,
+            "total_keys": out_total,
+            "all_bitwise_equal": out_equal == out_total and not out_mismatches,
+            "atom_positions_predicted_bitwise_equal": bool(
+                torch.equal(
+                    outputs_a["atom_positions_predicted"],
+                    outputs_b["atom_positions_predicted"],
+                )
+            ),
+            "mismatches": out_mismatches,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query-json",
+        type=Path,
+        default=Path(
+            "examples/example_inference_inputs/query_single_protein_single_ligand.json"
+        ),
+    )
+    parser.add_argument(
+        "--runner-yaml",
+        type=Path,
+        default=Path("examples/example_runner_yamls/smoke_inference.yml"),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.use_deterministic_algorithms(False)
+
+    configs = [
+        PatchState(feature_seeding=False, segmented_atom_agg=False),
+        PatchState(feature_seeding=True, segmented_atom_agg=False),
+        PatchState(feature_seeding=False, segmented_atom_agg=True),
+        PatchState(feature_seeding=True, segmented_atom_agg=True),
+    ]
+
+    results = [
+        check_configuration(cfg, args.query_json, args.runner_yaml, args.seed)
+        for cfg in configs
+    ]
+    print(json.dumps(results, indent=2))
+
+    print(
+        textwrap.dedent(
+            f"""
+            Matrix (production math, seed={args.seed}):
+            - feature repeats: global RNG polluted before each featurization, no pre-seed
+            - output repeats: same batch, predict_step-style reseed before each forward
+
+            configuration                         | features equal | outputs equal
+            --------------------------------------|----------------|---------------
+            """
+        ).rstrip()
+    )
+    for row in results:
+        print(
+            f"{row['configuration']:<37} | "
+            f"{str(row['features']['all_bitwise_equal']):<14} | "
+            f"{str(row['outputs']['all_bitwise_equal'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/profile_inference_stages.py
+++ b/scripts/dev/profile_inference_stages.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+"""Stage timing and top-level memory profiling for OF3 inference.
+
+Protocol:
+1. warm-up forward
+2. unhooked measured forward (overall peak + wall)
+3. hooked forward (top-level / trunk-substage peaks + nested timing)
+
+Only sequential memory-tracked stages reset CUDA peak stats. Nested hooks are
+timing-only so they do not corrupt enclosing peaks.
+
+1U = N² × c_z × 4 bytes. The gate metric is peak CUDA allocation above live
+model parameter (+ buffer) bytes — not peak minus ambient allocator residency
+and not raw ``max_memory_allocated()`` alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import OrderedDict
+from pathlib import Path
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_RUNNER_YAML = REPO / "examples/example_runner_yamls/cuequivariance.yml"
+
+KNOWN_QUERIES = {
+    "ubiquitin": REPO / "examples/example_inference_inputs/query_ubiquitin.json",
+    "homo_1200": REPO / "data/inference_outputs/profiling/queries/homo_1200.json",
+    "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
+}
+KNOWN_RUNNERS = {
+    "mcl1": REPO / "data/inference_benchmark_msa_template/runner.yml",
+}
+
+
+def _gib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**3
+
+
+def _mib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**2
+
+
+class FastStageProfiler:
+    def __init__(self):
+        self.stats: OrderedDict[str, dict] = OrderedDict()
+        self._patches: list[tuple[object, str, object]] = []
+
+    def wrap(self, obj, attr: str, name: str, track_mem: bool = False) -> None:
+        orig = getattr(obj, attr)
+
+        def hook(*args, **kwargs):
+            if track_mem:
+                torch.cuda.synchronize()
+                before = torch.cuda.memory_allocated()
+                torch.cuda.reset_peak_memory_stats()
+            else:
+                before = 0
+
+            start_ev = torch.cuda.Event(enable_timing=True)
+            end_ev = torch.cuda.Event(enable_timing=True)
+            start_ev.record()
+            out = orig(*args, **kwargs)
+            end_ev.record()
+            torch.cuda.synchronize()
+
+            cuda_ms = start_ev.elapsed_time(end_ev)
+            peak = torch.cuda.max_memory_allocated() if track_mem else 0
+            after = torch.cuda.memory_allocated() if track_mem else 0
+
+            stat = self.stats.setdefault(
+                name,
+                {
+                    "abs_peak_bytes": 0,
+                    "before_bytes": before,
+                    "after_bytes": after,
+                    "peak_over_before_bytes": 0,
+                    "cuda_ms": 0.0,
+                    "total_calls": 0,
+                    "memory_tracked": track_mem,
+                },
+            )
+            stat["total_calls"] += 1
+            stat["cuda_ms"] += cuda_ms
+            if track_mem and peak > stat["abs_peak_bytes"]:
+                stat["abs_peak_bytes"] = peak
+                stat["before_bytes"] = before
+                stat["after_bytes"] = after
+                stat["peak_over_before_bytes"] = peak - before
+            return out
+
+        setattr(obj, attr, hook)
+        self._patches.append((obj, attr, orig))
+
+    def unwrap_all(self) -> None:
+        for obj, attr, orig in reversed(self._patches):
+            setattr(obj, attr, orig)
+        self._patches.clear()
+
+
+def install_hooks(
+    model, prof: FastStageProfiler, track_trunk_substages: bool
+) -> None:
+    prof.wrap(model, "run_trunk", "TRUNK", track_mem=not track_trunk_substages)
+    prof.wrap(model.sample_diffusion, "forward", "DIFFUSION", track_mem=True)
+    prof.wrap(model.aux_heads, "forward", "CONFIDENCE", track_mem=True)
+
+    prof.wrap(
+        model.input_embedder,
+        "forward",
+        "trunk.input_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.template_embedder,
+        "forward",
+        "trunk.template_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.msa_module,
+        "forward",
+        "trunk.msa_module",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.pairformer_stack,
+        "forward",
+        "trunk.pairformer",
+        track_mem=track_trunk_substages,
+    )
+
+    # Timing-only nested hooks for first-pass localization.
+    prof.wrap(model.diffusion_module, "forward", "diff.per_step")
+    if hasattr(model.aux_heads, "pairformer_embedding"):
+        prof.wrap(
+            model.aux_heads.pairformer_embedding, "forward", "conf.pairformer_emb"
+        )
+
+
+def resolve_paths(args) -> tuple[Path, Path]:
+    if args.query_json is not None:
+        query_json = args.query_json
+    elif args.query in KNOWN_QUERIES:
+        query_json = KNOWN_QUERIES[args.query]
+    else:
+        raise FileNotFoundError(
+            f"Unknown query {args.query!r}; pass --query-json or one of "
+            f"{sorted(KNOWN_QUERIES)}"
+        )
+    if not query_json.exists():
+        raise FileNotFoundError(query_json)
+
+    if args.runner_yaml is not None:
+        runner_yaml = args.runner_yaml
+    elif args.query in KNOWN_RUNNERS:
+        runner_yaml = KNOWN_RUNNERS[args.query]
+    else:
+        runner_yaml = DEFAULT_RUNNER_YAML
+    if not runner_yaml.exists():
+        raise FileNotFoundError(runner_yaml)
+    return query_json, runner_yaml
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    num_samples: int,
+    offload_token_cutoff: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=num_samples,
+        use_msa_server=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = offload_token_cutoff
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner, device: torch.device) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to(device), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def model_parameter_bytes(model: torch.nn.Module) -> dict[str, int]:
+    """Exact live parameter/buffer payload on the current device."""
+    param_bytes = sum(p.numel() * p.element_size() for p in model.parameters())
+    buffer_bytes = sum(b.numel() * b.element_size() for b in model.buffers())
+    return {
+        "model_params_bytes": param_bytes,
+        "model_buffer_bytes": buffer_bytes,
+        "model_params_and_buffers_bytes": param_bytes + buffer_bytes,
+    }
+
+
+def profile(args) -> dict:
+    query_json, runner_yaml = resolve_paths(args)
+    device = torch.device("cuda")
+    print(f"Building runner for {query_json} (samples={args.samples})...")
+
+    runner = build_runner(
+        query_json=query_json,
+        runner_yaml=runner_yaml,
+        num_samples=args.samples,
+        offload_token_cutoff=args.offload_token_cutoff,
+    )
+    lightning_module = runner.lightning_module.to(device).eval()
+    model = lightning_module.model
+    param_info = model_parameter_bytes(model)
+    model_params_bytes = param_info["model_params_and_buffers_bytes"]
+
+    batch = get_batch(runner, device)
+    n_tok = int(batch["token_mask"].shape[-1])
+    n_atom = int(batch["atom_mask"].shape[-1]) if "atom_mask" in batch else -1
+    c_z = int(model.config.architecture.shared.c_z)
+    u_bytes = n_tok * n_tok * c_z * 4
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    cuda_allocated_after_load = torch.cuda.memory_allocated()
+
+    print(f"n_tokens={n_tok}, n_atoms={n_atom}, c_z={c_z}")
+    print(f"1U = {_mib(u_bytes):.1f} MiB")
+    print(
+        f"Model params+buffers: {_mib(model_params_bytes):.1f} MiB "
+        f"(cuda allocated after load: {_mib(cuda_allocated_after_load):.1f} MiB)"
+    )
+
+    print("Warm-up forward...")
+    batch = get_batch(runner, device)
+    with torch.inference_mode():
+        lightning_module(batch)
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+    print("Overall measured forward...")
+    batch = get_batch(runner, device)
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.perf_counter()
+    with torch.inference_mode():
+        lightning_module(batch)
+    torch.cuda.synchronize()
+    overall_wall_s = time.perf_counter() - t0
+    overall_peak_bytes = torch.cuda.max_memory_allocated()
+    del batch
+    torch.cuda.empty_cache()
+
+    print("Hooked stage forward...")
+    batch = get_batch(runner, device)
+    profiler = FastStageProfiler()
+    install_hooks(
+        model, profiler, track_trunk_substages=args.track_trunk_substages
+    )
+    try:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        t0 = time.perf_counter()
+        with torch.inference_mode():
+            lightning_module(batch)
+        torch.cuda.synchronize()
+        stage_wall_s = time.perf_counter() - t0
+    finally:
+        profiler.unwrap_all()
+        del batch
+
+    peak_above_params = overall_peak_bytes - model_params_bytes
+    return {
+        "query_json": str(query_json),
+        "runner_yaml": str(runner_yaml),
+        "n_tokens": n_tok,
+        "n_atoms": n_atom,
+        "n_diffusion_samples": args.samples,
+        "c_z": c_z,
+        "U_bytes": u_bytes,
+        **param_info,
+        "cuda_allocated_after_load_bytes": cuda_allocated_after_load,
+        "overall_peak_bytes": overall_peak_bytes,
+        "peak_above_params_bytes": peak_above_params,
+        "peak_above_params_U": peak_above_params / u_bytes,
+        "overall_wall_s": round(overall_wall_s, 2),
+        "stage_wall_s": round(stage_wall_s, 2),
+        "offload_token_cutoff": args.offload_token_cutoff,
+        "track_trunk_substages": args.track_trunk_substages,
+        "tri_attn_chunk_cap": os.environ.get("OPENFOLD3_TRI_ATTN_CHUNK_CAP"),
+        "trimul_chunk_cap": os.environ.get("OPENFOLD3_TRIMUL_CHUNK_CAP"),
+        "transition_chunk_cap": os.environ.get("OPENFOLD3_TRANSITION_CHUNK_CAP"),
+        "stages": profiler.stats,
+    }
+
+
+def print_report(result: dict) -> None:
+    params = result["model_params_and_buffers_bytes"]
+    peak = result["overall_peak_bytes"]
+    u_bytes = result["U_bytes"]
+    above = peak - params
+
+    print()
+    print("=" * 100)
+    print(
+        f"n_tok={result['n_tokens']} n_atom={result['n_atoms']} "
+        f"samples={result['n_diffusion_samples']} 1U={_mib(u_bytes):.1f} MiB"
+    )
+    print(
+        f"model_params+buffers={_gib(params):.2f} GiB  "
+        f"total_peak={_gib(peak):.2f} GiB"
+    )
+    print(f"peak_above_params={_gib(above):.2f} GiB = {above / u_bytes:.2f}U")
+    print(
+        f"overall_wall={result['overall_wall_s']:.2f}s  "
+        f"stage_wall={result['stage_wall_s']:.2f}s"
+    )
+    print("=" * 100)
+    print(
+        f"{'stage':<28s} {'above_U':>8s} {'trans_U':>8s} "
+        f"{'ms':>10s} {'calls':>7s} {'memory':>8s}"
+    )
+    print("-" * 100)
+    for name, stage in result["stages"].items():
+        if stage.get("memory_tracked", False):
+            above_u = (stage["abs_peak_bytes"] - params) / u_bytes
+            trans_u = stage["peak_over_before_bytes"] / u_bytes
+            above_s = f"{above_u:8.2f}"
+            trans_s = f"{trans_u:8.2f}"
+            mem_s = "yes"
+        else:
+            above_s = f"{'-':>8s}"
+            trans_s = f"{'-':>8s}"
+            mem_s = "timing"
+        print(
+            f"{name:<28s} {above_s} {trans_s} "
+            f"{stage['cuda_ms']:10.1f} {stage['total_calls']:7d} {mem_s:>8s}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        default="ubiquitin",
+        help=f"Known query key: {sorted(KNOWN_QUERIES)}",
+    )
+    parser.add_argument("--query-json", type=Path, default=None)
+    parser.add_argument("--runner-yaml", type=Path, default=None)
+    parser.add_argument("--samples", type=int, default=1)
+    parser.add_argument(
+        "--offload-token-cutoff",
+        type=int,
+        default=10_000_000,
+        help="Default disables offload for practical gate sizes",
+    )
+    parser.add_argument(
+        "--track-trunk-substages",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Track input/template/MSA/Pairformer memory separately (default: on)",
+    )
+    parser.add_argument(
+        "--triangle-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRI_ATTN_CHUNK_CAP and OPENFOLD3_TRIMUL_CHUNK_CAP "
+            "(shared MSA/template/pairformer/confidence triangle ops)"
+        ),
+    )
+    parser.add_argument(
+        "--transition-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRANSITION_CHUNK_CAP to force row-chunked "
+            "pair/MSA transitions (and OPM) after the chunk-size tuner"
+        ),
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.triangle_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRI_ATTN_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+        os.environ["OPENFOLD3_TRIMUL_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+    if args.transition_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRANSITION_CHUNK_CAP"] = str(args.transition_chunk_cap)
+
+    result = profile(args)
+    print_report(result)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(result, indent=2))
+        print(f"Saved {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Second PR in the [#318](https://github.com/aqlaboratory/openfold-3/pull/318) breakdown, stacked on [#320](https://github.com/aqlaboratory/openfold-3/pull/320). This one cuts inference peak memory with opt-in chunk caps and shorter N² lifetimes — no fused pair kernels. Offload stays off in the numbers below.

Until #320 merges, the GitHub diff against `main` also includes that PR. The three commits unique to this branch are:

- `perf: release trunk pair after confidence clone`
- `perf: add opt-in triangle and transition chunk caps`
- `perf: chunk diffusion conditioning and stream templates`

### Why N² features and intermediates dominate

Define `1U = N² × c_z × 4` — the storage of one fp32 trunk pair tensor. At long targets, almost every large allocation is pair-shaped: the working `z`, transition / triangle scratch, template distogram and unit-vector features, and diffusion relpos concatenations. Singles, atom tensors, and MSA rows are small next to that (fractions of a U). So peak memory is mostly how many N² tensors coexist, and how large the pair-op scratch is while they do.

This PR attacks that two ways: bound the pair-op working sets with opt-in chunk caps, and shorten lifetimes so fewer full N² tensors sit resident at once. Fused kernels that avoid materializing those intermediates are left for later.

Primary metric: peak CUDA alloc above live model params+buffers, reported in U.

### Measured peak (homo_1200, S=1, cuEq, offload off)

| Configuration | Peak above params | Limiting stage |
|---|---:|---|
| Default (no caps, no lifecycle) | 17.40U | CONFIDENCE |
| Same caps, default lifecycle | ~10U | DIFFUSION |
| This PR (caps + lifecycle) | 6.63U | input_embedder |

Warm forward with caps+lifecycle is ~108s vs ~87s uncapped default; eager trimul chunking is the main wall cost.

Caps alone bound PairBlock / transition / OPM scratch. They do not touch diffusion's full `[N,N,267]` relpos+concat (~10U), the 4-wide template embed (~9.5U), or input-embedder relpos staging (~6.6U). The drop from ~10U to 6.63U is the lifetime work on top of those caps:

| Change | Effect |
|---|---|
| Release trunk pair after confidence clone | −1.0U early; secondary once caps apply |
| Row-chunk diffusion conditioning (128) | DIFFUSION 10.1U → 6.4U |
| Stream templates one-at-a-time on GPU | template 9.5U → 5.9U |

After that, the global peak is `input_embedder` at 6.63U. Template distogram (~1.2U) stays in `batch` for the whole forward — no CPU park in this PR.

### What this PR changes

- Opt-in env caps: `OPENFOLD3_TRI_ATTN_CHUNK_CAP`, `OPENFOLD3_TRIMUL_CHUNK_CAP`, `OPENFOLD3_TRANSITION_CHUNK_CAP` (unset = upstream default)
- Under a trimul cap and inplace-safe inference, skip cuEq trimul and use eager `_inference_forward` with that chunk
- Confidence: ownership handoff so the trunk pair can be freed after the confidence clone
- Diffusion conditioning: row-chunked trunk-pair + relpos embed (`row_slice` on `relpos_complex`)
- Templates: GPU streaming when `inplace_safe` and `n_templ > 1`
- `scripts/dev/profile_inference_stages.py` for warm / overall / hooked stage peaks

### Out of scope

Fused SwiGLU / trimul / tri-attn / input-relpos, template CPU-park or O(N) coordinate templates, and dual `z_init`+`z` residency. Those are what the original tip used to reach ~4.2U; this PR stops at ~6.6U on homo_1200.

## Test plan

- [ ] Focused pytest: `test_heads`, `test_diffusion_conditioning`, `test_template_module`, `test_utils` (cap envs)
- [ ] Profile homo_1200 S=1 with `--triangle-chunk-cap 128 --transition-chunk-cap 128`; expect ~6.6U, input_embedder peak
- [ ] Same profile with caps unset: lifecycle-only path still correct; peak higher
- [ ] Ubiquitin / MCL1 smoke under the same protocol