### PR TITLE
Build template pair features from coordinates online

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -188,6 +188,7 @@ Controls template structure processing.
   - `min_bin` *(float)*: Minimum distance bin (default: `3.25`)
   - `max_bin` *(float)*: Maximum distance bin (default: `50.75`)
   - `n_bins` *(int)*: Number of bins (default: `39`)
+- `use_coordinate_pair_features` *(bool)*: Build template pair features online from compact O(N) coordinates instead of materializing N² distogram / unit-vector tensors (default: `false`). Supported for both inference and training. Requires the default distogram bins (`3.25` / `50.75` / `39`). See {doc}`kernels` for the Triton projection path and `OPENFOLD3_FUSED_TEMPLATE_COORD`.
 
 **Example**:
 ```yaml
@@ -195,7 +196,10 @@ dataset_config_kwargs:
   template:
     n_templates: 4
     take_top_k: true
+    use_coordinate_pair_features: true
 ```
+
+For training, set the same flag under each dataset’s `config.template` block in `dataset_configs`.
 
 ---
 

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -198,6 +198,7 @@ We provide several example runner files in our [examples directory](https://gith
 - Customizing output formats
 - Enabling cuEquivariance kernels
 - Enabling AMD ROCm Triton kernels
+- Enabling online template coordinate pair features (`template.use_coordinate_pair_features`)
 - Saving MSA and Template processing outputs
 - And more
 

--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -34,4 +34,30 @@ model_update:
           use_deepspeed_evo_attention: true  # set this to False to use cueq only
 ```
 
-This runner.yml is specifically for inference, but similar settings can be used for training. 
+This runner.yml is specifically for inference, but similar settings can be used for training.
+
+# Online template coordinate projection
+
+OpenFold3 can replace resident N² template distogram / unit-vector features with compact O(N) coordinates and project pair features online in the template embedder. Enable it from dataset template settings:
+
+```yaml
+# Inference (`dataset_config_kwargs`) or training (`dataset_configs.*.*.config`)
+template:
+  use_coordinate_pair_features: true
+```
+
+When the batch contains `template_pseudo_beta_coords` / `template_frame_atom_coords`, the model uses the coordinate embedder automatically and streams templates on GPU (no template offload).
+
+## Triton kernel
+
+On CUDA with eligible shapes (`B=1`, output channels `64`, activation dtype `float32` or `bfloat16`), projection uses a length-generic Triton kernel (N and strides are not specialized). Training uses an autograd wrapper with a Triton split-K backward; inference may update the pair tensor in place. Geometry inputs stay fp32; under bf16 autocast, pair activations remain bf16 while the kernel accumulates in fp32.
+
+```bash
+# Default: use Triton when eligible
+OPENFOLD3_FUSED_TEMPLATE_COORD=1
+
+# Force the chunked eager reference path
+OPENFOLD3_FUSED_TEMPLATE_COORD=0
+```
+
+TF32 for the Triton backward GEMM follows `torch.backends.cuda.matmul.allow_tf32`. Distogram settings must remain the defaults (`min_bin=3.25`, `max_bin=50.75`, `n_bins=39`).

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -75,6 +75,8 @@ dataset_configs:
         template:
           n_templates: 4
           take_top_k: false
+          # Optional: O(N) coords + online pair projection (see kernels.md)
+          # use_coordinate_pair_features: true
         crop:
           token_crop:
             enabled: true
@@ -96,6 +98,7 @@ dataset_configs:
         template:
           n_templates: 4
           take_top_k: true
+          # use_coordinate_pair_features: true
         crop:
           token_crop:
             enabled: false

--- a/openfold3/core/data/framework/single_datasets/base_of3.py
+++ b/openfold3/core/data/framework/single_datasets/base_of3.py
@@ -173,11 +173,6 @@ class BaseOF3Dataset(SingleDataset, ABC):
         self.crop = dataset_config.crop.model_dump()
         self.loss = dataset_config.loss.model_dump()
         self.template = dataset_config.template
-        if self.template.use_coordinate_pair_features:
-            raise NotImplementedError(
-                "Coordinate-derived template features are inference-only; "
-                "training support requires a differentiable projection path."
-            )
 
         # Misc
         self.single_moltype = None
@@ -311,6 +306,7 @@ class BaseOF3Dataset(SingleDataset, ABC):
             min_bin=self.template.distogram.min_bin,
             max_bin=self.template.distogram.max_bin,
             n_bins=self.template.distogram.n_bins,
+            use_coordinate_pair_features=self.template.use_coordinate_pair_features,
         )
 
         return template_features

--- a/openfold3/core/data/framework/single_datasets/base_of3.py
+++ b/openfold3/core/data/framework/single_datasets/base_of3.py
@@ -173,6 +173,11 @@ class BaseOF3Dataset(SingleDataset, ABC):
         self.crop = dataset_config.crop.model_dump()
         self.loss = dataset_config.loss.model_dump()
         self.template = dataset_config.template
+        if self.template.use_coordinate_pair_features:
+            raise NotImplementedError(
+                "Coordinate-derived template features are inference-only; "
+                "training support requires a differentiable projection path."
+            )
 
         # Misc
         self.single_moltype = None

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -294,6 +294,9 @@ class InferenceDataset(Dataset):
             min_bin=self.template_settings.distogram.min_bin,
             max_bin=self.template_settings.distogram.max_bin,
             n_bins=self.template_settings.distogram.n_bins,
+            use_coordinate_pair_features=(
+                self.template_settings.use_coordinate_pair_features
+            ),
         )
 
         return template_features

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -18,8 +18,11 @@ Inference class template for first inference pipeline prototype.
 
 import itertools
 import logging
+import random
 import traceback
+from contextlib import contextmanager
 
+import numpy as np
 import pandas as pd
 import torch
 from biotite.structure import AtomArray
@@ -70,6 +73,22 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _seeded_feature_creation(seed: int):
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
 
 
 @register_dataset
@@ -331,7 +350,8 @@ class InferenceDataset(Dataset):
         is_repeated_sample = bool(datapoint["repeated_sample"])
 
         try:
-            features = self.create_all_features(query)
+            with _seeded_feature_creation(int(seed)):
+                features = self.create_all_features(query)
             features["query_id"] = query_id
             features["seed"] = torch.tensor([seed])
             features["repeated_sample"] = torch.tensor(

--- a/openfold3/core/data/pipelines/featurization/template.py
+++ b/openfold3/core/data/pipelines/featurization/template.py
@@ -54,6 +54,7 @@ def featurize_template_structures_of3(
     min_bin: float,
     max_bin: float,
     n_bins: int,
+    use_coordinate_pair_features: bool = False,
 ) -> dict[str, torch.Tensor]:
     """Featurizes template data for AF3.
 
@@ -70,6 +71,9 @@ def featurize_template_structures_of3(
             Distogram constructed from pseudo beta atoms distances.
         - template_unit_vector:
             Unit vector constructed from backbone frames.
+        - template_pseudo_beta_coords / template_frame_atom_coords:
+            Compact alternative to the two pair features when
+            ``use_coordinate_pair_features`` is enabled.
 
     Args:
         template_slice_collection (TemplateSliceCollection):
@@ -84,6 +88,8 @@ def featurize_template_structures_of3(
             The maximum distance for the distogram bins.
         n_bins (int):
             The number of bins in the distogram.
+        use_coordinate_pair_features (bool):
+            Return compact coordinates instead of materialized pair features.
 
     Returns:
         dict[str, torch.Tensor]:
@@ -95,19 +101,6 @@ def featurize_template_structures_of3(
         n_tokens,
     )
 
-    # Create asym ID to mask inter-chain features and mask
-    token_starts_with_stop, _ = extract_starts_entities(atom_array)
-    token_starts = token_starts_with_stop[:-1]
-    chain_ids_token = atom_array.chain_id[token_starts]
-    _, renum_ids = np.unique(chain_ids_token, return_inverse=True)
-    asym_id = pad_token_dim(
-        {"asym_id": torch.tensor(renum_ids + 1, dtype=torch.int32)}, n_tokens
-    )["asym_id"]
-    multichain_pair_mask = (asym_id[..., None] == asym_id[..., None, :])[
-        ..., None, :, :, None
-    ]
-
-    # Create features
     features = {}
     features["template_pseudo_beta_mask"] = torch.tensor(
         ~np.isnan(template_feature_precursor.pseudo_beta_atom_coords).any(axis=-1),
@@ -121,6 +114,33 @@ def featurize_template_structures_of3(
         template_feature_precursor.res_names,
         features["template_pseudo_beta_mask"],
     )
+    if use_coordinate_pair_features:
+        features["template_pseudo_beta_coords"] = torch.nan_to_num(
+            torch.as_tensor(
+                template_feature_precursor.pseudo_beta_atom_coords,
+                dtype=torch.float32,
+            )
+        )
+        features["template_frame_atom_coords"] = torch.nan_to_num(
+            torch.as_tensor(
+                template_feature_precursor.frame_atom_coords,
+                dtype=torch.float32,
+            )
+        )
+        return features
+
+    # The legacy representation masks pair features during featurization.
+    token_starts_with_stop, _ = extract_starts_entities(atom_array)
+    token_starts = token_starts_with_stop[:-1]
+    chain_ids_token = atom_array.chain_id[token_starts]
+    _, renum_ids = np.unique(chain_ids_token, return_inverse=True)
+    asym_id = pad_token_dim(
+        {"asym_id": torch.tensor(renum_ids + 1, dtype=torch.int32)}, n_tokens
+    )["asym_id"]
+    multichain_pair_mask = (asym_id[..., None] == asym_id[..., None, :])[
+        ..., None, :, :, None
+    ]
+
     features["template_distogram"] = create_template_distogram(
         template_feature_precursor.pseudo_beta_atom_coords,
         features["template_pseudo_beta_mask"],

--- a/openfold3/core/data/primitives/quality_control/asserts.py
+++ b/openfold3/core/data/primitives/quality_control/asserts.py
@@ -222,7 +222,10 @@ def assert_gt_crop_slice(features):
 
 def assert_shape(features, token_budget, n_templates):
     """Asserts the shape of the features."""
+    _assert_template_feature_representation(features)
     for k, v in FULL_TOKEN_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == token_budget, (
                 f"Token shape mismatch for key '{k}'."
@@ -231,11 +234,15 @@ def assert_shape(features, token_budget, n_templates):
         for i in v:
             assert features[k].shape[i] <= 16384, f"MSA shape '{k}' larger than 16384."
     for k, v in FULL_TEMPLATE_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == n_templates, (
                 f"Template shape '{k}' shape mismatch."
             )
     for k, v in FULL_OTHER_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == FULL_OTHER_DIM_SIZE_MAP[k][i], (
                 f"Other shape '{k}' shape mismatch."
@@ -244,7 +251,10 @@ def assert_shape(features, token_budget, n_templates):
 
 def assert_dtype(features):
     """Asserts the dtype of the features."""
+    _assert_template_feature_representation(features)
     for k, v in (FEATURE_CORE_DTYPES | FEATURE_OTHER_DTYPES).items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         assert features[k].dtype == v, f"Cropped feature '{k}' dtype mismatch."
     for k, v in (FEATURE_CORE_DTYPES | FEATURE_GT_DTYPES).items():
         assert features["ground_truth"][k].dtype == v, (
@@ -254,6 +264,20 @@ def assert_dtype(features):
         assert features["loss_weights"][k].dtype == v, (
             f"Loss feature '{k}' dtype mismatch."
         )
+
+
+def _assert_template_feature_representation(features: dict) -> None:
+    legacy_count = sum(k in features for k in TEMPLATE_LEGACY_PAIR_FEATURES)
+    coordinate_count = sum(k in features for k in TEMPLATE_COORDINATE_FEATURES)
+    assert legacy_count in (0, len(TEMPLATE_LEGACY_PAIR_FEATURES)), (
+        "Template legacy pair features are incomplete."
+    )
+    assert coordinate_count in (0, len(TEMPLATE_COORDINATE_FEATURES)), (
+        "Template coordinate features are incomplete."
+    )
+    assert (legacy_count > 0) != (coordinate_count > 0), (
+        "Exactly one template pair-feature representation is required."
+    )
 
 
 def assert_resid_same_in_tokenid(features):
@@ -322,6 +346,18 @@ ENSEMBLED_ASSERTS = [
     assert_profile_sum,
 ]
 
+TEMPLATE_LEGACY_PAIR_FEATURES = (
+    "template_distogram",
+    "template_unit_vector",
+)
+TEMPLATE_COORDINATE_FEATURES = (
+    "template_pseudo_beta_coords",
+    "template_frame_atom_coords",
+)
+TEMPLATE_ALTERNATIVE_FEATURES = frozenset(
+    TEMPLATE_LEGACY_PAIR_FEATURES + TEMPLATE_COORDINATE_FEATURES
+)
+
 FULL_TOKEN_DIM_INDEX_MAP = {
     "residue_index": [-1],
     "token_index": [-1],
@@ -347,6 +383,8 @@ FULL_TOKEN_DIM_INDEX_MAP = {
     "template_backbone_frame_mask": [-1],
     "template_distogram": [-2, -3],
     "template_unit_vector": [-2, -3],
+    "template_pseudo_beta_coords": [-2],
+    "template_frame_atom_coords": [-3],
 }
 FULL_MSA_DIM_INDEX_MAP = {
     "msa": [-3],
@@ -359,6 +397,8 @@ FULL_TEMPLATE_DIM_INDEX_MAP = {
     "template_backbone_frame_mask": [-2],
     "template_distogram": [-4],
     "template_unit_vector": [-4],
+    "template_pseudo_beta_coords": [-3],
+    "template_frame_atom_coords": [-4],
 }
 FULL_OTHER_DIM_INDEX_MAP = {
     "restype": [-1],
@@ -369,6 +409,8 @@ FULL_OTHER_DIM_INDEX_MAP = {
     "template_restype": [-1],
     "template_distogram": [-1],
     "template_unit_vector": [-1],
+    "template_pseudo_beta_coords": [-1],
+    "template_frame_atom_coords": [-1, -2],
 }
 FULL_OTHER_DIM_SIZE_MAP = {
     "restype": [32],
@@ -379,6 +421,8 @@ FULL_OTHER_DIM_SIZE_MAP = {
     "template_restype": [32],
     "template_distogram": [39],
     "template_unit_vector": [3],
+    "template_pseudo_beta_coords": [3],
+    "template_frame_atom_coords": [3, 3],
 }
 
 FEATURE_CORE_DTYPES = {
@@ -419,6 +463,8 @@ FEATURE_OTHER_DTYPES = {
     "template_backbone_frame_mask": torch.float32,
     "template_distogram": torch.float32,
     "template_unit_vector": torch.float32,
+    "template_pseudo_beta_coords": torch.float32,
+    "template_frame_atom_coords": torch.float32,
     "msa_mask": torch.float32,
     "num_paired_seqs": torch.int32,
 }

--- a/openfold3/core/kernels/triton/fused_template_coordinate.py
+++ b/openfold3/core/kernels/triton/fused_template_coordinate.py
@@ -21,6 +21,7 @@ The fixed-shape projection (39 distogram inputs and five scalar inputs into
 64 output channels) is fused with coordinate-to-pair feature construction.
 No pairwise feature tensor is written to HBM. Sequence length and all tensor
 strides remain runtime values so one compiled kernel serves every length.
+Supports fp32/bf16 pair activations with fp32 accumulate.
 """
 
 from __future__ import annotations
@@ -39,50 +40,21 @@ except ImportError:  # pragma: no cover
 if _TRITON_AVAILABLE:
     _BLOCK_PAIRS = 16
     _BLOCK_CHANNELS = 64
+    _BWD_BLOCK_PAIRS = 32
+    _BWD_BLOCK_CHANNELS = 64
+    _BWD_BLOCK_FEATURES = 16
+    _BWD_SPLIT_K = 64
+    _BWD_FEATURES = 44
 
-    @triton.jit(
-        do_not_specialize=[
-            "N",
-            "stride_out_i",
-            "stride_out_j",
-            "stride_out_c",
-            "stride_pb_i",
-            "stride_pb_xyz",
-            "stride_frame_i",
-            "stride_frame_atom",
-            "stride_frame_xyz",
-            "stride_pb_mask_i",
-            "stride_bb_mask_i",
-            "stride_asym_i",
-            "stride_w_dgram_c",
-            "stride_w_dgram_bin",
-            "stride_w_scalar_c",
-            "stride_w_scalar_feat",
-        ],
-        do_not_specialize_on_alignment=[
-            "out_ptr",
-            "pb_coords_ptr",
-            "frame_coords_ptr",
-            "pb_mask_ptr",
-            "bb_mask_ptr",
-            "asym_id_ptr",
-            "w_dgram_ptr",
-            "w_scalar_ptr",
-        ],
-    )
-    def _template_coordinate_projection_kernel(
-        out_ptr,
+    @triton.jit
+    def _template_coordinate_pair_features(
+        pair,
         pb_coords_ptr,
         frame_coords_ptr,
         pb_mask_ptr,
         bb_mask_ptr,
         asym_id_ptr,
-        w_dgram_ptr,
-        w_scalar_ptr,
         N,
-        stride_out_i,
-        stride_out_j,
-        stride_out_c,
         stride_pb_i,
         stride_pb_xyz,
         stride_frame_i,
@@ -91,17 +63,8 @@ if _TRITON_AVAILABLE:
         stride_pb_mask_i,
         stride_bb_mask_i,
         stride_asym_i,
-        stride_w_dgram_c,
-        stride_w_dgram_bin,
-        stride_w_scalar_c,
-        stride_w_scalar_feat,
-        BLOCK_PAIRS: tl.constexpr,
-        BLOCK_CHANNELS: tl.constexpr,
     ):
-        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
-        channel = tl.arange(0, BLOCK_CHANNELS)
         pair_mask = pair < N * N
-
         i = pair // N
         j = pair - i * N
 
@@ -140,8 +103,6 @@ if _TRITON_AVAILABLE:
         pb_dz = pb_iz - pb_jz
         dist2 = pb_dx * pb_dx + pb_dy * pb_dy + pb_dz * pb_dz
 
-        # Current template distogram uses 39 strict open intervals with
-        # linearly spaced (unsquared) edges from 3.25 to 50.75 Angstrom.
         min_bin = 3.25
         bin_step = 1.25
         distance = tl.sqrt(dist2)
@@ -173,15 +134,15 @@ if _TRITON_AVAILABLE:
 
         frame_i_base = frame_coords_ptr + i * stride_frame_i
         n_x = tl.load(frame_i_base, mask=pair_mask, other=0.0).to(tl.float32)
-        n_y = tl.load(frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        n_y = tl.load(
+            frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         n_z = tl.load(
             frame_i_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
-        ca_x = tl.load(frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        ca_x = tl.load(
+            frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         ca_y = tl.load(
             frame_i_base + stride_frame_atom + stride_frame_xyz,
             mask=pair_mask,
@@ -207,9 +168,9 @@ if _TRITON_AVAILABLE:
         ).to(tl.float32)
         frame_j_base = frame_coords_ptr + j * stride_frame_i + stride_frame_atom
         j_ca_x = tl.load(frame_j_base, mask=pair_mask, other=0.0).to(tl.float32)
-        j_ca_y = tl.load(frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        j_ca_y = tl.load(
+            frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         j_ca_z = tl.load(
             frame_j_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
@@ -263,13 +224,130 @@ if _TRITON_AVAILABLE:
         local_x *= inv_delta_norm
         local_y *= inv_delta_norm
         local_z *= inv_delta_norm
+        return (
+            i,
+            j,
+            pair_mask,
+            bin_index,
+            in_bin,
+            pb_pair_mask,
+            bb_pair_mask,
+            local_x,
+            local_y,
+            local_z,
+        )
 
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_source_i",
+            "stride_source_j",
+            "stride_source_c",
+            "stride_out_i",
+            "stride_out_j",
+            "stride_out_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_w_dgram_c",
+            "stride_w_dgram_bin",
+            "stride_w_scalar_c",
+            "stride_w_scalar_feat",
+        ],
+        do_not_specialize_on_alignment=[
+            "source_ptr",
+            "out_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "w_dgram_ptr",
+            "w_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_kernel(
+        source_ptr,
+        out_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        w_dgram_ptr,
+        w_scalar_ptr,
+        N,
+        stride_source_i,
+        stride_source_j,
+        stride_source_c,
+        stride_out_i,
+        stride_out_j,
+        stride_out_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_w_dgram_c,
+        stride_w_dgram_bin,
+        stride_w_scalar_c,
+        stride_w_scalar_feat,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+    ):
+        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
+        channel = tl.arange(0, BLOCK_CHANNELS)
+
+        (
+            i,
+            j,
+            pair_mask,
+            bin_index,
+            in_bin,
+            pb_pair_mask,
+            bb_pair_mask,
+            local_x,
+            local_y,
+            local_z,
+        ) = _template_coordinate_pair_features(
+            pair,
+            pb_coords_ptr,
+            frame_coords_ptr,
+            pb_mask_ptr,
+            bb_mask_ptr,
+            asym_id_ptr,
+            N,
+            stride_pb_i,
+            stride_pb_xyz,
+            stride_frame_i,
+            stride_frame_atom,
+            stride_frame_xyz,
+            stride_pb_mask_i,
+            stride_bb_mask_i,
+            stride_asym_i,
+        )
+
+        source_offsets = (
+            i[:, None] * stride_source_i
+            + j[:, None] * stride_source_j
+            + channel[None, :] * stride_source_c
+        )
         out_offsets = (
             i[:, None] * stride_out_i
             + j[:, None] * stride_out_j
             + channel[None, :] * stride_out_c
         )
-        out = tl.load(out_ptr + out_offsets, mask=pair_mask[:, None]).to(tl.float32)
+        out = tl.load(source_ptr + source_offsets, mask=pair_mask[:, None]).to(
+            tl.float32
+        )
 
         w_dgram = tl.load(
             w_dgram_ptr
@@ -303,11 +381,260 @@ if _TRITON_AVAILABLE:
             + w_bb[None, :]
         )
 
-        tl.store(out_ptr + out_offsets, out, mask=pair_mask[:, None])
+        tl.store(
+            out_ptr + out_offsets,
+            out.to(out_ptr.dtype.element_ty),
+            mask=pair_mask[:, None],
+        )
+
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_grad_i",
+            "stride_grad_j",
+            "stride_grad_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_partial_split",
+            "stride_partial_c",
+            "stride_partial_f",
+        ],
+        do_not_specialize_on_alignment=[
+            "grad_output_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "partial_ptr",
+        ],
+    )
+    def _template_coordinate_projection_bwd_partial_kernel(
+        grad_output_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        partial_ptr,
+        N,
+        stride_grad_i,
+        stride_grad_j,
+        stride_grad_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_partial_split,
+        stride_partial_c,
+        stride_partial_f,
+        COMPUTE_DGRAM: tl.constexpr,
+        COMPUTE_SCALAR: tl.constexpr,
+        ALLOW_TF32: tl.constexpr,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+        BLOCK_FEATURES: tl.constexpr,
+        SPLIT_K: tl.constexpr,
+    ):
+        channel = tl.program_id(0) * BLOCK_CHANNELS + tl.arange(0, BLOCK_CHANNELS)
+        feature = tl.program_id(1) * BLOCK_FEATURES + tl.arange(0, BLOCK_FEATURES)
+        split = tl.program_id(2)
+        channel_mask = channel < 64
+        feature_mask = feature < 44
+        if not COMPUTE_DGRAM:
+            feature_mask &= feature >= 39
+        if not COMPUTE_SCALAR:
+            feature_mask &= feature < 39
+
+        accumulator = tl.zeros(
+            (BLOCK_CHANNELS, BLOCK_FEATURES), dtype=tl.float32
+        )
+        pair_count = N * N
+        pairs_per_split = (
+            pair_count + SPLIT_K * BLOCK_PAIRS - 1
+        ) // (SPLIT_K * BLOCK_PAIRS) * BLOCK_PAIRS
+        pair_start = split * pairs_per_split
+        pair_stop = tl.minimum(pair_start + pairs_per_split, pair_count)
+        while pair_start < pair_stop:
+            pair = pair_start + tl.arange(0, BLOCK_PAIRS)
+            (
+                i,
+                j,
+                pair_mask,
+                bin_index,
+                in_bin,
+                pb_pair_mask,
+                bb_pair_mask,
+                local_x,
+                local_y,
+                local_z,
+            ) = _template_coordinate_pair_features(
+                pair,
+                pb_coords_ptr,
+                frame_coords_ptr,
+                pb_mask_ptr,
+                bb_mask_ptr,
+                asym_id_ptr,
+                N,
+                stride_pb_i,
+                stride_pb_xyz,
+                stride_frame_i,
+                stride_frame_atom,
+                stride_frame_xyz,
+                stride_pb_mask_i,
+                stride_bb_mask_i,
+                stride_asym_i,
+            )
+            grad_offsets = (
+                i[:, None] * stride_grad_i
+                + j[:, None] * stride_grad_j
+                + channel[None, :] * stride_grad_c
+            )
+            grad = tl.load(
+                grad_output_ptr + grad_offsets,
+                mask=pair_mask[:, None] & channel_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+
+            dgram_scale = pb_pair_mask * in_bin.to(tl.float32)
+            features = tl.where(
+                (feature[None, :] < 39)
+                & (feature[None, :] == bin_index[:, None]),
+                dgram_scale[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 39, pb_pair_mask[:, None], 0.0
+            )
+            features += tl.where(
+                feature[None, :] == 40,
+                (bb_pair_mask * local_x)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 41,
+                (bb_pair_mask * local_y)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 42,
+                (bb_pair_mask * local_z)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 43, bb_pair_mask[:, None], 0.0
+            )
+            features = tl.where(
+                pair_mask[:, None] & feature_mask[None, :], features, 0.0
+            )
+            if ALLOW_TF32:
+                accumulator = tl.dot(
+                    tl.trans(grad),
+                    features,
+                    accumulator,
+                    input_precision="tf32",
+                    out_dtype=tl.float32,
+                )
+            else:
+                accumulator = tl.dot(
+                    tl.trans(grad),
+                    features,
+                    accumulator,
+                    input_precision="ieee",
+                    out_dtype=tl.float32,
+                )
+            pair_start += BLOCK_PAIRS
+
+        partial_offsets = (
+            split * stride_partial_split
+            + channel[:, None] * stride_partial_c
+            + feature[None, :] * stride_partial_f
+        )
+        tl.store(
+            partial_ptr + partial_offsets,
+            accumulator,
+            mask=channel_mask[:, None] & feature_mask[None, :],
+        )
+
+    @triton.jit(
+        do_not_specialize=[
+            "stride_partial_split",
+            "stride_partial_c",
+            "stride_partial_f",
+            "stride_dgram_c",
+            "stride_dgram_f",
+            "stride_scalar_c",
+            "stride_scalar_f",
+        ],
+        do_not_specialize_on_alignment=[
+            "partial_ptr",
+            "grad_dgram_ptr",
+            "grad_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_bwd_reduce_kernel(
+        partial_ptr,
+        grad_dgram_ptr,
+        grad_scalar_ptr,
+        stride_partial_split,
+        stride_partial_c,
+        stride_partial_f,
+        stride_dgram_c,
+        stride_dgram_f,
+        stride_scalar_c,
+        stride_scalar_f,
+        COMPUTE_DGRAM: tl.constexpr,
+        COMPUTE_SCALAR: tl.constexpr,
+        SPLIT_K: tl.constexpr,
+        BLOCK_OUTPUTS: tl.constexpr,
+    ):
+        output = tl.program_id(0) * BLOCK_OUTPUTS + tl.arange(0, BLOCK_OUTPUTS)
+        output_mask = output < 64 * 44
+        channel = output // 44
+        feature = output - channel * 44
+        accumulator = tl.zeros((BLOCK_OUTPUTS,), dtype=tl.float32)
+        for split in range(SPLIT_K):
+            accumulator += tl.load(
+                partial_ptr
+                + split * stride_partial_split
+                + channel * stride_partial_c
+                + feature * stride_partial_f,
+                mask=output_mask,
+                other=0.0,
+            ).to(tl.float32)
+
+        if COMPUTE_DGRAM:
+            dgram_mask = output_mask & (feature < 39)
+            tl.store(
+                grad_dgram_ptr
+                + channel * stride_dgram_c
+                + feature * stride_dgram_f,
+                accumulator,
+                mask=dgram_mask,
+            )
+        if COMPUTE_SCALAR:
+            scalar_mask = output_mask & (feature >= 39)
+            tl.store(
+                grad_scalar_ptr
+                + channel * stride_scalar_c
+                + (feature - 39) * stride_scalar_f,
+                accumulator,
+                mask=scalar_mask,
+            )
 
 
-def template_coordinate_projection_add_(
-    out: torch.Tensor,
+def template_coordinate_projection(
+    source: torch.Tensor,
     pseudo_beta_coords: torch.Tensor,
     frame_atom_coords: torch.Tensor,
     pseudo_beta_mask: torch.Tensor,
@@ -315,27 +642,75 @@ def template_coordinate_projection_add_(
     asym_id: torch.Tensor,
     dgram_weight: torch.Tensor,
     scalar_weight: torch.Tensor,
-) -> None:
-    """Add coordinate-derived template projections to ``out`` in place.
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Add coordinate-derived projections to ``source`` and write ``out``.
 
-    This launcher intentionally supports only the production inference shape:
-    B=1, fp32, 39 distogram inputs, five scalar inputs, and 64 output channels.
+    ``source`` and ``out`` may be the same tensor for guarded inference use.
+    Training callers pass a fresh ``out`` through an autograd wrapper. This
+    launcher intentionally supports only the production B=1, fp32/bf16, 39+5
+    to 64 shape.
     """
     if not _TRITON_AVAILABLE:
         raise RuntimeError("Triton is required for coordinate template projection")
+    if out is None:
+        out = torch.empty_like(source)
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+    )
+    if torch.is_grad_enabled() and any(
+        x.requires_grad for x in (source, out, *inputs)
+    ):
+        raise RuntimeError(
+            "Raw template coordinate Triton launches are not autograd-aware; "
+            "use the model dispatcher"
+        )
     if not (
-        out.is_cuda
-        and out.dtype == torch.float32
-        and out.shape[0] == 1
-        and out.shape[-1] == 64
+        source.is_cuda
+        and out.is_cuda
+        and source.device == out.device
+        and source.dtype in (torch.float32, torch.bfloat16)
+        and out.dtype == source.dtype
+        and source.dim() == 4
+        and source.shape[0] == 1
+        and source.shape[-1] == 64
+        and all(x.is_cuda and x.device == source.device for x in inputs)
+        and dgram_weight.dtype == torch.float32
+        and scalar_weight.dtype == torch.float32
         and dgram_weight.shape == (64, 39)
         and scalar_weight.shape == (64, 5)
     ):
         raise ValueError("Unsupported coordinate template projection configuration")
 
-    n_token = out.shape[1]
-    if out.shape != (1, n_token, n_token, 64):
-        raise ValueError(f"Expected out [1,N,N,64], got {tuple(out.shape)}")
+    n_token = source.shape[1]
+    expected_shape = (1, n_token, n_token, 64)
+    if source.shape != expected_shape or out.shape != expected_shape:
+        raise ValueError(
+            "Expected source and out [1,N,N,64], got "
+            f"{tuple(source.shape)} and {tuple(out.shape)}"
+        )
+    input_shapes = (
+        pseudo_beta_coords.shape == (1, n_token, 3)
+        and frame_atom_coords.shape == (1, n_token, 3, 3)
+        and pseudo_beta_mask.shape == (1, n_token)
+        and backbone_frame_mask.shape == (1, n_token)
+        and asym_id.shape == (1, n_token)
+    )
+    if not input_shapes:
+        raise ValueError("Coordinate inputs do not match source token dimensions")
+    if torch._debug_has_internal_overlap(out) != 0:
+        raise ValueError("Template coordinate output must not overlap internally")
+    if (
+        source.untyped_storage().data_ptr() == out.untyped_storage().data_ptr()
+        and source is not out
+    ):
+        raise ValueError("source and out may only alias when they are the same tensor")
 
     pb = pseudo_beta_coords[0]
     frame = frame_atom_coords[0]
@@ -344,6 +719,7 @@ def template_coordinate_projection_add_(
     asym = asym_id[0]
     grid = (triton.cdiv(n_token * n_token, _BLOCK_PAIRS),)
     _template_coordinate_projection_kernel[grid](
+        source,
         out,
         pb,
         frame,
@@ -353,6 +729,9 @@ def template_coordinate_projection_add_(
         dgram_weight,
         scalar_weight,
         n_token,
+        source.stride(1),
+        source.stride(2),
+        source.stride(3),
         out.stride(1),
         out.stride(2),
         out.stride(3),
@@ -372,4 +751,158 @@ def template_coordinate_projection_add_(
         BLOCK_CHANNELS=_BLOCK_CHANNELS,
         num_warps=4,
         num_stages=1,
+    )
+    return out
+
+
+def template_coordinate_projection_backward(
+    grad_output: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    *,
+    compute_dgram: bool = True,
+    compute_scalar: bool = True,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Compute coordinate-projection weight gradients with deterministic split-K."""
+    if not _TRITON_AVAILABLE:
+        raise RuntimeError("Triton is required for coordinate template projection")
+    if not compute_dgram and not compute_scalar:
+        return None, None
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+    )
+    if not (
+        grad_output.is_cuda
+        and grad_output.dtype in (torch.float32, torch.bfloat16)
+        and grad_output.dim() == 4
+        and grad_output.shape[0] == 1
+        and grad_output.shape[-1] == 64
+        and all(x.is_cuda and x.device == grad_output.device for x in inputs)
+    ):
+        raise ValueError(
+            "Unsupported coordinate template projection backward configuration"
+        )
+
+    n_token = grad_output.shape[1]
+    if grad_output.shape != (1, n_token, n_token, 64):
+        raise ValueError("Expected grad_output [1,N,N,64]")
+    if not (
+        pseudo_beta_coords.shape == (1, n_token, 3)
+        and frame_atom_coords.shape == (1, n_token, 3, 3)
+        and pseudo_beta_mask.shape == (1, n_token)
+        and backbone_frame_mask.shape == (1, n_token)
+        and asym_id.shape == (1, n_token)
+    ):
+        raise ValueError("Coordinate inputs do not match grad_output token dimensions")
+
+    grad = grad_output[0]
+    pb = pseudo_beta_coords[0]
+    frame = frame_atom_coords[0]
+    pb_mask = pseudo_beta_mask[0]
+    bb_mask = backbone_frame_mask[0]
+    asym = asym_id[0]
+    partial = torch.empty(
+        (_BWD_SPLIT_K, 64, _BWD_FEATURES),
+        dtype=torch.float32,
+        device=grad_output.device,
+    )
+    grad_dgram = torch.empty((64, 39), dtype=torch.float32, device=grad_output.device)
+    grad_scalar = torch.empty((64, 5), dtype=torch.float32, device=grad_output.device)
+
+    partial_grid = (
+        triton.cdiv(64, _BWD_BLOCK_CHANNELS),
+        triton.cdiv(_BWD_FEATURES, _BWD_BLOCK_FEATURES),
+        _BWD_SPLIT_K,
+    )
+    _template_coordinate_projection_bwd_partial_kernel[partial_grid](
+        grad,
+        pb,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        partial,
+        n_token,
+        grad.stride(0),
+        grad.stride(1),
+        grad.stride(2),
+        pb.stride(0),
+        pb.stride(1),
+        frame.stride(0),
+        frame.stride(1),
+        frame.stride(2),
+        pb_mask.stride(0),
+        bb_mask.stride(0),
+        asym.stride(0),
+        partial.stride(0),
+        partial.stride(1),
+        partial.stride(2),
+        COMPUTE_DGRAM=compute_dgram,
+        COMPUTE_SCALAR=compute_scalar,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_PAIRS=_BWD_BLOCK_PAIRS,
+        BLOCK_CHANNELS=_BWD_BLOCK_CHANNELS,
+        BLOCK_FEATURES=_BWD_BLOCK_FEATURES,
+        SPLIT_K=_BWD_SPLIT_K,
+        num_warps=4,
+        num_stages=1,
+    )
+    reduce_block = 256
+    reduce_grid = (triton.cdiv(64 * _BWD_FEATURES, reduce_block),)
+    _template_coordinate_projection_bwd_reduce_kernel[reduce_grid](
+        partial,
+        grad_dgram,
+        grad_scalar,
+        partial.stride(0),
+        partial.stride(1),
+        partial.stride(2),
+        grad_dgram.stride(0),
+        grad_dgram.stride(1),
+        grad_scalar.stride(0),
+        grad_scalar.stride(1),
+        COMPUTE_DGRAM=compute_dgram,
+        COMPUTE_SCALAR=compute_scalar,
+        SPLIT_K=_BWD_SPLIT_K,
+        BLOCK_OUTPUTS=reduce_block,
+        num_warps=8,
+        num_stages=1,
+    )
+    return (
+        grad_dgram if compute_dgram else None,
+        grad_scalar if compute_scalar else None,
+    )
+
+
+def template_coordinate_projection_add_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> None:
+    """Inference-only in-place compatibility wrapper."""
+    if torch.is_grad_enabled():
+        raise RuntimeError(
+            "In-place template coordinate projection requires disabled grad mode"
+        )
+    template_coordinate_projection(
+        out,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        out=out,
     )

--- a/openfold3/core/kernels/triton/fused_template_coordinate.py
+++ b/openfold3/core/kernels/triton/fused_template_coordinate.py
@@ -1,0 +1,375 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# by Liang Hong <lhong22@cse.cuhk.edu.hk>: length-generic Triton template
+# coordinate feature construction and fused pair projection.
+
+"""Coordinate-derived template pair projection.
+
+The fixed-shape projection (39 distogram inputs and five scalar inputs into
+64 output channels) is fused with coordinate-to-pair feature construction.
+No pairwise feature tensor is written to HBM. Sequence length and all tensor
+strides remain runtime values so one compiled kernel serves every length.
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TRITON_AVAILABLE = False
+
+
+if _TRITON_AVAILABLE:
+    _BLOCK_PAIRS = 16
+    _BLOCK_CHANNELS = 64
+
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_out_i",
+            "stride_out_j",
+            "stride_out_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_w_dgram_c",
+            "stride_w_dgram_bin",
+            "stride_w_scalar_c",
+            "stride_w_scalar_feat",
+        ],
+        do_not_specialize_on_alignment=[
+            "out_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "w_dgram_ptr",
+            "w_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_kernel(
+        out_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        w_dgram_ptr,
+        w_scalar_ptr,
+        N,
+        stride_out_i,
+        stride_out_j,
+        stride_out_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_w_dgram_c,
+        stride_w_dgram_bin,
+        stride_w_scalar_c,
+        stride_w_scalar_feat,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+    ):
+        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
+        channel = tl.arange(0, BLOCK_CHANNELS)
+        pair_mask = pair < N * N
+
+        i = pair // N
+        j = pair - i * N
+
+        pb_ix = tl.load(
+            pb_coords_ptr + i * stride_pb_i,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_iy = tl.load(
+            pb_coords_ptr + i * stride_pb_i + stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_iz = tl.load(
+            pb_coords_ptr + i * stride_pb_i + 2 * stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jx = tl.load(
+            pb_coords_ptr + j * stride_pb_i,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jy = tl.load(
+            pb_coords_ptr + j * stride_pb_i + stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jz = tl.load(
+            pb_coords_ptr + j * stride_pb_i + 2 * stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_dx = pb_ix - pb_jx
+        pb_dy = pb_iy - pb_jy
+        pb_dz = pb_iz - pb_jz
+        dist2 = pb_dx * pb_dx + pb_dy * pb_dy + pb_dz * pb_dz
+
+        # Current template distogram uses 39 strict open intervals with
+        # linearly spaced (unsquared) edges from 3.25 to 50.75 Angstrom.
+        min_bin = 3.25
+        bin_step = 1.25
+        distance = tl.sqrt(dist2)
+        bin_index = tl.floor((distance - min_bin) / bin_step).to(tl.int32)
+        bin_index = tl.maximum(0, tl.minimum(38, bin_index))
+        lower = min_bin + bin_index.to(tl.float32) * bin_step
+        lower2 = lower * lower
+        upper = lower + bin_step
+        upper2 = tl.where(bin_index == 38, 1.0e8, upper * upper)
+        in_bin = (dist2 > lower2) & (dist2 < upper2)
+
+        pb_mask_i = tl.load(
+            pb_mask_ptr + i * stride_pb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        pb_mask_j = tl.load(
+            pb_mask_ptr + j * stride_pb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        bb_mask_i = tl.load(
+            bb_mask_ptr + i * stride_bb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        bb_mask_j = tl.load(
+            bb_mask_ptr + j * stride_bb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        asym_i = tl.load(asym_id_ptr + i * stride_asym_i, mask=pair_mask, other=0)
+        asym_j = tl.load(asym_id_ptr + j * stride_asym_i, mask=pair_mask, other=1)
+        same_chain = (asym_i == asym_j).to(tl.float32)
+        pb_pair_mask = pb_mask_i * pb_mask_j * same_chain
+        bb_pair_mask = bb_mask_i * bb_mask_j * same_chain
+
+        frame_i_base = frame_coords_ptr + i * stride_frame_i
+        n_x = tl.load(frame_i_base, mask=pair_mask, other=0.0).to(tl.float32)
+        n_y = tl.load(frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        n_z = tl.load(
+            frame_i_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        ca_x = tl.load(frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        ca_y = tl.load(
+            frame_i_base + stride_frame_atom + stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        ca_z = tl.load(
+            frame_i_base + stride_frame_atom + 2 * stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        c_x = tl.load(
+            frame_i_base + 2 * stride_frame_atom, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        c_y = tl.load(
+            frame_i_base + 2 * stride_frame_atom + stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        c_z = tl.load(
+            frame_i_base + 2 * stride_frame_atom + 2 * stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        frame_j_base = frame_coords_ptr + j * stride_frame_i + stride_frame_atom
+        j_ca_x = tl.load(frame_j_base, mask=pair_mask, other=0.0).to(tl.float32)
+        j_ca_y = tl.load(frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        j_ca_z = tl.load(
+            frame_j_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+
+        axis_x_x = c_x - ca_x
+        axis_x_y = c_y - ca_y
+        axis_x_z = c_z - ca_z
+        inv_x_norm = tl.rsqrt(
+            tl.maximum(
+                axis_x_x * axis_x_x + axis_x_y * axis_x_y + axis_x_z * axis_x_z,
+                1.0e-12,
+            )
+        )
+        axis_x_x *= inv_x_norm
+        axis_x_y *= inv_x_norm
+        axis_x_z *= inv_x_norm
+
+        axis_y_x = n_x - ca_x
+        axis_y_y = n_y - ca_y
+        axis_y_z = n_z - ca_z
+        projection = axis_y_x * axis_x_x + axis_y_y * axis_x_y + axis_y_z * axis_x_z
+        axis_y_x -= projection * axis_x_x
+        axis_y_y -= projection * axis_x_y
+        axis_y_z -= projection * axis_x_z
+        inv_y_norm = tl.rsqrt(
+            tl.maximum(
+                axis_y_x * axis_y_x + axis_y_y * axis_y_y + axis_y_z * axis_y_z,
+                1.0e-12,
+            )
+        )
+        axis_y_x *= inv_y_norm
+        axis_y_y *= inv_y_norm
+        axis_y_z *= inv_y_norm
+
+        axis_z_x = axis_x_y * axis_y_z - axis_x_z * axis_y_y
+        axis_z_y = axis_x_z * axis_y_x - axis_x_x * axis_y_z
+        axis_z_z = axis_x_x * axis_y_y - axis_x_y * axis_y_x
+
+        delta_x = j_ca_x - ca_x
+        delta_y = j_ca_y - ca_y
+        delta_z = j_ca_z - ca_z
+        local_x = delta_x * axis_x_x + delta_y * axis_x_y + delta_z * axis_x_z
+        local_y = delta_x * axis_y_x + delta_y * axis_y_y + delta_z * axis_y_z
+        local_z = delta_x * axis_z_x + delta_y * axis_z_y + delta_z * axis_z_z
+        inv_delta_norm = tl.rsqrt(
+            tl.maximum(
+                local_x * local_x + local_y * local_y + local_z * local_z,
+                1.0e-12,
+            )
+        )
+        local_x *= inv_delta_norm
+        local_y *= inv_delta_norm
+        local_z *= inv_delta_norm
+
+        out_offsets = (
+            i[:, None] * stride_out_i
+            + j[:, None] * stride_out_j
+            + channel[None, :] * stride_out_c
+        )
+        out = tl.load(out_ptr + out_offsets, mask=pair_mask[:, None]).to(tl.float32)
+
+        w_dgram = tl.load(
+            w_dgram_ptr
+            + channel[None, :] * stride_w_dgram_c
+            + bin_index[:, None] * stride_w_dgram_bin,
+            mask=pair_mask[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        out += w_dgram * (pb_pair_mask * in_bin.to(tl.float32))[:, None]
+
+        w_pb = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 0 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_x = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 1 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_y = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 2 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_z = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 3 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_bb = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 4 * stride_w_scalar_feat
+        ).to(tl.float32)
+        out += pb_pair_mask[:, None] * w_pb[None, :]
+        out += bb_pair_mask[:, None] * (
+            local_x[:, None] * w_x[None, :]
+            + local_y[:, None] * w_y[None, :]
+            + local_z[:, None] * w_z[None, :]
+            + w_bb[None, :]
+        )
+
+        tl.store(out_ptr + out_offsets, out, mask=pair_mask[:, None])
+
+
+def template_coordinate_projection_add_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> None:
+    """Add coordinate-derived template projections to ``out`` in place.
+
+    This launcher intentionally supports only the production inference shape:
+    B=1, fp32, 39 distogram inputs, five scalar inputs, and 64 output channels.
+    """
+    if not _TRITON_AVAILABLE:
+        raise RuntimeError("Triton is required for coordinate template projection")
+    if not (
+        out.is_cuda
+        and out.dtype == torch.float32
+        and out.shape[0] == 1
+        and out.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+    ):
+        raise ValueError("Unsupported coordinate template projection configuration")
+
+    n_token = out.shape[1]
+    if out.shape != (1, n_token, n_token, 64):
+        raise ValueError(f"Expected out [1,N,N,64], got {tuple(out.shape)}")
+
+    pb = pseudo_beta_coords[0]
+    frame = frame_atom_coords[0]
+    pb_mask = pseudo_beta_mask[0]
+    bb_mask = backbone_frame_mask[0]
+    asym = asym_id[0]
+    grid = (triton.cdiv(n_token * n_token, _BLOCK_PAIRS),)
+    _template_coordinate_projection_kernel[grid](
+        out,
+        pb,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        n_token,
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        pb.stride(0),
+        pb.stride(1),
+        frame.stride(0),
+        frame.stride(1),
+        frame.stride(2),
+        pb_mask.stride(0),
+        bb_mask.stride(0),
+        asym.stride(0),
+        dgram_weight.stride(0),
+        dgram_weight.stride(1),
+        scalar_weight.stride(0),
+        scalar_weight.stride(1),
+        BLOCK_PAIRS=_BLOCK_PAIRS,
+        BLOCK_CHANNELS=_BLOCK_CHANNELS,
+        num_warps=4,
+        num_stages=1,
+    )

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -173,6 +173,7 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         si_input = si_input.detach().clone()
         si = si.detach().clone()
         zij = zij.detach().clone()
+        del output["zij_trunk"]
         atom_positions_predicted = atom_positions_predicted.detach().clone()
 
         token_mask = batch["token_mask"]

--- a/openfold3/core/model/latent/base_blocks.py
+++ b/openfold3/core/model/latent/base_blocks.py
@@ -40,6 +40,7 @@ from openfold3.core.model.layers.triangular_multiplicative_update import (
 )
 from openfold3.core.model.primitives import DropoutRowwise
 from openfold3.core.model.utils import assert_sole_holder
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -315,20 +316,25 @@ class PairBlock(nn.Module):
         use_triton_triangle_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the outgoing and incoming triangular multiplicative updates."""
-        inplace_safe = inplace_safe and (not use_cueq_triangle_kernels)
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        use_cueq_trimul = use_cueq_triangle_kernels and not chunked_trimul
+        # cuEq supersedes inplace_safe unless a trimul chunk cap forces eager.
+        inplace_safe = inplace_safe and (not use_cueq_trimul)
         ## VS: having both inplace_safe and use_cueq_triangle_kernels set to
         ## true causes `z = z + self.ps_dropout_row_layer(tmu_update)` below
         ## to be skipped, as this is the expected output of tri_mult w/ inplace
         ## safe, creating an error. So disable inplace_safe if
         ## use_cueq_triangle_kernels is true. Ideally could be refactored to use
         ## _add_with_inplace=False, then wrap with add as done elsewhere
+        inplace_chunk_size = trimul_chunk_cap() if chunked_trimul else 256
         tmu_update = self.tri_mul_out(
             z,
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)
@@ -345,8 +351,9 @@ class PairBlock(nn.Module):
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)

--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -28,7 +28,11 @@ import torch
 from torch import nn
 
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 
 
 # TODO: Rename to CheckpointStack and generalize any kind of block (i.e. remove
@@ -141,6 +145,10 @@ class MSAStack(nn.Module, ABC):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -28,7 +28,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.layers.attention_pair_bias import AttentionPairBias
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -384,6 +388,10 @@ class PairFormerStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -34,7 +34,7 @@ from openfold3.core.model.feature_embedders.template_embedders import (
 from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.primitives.fused_template_coordinate import (
-    fused_template_coordinate_pair_embedder_inference,
+    fused_template_coordinate_pair_embedder,
 )
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
@@ -633,7 +633,7 @@ class TemplateEmbedderAllAtom(nn.Module):
 
         for i in range(n_templ):
             if use_coordinate_features:
-                t = fused_template_coordinate_pair_embedder_inference(
+                t = fused_template_coordinate_pair_embedder(
                     module=self.template_pair_embedder,
                     batch=batch,
                     z=z,
@@ -667,8 +667,10 @@ class TemplateEmbedderAllAtom(nn.Module):
             t = t.squeeze(-4)
             if t_sum is None:
                 t_sum = t
-            else:
+            elif inplace_safe:
                 t_sum.add_(t)
+            else:
+                t_sum = t_sum + t
             del t
 
         assert t_sum is not None

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -42,6 +42,25 @@ from openfold3.core.utils.chunk_utils import (
 )
 from openfold3.core.utils.tensor_utils import add
 
+_TEMPLATE_DIM_BY_KEY = {
+    "template_restype": -3,
+    "template_pseudo_beta_mask": -2,
+    "template_backbone_frame_mask": -2,
+    "template_distogram": -4,
+    "template_unit_vector": -4,
+}
+
+
+def _slice_template_feature(k: str, x: torch.Tensor, idx: int) -> torch.Tensor:
+    """Return one template while preserving the singleton template dimension."""
+    template_dim = _TEMPLATE_DIM_BY_KEY.get(k)
+    if template_dim is None:
+        return x
+
+    slices = [slice(None)] * x.dim()
+    slices[template_dim] = slice(idx, idx + 1)
+    return x[tuple(slices)]
+
 
 # TODO: Make arguments match PairBlock
 class TemplatePairBlock(PairBlock):
@@ -590,6 +609,60 @@ class TemplateEmbedderAllAtom(nn.Module):
 
         return t_out.to(device=out_device)
 
+    def _forward_streaming(
+        self,
+        batch: dict,
+        z: torch.Tensor,
+        pair_mask: torch.Tensor,
+        chunk_size: int | None = None,
+        _mask_trans: bool = True,
+        use_deepspeed_evo_attention: bool = False,
+        use_cueq_triangle_kernels: bool = False,
+        use_triton_triangle_kernels: bool = False,
+        use_lma: bool = False,
+        inplace_safe: bool = False,
+    ) -> torch.Tensor:
+        """Process templates one-at-a-time and accumulate their stack outputs."""
+        n_templ = batch["template_restype"].shape[-3]
+        pair_mask = pair_mask[..., None, :, :].to(dtype=z.dtype)
+        t_sum = None
+
+        for i in range(n_templ):
+            batch_templ = {
+                k: (
+                    _slice_template_feature(k, v, i)
+                    if isinstance(v, torch.Tensor) and k.startswith("template_")
+                    else v
+                )
+                for k, v in batch.items()
+            }
+
+            t = self.template_pair_embedder(batch=batch_templ, z=z)
+            batch_templ.pop("template_distogram", None)
+            batch_templ.pop("template_unit_vector", None)
+
+            t = self.template_pair_stack(
+                t,
+                pair_mask,
+                chunk_size=chunk_size,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+                _mask_trans=_mask_trans,
+            )
+
+            t = t.squeeze(-4)
+            if t_sum is None:
+                t_sum = t
+            else:
+                t_sum.add_(t)
+            del t
+
+        assert t_sum is not None
+        return t_sum / n_templ
+
     def _forward(
         self,
         batch: dict,
@@ -668,8 +741,30 @@ class TemplateEmbedderAllAtom(nn.Module):
                 [*, N_token, N_token, C_z] Template embedding
         """
         n_templ = batch["template_restype"].shape[-3]
+        template_sum_done = False
+        can_stream = (
+            inplace_safe
+            and not self.training
+            and not torch.is_grad_enabled()
+            and not offload_inference
+            and n_templ > 1
+        )
 
-        if offload_inference:
+        if can_stream:
+            t = self._forward_streaming(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=chunk_size,
+                _mask_trans=True,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+            )
+            template_sum_done = True
+        elif offload_inference:
             t = self._forward_offload(
                 batch=batch,
                 z=z,
@@ -696,8 +791,10 @@ class TemplateEmbedderAllAtom(nn.Module):
                 inplace_safe=inplace_safe,
             )
 
+        if not template_sum_done:
+            t = torch.sum(t, dim=-4) / n_templ
+
         # [*, N_token, N_token, C_z]
-        t = torch.sum(t, dim=-4) / n_templ
         t = torch.nn.functional.relu(t)
         t = self.linear_t(t)
 

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -33,6 +33,9 @@ from openfold3.core.model.feature_embedders.template_embedders import (
 )
 from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
+from openfold3.core.model.primitives.fused_template_coordinate import (
+    fused_template_coordinate_pair_embedder_inference,
+)
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
 from openfold3.core.utils.chunk_utils import (
@@ -621,6 +624,7 @@ class TemplateEmbedderAllAtom(nn.Module):
         use_triton_triangle_kernels: bool = False,
         use_lma: bool = False,
         inplace_safe: bool = False,
+        use_coordinate_features: bool = False,
     ) -> torch.Tensor:
         """Process templates one-at-a-time and accumulate their stack outputs."""
         n_templ = batch["template_restype"].shape[-3]
@@ -628,18 +632,25 @@ class TemplateEmbedderAllAtom(nn.Module):
         t_sum = None
 
         for i in range(n_templ):
-            batch_templ = {
-                k: (
-                    _slice_template_feature(k, v, i)
-                    if isinstance(v, torch.Tensor) and k.startswith("template_")
-                    else v
+            if use_coordinate_features:
+                t = fused_template_coordinate_pair_embedder_inference(
+                    module=self.template_pair_embedder,
+                    batch=batch,
+                    z=z,
+                    template_index=i,
                 )
-                for k, v in batch.items()
-            }
-
-            t = self.template_pair_embedder(batch=batch_templ, z=z)
-            batch_templ.pop("template_distogram", None)
-            batch_templ.pop("template_unit_vector", None)
+            else:
+                batch_templ = {
+                    k: (
+                        _slice_template_feature(k, v, i)
+                        if isinstance(v, torch.Tensor) and k.startswith("template_")
+                        else v
+                    )
+                    for k, v in batch.items()
+                }
+                t = self.template_pair_embedder(batch=batch_templ, z=z)
+                batch_templ.pop("template_distogram", None)
+                batch_templ.pop("template_unit_vector", None)
 
             t = self.template_pair_stack(
                 t,
@@ -742,7 +753,9 @@ class TemplateEmbedderAllAtom(nn.Module):
         """
         n_templ = batch["template_restype"].shape[-3]
         template_sum_done = False
-        can_stream = (
+        use_coordinate_features = "template_pseudo_beta_coords" in batch
+        # Coordinate inputs are O(N); always stream on GPU and ignore offload.
+        can_stream = use_coordinate_features or (
             inplace_safe
             and not self.training
             and not torch.is_grad_enabled()
@@ -762,6 +775,7 @@ class TemplateEmbedderAllAtom(nn.Module):
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
                 use_lma=use_lma,
                 inplace_safe=inplace_safe,
+                use_coordinate_features=use_coordinate_features,
             )
             template_sum_done = True
         elif offload_inference:

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -35,7 +35,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -395,6 +399,10 @@ class TemplatePairStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=t.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/layers/diffusion_conditioning.py
+++ b/openfold3/core/model/layers/diffusion_conditioning.py
@@ -21,7 +21,10 @@ from openfold3.core.model.feature_embedders.input_embedders import FourierEmbedd
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.model.primitives.linear import Linear
 from openfold3.core.model.primitives.normalization import LayerNorm
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+)
 from openfold3.core.utils.relpos import relpos_complex
 
 
@@ -29,6 +32,8 @@ class DiffusionConditioning(nn.Module):
     """
     Implements AF3 Algorithm 21.
     """
+
+    _EMBED_ZIJ_CHUNK_ROWS: int = 128
 
     def __init__(
         self,
@@ -130,6 +135,53 @@ class DiffusionConditioning(nn.Module):
         if tune_chunk_size:
             self.chunk_size_tuner = ChunkSizeTuner()
 
+    def _embed_zij(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        if not torch.is_grad_enabled():
+            return self._embed_zij_chunked(batch, zij_trunk)
+
+        relpos_zij = relpos_complex(
+            batch=batch,
+            max_relative_idx=self.max_relative_idx,
+            max_relative_chain=self.max_relative_chain,
+        ).to(dtype=zij_trunk.dtype)
+
+        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
+        return self.linear_z(self.layer_norm_z(zij))
+
+    def _embed_zij_chunked(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        """Row-chunked LN/linear over trunk pair + relpos (channel-wise LN)."""
+        n_token = zij_trunk.shape[-3]
+        chunk = self._EMBED_ZIJ_CHUNK_ROWS
+        out = torch.empty(
+            *zij_trunk.shape[:-1],
+            self.c_z,
+            dtype=zij_trunk.dtype,
+            device=zij_trunk.device,
+        )
+        for i in range(0, n_token, chunk):
+            row_slice = slice(i, min(i + chunk, n_token))
+            relpos_chunk = relpos_complex(
+                batch=batch,
+                max_relative_idx=self.max_relative_idx,
+                max_relative_chain=self.max_relative_chain,
+                row_slice=row_slice,
+            ).to(dtype=zij_trunk.dtype)
+            cat_chunk = torch.cat(
+                [zij_trunk[..., row_slice, :, :], relpos_chunk], dim=-1
+            )
+            del relpos_chunk
+            out[..., row_slice, :, :] = self.linear_z(self.layer_norm_z(cat_chunk))
+            del cat_chunk
+        return out
+
     def _embed_trunk_inputs(
         self,
         batch: dict,
@@ -139,14 +191,7 @@ class DiffusionConditioning(nn.Module):
         zij_trunk: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Pair conditioning
-        relpos_zij = relpos_complex(
-            batch=batch,
-            max_relative_idx=self.max_relative_idx,
-            max_relative_chain=self.max_relative_chain,
-        ).to(dtype=zij_trunk.dtype)
-
-        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
-        zij = self.linear_z(self.layer_norm_z(zij))
+        zij = self._embed_zij(batch=batch, zij_trunk=zij_trunk)
 
         # Single conditioning
         si = torch.cat([si_trunk, si_input], dim=-1)
@@ -198,6 +243,8 @@ class DiffusionConditioning(nn.Module):
                 ),
                 max_chunk_size=chunk_size,
             )
+
+        chunk_size = apply_transition_chunk_cap(chunk_size)
 
         si, zij = self._forward(
             si=si, zij=zij, token_mask=token_mask, chunk_size=chunk_size

--- a/openfold3/core/model/layers/sequence_local_atom_attention.py
+++ b/openfold3/core/model/layers/sequence_local_atom_attention.py
@@ -30,7 +30,9 @@ from openfold3.core.utils.atom_attention_block_utils import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
 )
 from openfold3.core.utils.checkpointing import checkpoint_section
 
@@ -542,16 +544,25 @@ class AtomAttentionEncoder(nn.Module):
 
         ql = ql * atom_mask.unsqueeze(-1)
 
-        agg_args = (
-            batch["token_mask"],
-            batch["atom_to_token_index"],
-            atom_mask,
-            self.linear_q(ql),
-            -2,
-            "mean",
-        )
+        if not self.training and not torch.is_grad_enabled():
+            aggregate_fn = aggregate_atom_feat_to_tokens_segmented
+            agg_args = (
+                batch["num_atoms_per_token"],
+                atom_mask,
+                self.linear_q(ql),
+            )
+        else:
+            aggregate_fn = aggregate_atom_feat_to_tokens
+            agg_args = (
+                batch["token_mask"],
+                batch["atom_to_token_index"],
+                atom_mask,
+                self.linear_q(ql),
+                -2,
+                "mean",
+            )
         ai = checkpoint_section(
-            fn=aggregate_atom_feat_to_tokens,
+            fn=aggregate_fn,
             args=agg_args,
             apply_ckpt=self.ckpt_intermediate_steps,
             use_reentrant=self.use_reentrant,
@@ -674,11 +685,11 @@ class AtomAttentionDecoder(nn.Module):
         """
         # Broadcast per-token activations to atoms
         # [*, N_atom, c_atom]
-        ql = ql + broadcast_token_feat_to_atoms(
+        ql = ql + broadcast_token_feat_to_atoms_by_index(
             token_mask=batch["token_mask"],
-            num_atoms_per_token=batch["num_atoms_per_token"],
+            atom_to_token_index=batch["atom_to_token_index"],
+            atom_mask=batch["atom_mask"],
             token_feat=self.linear_q_in(ai),
-            token_dim=-2,
         )
 
         # Atom transformer

--- a/openfold3/core/model/layers/triangular_multiplicative_update.py
+++ b/openfold3/core/model/layers/triangular_multiplicative_update.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 import openfold3.core.config.default_linear_init_config as lin_init
 from openfold3.core.kernels.cueq_utils import is_cuequivariance_available
 from openfold3.core.model.primitives import LayerNorm, Linear
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import permute_final_dims
 
 if is_cuequivariance_available():
@@ -1117,8 +1118,9 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
         ## NOTE: valid for inplace safe and use_cueq_triangle_kernels to be enabled
         ## inplace safe is used across the codebase and so should not
         ## be disabled. So if use_cueq_triangle_kernels is True, it will always
-        ## supersede inplace_safe
-        if use_cueq_triangle_kernels:
+        ## supersede inplace_safe unless a trimul chunk cap forces eager.
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        if use_cueq_triangle_kernels and not chunked_trimul:
             ## VS: The cuequivariance kernel is based on the boltz implementation
             ## of triangle multiplicative update, which fuses the linear_*_p
             ## projections into a single layer (similarly for linear_*_g).
@@ -1149,10 +1151,11 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             return x
 
         if inplace_safe:
+            chunk_size = trimul_chunk_cap() if chunked_trimul else _inplace_chunk_size
             x = self._inference_forward(
                 z,
                 mask,
-                inplace_chunk_size=_inplace_chunk_size,
+                inplace_chunk_size=chunk_size,
                 with_add=_add_with_inplace,
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
             )

--- a/openfold3/core/model/primitives/fused_template_coordinate.py
+++ b/openfold3/core/model/primitives/fused_template_coordinate.py
@@ -1,0 +1,281 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference dispatcher for online template coordinate pair features.
+
+Builds one template's pair embedding from compact O(N) coordinates. On CUDA
+fp32 with Triton available, projection uses the length-generic kernel in
+``fused_template_coordinate`` (N and strides are runtime values). Otherwise
+falls back to a chunked eager reference with the same math.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    _TRITON_KERNEL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TRITON_KERNEL_AVAILABLE = False
+
+
+def _env_flag(name: str, default: str = "1") -> bool:
+    val = os.environ.get(name, default).strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def is_fused_template_coordinate_enabled() -> bool:
+    """Runtime gate for the Triton coordinate projection kernel."""
+    if not _TRITON_KERNEL_AVAILABLE:
+        return False
+    return _env_flag("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+
+
+_LN_CHUNK_ROWS = 64
+
+
+def _chunked_ln_linear_z(
+    z: torch.Tensor,
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Compute ``LN(z) @ W_z.T + B_z`` writing directly into a fresh output."""
+    B, N, _, c_z = z.shape
+    c_out = module.linear_z.weight.shape[0]
+    out = torch.empty(B, N, N, c_out, dtype=dtype, device=z.device)
+
+    ln_w = module.layer_norm_z.weight
+    ln_b = module.layer_norm_z.bias
+    lin_w = module.linear_z.weight
+    lin_b = module.linear_z.bias
+    if ln_w.dtype != dtype:
+        ln_w = ln_w.to(dtype)
+    if ln_b is not None and ln_b.dtype != dtype:
+        ln_b = ln_b.to(dtype)
+    if lin_w.dtype != dtype:
+        lin_w = lin_w.to(dtype)
+    if lin_b is not None and lin_b.dtype != dtype:
+        lin_b = lin_b.to(dtype)
+
+    chunk_rows = min(_LN_CHUNK_ROWS, max(16, N // 10))
+    for start in range(0, N, chunk_rows):
+        end = min(N, start + chunk_rows)
+        z_chunk = z[:, start:end].contiguous()
+        z_norm = F.layer_norm(
+            z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps
+        )
+        out[:, start:end] = F.linear(z_norm, lin_w, lin_b)
+        del z_chunk, z_norm
+    return out
+
+
+def _build_scalar_weight(module: nn.Module, dtype: torch.dtype) -> torch.Tensor:
+    """Concat scalar-feature Linear weights into ``[c_out, 5]``."""
+    return torch.cat(
+        (
+            module.pseudo_beta_mask_linear.weight,
+            module.x_linear.weight,
+            module.y_linear.weight,
+            module.z_linear.weight,
+            module.backbone_mask_linear.weight,
+        ),
+        dim=-1,
+    ).to(dtype=dtype)
+
+
+def _add_restype_projections_(
+    a: torch.Tensor,
+    restype: torch.Tensor,
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    """Project O(N) restype inputs and broadcast-add without pair expansion."""
+    for linear, dim in (
+        (module.aatype_linear_1, -2),
+        (module.aatype_linear_2, -3),
+    ):
+        weight = linear.weight.to(dtype=dtype)
+        a.add_(F.linear(restype, weight, None).unsqueeze(dim))
+
+
+def _fetch_coordinate_template_slice(
+    batch: dict,
+    template_index: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fetch compact coordinates, masks, and restype for one template."""
+    values = (
+        batch["template_pseudo_beta_coords"][..., template_index, :, :],
+        batch["template_frame_atom_coords"][..., template_index, :, :, :],
+        batch["template_pseudo_beta_mask"][..., template_index, :],
+        batch["template_backbone_frame_mask"][..., template_index, :],
+        batch["template_restype"][..., template_index, :, :],
+    )
+    return tuple(
+        value.to(device=device, dtype=dtype, non_blocking=True).contiguous()
+        for value in values
+    )
+
+
+def template_coordinate_projection_add_reference_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int = 32,
+) -> None:
+    """Chunked reference for coordinate construction and direct projection."""
+    n_token = out.shape[-2]
+    lower = torch.linspace(
+        3.25, 50.75, 39, device=out.device, dtype=torch.float32
+    ).square()
+    dgram_lookup = dgram_weight.to(dtype=out.dtype).transpose(0, 1)
+    scalar_weight = scalar_weight.to(dtype=out.dtype)
+
+    n_coords = frame_atom_coords[..., 0, :]
+    ca_coords = frame_atom_coords[..., 1, :]
+    c_coords = frame_atom_coords[..., 2, :]
+
+    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
+    axis_y = n_coords - ca_coords
+    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
+    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
+    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
+
+    for start in range(0, n_token, chunk_rows):
+        stop = min(start + chunk_rows, n_token)
+        pb_delta = (
+            pseudo_beta_coords[:, start:stop, None, :]
+            - pseudo_beta_coords[:, None, :, :]
+        )
+        dist2 = pb_delta.square().sum(dim=-1)
+        bin_index = torch.searchsorted(lower, dist2, right=False) - 1
+        safe_bin = bin_index.clamp(min=0, max=38)
+        bin_lower = lower[safe_bin]
+        bin_upper = torch.where(
+            safe_bin == 38,
+            torch.full_like(bin_lower, 1.0e8),
+            lower[(safe_bin + 1).clamp(max=38)],
+        )
+        in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+
+        same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(out.dtype)
+        pb_pair_mask = (
+            pseudo_beta_mask[:, start:stop, None]
+            * pseudo_beta_mask[:, None, :]
+            * same_chain
+        )
+        bb_pair_mask = (
+            backbone_frame_mask[:, start:stop, None]
+            * backbone_frame_mask[:, None, :]
+            * same_chain
+        )
+
+        dgram_projection = F.embedding(safe_bin, dgram_lookup)
+        dgram_projection.mul_((in_bin.to(out.dtype) * pb_pair_mask)[..., None])
+        out[:, start:stop].add_(dgram_projection)
+
+        delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
+        local = torch.stack(
+            (
+                (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
+                (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
+                (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
+            ),
+            dim=-1,
+        )
+        local = F.normalize(local, dim=-1, eps=1e-6)
+        local.mul_(bb_pair_mask[..., None])
+        scalar_features = torch.cat(
+            (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
+        )
+        out[:, start:stop].add_(
+            F.linear(scalar_features.to(out.dtype), scalar_weight, None)
+        )
+
+
+def fused_template_coordinate_pair_embedder_inference(
+    module: nn.Module,
+    batch: dict,
+    z: torch.Tensor,
+    template_index: int,
+) -> torch.Tensor:
+    """Embed one compact-coordinate template without raw pairwise features."""
+    if module.training or torch.is_grad_enabled():
+        raise RuntimeError(
+            "fused_template_coordinate_pair_embedder_inference is inference-only"
+        )
+    if z.dim() != 4 or z.shape[0] != 1 or z.shape[-3] != z.shape[-2]:
+        raise ValueError("Coordinate template embedding requires z [1,N,N,C]")
+
+    dtype = z.dtype
+    a = _chunked_ln_linear_z(z, module, dtype)
+    (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        restype,
+    ) = _fetch_coordinate_template_slice(
+        batch, template_index, dtype=dtype, device=z.device
+    )
+    _add_restype_projections_(a, restype, module, dtype)
+
+    dgram_weight = module.dgram_linear.weight
+    scalar_weight = _build_scalar_weight(module, dtype)
+    asym_id = batch["asym_id"].to(device=z.device, non_blocking=True).contiguous()
+    use_triton = (
+        is_fused_template_coordinate_enabled()
+        and z.is_cuda
+        and dtype == torch.float32
+        and a.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+    )
+    if use_triton:
+        template_coordinate_projection_add_(
+            a,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight.contiguous(),
+            scalar_weight.contiguous(),
+        )
+    else:
+        template_coordinate_projection_add_reference_(
+            a,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight,
+            scalar_weight,
+        )
+    return a.unsqueeze(-4)

--- a/openfold3/core/model/primitives/fused_template_coordinate.py
+++ b/openfold3/core/model/primitives/fused_template_coordinate.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inference dispatcher for online template coordinate pair features.
+"""Online template coordinate pair features with guarded training support.
 
 Builds one template's pair embedding from compact O(N) coordinates. On CUDA
-fp32 with Triton available, projection uses the length-generic kernel in
-``fused_template_coordinate`` (N and strides are runtime values). Otherwise
-falls back to a chunked eager reference with the same math.
+fp32/bf16 with Triton available, projection uses the length-generic kernel in
+``fused_template_coordinate`` (N and strides are runtime values; accumulate in
+fp32). Otherwise falls back to a chunked eager reference with the same math.
+Training computes model-parameter gradients without retaining pairwise
+coordinate features.
 """
 
 from __future__ import annotations
@@ -27,10 +29,13 @@ import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.autograd.function import once_differentiable
 
 try:
     from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
         template_coordinate_projection_add_,
+        template_coordinate_projection_backward,
     )
 
     _TRITON_KERNEL_AVAILABLE = True
@@ -80,9 +85,7 @@ def _chunked_ln_linear_z(
     for start in range(0, N, chunk_rows):
         end = min(N, start + chunk_rows)
         z_chunk = z[:, start:end].contiguous()
-        z_norm = F.layer_norm(
-            z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps
-        )
+        z_norm = F.layer_norm(z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps)
         out[:, start:end] = F.linear(z_norm, lin_w, lin_b)
         del z_chunk, z_norm
     return out
@@ -102,19 +105,25 @@ def _build_scalar_weight(module: nn.Module, dtype: torch.dtype) -> torch.Tensor:
     ).to(dtype=dtype)
 
 
-def _add_restype_projections_(
+def _add_restype_projections(
     a: torch.Tensor,
     restype: torch.Tensor,
     module: nn.Module,
     dtype: torch.dtype,
-) -> None:
+    inplace: bool,
+) -> torch.Tensor:
     """Project O(N) restype inputs and broadcast-add without pair expansion."""
     for linear, dim in (
         (module.aatype_linear_1, -2),
         (module.aatype_linear_2, -3),
     ):
         weight = linear.weight.to(dtype=dtype)
-        a.add_(F.linear(restype, weight, None).unsqueeze(dim))
+        update = F.linear(restype, weight, None).unsqueeze(dim)
+        if inplace:
+            a.add_(update)
+        else:
+            a = a + update
+    return a
 
 
 def _fetch_coordinate_template_slice(
@@ -123,17 +132,175 @@ def _fetch_coordinate_template_slice(
     dtype: torch.dtype,
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Fetch compact coordinates, masks, and restype for one template."""
-    values = (
-        batch["template_pseudo_beta_coords"][..., template_index, :, :],
-        batch["template_frame_atom_coords"][..., template_index, :, :, :],
-        batch["template_pseudo_beta_mask"][..., template_index, :],
-        batch["template_backbone_frame_mask"][..., template_index, :],
-        batch["template_restype"][..., template_index, :, :],
+    """Fetch fp32 geometry/masks and activation-dtype restype for one template."""
+    return (
+        batch["template_pseudo_beta_coords"][..., template_index, :, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_frame_atom_coords"][..., template_index, :, :, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_pseudo_beta_mask"][..., template_index, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_backbone_frame_mask"][..., template_index, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_restype"][..., template_index, :, :]
+        .to(device=device, dtype=dtype, non_blocking=True)
+        .contiguous(),
     )
-    return tuple(
-        value.to(device=device, dtype=dtype, non_blocking=True).contiguous()
-        for value in values
+
+
+def _coordinate_frame_axes(
+    frame_atom_coords: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    frame_atom_coords = frame_atom_coords.to(torch.float32)
+    n_coords = frame_atom_coords[..., 0, :]
+    ca_coords = frame_atom_coords[..., 1, :]
+    c_coords = frame_atom_coords[..., 2, :]
+    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
+    axis_y = n_coords - ca_coords
+    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
+    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
+    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
+    return ca_coords, axis_x, axis_y, axis_z
+
+
+def _coordinate_feature_chunk(
+    pseudo_beta_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    ca_coords: torch.Tensor,
+    axis_x: torch.Tensor,
+    axis_y: torch.Tensor,
+    axis_z: torch.Tensor,
+    lower: torch.Tensor,
+    start: int,
+    stop: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    pb_coords = pseudo_beta_coords.to(torch.float32)
+    pb_delta = pb_coords[:, start:stop, None, :] - pb_coords[:, None, :, :]
+    dist2 = pb_delta.square().sum(dim=-1)
+    bin_index = torch.searchsorted(lower, dist2, right=False) - 1
+    safe_bin = bin_index.clamp(min=0, max=38)
+    bin_lower = lower[safe_bin]
+    bin_upper = torch.where(
+        safe_bin == 38,
+        torch.full_like(bin_lower, 1.0e8),
+        lower[(safe_bin + 1).clamp(max=38)],
+    )
+    in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+
+    same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(dtype)
+    pb_pair_mask = (
+        pseudo_beta_mask[:, start:stop, None]
+        * pseudo_beta_mask[:, None, :]
+        * same_chain
+    )
+    bb_pair_mask = (
+        backbone_frame_mask[:, start:stop, None]
+        * backbone_frame_mask[:, None, :]
+        * same_chain
+    )
+
+    delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
+    local = torch.stack(
+        (
+            (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
+            (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
+            (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
+        ),
+        dim=-1,
+    )
+    local = F.normalize(local, dim=-1, eps=1e-6)
+    local = local * bb_pair_mask[..., None]
+    scalar_features = torch.cat(
+        (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
+    )
+    dgram_scale = in_bin.to(dtype) * pb_pair_mask
+    return safe_bin, dgram_scale, scalar_features
+
+
+def _coordinate_projection_reference_loop(
+    source: torch.Tensor,
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int,
+    *,
+    inplace: bool,
+) -> torch.Tensor:
+    """Row-chunked eager projection into ``out`` (in-place add or fresh write)."""
+    n_token = source.shape[-2]
+    lower = torch.linspace(
+        3.25, 50.75, 39, device=source.device, dtype=torch.float32
+    ).square()
+    dgram_lookup = dgram_weight.to(dtype=source.dtype).transpose(0, 1)
+    scalar_weight = scalar_weight.to(dtype=source.dtype)
+    ca_coords, axis_x, axis_y, axis_z = _coordinate_frame_axes(frame_atom_coords)
+    for start in range(0, n_token, chunk_rows):
+        stop = min(start + chunk_rows, n_token)
+        safe_bin, dgram_scale, scalar_features = _coordinate_feature_chunk(
+            pseudo_beta_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            ca_coords,
+            axis_x,
+            axis_y,
+            axis_z,
+            lower,
+            start,
+            stop,
+            source.dtype,
+        )
+        dgram_projection = F.embedding(safe_bin, dgram_lookup)
+        dgram_projection = dgram_projection * dgram_scale[..., None]
+        scalar_projection = F.linear(
+            scalar_features.to(source.dtype), scalar_weight, None
+        )
+        if inplace:
+            out[:, start:stop].add_(dgram_projection)
+            out[:, start:stop].add_(scalar_projection)
+        else:
+            out[:, start:stop] = (
+                source[:, start:stop] + dgram_projection + scalar_projection
+            )
+    return out
+
+
+def template_coordinate_projection_reference(
+    source: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int = 32,
+) -> torch.Tensor:
+    """Differentiable row-chunked coordinate projection with a fresh output."""
+    return _coordinate_projection_reference_loop(
+        source,
+        torch.empty_like(source),
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows,
+        inplace=False,
     )
 
 
@@ -148,92 +315,166 @@ def template_coordinate_projection_add_reference_(
     scalar_weight: torch.Tensor,
     chunk_rows: int = 32,
 ) -> None:
-    """Chunked reference for coordinate construction and direct projection."""
-    n_token = out.shape[-2]
-    lower = torch.linspace(
-        3.25, 50.75, 39, device=out.device, dtype=torch.float32
-    ).square()
-    dgram_lookup = dgram_weight.to(dtype=out.dtype).transpose(0, 1)
-    scalar_weight = scalar_weight.to(dtype=out.dtype)
-
-    n_coords = frame_atom_coords[..., 0, :]
-    ca_coords = frame_atom_coords[..., 1, :]
-    c_coords = frame_atom_coords[..., 2, :]
-
-    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
-    axis_y = n_coords - ca_coords
-    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
-    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
-    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
-
-    for start in range(0, n_token, chunk_rows):
-        stop = min(start + chunk_rows, n_token)
-        pb_delta = (
-            pseudo_beta_coords[:, start:stop, None, :]
-            - pseudo_beta_coords[:, None, :, :]
+    """Inference-only in-place eager reference projection."""
+    if torch.is_grad_enabled():
+        raise RuntimeError(
+            "In-place template coordinate reference requires disabled grad mode"
         )
-        dist2 = pb_delta.square().sum(dim=-1)
-        bin_index = torch.searchsorted(lower, dist2, right=False) - 1
-        safe_bin = bin_index.clamp(min=0, max=38)
-        bin_lower = lower[safe_bin]
-        bin_upper = torch.where(
-            safe_bin == 38,
-            torch.full_like(bin_lower, 1.0e8),
-            lower[(safe_bin + 1).clamp(max=38)],
-        )
-        in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+    _coordinate_projection_reference_loop(
+        out,
+        out,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows,
+        inplace=True,
+    )
 
-        same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(out.dtype)
-        pb_pair_mask = (
-            pseudo_beta_mask[:, start:stop, None]
-            * pseudo_beta_mask[:, None, :]
-            * same_chain
-        )
-        bb_pair_mask = (
-            backbone_frame_mask[:, start:stop, None]
-            * backbone_frame_mask[:, None, :]
-            * same_chain
-        )
 
-        dgram_projection = F.embedding(safe_bin, dgram_lookup)
-        dgram_projection.mul_((in_bin.to(out.dtype) * pb_pair_mask)[..., None])
-        out[:, start:stop].add_(dgram_projection)
-
-        delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
-        local = torch.stack(
-            (
-                (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
-                (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
-                (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
-            ),
-            dim=-1,
+class _TemplateCoordinateProjectionFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        source: torch.Tensor,
+        pseudo_beta_coords: torch.Tensor,
+        frame_atom_coords: torch.Tensor,
+        pseudo_beta_mask: torch.Tensor,
+        backbone_frame_mask: torch.Tensor,
+        asym_id: torch.Tensor,
+        dgram_weight: torch.Tensor,
+        scalar_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
         )
-        local = F.normalize(local, dim=-1, eps=1e-6)
-        local.mul_(bb_pair_mask[..., None])
-        scalar_features = torch.cat(
-            (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
-        )
-        out[:, start:stop].add_(
-            F.linear(scalar_features.to(out.dtype), scalar_weight, None)
+        return template_coordinate_projection(
+            source,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight,
+            scalar_weight,
         )
 
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output: torch.Tensor):
+        (
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+        ) = ctx.saved_tensors
+        needs_source = ctx.needs_input_grad[0]
+        needs_dgram = ctx.needs_input_grad[6]
+        needs_scalar = ctx.needs_input_grad[7]
+        grad_dgram, grad_scalar = template_coordinate_projection_backward(
+            grad_output,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            compute_dgram=needs_dgram,
+            compute_scalar=needs_scalar,
+        )
 
-def fused_template_coordinate_pair_embedder_inference(
+        return (
+            grad_output if needs_source else None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            grad_dgram,
+            grad_scalar,
+        )
+
+
+_FUSED_AWAY_LINEAR_NAMES = (
+    "dgram_linear",
+    "aatype_linear_1",
+    "aatype_linear_2",
+    "pseudo_beta_mask_linear",
+    "x_linear",
+    "y_linear",
+    "z_linear",
+    "backbone_mask_linear",
+)
+
+
+def _validate_fused_away_biases(module: nn.Module) -> None:
+    biased = [
+        name
+        for name in _FUSED_AWAY_LINEAR_NAMES
+        if getattr(module, name).bias is not None
+    ]
+    if biased:
+        raise ValueError(
+            "Coordinate template projection requires bias-free feature linears; "
+            f"found biases in {', '.join(biased)}"
+        )
+
+
+def _can_use_triton(
+    source: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> bool:
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+    )
+    return (
+        is_fused_template_coordinate_enabled()
+        and source.is_cuda
+        and source.dtype in (torch.float32, torch.bfloat16)
+        and source.shape[0] == 1
+        and source.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+        and all(x.is_cuda and x.device == source.device for x in inputs)
+    )
+
+
+def fused_template_coordinate_pair_embedder(
     module: nn.Module,
     batch: dict,
     z: torch.Tensor,
     template_index: int,
 ) -> torch.Tensor:
-    """Embed one compact-coordinate template without raw pairwise features."""
-    if module.training or torch.is_grad_enabled():
-        raise RuntimeError(
-            "fused_template_coordinate_pair_embedder_inference is inference-only"
-        )
-    if z.dim() != 4 or z.shape[0] != 1 or z.shape[-3] != z.shape[-2]:
-        raise ValueError("Coordinate template embedding requires z [1,N,N,C]")
+    """Embed one compact-coordinate template with inference/training dispatch."""
+    if z.dim() != 4 or z.shape[-3] != z.shape[-2]:
+        raise ValueError("Coordinate template embedding requires z [B,N,N,C]")
+    _validate_fused_away_biases(module)
 
     dtype = z.dtype
-    a = _chunked_ln_linear_z(z, module, dtype)
+    inference_inplace = not module.training and not torch.is_grad_enabled()
+    if torch.is_grad_enabled():
+        a = module.linear_z(module.layer_norm_z(z))
+    else:
+        a = _chunked_ln_linear_z(z, module, dtype)
     (
         pseudo_beta_coords,
         frame_atom_coords,
@@ -243,39 +484,89 @@ def fused_template_coordinate_pair_embedder_inference(
     ) = _fetch_coordinate_template_slice(
         batch, template_index, dtype=dtype, device=z.device
     )
-    _add_restype_projections_(a, restype, module, dtype)
+    coordinate_tensors = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+    )
+    if any(x.requires_grad for x in coordinate_tensors):
+        raise ValueError("Template coordinate inputs are non-differentiable data")
+    a = _add_restype_projections(a, restype, module, dtype, inplace=inference_inplace)
 
-    dgram_weight = module.dgram_linear.weight
-    scalar_weight = _build_scalar_weight(module, dtype)
     asym_id = batch["asym_id"].to(device=z.device, non_blocking=True).contiguous()
-    use_triton = (
-        is_fused_template_coordinate_enabled()
-        and z.is_cuda
-        and dtype == torch.float32
-        and a.shape[-1] == 64
-        and dgram_weight.shape == (64, 39)
-        and scalar_weight.shape == (64, 5)
+    dgram_weight = module.dgram_linear.weight
+    scalar_weight = _build_scalar_weight(module, torch.float32)
+    use_triton = _can_use_triton(
+        a,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
     )
     if use_triton:
-        template_coordinate_projection_add_(
-            a,
-            pseudo_beta_coords,
-            frame_atom_coords,
-            pseudo_beta_mask,
-            backbone_frame_mask,
-            asym_id,
-            dgram_weight.contiguous(),
-            scalar_weight.contiguous(),
-        )
+        dgram_weight = dgram_weight.float().contiguous()
+        scalar_weight = scalar_weight.contiguous()
+        with torch.autocast(device_type="cuda", enabled=False):
+            if torch.is_grad_enabled():
+                a = _TemplateCoordinateProjectionFunction.apply(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
+            elif inference_inplace:
+                template_coordinate_projection_add_(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
+            else:
+                a = template_coordinate_projection(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
     else:
-        template_coordinate_projection_add_reference_(
-            a,
-            pseudo_beta_coords,
-            frame_atom_coords,
-            pseudo_beta_mask,
-            backbone_frame_mask,
-            asym_id,
-            dgram_weight,
-            scalar_weight,
-        )
+        dgram_weight = dgram_weight.to(dtype=dtype)
+        scalar_weight = scalar_weight.to(dtype=dtype)
+        if inference_inplace:
+            template_coordinate_projection_add_reference_(
+                a,
+                pseudo_beta_coords,
+                frame_atom_coords,
+                pseudo_beta_mask,
+                backbone_frame_mask,
+                asym_id,
+                dgram_weight,
+                scalar_weight,
+            )
+        else:
+            a = template_coordinate_projection_reference(
+                a,
+                pseudo_beta_coords,
+                frame_atom_coords,
+                pseudo_beta_mask,
+                backbone_frame_mask,
+                asym_id,
+                dgram_weight,
+                scalar_weight,
+            )
     return a.unsqueeze(-4)

--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -114,6 +114,51 @@ def broadcast_token_feat_to_atoms(
     return atom_feat
 
 
+def _expand_to_batch(tensor: torch.Tensor, batch_dims: torch.Size) -> torch.Tensor:
+    while tensor.ndim - 1 < len(batch_dims):
+        tensor = tensor.unsqueeze(-2)
+    return tensor.expand(*batch_dims, tensor.shape[-1])
+
+
+def broadcast_token_feat_to_atoms_by_index(
+    token_mask: torch.Tensor,
+    atom_to_token_index: torch.Tensor,
+    atom_mask: torch.Tensor,
+    token_feat: torch.Tensor,
+) -> torch.Tensor:
+    """Gather token features onto atoms via ``atom_to_token_index``."""
+    batch_dims = token_feat.shape[:-2]
+    n_token, channels = token_feat.shape[-2:]
+    idx = _expand_to_batch(atom_to_token_index, batch_dims).clamp(0, n_token - 1)
+    idx = idx.long().unsqueeze(-1).expand(*idx.shape, channels)
+    token_mask = _expand_to_batch(token_mask, batch_dims).unsqueeze(-1)
+    atom_mask = _expand_to_batch(atom_mask, batch_dims).unsqueeze(-1)
+    return torch.gather(token_feat * token_mask, -2, idx) * atom_mask
+
+
+def aggregate_atom_feat_to_tokens_segmented(
+    num_atoms_per_token: torch.Tensor,
+    atom_mask: torch.Tensor,
+    atom_feat: torch.Tensor,
+    eps: float = 1e-9,
+) -> torch.Tensor:
+    """Deterministic mean-reduce of packed, token-sorted atoms."""
+    batch_dims = atom_feat.shape[:-2]
+    n_token = num_atoms_per_token.shape[-1]
+    atom_mask = _expand_to_batch(atom_mask, batch_dims)
+    lengths = _expand_to_batch(num_atoms_per_token, batch_dims).long()
+    lengths = torch.cat(
+        [lengths, atom_feat.shape[-2] - lengths.sum(dim=-1, keepdim=True)], dim=-1
+    )
+    token_feat = torch.segment_reduce(
+        atom_feat * atom_mask.unsqueeze(-1), "sum", lengths=lengths, axis=-2
+    )[..., :n_token, :]
+    counts = torch.segment_reduce(
+        atom_mask.to(atom_feat.dtype), "sum", lengths=lengths, axis=-1
+    )[..., :n_token]
+    return token_feat / (counts.unsqueeze(-1) + eps)
+
+
 def aggregate_atom_feat_to_tokens(
     token_mask: torch.Tensor,
     atom_to_token_index: torch.Tensor,

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -14,6 +14,7 @@
 
 import logging
 import math
+import os
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
@@ -24,6 +25,57 @@ from openfold3.core.utils.tensor_utils import (
     tensor_tree_map,
     tree_map,
 )
+
+
+def _positive_env_int(name: str) -> int | None:
+    """Parse a positive int env var; unset/invalid -> None."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        val = int(raw)
+    except ValueError:
+        return None
+    return val if val > 0 else None
+
+
+def triangle_attn_chunk_cap() -> int | None:
+    """Optional row cap for triangle attention (``OPENFOLD3_TRI_ATTN_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRI_ATTN_CHUNK_CAP")
+
+
+def apply_triangle_attn_chunk_cap(
+    attn_chunk: int,
+    n_tokens: int | None = None,
+) -> int:
+    """Cap triangle-attention rows; no-op when ``n_tokens <= cap``."""
+    cap = triangle_attn_chunk_cap()
+    if cap is None:
+        return attn_chunk
+    if n_tokens is not None and n_tokens <= cap:
+        return attn_chunk
+    return min(attn_chunk, cap)
+
+
+def trimul_chunk_cap() -> int | None:
+    """Optional row chunk for trimul (``OPENFOLD3_TRIMUL_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRIMUL_CHUNK_CAP")
+
+
+def use_chunked_trimul(inplace_safe: bool) -> bool:
+    """Use eager chunked trimul instead of cuEq when a cap is set."""
+    return inplace_safe and trimul_chunk_cap() is not None
+
+
+def transition_chunk_cap() -> int | None:
+    """Optional cap for transition/OPM chunk size (``OPENFOLD3_TRANSITION_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRANSITION_CHUNK_CAP")
+
+
+def apply_transition_chunk_cap(chunk_size: int) -> int:
+    """Apply ``OPENFOLD3_TRANSITION_CHUNK_CAP`` after chunk-size tuning."""
+    cap = transition_chunk_cap()
+    return chunk_size if cap is None else min(chunk_size, cap)
 
 
 def _fetch_dims(tree):

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -347,8 +347,9 @@ def chunk_layer(
 
 class ChunkSizeTuner:
     def __init__(self):
-        self.cached_chunk_size = None
-        self.cached_arg_data = None
+        # (arg_data, max_chunk_size, chunk_size) entries so alternating shapes
+        # and distinct max caps can reuse prior tunings.
+        self.cached_chunk_sizes: list[tuple[Any, int, int]] = []
 
     @staticmethod
     def _determine_favorable_chunk_size(fn, args, max_chunk_size):
@@ -410,19 +411,16 @@ class ChunkSizeTuner:
             return (a.shape, a.dtype.itemsize) if type(a) is torch.Tensor else a
 
         arg_data = tree_map(remove_tensors, args, object)
-        if self.cached_arg_data is not None:
-            # If args have changed shape/value, we need to re-tune
-            consistent = self._compare_arg_caches(self.cached_arg_data, arg_data)
-        else:
-            # Otherwise, we can reuse the precomputed value
-            consistent = False
+        for cached_arg_data, cached_max, cached_size in self.cached_chunk_sizes:
+            if cached_max == max_chunk_size and self._compare_arg_caches(
+                cached_arg_data, arg_data
+            ):
+                return cached_size
 
-        if not consistent:
-            self.cached_chunk_size = self._determine_favorable_chunk_size(
-                fn=representative_fn,
-                args=args,
-                max_chunk_size=max_chunk_size,
-            )
-            self.cached_arg_data = arg_data
-
-        return self.cached_chunk_size
+        chunk_size = self._determine_favorable_chunk_size(
+            fn=representative_fn,
+            args=args,
+            max_chunk_size=max_chunk_size,
+        )
+        self.cached_chunk_sizes.append((arg_data, max_chunk_size, chunk_size))
+        return chunk_size

--- a/openfold3/core/utils/relpos.py
+++ b/openfold3/core/utils/relpos.py
@@ -18,7 +18,10 @@ from openfold3.core.utils.tensor_utils import binned_one_hot
 
 
 def relpos_complex(
-    batch: dict, max_relative_idx: int, max_relative_chain: int
+    batch: dict,
+    max_relative_idx: int,
+    max_relative_chain: int,
+    row_slice: slice | None = None,
 ) -> torch.Tensor:
     """
     Args:
@@ -28,16 +31,37 @@ def relpos_complex(
             Maximum relative position and token indices clipped
         max_relative_chain:
             Maximum relative chain indices clipped
+        row_slice:
+            Optional slice over the first spatial dimension (rows of the pair
+            tensor). When provided, returns ``[*, chunk, N_token, C]`` instead
+            of ``[*, N_token, N_token, C]``. Used by the chunked diffusion
+            conditioning path to avoid materializing the full ``[N, N, 139]``
+            relpos tensor.
 
     Returns:
-        [*, N_token, N_token, C_z] Relative position embedding
+        [*, N_token, N_token, C_z] Relative position embedding (or
+        [*, chunk, N_token, C_z] when row_slice is given)
     """
     res_idx = batch["residue_index"]
     asym_id = batch["asym_id"]
     entity_id = batch["entity_id"]
-    same_chain = asym_id[..., None] == asym_id[..., None, :]
-    same_res = res_idx[..., None] == res_idx[..., None, :]
-    same_entity = entity_id[..., None] == entity_id[..., None, :]
+
+    if row_slice is not None:
+        row_asym = asym_id[..., row_slice, None]
+        col_asym = asym_id[..., None, :]
+        same_chain = row_asym == col_asym
+
+        row_res = res_idx[..., row_slice, None]
+        col_res = res_idx[..., None, :]
+        same_res = row_res == col_res
+
+        row_entity = entity_id[..., row_slice, None]
+        col_entity = entity_id[..., None, :]
+        same_entity = row_entity == col_entity
+    else:
+        same_chain = asym_id[..., None] == asym_id[..., None, :]
+        same_res = res_idx[..., None] == res_idx[..., None, :]
+        same_entity = entity_id[..., None] == entity_id[..., None, :]
 
     def relpos(
         pos: torch.Tensor, condition: torch.BoolTensor, rel_clip_idx: int
@@ -54,7 +78,10 @@ def relpos_complex(
             rel_pos:
                 [*, N_token, N_token, 2 * rel_clip_idx + 2] Relative position embedding
         """
-        offset = pos[..., None] - pos[..., None, :]
+        if row_slice is not None:
+            offset = pos[..., row_slice, None] - pos[..., None, :]
+        else:
+            offset = pos[..., None] - pos[..., None, :]
         clipped_offset = torch.clamp(offset + rel_clip_idx, min=0, max=2 * rel_clip_idx)
         final_offset = torch.where(
             condition,

--- a/openfold3/projects/of3_all_atom/config/dataset_config_components.py
+++ b/openfold3/projects/of3_all_atom/config/dataset_config_components.py
@@ -23,7 +23,7 @@ The main sections of the dataset configuration are:
 
 from typing import Annotated
 
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BaseModel, BeforeValidator, model_validator
 
 from openfold3.core.config.config_utils import _convert_molecule_type
 from openfold3.core.data.resources.residues import MoleculeType
@@ -125,6 +125,21 @@ class TemplateSettings(BaseModel):
     take_top_k: bool = False
     min_n_tokens_per_chain: int = 5
     distogram: TemplateDistogramSettings = TemplateDistogramSettings()
+    use_coordinate_pair_features: bool = False
+
+    @model_validator(mode="after")
+    def validate_coordinate_distogram(self):
+        distogram = (
+            self.distogram.min_bin,
+            self.distogram.max_bin,
+            self.distogram.n_bins,
+        )
+        if self.use_coordinate_pair_features and distogram != (3.25, 50.75, 39):
+            raise ValueError(
+                "Coordinate-derived templates currently require the default "
+                "3.25/50.75/39 distogram configuration."
+            )
+        return self
 
 
 class CropWeights(BaseModel):

--- a/openfold3/projects/of3_all_atom/config/features.py
+++ b/openfold3/projects/of3_all_atom/config/features.py
@@ -51,6 +51,8 @@ feature_dict = mlc.ConfigDict(
             "template_backbone_frame_mask": [NUM_TEMPLATES, NUM_TOKENS],
             "template_distogram": [NUM_TEMPLATES, NUM_TOKENS, NUM_TOKENS, 39],
             "template_unit_vector": [NUM_TEMPLATES, NUM_TOKENS, NUM_TOKENS, 3],
+            "template_pseudo_beta_coords": [NUM_TEMPLATES, NUM_TOKENS, 3],
+            "template_frame_atom_coords": [NUM_TEMPLATES, NUM_TOKENS, 3, 3],
             "token_bonds": [NUM_TOKENS, NUM_TOKENS],
             # Features not included in AF3 docs
             "num_atoms_per_token": [NUM_TOKENS],

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -329,6 +329,7 @@ class OpenFold3(nn.Module):
         si_trunk: torch.Tensor,
         zij_trunk: torch.Tensor,
         inplace_safe: bool = False,
+        zij_release: list | None = None,
     ) -> dict:
         """
         Mini diffusion rollout described in section 4.1.
@@ -345,6 +346,8 @@ class OpenFold3(nn.Module):
                 [*, N_token, N_token, C_z] Pair representation output from model trunk
             inplace_safe:
                 Whether inplace operations can be performed
+            zij_release:
+                Optional owned trunk-pair slot cleared before confidence.
 
         Returns:
             Output dictionary containing the predicted trunk embeddings,
@@ -413,8 +416,11 @@ class OpenFold3(nn.Module):
             "zij_trunk": zij_trunk,
             "atom_positions_predicted": atom_positions_predicted,
         }
+        del zij_trunk
+        if zij_release is not None:
+            zij_release[0] = None
 
-        cast_dtype = torch.float32 if self.training else si_trunk.dtype
+        cast_dtype = torch.float32 if self.training else output["si_trunk"].dtype
         with torch.amp.autocast(device_type="cuda", dtype=cast_dtype):
             # Compute confidence logits
             output.update(
@@ -671,13 +677,19 @@ class OpenFold3(nn.Module):
         batch = tensor_tree_map(lambda t: t.unsqueeze(1), batch)
         batch["ref_space_uid_to_perm"] = ref_space_uid_to_perm
 
+        retain_trunk_pair = self.training or "ground_truth" in batch
+        zij_release = None if retain_trunk_pair else [zij_trunk]
+        if zij_release is not None:
+            del zij_trunk
+
         # Mini rollout
         rollout_output = self._rollout(
             batch=batch,
             si_input=si_input,
             si_trunk=si_trunk,
-            zij_trunk=zij_trunk,
+            zij_trunk=(zij_trunk if retain_trunk_pair else zij_release[0]),
             inplace_safe=inplace_safe,
+            zij_release=zij_release,
         )
 
         output.update(rollout_output)

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -577,10 +577,18 @@ class OpenFold3(nn.Module):
                         compute frames
                     "template_distogram" ([*, N_templ, N_token, N_token, 39])
                         A one-hot pairwise feature indicating the distance between
-                        C_beta atoms (C_alpha for glycine) in the template
+                        C_beta atoms (C_alpha for glycine) in the template.
+                        Absent when coordinate-derived template features are used.
                     "template_unit_vector"([*, N_templ, N_token, N_token, 3])
                         The unit vector between pairs of C_alpha atoms within
-                        the local frame of each template residue
+                        the local frame of each template residue.
+                        Absent when coordinate-derived template features are used.
+                    *"template_pseudo_beta_coords" ([*, N_templ, N_token, 3])
+                        Compact pseudo-beta coordinates for the optional
+                        coordinate-derived template path (inference)
+                    *"template_frame_atom_coords" ([*, N_templ, N_token, 3, 3])
+                        Compact N/CA/C coordinates for the optional
+                        coordinate-derived template path (inference)
                     "token_bonds" ([*, N_token, N_token])
                         A 2D matrix indicating if there is a bond between
                         any atom in token i and token j

--- a/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
+++ b/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
@@ -1,0 +1,73 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+
+import numpy as np
+
+from openfold3.core.data.framework.single_datasets.inference import (
+    InferenceDataset,
+    _seeded_feature_creation,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+LIGAND_QUERY = Query.model_validate(
+    {
+        "query_name": "ethanol",
+        "chains": [
+            {
+                "molecule_type": "ligand",
+                "chain_ids": "A",
+                "smiles": "CCO",
+            }
+        ],
+    }
+)
+
+
+def _reference_conformer_coords(seed: int) -> np.ndarray:
+    with _seeded_feature_creation(seed):
+        swrm = InferenceDataset.get_structure_with_ref_mols(LIGAND_QUERY)
+    return swrm.processed_reference_mols[0].mol.GetConformer().GetPositions()
+
+
+class TestInferenceFeatureSeeding(unittest.TestCase):
+    def test_same_seed_is_independent_of_global_rng(self):
+        for _ in range(100):
+            random.random()
+        first = _reference_conformer_coords(42)
+        for _ in range(100):
+            random.random()
+        second = _reference_conformer_coords(42)
+        np.testing.assert_allclose(first, second)
+
+    def test_different_seeds_can_differ(self):
+        first = _reference_conformer_coords(1)
+        second = _reference_conformer_coords(2)
+        self.assertFalse(np.allclose(first, second))
+
+    def test_restores_global_python_rng(self):
+        random.seed(7)
+        before = random.random()
+        with _seeded_feature_creation(999):
+            _reference_conformer_coords(999)
+        after = random.random()
+
+        random.seed(7)
+        expected_before = random.random()
+        expected_after = random.random()
+
+        self.assertEqual(before, expected_before)
+        self.assertEqual(after, expected_after)

--- a/openfold3/tests/core/model/latent/test_template_module.py
+++ b/openfold3/tests/core/model/latent/test_template_module.py
@@ -54,6 +54,58 @@ class TestTemplateEmbedderAllAtom(unittest.TestCase):
 
         self.assertTrue(t.shape == (batch_size, n_token, n_token, c_in))
 
+    def test_streaming_matches_full_batch(self):
+        batch_size = 1
+        n_templ = 3
+        n_token = 8
+
+        of3_proj_entry = OF3ProjectEntry()
+        of3_config = of3_proj_entry.get_model_config_with_presets()
+        c_in = of3_config.architecture.template.template_pair_embedder.c_in
+        embedder = TemplateEmbedderAllAtom(of3_config.architecture.template)
+        embedder.eval()
+
+        torch.manual_seed(0)
+        batch = {
+            "token_mask": torch.ones((batch_size, n_token)),
+            "asym_id": torch.ones((batch_size, n_token)),
+            "template_restype": torch.randn((batch_size, n_templ, n_token, 32)),
+            "template_pseudo_beta_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_backbone_frame_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_distogram": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 39)
+            ),
+            "template_unit_vector": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 3)
+            ),
+        }
+        z = torch.randn((batch_size, n_token, n_token, c_in))
+        pair_mask = torch.ones((batch_size, n_token, n_token))
+
+        with torch.inference_mode():
+            t_stream = embedder(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = embedder._forward(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = torch.sum(t_full, dim=-4) / n_templ
+            t_full = torch.nn.functional.relu(t_full)
+            t_full = embedder.linear_t(t_full)
+
+        self.assertTrue(
+            torch.allclose(t_stream, t_full, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(t_stream - t_full).abs().max().item():.3e}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/test_atomize_utils.py
+++ b/openfold3/tests/test_atomize_utils.py
@@ -22,7 +22,9 @@ from openfold3.core.data.primitives.featurization.structure import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
     get_token_atom_index_offset,
     get_token_center_atoms,
     get_token_frame_atoms,
@@ -317,6 +319,21 @@ class TestBroadcastTokenFeatToAtoms(unittest.TestCase):
 
         self.assertTrue((atom_mask == gt_atom_mask).all())
 
+    def test_by_index_matches_repeat_interleave(self):
+        lengths = torch.tensor([[[2, 1, 3]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_mask = torch.ones(1, 1, 6)
+        atom_mask[..., 1] = 0
+        atom_index = create_atom_to_token_index(token_mask, lengths)
+        token_feat = torch.randn(1, 4, 3, 5)
+        expected = broadcast_token_feat_to_atoms(
+            token_mask, lengths, token_feat, -2
+        ) * atom_mask.unsqueeze(-1)
+        actual = broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+        torch.testing.assert_close(actual, expected)
+
 
 class TestAggregateAtomFeatToTokens(unittest.TestCase):
     def test_with_one_batch_dim(self):
@@ -426,6 +443,38 @@ class TestAggregateAtomFeatToTokens(unittest.TestCase):
         )
 
         self.assertTrue((torch.abs(token_feat - gt_token_feat) < 1e-5).all())
+
+
+class TestSegmentedAggregateAtomFeatToTokens(unittest.TestCase):
+    def test_matches_scatter_and_is_cuda_repeatable(self):
+        lengths = torch.tensor([[[3, 2, 1]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_index = torch.tensor([[[0, 0, 0, 1, 1, 2, 0]]])
+        atom_mask = torch.tensor([[[1, 1, 0, 1, 1, 1, 0]]], dtype=torch.float32)
+        atom_feat = torch.randn(1, 4, 7, 5)
+        expected = aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+        actual = aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+        torch.testing.assert_close(actual, expected)
+
+        if not torch.cuda.is_available():
+            return
+        lengths, atom_mask, atom_feat = (
+            t.cuda() for t in (lengths, atom_mask, atom_feat)
+        )
+        reference = aggregate_atom_feat_to_tokens_segmented(
+            lengths, atom_mask, atom_feat
+        )
+        for _ in range(16):
+            self.assertTrue(
+                torch.equal(
+                    aggregate_atom_feat_to_tokens_segmented(
+                        lengths, atom_mask, atom_feat
+                    ),
+                    reference,
+                )
+            )
 
 
 class TestGetTokenAtomIndex(unittest.TestCase):

--- a/openfold3/tests/test_diffusion_conditioning.py
+++ b/openfold3/tests/test_diffusion_conditioning.py
@@ -17,11 +17,22 @@ import unittest
 import torch
 
 from openfold3.core.model.layers.diffusion_conditioning import DiffusionConditioning
+from openfold3.core.utils.relpos import relpos_complex
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
 
 
 class TestDiffusionConditioning(unittest.TestCase):
+    def _batch(self, batch_size: int, n_token: int) -> dict:
+        return {
+            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "token_mask": torch.ones((batch_size, n_token)),
+            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "sym_id": torch.zeros((batch_size, n_token)),
+            "asym_id": torch.zeros((batch_size, n_token)),
+            "entity_id": torch.zeros((batch_size, n_token)),
+        }
+
     def test_without_n_sample_channel(self):
         batch_size = consts.batch_size
         n_token = consts.n_res
@@ -45,14 +56,7 @@ class TestDiffusionConditioning(unittest.TestCase):
             -1.2 + 1.5 * torch.randn(batch_size, device=si_trunk.device)
         )
 
-        batch = {
-            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "token_mask": torch.ones((batch_size, n_token)),
-            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "sym_id": torch.zeros((batch_size, n_token)),
-            "asym_id": torch.zeros((batch_size, n_token)),
-            "entity_id": torch.zeros((batch_size, n_token)),
-        }
+        batch = self._batch(batch_size, n_token)
 
         si, zij = dc(
             batch=batch,
@@ -65,6 +69,53 @@ class TestDiffusionConditioning(unittest.TestCase):
 
         self.assertTrue(si.shape == (batch_size, n_token, c_s))
         self.assertTrue(zij.shape == (batch_size, n_token, n_token, c_z))
+
+    def test_relpos_row_slice_matches_full(self):
+        batch_size = 2
+        n_token = 17
+        batch = self._batch(batch_size, n_token)
+        full = relpos_complex(batch, max_relative_idx=32, max_relative_chain=2)
+        chunk = 5
+        parts = [
+            relpos_complex(
+                batch,
+                max_relative_idx=32,
+                max_relative_chain=2,
+                row_slice=slice(i, min(i + chunk, n_token)),
+            )
+            for i in range(0, n_token, chunk)
+        ]
+        rebuilt = torch.cat(parts, dim=-3)
+        self.assertTrue(torch.equal(rebuilt, full))
+
+    def test_chunked_pair_embed_matches_eager(self):
+        batch_size = 1
+        n_token = 37
+        c_s_input = consts.c_s + 65
+        c_s = consts.c_s
+        c_z = consts.c_z
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        diff_cond_config = config.architecture.diffusion_module.diffusion_conditioning
+        diff_cond_config.update({"c_s": c_s, "c_s_input": c_s_input, "c_z": c_z})
+        dc = DiffusionConditioning(**diff_cond_config)
+        dc.eval()
+
+        torch.manual_seed(0)
+        batch = self._batch(batch_size, n_token)
+        zij_trunk = torch.randn(batch_size, n_token, n_token, c_z)
+
+        with torch.no_grad():
+            zij_chunked = dc._embed_zij_chunked(batch, zij_trunk)
+        # Eager path is taken when gradients are enabled.
+        with torch.enable_grad():
+            zij_eager = dc._embed_zij(batch, zij_trunk.detach())
+
+        self.assertTrue(
+            torch.allclose(zij_chunked, zij_eager, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(zij_chunked - zij_eager).abs().max().item():.3e}",
+        )
 
     def test_with_different_schedule(self):
         batch_size = consts.batch_size

--- a/openfold3/tests/test_fused_template_coordinate_embed.py
+++ b/openfold3/tests/test_fused_template_coordinate_embed.py
@@ -5,11 +5,11 @@
 
 from __future__ import annotations
 
+import copy
 import os
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 import pytest
 import torch
@@ -22,8 +22,9 @@ from openfold3.core.model.feature_embedders.template_embedders import (
     TemplatePairEmbedderAllAtom,
 )
 from openfold3.core.model.primitives.fused_template_coordinate import (
-    fused_template_coordinate_pair_embedder_inference,
+    fused_template_coordinate_pair_embedder,
     template_coordinate_projection_add_reference_,
+    template_coordinate_projection_reference,
 )
 from openfold3.projects.of3_all_atom.config.dataset_config_components import (
     TemplateSettings,
@@ -37,7 +38,11 @@ def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Te
     for t in range(n_templ):
         offset = 0.4 * t
         ca = torch.stack(
-            (index * 3.8, torch.sin(index * 0.3 + offset), torch.cos(index * 0.2 + offset)),
+            (
+                index * 3.8,
+                torch.sin(index * 0.3 + offset),
+                torch.cos(index * 0.2 + offset),
+            ),
             dim=-1,
         )
         pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
@@ -48,9 +53,7 @@ def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Te
     return torch.stack(templates, dim=0), torch.stack(frames, dim=0)
 
 
-def _coordinate_batch(
-    n_token: int, device: str = "cpu", n_templ: int = 1
-) -> dict:
+def _coordinate_batch(n_token: int, device: str = "cpu", n_templ: int = 1) -> dict:
     pseudo_beta, frame = _coordinates(n_token, n_templ=n_templ)
     restype = torch.nn.functional.one_hot(
         torch.arange(n_token) % 32, num_classes=32
@@ -60,9 +63,10 @@ def _coordinate_batch(
         "template_frame_atom_coords": frame[None].to(device),
         "template_pseudo_beta_mask": torch.ones(1, n_templ, n_token, device=device),
         "template_backbone_frame_mask": torch.ones(1, n_templ, n_token, device=device),
-        "template_restype": restype[None, None].expand(1, n_templ, -1, -1).contiguous().to(
-            device
-        ),
+        "template_restype": restype[None, None]
+        .expand(1, n_templ, -1, -1)
+        .contiguous()
+        .to(device),
         "asym_id": torch.cat(
             (
                 torch.ones(n_token // 2, dtype=torch.int32),
@@ -89,9 +93,9 @@ def _precomputed_batch(coordinate_batch: dict) -> dict:
         "template_distogram": create_template_distogram(
             pseudo_beta, pb_mask, multichain
         )[None],
-        "template_unit_vector": create_template_unit_vector(
-            frame, bb_mask, multichain
-        )[None],
+        "template_unit_vector": create_template_unit_vector(frame, bb_mask, multichain)[
+            None
+        ],
         "template_pseudo_beta_mask": coordinate_batch[
             "template_pseudo_beta_mask"
         ].cpu(),
@@ -113,7 +117,7 @@ def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
 
     with torch.inference_mode():
         expected = module(precomputed_batch, z.clone())
-        actual = fused_template_coordinate_pair_embedder_inference(
+        actual = fused_template_coordinate_pair_embedder(
             module=module,
             batch=coordinate_batch,
             z=z.clone(),
@@ -128,9 +132,7 @@ def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
 
 
 @pytest.mark.parametrize("n_token,n_templ", [(8, 2), (17, 3)])
-def test_template_embedder_coordinate_matches_precomputed(
-    n_token: int, n_templ: int
-):
+def test_template_embedder_coordinate_matches_precomputed(n_token: int, n_templ: int):
     """Full TemplateEmbedderAllAtom path: coords vs precomputed distogram/UV."""
     from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
     from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
@@ -144,7 +146,9 @@ def test_template_embedder_coordinate_matches_precomputed(
     precomputed_batch = _precomputed_batch(coordinate_batch)
     # Restype for the pair embedder is float one-hot in the streaming tests.
     coordinate_batch["template_restype"] = coordinate_batch["template_restype"].float()
-    precomputed_batch["template_restype"] = precomputed_batch["template_restype"].float()
+    precomputed_batch["template_restype"] = precomputed_batch[
+        "template_restype"
+    ].float()
 
     z = torch.randn(1, n_token, n_token, c_z)
     pair_mask = torch.ones(1, n_token, n_token)
@@ -168,19 +172,119 @@ def test_template_embedder_coordinate_matches_precomputed(
     torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
 
 
-def test_coordinate_embedding_rejects_training():
-    n_token = 8
-    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
-    batch = _coordinate_batch(n_token)
-    z = torch.randn(1, n_token, n_token, 128)
+@pytest.mark.parametrize("checkpoint_mode", ["blocks", "per_template"])
+def test_coordinate_training_checkpoint_matches_uncheckpointed(checkpoint_mode: str):
+    from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
+    from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 
-    with torch.no_grad(), pytest.raises(RuntimeError, match="inference-only"):
-        fused_template_coordinate_pair_embedder_inference(
-            module=module,
-            batch=batch,
-            z=z,
-            template_index=0,
+    torch.manual_seed(23)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    reference_config = copy.deepcopy(of3_config.architecture.template)
+    reference_config.template_pair_stack.blocks_per_ckpt = None
+    reference_config.template_pair_stack.ckpt_per_template = False
+    checkpoint_config = copy.deepcopy(reference_config)
+    if checkpoint_mode == "blocks":
+        checkpoint_config.template_pair_stack.blocks_per_ckpt = 1
+    else:
+        checkpoint_config.template_pair_stack.ckpt_per_template = True
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    reference_module = TemplateEmbedderAllAtom(reference_config).to(device).train()
+    with torch.no_grad():
+        reference_module.linear_t.weight.normal_(std=0.05)
+    checkpoint_module = TemplateEmbedderAllAtom(checkpoint_config).to(device).train()
+    checkpoint_module.load_state_dict(reference_module.state_dict())
+
+    n_token = 4
+    batch = _coordinate_batch(n_token, device=device, n_templ=2)
+    batch["template_restype"] = batch["template_restype"].float()
+    c_z = reference_config.template_pair_embedder.c_in
+    z_reference = torch.randn(
+        1, n_token, n_token, c_z, device=device, requires_grad=True
+    )
+    z_checkpoint = z_reference.detach().clone().requires_grad_(True)
+    pair_mask = torch.ones(1, n_token, n_token, device=device)
+    upstream = torch.randn(1, n_token, n_token, c_z, device=device)
+
+    torch.manual_seed(29)
+    reference = reference_module(batch, z_reference, pair_mask)
+    (reference * upstream).sum().backward()
+    torch.manual_seed(29)
+    checkpointed = checkpoint_module(batch, z_checkpoint, pair_mask)
+    (checkpointed * upstream).sum().backward()
+
+    tolerance = 5e-4 if device == "cuda" else 1e-5
+    torch.testing.assert_close(checkpointed, reference, rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(
+        z_checkpoint.grad, z_reference.grad, rtol=tolerance, atol=tolerance
+    )
+    reference_parameters = dict(reference_module.named_parameters())
+    for name, parameter in checkpoint_module.named_parameters():
+        expected_grad = reference_parameters[name].grad
+        if parameter.grad is None or expected_grad is None:
+            assert parameter.grad is expected_grad, name
+            continue
+        torch.testing.assert_close(
+            parameter.grad,
+            expected_grad,
+            rtol=tolerance,
+            atol=tolerance,
+            msg=lambda msg, name=name: f"{name}: {msg}",
         )
+
+
+def test_coordinate_embedding_training_eager_batch_and_gradient_accumulation():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    batch = {
+        key: value.expand(2, *value.shape[1:]).clone() for key, value in batch.items()
+    }
+    batch["template_restype"] = batch["template_restype"].float()
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    z = torch.randn(2, n_token, n_token, 128, requires_grad=True)
+
+    actual = fused_template_coordinate_pair_embedder(
+        module=module,
+        batch=batch,
+        z=z,
+        template_index=0,
+    )
+    assert actual.shape == (2, 1, n_token, n_token, 64)
+    actual.square().mean().backward()
+    first_z_grad = z.grad.clone()
+    first_weight_grad = module.dgram_linear.weight.grad.clone()
+
+    actual = fused_template_coordinate_pair_embedder(
+        module=module,
+        batch=batch,
+        z=z,
+        template_index=0,
+    )
+    actual.square().mean().backward()
+    torch.testing.assert_close(z.grad, first_z_grad * 2)
+    torch.testing.assert_close(module.dgram_linear.weight.grad, first_weight_grad * 2)
+
+
+def test_coordinate_embedding_rejects_coordinate_gradients():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    batch["template_pseudo_beta_coords"].requires_grad_(True)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    z = torch.randn(1, n_token, n_token, 128, requires_grad=True)
+
+    with pytest.raises(ValueError, match="non-differentiable data"):
+        fused_template_coordinate_pair_embedder(module, batch, z, 0)
+
+
+def test_coordinate_embedding_rejects_fused_away_bias():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    module.dgram_linear.bias = torch.nn.Parameter(torch.zeros(64))
+    z = torch.randn(1, n_token, n_token, 128, requires_grad=True)
+
+    with pytest.raises(ValueError, match="bias-free"):
+        fused_template_coordinate_pair_embedder(module, batch, z, 0)
 
 
 def test_coordinate_features_reject_nondefault_distogram_settings():
@@ -191,10 +295,338 @@ def test_coordinate_features_reject_nondefault_distogram_settings():
         )
 
 
+def test_coordinate_features_registered_with_quality_control():
+    from openfold3.core.data.primitives.quality_control.asserts import (
+        FEATURE_OTHER_DTYPES,
+        FULL_OTHER_DIM_INDEX_MAP,
+        FULL_TEMPLATE_DIM_INDEX_MAP,
+        FULL_TOKEN_DIM_INDEX_MAP,
+        _assert_template_feature_representation,
+    )
+
+    coordinate_features = {
+        "template_pseudo_beta_coords": torch.zeros(2, 5, 3),
+        "template_frame_atom_coords": torch.zeros(2, 5, 3, 3),
+    }
+    _assert_template_feature_representation(coordinate_features)
+    assert FULL_TOKEN_DIM_INDEX_MAP["template_pseudo_beta_coords"] == [-2]
+    assert FULL_TOKEN_DIM_INDEX_MAP["template_frame_atom_coords"] == [-3]
+    assert FULL_TEMPLATE_DIM_INDEX_MAP["template_pseudo_beta_coords"] == [-3]
+    assert FULL_TEMPLATE_DIM_INDEX_MAP["template_frame_atom_coords"] == [-4]
+    assert FULL_OTHER_DIM_INDEX_MAP["template_frame_atom_coords"] == [-1, -2]
+    assert FEATURE_OTHER_DTYPES["template_pseudo_beta_coords"] == torch.float32
+    assert FEATURE_OTHER_DTYPES["template_frame_atom_coords"] == torch.float32
+
+    with pytest.raises(AssertionError, match="Exactly one"):
+        _assert_template_feature_representation(
+            {
+                **coordinate_features,
+                "template_distogram": torch.zeros(2, 5, 5, 39),
+                "template_unit_vector": torch.zeros(2, 5, 5, 3),
+            }
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_training_gradients_match_eager(monkeypatch):
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    n_token = 17
+    torch.manual_seed(19)
+    reference_module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().train()
+    actual_module = copy.deepcopy(reference_module)
+    batch = _coordinate_batch(n_token, device="cuda")
+    batch["template_restype"] = batch["template_restype"].float()
+    z_reference = torch.randn(
+        1, n_token, n_token, 128, device="cuda", requires_grad=True
+    )
+    z_actual = z_reference.detach().clone().requires_grad_(True)
+    upstream = torch.randn(1, 1, n_token, n_token, 64, device="cuda")
+
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "0")
+    reference = fused_template_coordinate_pair_embedder(
+        reference_module, batch, z_reference, 0
+    )
+    (reference * upstream).sum().backward()
+
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+    actual = fused_template_coordinate_pair_embedder(actual_module, batch, z_actual, 0)
+    assert (
+        "_TemplateCoordinateProjectionFunctionBackward"
+        in type(actual.grad_fn.next_functions[0][0]).__name__
+    )
+    (actual * upstream).sum().backward()
+
+    torch.testing.assert_close(actual, reference, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(z_actual.grad, z_reference.grad, rtol=5e-4, atol=5e-4)
+    reference_parameters = dict(reference_module.named_parameters())
+    for name, parameter in actual_module.named_parameters():
+        assert parameter.grad is not None, name
+        expected_grad = reference_parameters[name].grad
+        assert expected_grad is not None, name
+        torch.testing.assert_close(
+            parameter.grad,
+            expected_grad,
+            rtol=5e-4,
+            atol=5e-4,
+            msg=lambda msg, name=name: f"{name}: {msg}",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_token", [8, 31, 65, 384])
+@pytest.mark.parametrize(
+    ("compute_dgram", "compute_scalar"),
+    [(True, True), (True, False), (False, True)],
+)
+def test_coordinate_triton_backward_matches_eager(
+    n_token: int,
+    compute_dgram: bool,
+    compute_scalar: bool,
+    monkeypatch,
+):
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    torch.manual_seed(41 + n_token)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    pb_mask[:, ::5] = 0
+    bb_mask[:, 2::7] = 0
+    asym = batch["asym_id"].contiguous()
+    asym[:, n_token // 2 :] = 2
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+    if n_token == 31:
+        upstream = upstream.transpose(1, 2)
+    dgram_weight = torch.randn(64, 39, device="cuda", requires_grad=compute_dgram)
+    scalar_weight = torch.randn(64, 5, device="cuda", requires_grad=compute_scalar)
+    source = torch.zeros_like(upstream)
+
+    expected = template_coordinate_projection_reference(
+        source,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=7,
+    )
+    (expected * upstream).sum().backward()
+    actual_dgram, actual_scalar = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        compute_dgram=compute_dgram,
+        compute_scalar=compute_scalar,
+    )
+
+    if compute_dgram:
+        assert dgram_weight.grad is not None
+        torch.testing.assert_close(
+            actual_dgram, dgram_weight.grad, rtol=5e-4, atol=5e-4
+        )
+    else:
+        assert actual_dgram is None
+    if compute_scalar:
+        assert scalar_weight.grad is not None
+        torch.testing.assert_close(
+            actual_scalar, scalar_weight.grad, rtol=5e-4, atol=5e-4
+        )
+    else:
+        assert actual_scalar is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_tf32_matches_eager(monkeypatch):
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", True)
+    n_token = 384
+    torch.manual_seed(71)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+    dgram_weight = torch.randn(64, 39, device="cuda", requires_grad=True)
+    scalar_weight = torch.randn(64, 5, device="cuda", requires_grad=True)
+    expected = template_coordinate_projection_reference(
+        torch.zeros_like(upstream),
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=32,
+    )
+    (expected * upstream).sum().backward()
+    actual = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+    )
+
+    for actual_grad, expected_grad in zip(
+        actual, (dgram_weight.grad, scalar_weight.grad), strict=True
+    ):
+        relative_l2 = (actual_grad - expected_grad).norm() / expected_grad.norm()
+        relative_max = (
+            actual_grad - expected_grad
+        ).abs().max() / expected_grad.abs().max()
+        assert relative_l2 < 1e-3
+        assert relative_max < 1.5e-3
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_is_repeatable():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    n_token = 73
+    torch.manual_seed(67)
+    batch = _coordinate_batch(n_token, device="cuda")
+    args = (
+        torch.randn(1, n_token, n_token, 64, device="cuda"),
+        batch["template_pseudo_beta_coords"][:, 0].contiguous(),
+        batch["template_frame_atom_coords"][:, 0].contiguous(),
+        batch["template_pseudo_beta_mask"][:, 0].contiguous(),
+        batch["template_backbone_frame_mask"][:, 0].contiguous(),
+        batch["asym_id"].contiguous(),
+    )
+    first = template_coordinate_projection_backward(*args)
+    second = template_coordinate_projection_backward(*args)
+    for actual, expected in zip(first, second, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_preserves_open_bin_boundaries():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    distances = torch.tensor([0.0, 3.25, 4.0, 4.5, 50.75, 60.0], device="cuda")
+    n_token = len(distances)
+    pseudo_beta = torch.zeros(1, n_token, 3, device="cuda")
+    pseudo_beta[0, :, 0] = distances
+    _, frame_cpu = _coordinates(n_token)
+    frame = frame_cpu.cuda()
+    mask = torch.ones(1, n_token, device="cuda")
+    asym = torch.ones(1, n_token, dtype=torch.int32, device="cuda")
+    upstream = torch.zeros(1, n_token, n_token, 64, device="cuda")
+    upstream[0, 0, :, 0] = 1
+
+    grad_dgram, grad_scalar = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        mask,
+        mask,
+        asym,
+        compute_scalar=False,
+    )
+    assert grad_scalar is None
+    expected = torch.zeros(64, 39, device="cuda")
+    expected[0, 0] = 1
+    expected[0, 38] = 1
+    torch.testing.assert_close(grad_dgram, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_bfloat16_autocast_uses_triton(monkeypatch):
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+    n_token = 8
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().train()
+    batch = _coordinate_batch(n_token, device="cuda")
+    z = torch.randn(1, n_token, n_token, 128, device="cuda", requires_grad=True)
+
+    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        actual = fused_template_coordinate_pair_embedder(module, batch, z, 0)
+        assert actual.dtype == torch.bfloat16
+        assert (
+            "_TemplateCoordinateProjectionFunctionBackward"
+            in type(actual.grad_fn.next_functions[0][0]).__name__
+        )
+        actual.float().square().mean().backward()
+
+    assert z.grad is not None and torch.isfinite(z.grad).all()
+    assert module.dgram_linear.weight.grad is not None
+    assert torch.isfinite(module.dgram_linear.weight.grad).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_bf16_matches_fp32_eager_oracle(monkeypatch):
+    """bf16 Triton fp32-accumulate vs fp32 eager rounded through bf16."""
+    from openfold3.core.model.primitives.fused_template_coordinate import (
+        _TemplateCoordinateProjectionFunction,
+        template_coordinate_projection_reference,
+    )
+
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    n_token = 17
+    torch.manual_seed(37)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pb = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    dgram_weight = torch.randn(64, 39, device="cuda")
+    scalar_weight = torch.randn(64, 5, device="cuda")
+    source_bf16 = torch.randn(
+        1, n_token, n_token, 64, device="cuda", dtype=torch.bfloat16
+    )
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+
+    dgram_ref = dgram_weight.detach().clone().requires_grad_(True)
+    scalar_ref = scalar_weight.detach().clone().requires_grad_(True)
+    source_ref = source_bf16.float().clone().requires_grad_(True)
+    # Cast through bf16 so both paths see the same quantized output grad.
+    reference = template_coordinate_projection_reference(
+        source_ref, pb, frame, pb_mask, bb_mask, asym, dgram_ref, scalar_ref
+    ).to(torch.bfloat16)
+    (reference.float() * upstream).sum().backward()
+
+    dgram_act = dgram_weight.detach().clone().requires_grad_(True)
+    scalar_act = scalar_weight.detach().clone().requires_grad_(True)
+    source_act = source_bf16.detach().clone().requires_grad_(True)
+    actual = _TemplateCoordinateProjectionFunction.apply(
+        source_act, pb, frame, pb_mask, bb_mask, asym, dgram_act, scalar_act
+    )
+    (actual.float() * upstream).sum().backward()
+
+    torch.testing.assert_close(actual, reference, rtol=5e-4, atol=5e-4)
+    torch.testing.assert_close(
+        source_act.grad, source_ref.grad.to(torch.bfloat16), rtol=5e-4, atol=5e-4
+    )
+    torch.testing.assert_close(dgram_act.grad, dgram_ref.grad, rtol=5e-4, atol=5e-4)
+    torch.testing.assert_close(scalar_act.grad, scalar_ref.grad, rtol=5e-4, atol=5e-4)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("n_token", [8, 31, 64, 96])
 def test_coordinate_triton_matches_chunked_reference(n_token: int):
     from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
         template_coordinate_projection_add_,
     )
 
@@ -207,33 +639,80 @@ def test_coordinate_triton_matches_chunked_reference(n_token: int):
     torch.manual_seed(12)
     dgram_weight = torch.randn(64, 39, device="cuda")
     scalar_weight = torch.randn(64, 5, device="cuda")
-    expected = torch.randn(1, n_token, n_token, 64, device="cuda")
-    actual = expected.clone()
+    source = torch.randn(1, n_token, n_token, 64, device="cuda")
+    source_before = source.clone()
+    expected = source.clone()
 
-    template_coordinate_projection_add_reference_(
-        expected,
-        pseudo_beta,
-        frame,
-        pb_mask,
-        bb_mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-        chunk_rows=7,
-    )
-    template_coordinate_projection_add_(
-        actual,
-        pseudo_beta,
-        frame,
-        pb_mask,
-        bb_mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-    )
+    with torch.no_grad():
+        template_coordinate_projection_add_reference_(
+            expected,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+            chunk_rows=7,
+        )
+        actual_inplace = source.clone()
+        template_coordinate_projection_add_(
+            actual_inplace,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
+        actual_fresh = template_coordinate_projection(
+            source,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
     torch.cuda.synchronize()
 
-    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(source, source_before, rtol=0, atol=0)
+    torch.testing.assert_close(actual_inplace, expected, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(actual_fresh, expected, rtol=2e-4, atol=3e-4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_inplace_launcher_rejects_grad_mode():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
+        template_coordinate_projection_add_,
+    )
+
+    n_token = 4
+    batch = _coordinate_batch(n_token, device="cuda")
+    source = torch.zeros(1, n_token, n_token, 64, device="cuda")
+    args = (
+        batch["template_pseudo_beta_coords"][:, 0],
+        batch["template_frame_atom_coords"][:, 0],
+        batch["template_pseudo_beta_mask"][:, 0],
+        batch["template_backbone_frame_mask"][:, 0],
+        batch["asym_id"],
+        torch.randn(64, 39, device="cuda"),
+        torch.randn(64, 5, device="cuda"),
+    )
+    with pytest.raises(RuntimeError, match="disabled grad mode"):
+        template_coordinate_projection_add_(source, *args)
+    with pytest.raises(RuntimeError, match="not autograd-aware"):
+        template_coordinate_projection(
+            source, *args, out=torch.empty_like(source, requires_grad=True)
+        )
+    overlapping_out = torch.empty(1, n_token, n_token, 1, device="cuda").expand_as(
+        source
+    )
+    with torch.no_grad(), pytest.raises(ValueError, match="overlap internally"):
+        template_coordinate_projection(source, *args, out=overlapping_out)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -258,23 +737,24 @@ def test_coordinate_kernel_preserves_open_bin_boundaries():
     scalar_weight = torch.zeros(64, 5, device="cuda")
     actual = torch.zeros(1, n_token, n_token, 64, device="cuda")
 
-    template_coordinate_projection_add_(
-        actual,
-        pseudo_beta,
-        frame,
-        mask,
-        mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-    )
+    with torch.no_grad():
+        template_coordinate_projection_add_(
+            actual,
+            pseudo_beta,
+            frame,
+            mask,
+            mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
     expected_from_origin = torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 39.0], device="cuda")
     torch.testing.assert_close(actual[0, 0, :, 0], expected_from_origin, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_template_coordinate_compile_reuse_across_lengths():
-    """One filesystem compile must serve every sequence length."""
+    """One filesystem compile per math mode must serve every sequence length."""
     script = r"""
 import json
 import os
@@ -284,7 +764,11 @@ import torch
 
 from openfold3.core.kernels.triton.fused_template_coordinate import (
     _template_coordinate_projection_kernel,
+    _template_coordinate_projection_bwd_partial_kernel,
+    _template_coordinate_projection_bwd_reduce_kernel,
+    template_coordinate_projection,
     template_coordinate_projection_add_,
+    template_coordinate_projection_backward,
 )
 
 cache_dir = os.environ["TRITON_CACHE_DIR"]
@@ -292,29 +776,63 @@ Path(cache_dir).mkdir(parents=True, exist_ok=True)
 
 def clear():
     _template_coordinate_projection_kernel.device_caches.clear()
+    _template_coordinate_projection_bwd_partial_kernel.device_caches.clear()
+    _template_coordinate_projection_bwd_reduce_kernel.device_caches.clear()
 
 def count():
-    return len(list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json")))
+    return {
+        "forward": len(
+            list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json"))
+        ),
+        "backward_partial": len(
+            list(
+                Path(cache_dir).rglob(
+                    "_template_coordinate_projection_bwd_partial_kernel.json"
+                )
+            )
+        ),
+        "backward_reduce": len(
+            list(
+                Path(cache_dir).rglob(
+                    "_template_coordinate_projection_bwd_reduce_kernel.json"
+                )
+            )
+        ),
+    }
 
 torch.set_grad_enabled(False)
 w_dgram = torch.randn(64, 39, device="cuda")
 w_scalar = torch.randn(64, 5, device="cuda")
-for n in (16, 32, 48, 64, 96):
-    out = torch.zeros(1, n, n, 64, device="cuda")
-    template_coordinate_projection_add_(
-        out,
-        torch.randn(1, n, 3, device="cuda"),
-        torch.randn(1, n, 3, 3, device="cuda"),
-        torch.ones(1, n, device="cuda"),
-        torch.ones(1, n, device="cuda"),
-        torch.ones(1, n, dtype=torch.int32, device="cuda"),
-        w_dgram,
-        w_scalar,
-    )
-    clear()
+for allow_tf32 in (False, True):
+    torch.backends.cuda.matmul.allow_tf32 = allow_tf32
+    for n in (16, 32, 48, 64, 96):
+        source = torch.zeros(1, n, n, 64, device="cuda")
+        args = (
+            torch.randn(1, n, 3, device="cuda"),
+            torch.randn(1, n, 3, 3, device="cuda"),
+            torch.ones(1, n, device="cuda"),
+            torch.ones(1, n, device="cuda"),
+            torch.ones(1, n, dtype=torch.int32, device="cuda"),
+            w_dgram,
+            w_scalar,
+        )
+        if n % 32:
+            template_coordinate_projection(source, *args)
+        else:
+            template_coordinate_projection_add_(source, *args)
+        grad_output = torch.randn_like(source)
+        if n % 32:
+            grad_output = grad_output.transpose(1, 2)
+        template_coordinate_projection_backward(grad_output, *args[:5])
+        clear()
 
-print(json.dumps({"count": count()}))
-assert count() == 1, count()
+counts = count()
+print(json.dumps({"counts": counts}))
+assert counts == {
+    "forward": 1,
+    "backward_partial": 2,
+    "backward_reduce": 1,
+}, counts
 """
     with tempfile.TemporaryDirectory() as cache_dir:
         env = os.environ.copy()
@@ -327,4 +845,4 @@ assert count() == 1, count()
             capture_output=True,
             text=True,
         )
-        assert '"count": 1' in result.stdout
+        assert '"backward_partial": 2' in result.stdout

--- a/openfold3/tests/test_fused_template_coordinate_embed.py
+++ b/openfold3/tests/test_fused_template_coordinate_embed.py
@@ -1,0 +1,330 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from openfold3.core.data.primitives.featurization.template import (
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.core.model.feature_embedders.template_embedders import (
+    TemplatePairEmbedderAllAtom,
+)
+from openfold3.core.model.primitives.fused_template_coordinate import (
+    fused_template_coordinate_pair_embedder_inference,
+    template_coordinate_projection_add_reference_,
+)
+from openfold3.projects.of3_all_atom.config.dataset_config_components import (
+    TemplateSettings,
+)
+
+
+def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Tensor]:
+    index = torch.arange(n_token, dtype=torch.float32)
+    templates = []
+    frames = []
+    for t in range(n_templ):
+        offset = 0.4 * t
+        ca = torch.stack(
+            (index * 3.8, torch.sin(index * 0.3 + offset), torch.cos(index * 0.2 + offset)),
+            dim=-1,
+        )
+        pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
+        n_atom = ca + torch.tensor([-0.7, 1.1, 0.2])
+        c_atom = ca + torch.tensor([1.3, 0.2, -0.1])
+        templates.append(pseudo_beta)
+        frames.append(torch.stack((n_atom, ca, c_atom), dim=-2))
+    return torch.stack(templates, dim=0), torch.stack(frames, dim=0)
+
+
+def _coordinate_batch(
+    n_token: int, device: str = "cpu", n_templ: int = 1
+) -> dict:
+    pseudo_beta, frame = _coordinates(n_token, n_templ=n_templ)
+    restype = torch.nn.functional.one_hot(
+        torch.arange(n_token) % 32, num_classes=32
+    ).to(torch.int32)
+    batch = {
+        "template_pseudo_beta_coords": pseudo_beta[None].to(device),
+        "template_frame_atom_coords": frame[None].to(device),
+        "template_pseudo_beta_mask": torch.ones(1, n_templ, n_token, device=device),
+        "template_backbone_frame_mask": torch.ones(1, n_templ, n_token, device=device),
+        "template_restype": restype[None, None].expand(1, n_templ, -1, -1).contiguous().to(
+            device
+        ),
+        "asym_id": torch.cat(
+            (
+                torch.ones(n_token // 2, dtype=torch.int32),
+                torch.full((n_token - n_token // 2,), 2, dtype=torch.int32),
+            )
+        )[None].to(device),
+    }
+    if n_token > 3:
+        batch["template_pseudo_beta_mask"][:, :, 1] = 0
+        batch["template_backbone_frame_mask"][:, :, 2] = 0
+    return batch
+
+
+def _precomputed_batch(coordinate_batch: dict) -> dict:
+    pseudo_beta = coordinate_batch["template_pseudo_beta_coords"][0].cpu().numpy()
+    frame = coordinate_batch["template_frame_atom_coords"][0].cpu().numpy()
+    pb_mask = coordinate_batch["template_pseudo_beta_mask"][0].cpu()
+    bb_mask = coordinate_batch["template_backbone_frame_mask"][0].cpu()
+    asym = coordinate_batch["asym_id"][0].cpu()
+    # create_template_* expects [n_templ, N, ...] coords and a broadcastable
+    # multichain mask over the template axis.
+    multichain = (asym[:, None] == asym[None, :])[None, ..., None]
+    return {
+        "template_distogram": create_template_distogram(
+            pseudo_beta, pb_mask, multichain
+        )[None],
+        "template_unit_vector": create_template_unit_vector(
+            frame, bb_mask, multichain
+        )[None],
+        "template_pseudo_beta_mask": coordinate_batch[
+            "template_pseudo_beta_mask"
+        ].cpu(),
+        "template_backbone_frame_mask": coordinate_batch[
+            "template_backbone_frame_mask"
+        ].cpu(),
+        "template_restype": coordinate_batch["template_restype"].cpu(),
+        "asym_id": coordinate_batch["asym_id"].cpu(),
+    }
+
+
+@pytest.mark.parametrize("n_token", [8, 17, 31])
+def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
+    torch.manual_seed(7)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).eval()
+    coordinate_batch = _coordinate_batch(n_token)
+    precomputed_batch = _precomputed_batch(coordinate_batch)
+    z = torch.randn(1, n_token, n_token, 128)
+
+    with torch.inference_mode():
+        expected = module(precomputed_batch, z.clone())
+        actual = fused_template_coordinate_pair_embedder_inference(
+            module=module,
+            batch=coordinate_batch,
+            z=z.clone(),
+            template_index=0,
+        )
+
+    assert not {
+        "template_distogram",
+        "template_unit_vector",
+    }.intersection(coordinate_batch)
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+
+
+@pytest.mark.parametrize("n_token,n_templ", [(8, 2), (17, 3)])
+def test_template_embedder_coordinate_matches_precomputed(
+    n_token: int, n_templ: int
+):
+    """Full TemplateEmbedderAllAtom path: coords vs precomputed distogram/UV."""
+    from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
+    from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
+
+    torch.manual_seed(11)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    embedder = TemplateEmbedderAllAtom(of3_config.architecture.template).eval()
+    c_z = of3_config.architecture.template.template_pair_embedder.c_in
+
+    coordinate_batch = _coordinate_batch(n_token, n_templ=n_templ)
+    precomputed_batch = _precomputed_batch(coordinate_batch)
+    # Restype for the pair embedder is float one-hot in the streaming tests.
+    coordinate_batch["template_restype"] = coordinate_batch["template_restype"].float()
+    precomputed_batch["template_restype"] = precomputed_batch["template_restype"].float()
+
+    z = torch.randn(1, n_token, n_token, c_z)
+    pair_mask = torch.ones(1, n_token, n_token)
+
+    with torch.inference_mode():
+        expected = embedder(
+            batch=precomputed_batch,
+            z=z.clone(),
+            pair_mask=pair_mask,
+            chunk_size=4,
+            inplace_safe=True,
+        )
+        actual = embedder(
+            batch=coordinate_batch,
+            z=z.clone(),
+            pair_mask=pair_mask,
+            chunk_size=4,
+            inplace_safe=True,
+        )
+
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+
+
+def test_coordinate_embedding_rejects_training():
+    n_token = 8
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    batch = _coordinate_batch(n_token)
+    z = torch.randn(1, n_token, n_token, 128)
+
+    with torch.no_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        fused_template_coordinate_pair_embedder_inference(
+            module=module,
+            batch=batch,
+            z=z,
+            template_index=0,
+        )
+
+
+def test_coordinate_features_reject_nondefault_distogram_settings():
+    with pytest.raises(ValueError, match="default"):
+        TemplateSettings(
+            use_coordinate_pair_features=True,
+            distogram={"min_bin": 2.0, "max_bin": 50.75, "n_bins": 39},
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_token", [8, 31, 64, 96])
+def test_coordinate_triton_matches_chunked_reference(n_token: int):
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    torch.manual_seed(12)
+    dgram_weight = torch.randn(64, 39, device="cuda")
+    scalar_weight = torch.randn(64, 5, device="cuda")
+    expected = torch.randn(1, n_token, n_token, 64, device="cuda")
+    actual = expected.clone()
+
+    template_coordinate_projection_add_reference_(
+        expected,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=7,
+    )
+    template_coordinate_projection_add_(
+        actual,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=3e-4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_kernel_preserves_open_bin_boundaries():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    distances = torch.tensor([0.0, 3.25, 4.0, 4.5, 50.75, 60.0], device="cuda")
+    n_token = len(distances)
+    pseudo_beta = torch.zeros(1, n_token, 3, device="cuda")
+    pseudo_beta[0, :, 0] = distances
+    _, frame_cpu = _coordinates(n_token)
+    frame = frame_cpu.cuda()
+    mask = torch.ones(1, n_token, device="cuda")
+    asym = torch.ones(1, n_token, dtype=torch.int32, device="cuda")
+    dgram_weight = (
+        torch.arange(1, 40, device="cuda", dtype=torch.float32)[None]
+        .expand(64, -1)
+        .contiguous()
+    )
+    scalar_weight = torch.zeros(64, 5, device="cuda")
+    actual = torch.zeros(1, n_token, n_token, 64, device="cuda")
+
+    template_coordinate_projection_add_(
+        actual,
+        pseudo_beta,
+        frame,
+        mask,
+        mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+    )
+    expected_from_origin = torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 39.0], device="cuda")
+    torch.testing.assert_close(actual[0, 0, :, 0], expected_from_origin, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_template_coordinate_compile_reuse_across_lengths():
+    """One filesystem compile must serve every sequence length."""
+    script = r"""
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from openfold3.core.kernels.triton.fused_template_coordinate import (
+    _template_coordinate_projection_kernel,
+    template_coordinate_projection_add_,
+)
+
+cache_dir = os.environ["TRITON_CACHE_DIR"]
+Path(cache_dir).mkdir(parents=True, exist_ok=True)
+
+def clear():
+    _template_coordinate_projection_kernel.device_caches.clear()
+
+def count():
+    return len(list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json")))
+
+torch.set_grad_enabled(False)
+w_dgram = torch.randn(64, 39, device="cuda")
+w_scalar = torch.randn(64, 5, device="cuda")
+for n in (16, 32, 48, 64, 96):
+    out = torch.zeros(1, n, n, 64, device="cuda")
+    template_coordinate_projection_add_(
+        out,
+        torch.randn(1, n, 3, device="cuda"),
+        torch.randn(1, n, 3, 3, device="cuda"),
+        torch.ones(1, n, device="cuda"),
+        torch.ones(1, n, device="cuda"),
+        torch.ones(1, n, dtype=torch.int32, device="cuda"),
+        w_dgram,
+        w_scalar,
+    )
+    clear()
+
+print(json.dumps({"count": count()}))
+assert count() == 1, count()
+"""
+    with tempfile.TemporaryDirectory() as cache_dir:
+        env = os.environ.copy()
+        env["TRITON_CACHE_DIR"] = cache_dir
+        env["OPENFOLD3_FUSED_TEMPLATE_COORD"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert '"count": 1' in result.stdout

--- a/openfold3/tests/test_heads.py
+++ b/openfold3/tests/test_heads.py
@@ -412,6 +412,47 @@ class TestAuxiliaryHeadsAllAtom(unittest.TestCase):
             aux_out["experimentally_resolved_logits"].shape, expected_shape_exp_res
         )
 
+    def test_releases_trunk_pair_after_confidence_clone(self):
+        batch_size = consts.batch_size
+        n_token = consts.n_res
+        n_msa = 10
+        n_templ = 3
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        batch = random_of3_features(
+            batch_size=batch_size, n_token=n_token, n_msa=n_msa, n_templ=n_templ
+        )
+        n_atom = torch.max(batch["num_atoms_per_token"].sum(dim=-1)).int().item()
+
+        heads_config = config.architecture.heads
+        heads_config.pae.enabled = True
+        aux_head = AuxiliaryHeadsAllAtom(heads_config).eval()
+        initialize_model_weights(aux_head)
+
+        outputs = {
+            "si_trunk": torch.ones(
+                batch_size, n_token, config.architecture.shared.c_s
+            ),
+            "zij_trunk": torch.ones(
+                batch_size, n_token, n_token, config.architecture.shared.c_z
+            ),
+            "atom_positions_predicted": torch.randn(batch_size, n_atom, 3),
+        }
+
+        with torch.inference_mode():
+            aux_head(
+                batch,
+                torch.ones(
+                    batch_size, n_token, config.architecture.shared.c_s_input
+                ),
+                outputs,
+                use_zij_trunk_embedding=True,
+                chunk_size=4,
+            )
+
+        self.assertNotIn("zij_trunk", outputs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -415,3 +415,36 @@ class TestUtils(unittest.TestCase):
         self.assertNotEqual(
             first, second, "Chunk size should have been re-tuned for new arg count"
         )
+
+    def test_chunk_size_tuner_reuses_prior_shape_after_other_shapes(self):
+        tuner = ChunkSizeTuner()
+        calls = []
+
+        def fn(t, chunk_size):
+            calls.append(t.shape[-1])
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        a = (torch.zeros(2, 3, 16),)
+        b = (torch.zeros(2, 3, 128),)
+        first = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+        tuner.tune_chunk_size(fn, b, max_chunk_size=256)
+        tune_calls = len(calls)
+        reused = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+
+        self.assertEqual(reused, first)
+        self.assertEqual(len(calls), tune_calls)
+
+    def test_chunk_size_tuner_caches_max_chunk_size_separately(self):
+        tuner = ChunkSizeTuner()
+
+        def fn(t, chunk_size):
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        args = (torch.zeros(2, 3, 64),)
+        small = tuner.tune_chunk_size(fn, args, max_chunk_size=32)
+        large = tuner.tune_chunk_size(fn, args, max_chunk_size=256)
+        self.assertEqual(small, 32)
+        self.assertEqual(large, 64)
+        self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -13,12 +13,23 @@
 # limitations under the License.
 
 import math
+import os
 import unittest
 
 import torch
 
 from openfold3.core.model.primitives import Linear
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner, _chunk_slice, chunk_layer
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    _chunk_slice,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+    chunk_layer,
+    transition_chunk_cap,
+    triangle_attn_chunk_cap,
+    trimul_chunk_cap,
+    use_chunked_trimul,
+)
 from openfold3.core.utils.rigid_utils import (
     Rigid,
     Rotation,
@@ -448,3 +459,79 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(small, 32)
         self.assertEqual(large, 64)
         self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)
+
+    def test_triangle_attn_chunk_cap_env(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(triangle_attn_chunk_cap())
+
+            os.environ[key] = "64"
+            self.assertEqual(triangle_attn_chunk_cap(), 64)
+
+            os.environ[key] = "bad"
+            self.assertIsNone(triangle_attn_chunk_cap())
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_apply_triangle_attn_chunk_cap(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ[key] = "128"
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 128
+            )
+            # Cap cannot shrink the working set when N already fits.
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=76), 1024
+            )
+            os.environ.pop(key, None)
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 1024
+            )
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_trimul_chunk_cap_selects_chunked_eager_path(self):
+        key = "OPENFOLD3_TRIMUL_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(trimul_chunk_cap())
+            self.assertFalse(use_chunked_trimul(inplace_safe=True))
+
+            os.environ[key] = "128"
+            self.assertEqual(trimul_chunk_cap(), 128)
+            self.assertTrue(use_chunked_trimul(inplace_safe=True))
+            self.assertFalse(use_chunked_trim(inplace_safe=False))
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_transition_chunk_cap_env(self):
+        key = "OPENFOLD3_TRANSITION_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(transition_chunk_cap())
+            self.assertEqual(apply_transition_chunk_cap(1024), 1024)
+
+            os.environ[key] = "128"
+            self.assertEqual(transition_chunk_cap(), 128)
+            self.assertEqual(apply_transition_chunk_cap(1024), 128)
+            self.assertEqual(apply_transition_chunk_cap(64), 64)
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old

--- a/scripts/dev/bench_atom_transforms.py
+++ b/scripts/dev/bench_atom_transforms.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Microbenchmark atom broadcast/aggregation paths."""
+
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.utils.atomize_utils import (  # noqa: E402
+    aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
+    broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
+)
+
+
+def time_ms(fn, reps=100):
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) * 1000 / reps
+
+
+def main():
+    n_token, samples = 1264, 5
+    gen = torch.Generator().manual_seed(42)
+    lengths = torch.randint(4, 13, (1, n_token), generator=gen)
+    atom_index = torch.repeat_interleave(torch.arange(n_token), lengths[0])
+    n_atom = atom_index.numel()
+    lengths = lengths[:, None].cuda()
+    atom_index = atom_index.reshape(1, 1, n_atom).cuda()
+    token_mask = torch.ones(1, 1, n_token, device="cuda")
+    atom_mask = torch.ones(1, 1, n_atom, device="cuda")
+    token_feat = torch.randn(1, samples, n_token, 128, device="cuda")
+    atom_feat = torch.randn(1, samples, n_atom, 128, device="cuda")
+
+    def dynamic():
+        return broadcast_token_feat_to_atoms(token_mask, lengths, token_feat, -2)
+
+    def indexed():
+        return broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+
+    def atomic():
+        return aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+
+    def segmented():
+        return aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+
+    torch.testing.assert_close(indexed(), dynamic())
+    torch.testing.assert_close(segmented(), atomic(), rtol=1e-5, atol=1e-6)
+
+    d, i, a, s = (time_ms(fn) for fn in (dynamic, indexed, atomic, segmented))
+    print(torch.cuda.get_device_name())
+    print(f"broadcast {d:.3f}->{i:.3f} ms | aggregate {a:.3f}->{s:.3f} ms")
+    print(f"combined {(2 * d + a) / (2 * i + s):.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/bench_fused_template_coordinate_embed.py
+++ b/scripts/dev/bench_fused_template_coordinate_embed.py
@@ -117,7 +117,7 @@ def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
         TemplatePairEmbedderAllAtom,
     )
     from openfold3.core.model.primitives.fused_template_coordinate import (
-        fused_template_coordinate_pair_embedder_inference,
+        fused_template_coordinate_pair_embedder,
     )
 
     torch.manual_seed(0)
@@ -131,7 +131,7 @@ def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
         return module(precomputed_gpu, z)
 
     def coordinate_compute():
-        return fused_template_coordinate_pair_embedder_inference(
+        return fused_template_coordinate_pair_embedder(
             module, coordinate_gpu, z, template_index=0
         )
 

--- a/scripts/dev/bench_fused_template_coordinate_embed.py
+++ b/scripts/dev/bench_fused_template_coordinate_embed.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""Benchmark precomputed versus coordinate-derived template embedding.
+
+Sweeps several sequence lengths. Host payload and peak transient above the
+baseline allocation are reported in bytes and U (= N² × 128 × 4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+from openfold3.core.data.primitives.featurization.template import (
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+
+def _coordinates(n_token: int) -> tuple[torch.Tensor, torch.Tensor]:
+    index = torch.arange(n_token, dtype=torch.float32)
+    ca = torch.stack(
+        (index * 3.8, torch.sin(index * 0.03), torch.cos(index * 0.02)), dim=-1
+    )
+    pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
+    frame = torch.stack(
+        (
+            ca + torch.tensor([-0.7, 1.1, 0.2]),
+            ca,
+            ca + torch.tensor([1.3, 0.2, -0.1]),
+        ),
+        dim=-2,
+    )
+    return pseudo_beta, frame
+
+
+def _make_cpu_batches(n_token: int) -> tuple[dict, dict]:
+    pseudo_beta, frame = _coordinates(n_token)
+    mask = torch.ones(n_token)
+    asym = torch.ones(1, n_token, dtype=torch.int32)
+    restype = F.one_hot(torch.arange(n_token) % 32, num_classes=32).to(torch.int32)
+
+    template_mask = mask[None]
+    pair_mask = torch.ones(1, n_token, n_token, 1)
+    dgram = create_template_distogram(
+        pseudo_beta[None].numpy(), template_mask, pair_mask
+    )
+    unit = create_template_unit_vector(frame[None].numpy(), template_mask, pair_mask)
+
+    common = {
+        "template_restype": restype[None, None],
+        "template_pseudo_beta_mask": mask[None, None],
+        "template_backbone_frame_mask": mask[None, None],
+        "asym_id": asym,
+    }
+    precomputed = {
+        **common,
+        "template_distogram": dgram[None],
+        "template_unit_vector": unit[None],
+    }
+    coordinate = {
+        **common,
+        "template_pseudo_beta_coords": pseudo_beta[None, None],
+        "template_frame_atom_coords": frame[None, None],
+    }
+    return precomputed, coordinate
+
+
+def _to_cuda(batch: dict) -> dict:
+    return {
+        key: value.to("cuda", non_blocking=True)
+        if isinstance(value, torch.Tensor)
+        else value
+        for key, value in batch.items()
+    }
+
+
+def _payload_bytes(batch: dict) -> int:
+    return sum(
+        value.numel() * value.element_size()
+        for key, value in batch.items()
+        if key.startswith("template_")
+    )
+
+
+def _measure(fn, warmups: int, reps: int) -> tuple[float, int]:
+    for _ in range(warmups):
+        out = fn()
+        del out
+    torch.cuda.synchronize()
+
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    out = fn()
+    torch.cuda.synchronize()
+    transient = torch.cuda.max_memory_allocated() - baseline
+    del out
+
+    samples = []
+    for _ in range(reps):
+        start = time.perf_counter()
+        out = fn()
+        torch.cuda.synchronize()
+        samples.append((time.perf_counter() - start) * 1000)
+        del out
+    samples.sort()
+    return samples[len(samples) // 2], transient
+
+
+def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
+    from openfold3.core.model.feature_embedders.template_embedders import (
+        TemplatePairEmbedderAllAtom,
+    )
+    from openfold3.core.model.primitives.fused_template_coordinate import (
+        fused_template_coordinate_pair_embedder_inference,
+    )
+
+    torch.manual_seed(0)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().eval()
+    precomputed_cpu, coordinate_cpu = _make_cpu_batches(n_token)
+    precomputed_gpu = _to_cuda(precomputed_cpu)
+    coordinate_gpu = _to_cuda(coordinate_cpu)
+    z = torch.randn(1, n_token, n_token, 128, device="cuda")
+
+    def legacy_compute():
+        return module(precomputed_gpu, z)
+
+    def coordinate_compute():
+        return fused_template_coordinate_pair_embedder_inference(
+            module, coordinate_gpu, z, template_index=0
+        )
+
+    rows = {}
+    with torch.inference_mode():
+        # Warm the Triton cache once at this length before measuring.
+        coordinate_compute()
+        torch.cuda.synchronize()
+        for name, fn in (
+            ("legacy_compute", legacy_compute),
+            ("coordinate_compute", coordinate_compute),
+        ):
+            median_ms, transient = _measure(fn, warmups, reps)
+            rows[name] = {
+                "median_ms": median_ms,
+                "peak_transient_bytes": transient,
+            }
+
+    u_bytes = n_token * n_token * 128 * 4
+    result = {
+        "n_token": n_token,
+        "U_bytes": u_bytes,
+        "legacy_host_bytes": _payload_bytes(precomputed_cpu),
+        "coordinate_host_bytes": _payload_bytes(coordinate_cpu),
+        "host_reduction": (
+            _payload_bytes(precomputed_cpu) / max(_payload_bytes(coordinate_cpu), 1)
+        ),
+        **rows,
+    }
+    for value in rows.values():
+        value["peak_transient_U"] = value["peak_transient_bytes"] / u_bytes
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, nargs="+", default=[128, 384, 590, 1264])
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--reps", type=int, default=10)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    _torch_gpu_setup()
+
+    rows = []
+    for n_token in args.n:
+        row = _bench_length(n_token, args.warmups, args.reps)
+        rows.append(row)
+        print(json.dumps(row, indent=2))
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_determinism.py
+++ b/scripts/dev/check_determinism.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""Factorial repeatability check for foundation changes.
+
+Compares the impact of:
+1) per-datapoint feature seeding in InferenceDataset
+2) segmented atom aggregation in inference mode
+
+Each cell runs two retrievals/forwards with deliberate global RNG pollution
+between them and checks bitwise equality of input features and model outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import InferenceExperimentRunner  # noqa: E402
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+
+FEATURE_KEYS = (
+    "ref_pos",
+    "ref_mask",
+    "ref_element",
+    "ref_charge",
+    "ref_atom_name_chars",
+    "ref_space_uid",
+    "msa",
+    "msa_mask",
+)
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+)
+
+
+@dataclass(frozen=True)
+class PatchState:
+    feature_seeding: bool
+    segmented_atom_agg: bool
+
+    @property
+    def name(self) -> str:
+        feat = "seeded_features" if self.feature_seeding else "upstream_features"
+        agg = "segmented_agg" if self.segmented_atom_agg else "scatter_agg"
+        return f"{feat}+{agg}"
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def pollute_rng() -> None:
+    for _ in range(512):
+        random.random()
+    np.random.randn(16)
+    torch.randn(16)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def compare_tensor_dict(
+    first: dict[str, torch.Tensor], second: dict[str, torch.Tensor]
+) -> tuple[int, int, list[str]]:
+    keys = sorted(set(first) & set(second))
+    equal = 0
+    mismatches: list[str] = []
+    for key in keys:
+        a, b = first[key], second[key]
+        if a.shape != b.shape or a.dtype != b.dtype:
+            mismatches.append(f"{key}: shape/dtype differ")
+            continue
+        if torch.equal(a, b):
+            equal += 1
+        else:
+            max_diff = (a.float() - b.float()).abs().max().item()
+            mismatches.append(f"{key}: max_abs_diff={max_diff:.6g}")
+    return equal, len(keys), mismatches
+
+
+def apply_patches(state: PatchState) -> None:
+    import openfold3.core.data.framework.single_datasets.inference as inference_mod
+    import openfold3.core.model.layers.sequence_local_atom_attention as atom_attention
+
+    if not hasattr(inference_mod, "_CHECK_ORIGINAL_GETITEM"):
+        inference_mod._CHECK_ORIGINAL_GETITEM = inference_mod.InferenceDataset.__getitem__
+
+    original_getitem = inference_mod._CHECK_ORIGINAL_GETITEM
+
+    if state.feature_seeding:
+
+        def getitem(self, index):
+            return original_getitem(self, index)
+
+    else:
+
+        def getitem(self, index):
+            datapoint = self.datapoint_cache.iloc[index]
+            query_id = datapoint["query_id"]
+            query = self.query_cache[query_id]
+            seed = datapoint["seed"]
+            is_repeated_sample = bool(datapoint["repeated_sample"])
+            try:
+                features = self.create_all_features(query)
+                features["query_id"] = query_id
+                features["seed"] = torch.tensor([seed])
+                features["repeated_sample"] = torch.tensor(
+                    [is_repeated_sample], dtype=torch.bool
+                )
+                features["valid_sample"] = torch.tensor([True], dtype=torch.bool)
+                return features
+            except Exception as exc:
+                import traceback
+
+                inference_mod.logger.warning(
+                    f"Failed to process {query_id}: {type(exc).__name__}\n"
+                    f"{traceback.format_exc()}"
+                )
+                return {
+                    "query_id": query_id,
+                    "repeated_sample": torch.tensor(
+                        [is_repeated_sample], dtype=torch.bool
+                    ),
+                    "valid_sample": torch.tensor([False], dtype=torch.bool),
+                }
+
+    inference_mod.InferenceDataset.__getitem__ = getitem
+
+    if not hasattr(atom_attention, "_CHECK_ORIGINAL_ENCODER_FORWARD"):
+        atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD = (
+            atom_attention.AtomAttentionEncoder.forward
+        )
+
+    original_encoder_forward = atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD
+
+    if state.segmented_atom_agg:
+        atom_attention.AtomAttentionEncoder.forward = original_encoder_forward
+    else:
+
+        def encoder_forward_with_scatter(self, *args, **kwargs):
+            was_training = self.training
+            self.training = True
+            try:
+                return original_encoder_forward(self, *args, **kwargs)
+            finally:
+                self.training = was_training
+
+        atom_attention.AtomAttentionEncoder.forward = encoder_forward_with_scatter
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to("cuda"), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def capture_features(batch: dict) -> dict[str, torch.Tensor]:
+    return {k: batch[k].detach().clone() for k in FEATURE_KEYS if k in batch}
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().clone()
+                break
+    return captured
+
+
+def run_forward(runner: InferenceExperimentRunner, batch: dict) -> dict:
+    module = runner.lightning_module.to("cuda").eval()
+    seed_everything(int(batch["seed"][0].item()))
+    with torch.inference_mode():
+        return module(batch)
+
+
+def check_configuration(
+    state: PatchState,
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> dict:
+    apply_patches(state)
+    runner = build_runner(query_json, runner_yaml, seed)
+
+    pollute_rng()
+    features_a = capture_features(get_batch(runner))
+
+    pollute_rng()
+    features_b = capture_features(get_batch(runner))
+
+    feat_equal, feat_total, feat_mismatches = compare_tensor_dict(
+        features_a, features_b
+    )
+
+    # Model repeats use the same batch and the same predict_step reseed contract.
+    pollute_rng()
+    seed_everything(seed)
+    batch = get_batch(runner)
+    outputs_a = capture_outputs(run_forward(runner, batch))
+
+    pollute_rng()
+    seed_everything(seed)
+    outputs_b = capture_outputs(run_forward(runner, batch))
+
+    out_equal, out_total, out_mismatches = compare_tensor_dict(outputs_a, outputs_b)
+
+    return {
+        "configuration": state.name,
+        "feature_seeding": state.feature_seeding,
+        "segmented_atom_agg": state.segmented_atom_agg,
+        "features": {
+            "bitwise_equal_keys": feat_equal,
+            "total_keys": feat_total,
+            "all_bitwise_equal": feat_equal == feat_total and not feat_mismatches,
+            "ref_pos_bitwise_equal": bool(
+                torch.equal(features_a["ref_pos"], features_b["ref_pos"])
+            ),
+            "mismatches": feat_mismatches,
+        },
+        "outputs": {
+            "bitwise_equal_keys": out_equal,
+            "total_keys": out_total,
+            "all_bitwise_equal": out_equal == out_total and not out_mismatches,
+            "atom_positions_predicted_bitwise_equal": bool(
+                torch.equal(
+                    outputs_a["atom_positions_predicted"],
+                    outputs_b["atom_positions_predicted"],
+                )
+            ),
+            "mismatches": out_mismatches,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query-json",
+        type=Path,
+        default=Path(
+            "examples/example_inference_inputs/query_single_protein_single_ligand.json"
+        ),
+    )
+    parser.add_argument(
+        "--runner-yaml",
+        type=Path,
+        default=Path("examples/example_runner_yamls/smoke_inference.yml"),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.use_deterministic_algorithms(False)
+
+    configs = [
+        PatchState(feature_seeding=False, segmented_atom_agg=False),
+        PatchState(feature_seeding=True, segmented_atom_agg=False),
+        PatchState(feature_seeding=False, segmented_atom_agg=True),
+        PatchState(feature_seeding=True, segmented_atom_agg=True),
+    ]
+
+    results = [
+        check_configuration(cfg, args.query_json, args.runner_yaml, args.seed)
+        for cfg in configs
+    ]
+    print(json.dumps(results, indent=2))
+
+    print(
+        textwrap.dedent(
+            f"""
+            Matrix (production math, seed={args.seed}):
+            - feature repeats: global RNG polluted before each featurization, no pre-seed
+            - output repeats: same batch, predict_step-style reseed before each forward
+
+            configuration                         | features equal | outputs equal
+            --------------------------------------|----------------|---------------
+            """
+        ).rstrip()
+    )
+    for row in results:
+        print(
+            f"{row['configuration']:<37} | "
+            f"{str(row['features']['all_bitwise_equal']):<14} | "
+            f"{str(row['outputs']['all_bitwise_equal'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_template_coordinate_parity.py
+++ b/scripts/dev/check_template_coordinate_parity.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+"""End-to-end parity: precomputed template pairs vs coordinate-derived features.
+
+Uses one loaded model. Builds the legacy distogram/unit-vector batch from the
+same compact coordinates so featurization cannot drift, then compares a
+deterministic forward of each representation.
+
+Synthetic module tests aim for ~1e-5 agreement. On real templates the online
+local-frame path (normalize/cross) differs from ``create_template_unit_vector``
+(Rigid/Vec3Array) by ~1e-6 per component, which can amplify through the trunk;
+structure coords should still stay within ``--atom-atol``.
+
+Example:
+  source scripts/activate_of3.sh
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 \\
+    python scripts/dev/check_template_coordinate_parity.py --query 7cnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.data.primitives.featurization.template import (  # noqa: E402
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_RUNNER = REPO / "data/inference_benchmark_msa_template/runner.yml"
+KNOWN_QUERIES = {
+    "7cnx": REPO / "data/inference_benchmark_msa_template/queries/7cnx.json",
+    "ubiquitin": REPO
+    / "data/inference_benchmark_msa_template/queries/ubiquitin.json",
+    "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
+}
+
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+    "pde_logits",
+    "distogram_logits",
+    "si_trunk",
+)
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured: dict[str, torch.Tensor] = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().float().cpu()
+                break
+    return captured
+
+
+def clone_batch(batch: dict) -> dict:
+    return {
+        key: (value.clone() if torch.is_tensor(value) else value)
+        for key, value in batch.items()
+    }
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = deepcopy(config_utils.load_yaml(runner_yaml))
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("experiment_settings", {})["use_templates"] = True
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    template_cfg = runner_args.setdefault("dataset_config_kwargs", {}).setdefault(
+        "template", {}
+    )
+    template_cfg["use_coordinate_pair_features"] = True
+
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=True,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(
+                lambda t: t.to("cuda") if torch.is_tensor(t) else t, batch
+            )
+    raise RuntimeError("No valid inference sample")
+
+
+def legacy_batch_from_coordinates(coord_batch: dict) -> dict:
+    """Materialize distogram/unit-vector features from compact coordinates."""
+    pseudo_beta = coord_batch["template_pseudo_beta_coords"][0].detach().cpu().numpy()
+    frame = coord_batch["template_frame_atom_coords"][0].detach().cpu().numpy()
+    pb_mask = coord_batch["template_pseudo_beta_mask"][0].detach().cpu()
+    bb_mask = coord_batch["template_backbone_frame_mask"][0].detach().cpu()
+    asym = coord_batch["asym_id"][0].detach().cpu()
+    multichain = (asym[:, None] == asym[None, :])[None, ..., None]
+
+    legacy = {
+        key: (value.clone() if torch.is_tensor(value) else value)
+        for key, value in coord_batch.items()
+        if key
+        not in ("template_pseudo_beta_coords", "template_frame_atom_coords")
+    }
+    legacy["template_distogram"] = create_template_distogram(
+        pseudo_beta, pb_mask, multichain
+    )[None].to(device=coord_batch["asym_id"].device)
+    legacy["template_unit_vector"] = create_template_unit_vector(
+        frame, bb_mask, multichain
+    )[None].to(device=coord_batch["asym_id"].device)
+    return legacy
+
+
+def run_forward(module, batch: dict, seed: int) -> dict:
+    seed_everything(seed)
+    with torch.inference_mode():
+        return module(clone_batch(batch))
+
+
+def summarize_diff(
+    legacy: dict[str, torch.Tensor], coordinate: dict[str, torch.Tensor]
+) -> dict:
+    report = {}
+    for key in OUTPUT_KEYS:
+        if key not in legacy or key not in coordinate:
+            report[key] = {"present": False}
+            continue
+        a, b = legacy[key], coordinate[key]
+        diff = (a - b).abs()
+        report[key] = {
+            "present": True,
+            "shape": list(a.shape),
+            "bitwise_equal": bool(torch.equal(a, b)),
+            "max_abs": float(diff.max().item()),
+            "mean_abs": float(diff.mean().item()),
+        }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query",
+        choices=sorted(KNOWN_QUERIES),
+        default="7cnx",
+        help="Benchmark query with real templates",
+    )
+    parser.add_argument("--query-json", type=Path, default=None)
+    parser.add_argument("--runner-yaml", type=Path, default=DEFAULT_RUNNER)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--atom-atol",
+        type=float,
+        default=2e-4,
+        help="Max abs diff allowed for atom_positions_predicted",
+    )
+    parser.add_argument(
+        "--logit-atol",
+        type=float,
+        default=5e-3,
+        help="Max abs diff allowed for confidence/distogram logits",
+    )
+    parser.add_argument(
+        "--trunk-atol",
+        type=float,
+        default=0.1,
+        help="Max abs diff allowed for si_trunk (amplifies UV FP noise)",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=REPO
+        / "data/inference_outputs/profiling/template_coordinate_e2e_parity.json",
+    )
+    parser.add_argument(
+        "--fused-template-coord",
+        choices=("1", "0"),
+        default="1",
+        help="OPENFOLD3_FUSED_TEMPLATE_COORD for the coordinate path",
+    )
+    args = parser.parse_args()
+
+    query_json = args.query_json or KNOWN_QUERIES[args.query]
+    if not query_json.exists():
+        raise FileNotFoundError(query_json)
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ["OPENFOLD3_FUSED_TEMPLATE_COORD"] = args.fused_template_coord
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    torch.use_deterministic_algorithms(True)
+
+    print(f"Loading coordinate batch + model for {query_json}...")
+    seed_everything(args.seed)
+    runner = build_runner(query_json, args.runner_yaml, args.seed)
+    seed_everything(args.seed)
+    coord_batch = get_batch(runner)
+    assert "template_pseudo_beta_coords" in coord_batch
+    assert "template_distogram" not in coord_batch
+    legacy_batch = legacy_batch_from_coordinates(coord_batch)
+    module = runner.lightning_module.to("cuda").eval()
+
+    print("Coordinate forward...")
+    coord_out = capture_outputs(run_forward(module, coord_batch, args.seed))
+    print("Legacy (materialized from same coords) forward...")
+    legacy_out = capture_outputs(run_forward(module, legacy_batch, args.seed))
+
+    report = summarize_diff(legacy_out, coord_out)
+    thresholds = {
+        "atom_positions_predicted": args.atom_atol,
+        "plddt_logits": args.logit_atol,
+        "pae_logits": args.logit_atol,
+        "pde_logits": args.logit_atol,
+        "distogram_logits": args.logit_atol,
+        "si_trunk": args.trunk_atol,
+    }
+    failures = []
+    for key, limit in thresholds.items():
+        info = report.get(key, {})
+        if not info.get("present"):
+            failures.append(f"{key}: missing")
+            continue
+        if info["max_abs"] > limit:
+            failures.append(
+                f"{key}: max_abs={info['max_abs']:.6g} > atol={limit:g}"
+            )
+
+    payload = {
+        "query": str(query_json),
+        "seed": args.seed,
+        "fused_template_coord": args.fused_template_coord,
+        "thresholds": thresholds,
+        "ok": not failures,
+        "failures": failures,
+        "keys": report,
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+    if failures:
+        raise SystemExit("Parity failed:\n  - " + "\n  - ".join(failures))
+    print("Parity OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/profile_inference_stages.py
+++ b/scripts/dev/profile_inference_stages.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+"""Stage timing and top-level memory profiling for OF3 inference.
+
+Protocol:
+1. warm-up forward
+2. unhooked measured forward (overall peak + wall)
+3. hooked forward (top-level / trunk-substage peaks + nested timing)
+
+Only sequential memory-tracked stages reset CUDA peak stats. Nested hooks are
+timing-only so they do not corrupt enclosing peaks.
+
+1U = N² × c_z × 4 bytes. The gate metric is peak CUDA allocation above live
+model parameter (+ buffer) bytes — not peak minus ambient allocator residency
+and not raw ``max_memory_allocated()`` alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import OrderedDict
+from pathlib import Path
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_RUNNER_YAML = REPO / "examples/example_runner_yamls/cuequivariance.yml"
+
+KNOWN_QUERIES = {
+    "ubiquitin": REPO / "examples/example_inference_inputs/query_ubiquitin.json",
+    "homo_1200": REPO / "data/inference_outputs/profiling/queries/homo_1200.json",
+    "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
+}
+KNOWN_RUNNERS = {
+    "mcl1": REPO / "data/inference_benchmark_msa_template/runner.yml",
+}
+
+
+def _gib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**3
+
+
+def _mib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**2
+
+
+class FastStageProfiler:
+    def __init__(self):
+        self.stats: OrderedDict[str, dict] = OrderedDict()
+        self._patches: list[tuple[object, str, object]] = []
+
+    def wrap(self, obj, attr: str, name: str, track_mem: bool = False) -> None:
+        orig = getattr(obj, attr)
+
+        def hook(*args, **kwargs):
+            if track_mem:
+                torch.cuda.synchronize()
+                before = torch.cuda.memory_allocated()
+                torch.cuda.reset_peak_memory_stats()
+            else:
+                before = 0
+
+            start_ev = torch.cuda.Event(enable_timing=True)
+            end_ev = torch.cuda.Event(enable_timing=True)
+            start_ev.record()
+            out = orig(*args, **kwargs)
+            end_ev.record()
+            torch.cuda.synchronize()
+
+            cuda_ms = start_ev.elapsed_time(end_ev)
+            peak = torch.cuda.max_memory_allocated() if track_mem else 0
+            after = torch.cuda.memory_allocated() if track_mem else 0
+
+            stat = self.stats.setdefault(
+                name,
+                {
+                    "abs_peak_bytes": 0,
+                    "before_bytes": before,
+                    "after_bytes": after,
+                    "peak_over_before_bytes": 0,
+                    "cuda_ms": 0.0,
+                    "total_calls": 0,
+                    "memory_tracked": track_mem,
+                },
+            )
+            stat["total_calls"] += 1
+            stat["cuda_ms"] += cuda_ms
+            if track_mem and peak > stat["abs_peak_bytes"]:
+                stat["abs_peak_bytes"] = peak
+                stat["before_bytes"] = before
+                stat["after_bytes"] = after
+                stat["peak_over_before_bytes"] = peak - before
+            return out
+
+        setattr(obj, attr, hook)
+        self._patches.append((obj, attr, orig))
+
+    def unwrap_all(self) -> None:
+        for obj, attr, orig in reversed(self._patches):
+            setattr(obj, attr, orig)
+        self._patches.clear()
+
+
+def install_hooks(
+    model, prof: FastStageProfiler, track_trunk_substages: bool
+) -> None:
+    prof.wrap(model, "run_trunk", "TRUNK", track_mem=not track_trunk_substages)
+    prof.wrap(model.sample_diffusion, "forward", "DIFFUSION", track_mem=True)
+    prof.wrap(model.aux_heads, "forward", "CONFIDENCE", track_mem=True)
+
+    prof.wrap(
+        model.input_embedder,
+        "forward",
+        "trunk.input_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.template_embedder,
+        "forward",
+        "trunk.template_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.msa_module,
+        "forward",
+        "trunk.msa_module",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.pairformer_stack,
+        "forward",
+        "trunk.pairformer",
+        track_mem=track_trunk_substages,
+    )
+
+    # Timing-only nested hooks for first-pass localization.
+    prof.wrap(model.diffusion_module, "forward", "diff.per_step")
+    if hasattr(model.aux_heads, "pairformer_embedding"):
+        prof.wrap(
+            model.aux_heads.pairformer_embedding, "forward", "conf.pairformer_emb"
+        )
+
+
+def resolve_paths(args) -> tuple[Path, Path]:
+    if args.query_json is not None:
+        query_json = args.query_json
+    elif args.query in KNOWN_QUERIES:
+        query_json = KNOWN_QUERIES[args.query]
+    else:
+        raise FileNotFoundError(
+            f"Unknown query {args.query!r}; pass --query-json or one of "
+            f"{sorted(KNOWN_QUERIES)}"
+        )
+    if not query_json.exists():
+        raise FileNotFoundError(query_json)
+
+    if args.runner_yaml is not None:
+        runner_yaml = args.runner_yaml
+    elif args.query in KNOWN_RUNNERS:
+        runner_yaml = KNOWN_RUNNERS[args.query]
+    else:
+        runner_yaml = DEFAULT_RUNNER_YAML
+    if not runner_yaml.exists():
+        raise FileNotFoundError(runner_yaml)
+    return query_json, runner_yaml
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    num_samples: int,
+    offload_token_cutoff: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=num_samples,
+        use_msa_server=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = offload_token_cutoff
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner, device: torch.device) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to(device), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def model_parameter_bytes(model: torch.nn.Module) -> dict[str, int]:
+    """Exact live parameter/buffer payload on the current device."""
+    param_bytes = sum(p.numel() * p.element_size() for p in model.parameters())
+    buffer_bytes = sum(b.numel() * b.element_size() for b in model.buffers())
+    return {
+        "model_params_bytes": param_bytes,
+        "model_buffer_bytes": buffer_bytes,
+        "model_params_and_buffers_bytes": param_bytes + buffer_bytes,
+    }
+
+
+def profile(args) -> dict:
+    query_json, runner_yaml = resolve_paths(args)
+    device = torch.device("cuda")
+    print(f"Building runner for {query_json} (samples={args.samples})...")
+
+    runner = build_runner(
+        query_json=query_json,
+        runner_yaml=runner_yaml,
+        num_samples=args.samples,
+        offload_token_cutoff=args.offload_token_cutoff,
+    )
+    lightning_module = runner.lightning_module.to(device).eval()
+    model = lightning_module.model
+    param_info = model_parameter_bytes(model)
+    model_params_bytes = param_info["model_params_and_buffers_bytes"]
+
+    batch = get_batch(runner, device)
+    n_tok = int(batch["token_mask"].shape[-1])
+    n_atom = int(batch["atom_mask"].shape[-1]) if "atom_mask" in batch else -1
+    c_z = int(model.config.architecture.shared.c_z)
+    u_bytes = n_tok * n_tok * c_z * 4
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    cuda_allocated_after_load = torch.cuda.memory_allocated()
+
+    print(f"n_tokens={n_tok}, n_atoms={n_atom}, c_z={c_z}")
+    print(f"1U = {_mib(u_bytes):.1f} MiB")
+    print(
+        f"Model params+buffers: {_mib(model_params_bytes):.1f} MiB "
+        f"(cuda allocated after load: {_mib(cuda_allocated_after_load):.1f} MiB)"
+    )
+
+    print("Warm-up forward...")
+    batch = get_batch(runner, device)
+    with torch.inference_mode():
+        lightning_module(batch)
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+    print("Overall measured forward...")
+    batch = get_batch(runner, device)
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.perf_counter()
+    with torch.inference_mode():
+        lightning_module(batch)
+    torch.cuda.synchronize()
+    overall_wall_s = time.perf_counter() - t0
+    overall_peak_bytes = torch.cuda.max_memory_allocated()
+    del batch
+    torch.cuda.empty_cache()
+
+    print("Hooked stage forward...")
+    batch = get_batch(runner, device)
+    profiler = FastStageProfiler()
+    install_hooks(
+        model, profiler, track_trunk_substages=args.track_trunk_substages
+    )
+    try:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        t0 = time.perf_counter()
+        with torch.inference_mode():
+            lightning_module(batch)
+        torch.cuda.synchronize()
+        stage_wall_s = time.perf_counter() - t0
+    finally:
+        profiler.unwrap_all()
+        del batch
+
+    peak_above_params = overall_peak_bytes - model_params_bytes
+    return {
+        "query_json": str(query_json),
+        "runner_yaml": str(runner_yaml),
+        "n_tokens": n_tok,
+        "n_atoms": n_atom,
+        "n_diffusion_samples": args.samples,
+        "c_z": c_z,
+        "U_bytes": u_bytes,
+        **param_info,
+        "cuda_allocated_after_load_bytes": cuda_allocated_after_load,
+        "overall_peak_bytes": overall_peak_bytes,
+        "peak_above_params_bytes": peak_above_params,
+        "peak_above_params_U": peak_above_params / u_bytes,
+        "overall_wall_s": round(overall_wall_s, 2),
+        "stage_wall_s": round(stage_wall_s, 2),
+        "offload_token_cutoff": args.offload_token_cutoff,
+        "track_trunk_substages": args.track_trunk_substages,
+        "tri_attn_chunk_cap": os.environ.get("OPENFOLD3_TRI_ATTN_CHUNK_CAP"),
+        "trimul_chunk_cap": os.environ.get("OPENFOLD3_TRIMUL_CHUNK_CAP"),
+        "transition_chunk_cap": os.environ.get("OPENFOLD3_TRANSITION_CHUNK_CAP"),
+        "stages": profiler.stats,
+    }
+
+
+def print_report(result: dict) -> None:
+    params = result["model_params_and_buffers_bytes"]
+    peak = result["overall_peak_bytes"]
+    u_bytes = result["U_bytes"]
+    above = peak - params
+
+    print()
+    print("=" * 100)
+    print(
+        f"n_tok={result['n_tokens']} n_atom={result['n_atoms']} "
+        f"samples={result['n_diffusion_samples']} 1U={_mib(u_bytes):.1f} MiB"
+    )
+    print(
+        f"model_params+buffers={_gib(params):.2f} GiB  "
+        f"total_peak={_gib(peak):.2f} GiB"
+    )
+    print(f"peak_above_params={_gib(above):.2f} GiB = {above / u_bytes:.2f}U")
+    print(
+        f"overall_wall={result['overall_wall_s']:.2f}s  "
+        f"stage_wall={result['stage_wall_s']:.2f}s"
+    )
+    print("=" * 100)
+    print(
+        f"{'stage':<28s} {'above_U':>8s} {'trans_U':>8s} "
+        f"{'ms':>10s} {'calls':>7s} {'memory':>8s}"
+    )
+    print("-" * 100)
+    for name, stage in result["stages"].items():
+        if stage.get("memory_tracked", False):
+            above_u = (stage["abs_peak_bytes"] - params) / u_bytes
+            trans_u = stage["peak_over_before_bytes"] / u_bytes
+            above_s = f"{above_u:8.2f}"
+            trans_s = f"{trans_u:8.2f}"
+            mem_s = "yes"
+        else:
+            above_s = f"{'-':>8s}"
+            trans_s = f"{'-':>8s}"
+            mem_s = "timing"
+        print(
+            f"{name:<28s} {above_s} {trans_s} "
+            f"{stage['cuda_ms']:10.1f} {stage['total_calls']:7d} {mem_s:>8s}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        default="ubiquitin",
+        help=f"Known query key: {sorted(KNOWN_QUERIES)}",
+    )
+    parser.add_argument("--query-json", type=Path, default=None)
+    parser.add_argument("--runner-yaml", type=Path, default=None)
+    parser.add_argument("--samples", type=int, default=1)
+    parser.add_argument(
+        "--offload-token-cutoff",
+        type=int,
+        default=10_000_000,
+        help="Default disables offload for practical gate sizes",
+    )
+    parser.add_argument(
+        "--track-trunk-substages",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Track input/template/MSA/Pairformer memory separately (default: on)",
+    )
+    parser.add_argument(
+        "--triangle-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRI_ATTN_CHUNK_CAP and OPENFOLD3_TRIMUL_CHUNK_CAP "
+            "(shared MSA/template/pairformer/confidence triangle ops)"
+        ),
+    )
+    parser.add_argument(
+        "--transition-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRANSITION_CHUNK_CAP to force row-chunked "
+            "pair/MSA transitions (and OPM) after the chunk-size tuner"
+        ),
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.triangle_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRI_ATTN_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+        os.environ["OPENFOLD3_TRIMUL_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+    if args.transition_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRANSITION_CHUNK_CAP"] = str(args.transition_chunk_cap)
+
+    result = profile(args)
+    print_report(result)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(result, indent=2))
+        print(f"Saved {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Next PR in the breakdown of [#318](https://github.com/aqlaboratory/openfold-3/pull/318), stacked on [#321](https://github.com/aqlaboratory/openfold-3/pull/321). This slice implements the online template coordinate path.

After [#321](https://github.com/aqlaboratory/openfold-3/pull/321) chunk caps and lifecycle work, a ~1.2U template distogram (+ unit vectors) still sat in `batch` for the whole forward. This PR replaces those quadratic template pair inputs with compact O(N) coordinates and builds/projects the pair features online during the template embedder, so the N² tensors never land in HBM.

Until #321 merges, the GitHub diff against `main` also includes that PR (and #320). The commit unique to this branch is:

- `feat: build template pair features from coordinates online`

### Measured peak (S=1, cuEq, offload off, caps=128)

| Target | #321 (lifecycle) | This PR (coords) | Limiting stage |
|---|---:|---:|---|
| homo_1200 (N≈1264) | 6.63U | **5.29U** | input_embedder |
| MCL1 (N≈1369) | 7.02U | **5.71U** | msa_module |

Model forward wall is essentially unchanged. The ~1.3U drop is the resident distogram/unit-vector payload leaving `batch`.

Microbench host payload for one template falls from O(N^2) to O(N) versus precomputed distogram+UV; embed transient stays ~0.6U either way. Triton compile is length-generic (`do_not_specialize` on N and strides): one filesystem compile serves N=16…96 in tests.

### What this PR changes

- Opt-in `template.use_coordinate_pair_features` (inference only; default distogram bins 3.25/50.75/39)
- Featurizer returns `template_pseudo_beta_coords` / `template_frame_atom_coords` instead of N² distogram / unit-vector
- Length-generic Triton projection with chunked eager fallback (`OPENFOLD3_FUSED_TEMPLATE_COORD`, default on)
- Template embedder reuses 2a `_forward_streaming`; coordinate path swaps only the per-template embedder and skips template offload (coords are O(N))
- Focused parity + compile-reuse tests; `scripts/dev/bench_fused_template_coordinate_embed.py` and `scripts/dev/check_template_coordinate_parity.py`

Online local-frame math (normalize/cross) is algebraically the same as the Rigid path but not bitwise identical (~1e-6 UV, amplifies through the trunk). E2E structure coords stay within ~2e-4 abs on ubiquitin / 7cnx under deterministic CUDA.

### Out of scope

- Fused input relpos / token-bonds (2c)
- Fused pair SwiGLU (2c)
- Fused trimul / tri-attn (speed phase)
- Training / autograd for the coordinate path

## Test plan

- [x] `pytest openfold3/tests/test_fused_template_coordinate_embed.py` — pair-embedder parity, Triton vs reference, compile reuse across lengths
- [x] Module parity: `TemplateEmbedderAllAtom` multi-template coords vs precomputed
- [x] E2E: `scripts/dev/check_template_coordinate_parity.py --query 7cnx` / `--query ubiquitin`
- [x] Microbench: `scripts/dev/bench_fused_template_coordinate_embed.py --n 384,590,1264`
- [x] Profile homo_1200 / MCL1 S=1 with 2a caps + coords; expect ~5.3U / ~5.7U