### PR TITLE
Optimize the handling of missing version_tensor

### DIFF
--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -668,18 +668,27 @@ class InferenceExperimentRunner(ExperimentRunner):
         self, state_dict: dict
     ) -> None:
         """Load state dict, warning if only version_tensor is missing."""
-        try:
-            self.lightning_module.load_state_dict(state_dict, strict=True)
-        except RuntimeError as e:
-            if 'Missing key(s) in state_dict: "model.version_tensor".' in str(e):
-                logger.warning(
-                    "No version_tensor is found for this checkpoint."
-                    "Assuming the user knows checkpoints are parameters are compatible,"
-                    " continuing..."
-                )
-                self.lightning_module.load_state_dict(state_dict, strict=False)
-            else:
-                raise
+        missing_keys, unexpected_keys = self.lightning_module.load_state_dict(state_dict, strict=False)
+
+        # No issues with loaded state dict
+        if not missing_keys and not unexpected_keys:
+            return
+
+        # Only version_tensor is missing
+        if missing_keys == ["model.version_tensor"] and not unexpected_keys:
+            logger.warning(
+                "No version_tensor is found for this checkpoint. "
+                "Assuming the user knows checkpoints are parameters are compatible, "
+                "continuing..."
+            )
+            return
+
+        # There are missing keys other than version_tensor and/or unexpected keys
+        raise RuntimeError(
+            f"Runtime error loading state dict for {self.lightning_module.__class__.__name__}\n"
+            f"Missing keys: {missing_keys}\n"
+            f"Unexpected keys: {unexpected_keys}"
+        )
 
     def setup(self) -> None:
         """Set up environment and load checkpoints."""

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -678,7 +678,7 @@ class InferenceExperimentRunner(ExperimentRunner):
         if missing_keys == ["model.version_tensor"] and not unexpected_keys:
             logger.warning(
                 "No version_tensor is found for this checkpoint. "
-                "Assuming the user knows checkpoints are parameters are compatible, "
+                "Assuming the user knows the given checkpoint parameters are compatible with the model, "
                 "continuing..."
             )
             return


### PR DESCRIPTION
Previously, the implementation of _warn_on_missing_version_tensor_in_load_statedict would potentially call load_state_dict twice if version_tensor was missing, causing unnecessary overhead. The new implementation guarantees that load_state_dict only be executed once.

Details of change:
load_state_dict is called once with strict=False. Then, manual checks are performed based on the missing/unexpected keys returned, and the appropriate action (continue directly, issue warning, or raise exception) is performed accordingly. Previously, the appropriate action was determined off of exception catching and exception message parsing, which was slower and less reliable.