### PR TITLE
Preserve ccd stereochemistry

### DIFF
--- a/openfold3/core/data/primitives/structure/query.py
+++ b/openfold3/core/data/primitives/structure/query.py
@@ -211,6 +211,8 @@ def processed_reference_molecule_from_atom_array(
     # Convert to RDKit mol
     mol = to_mol(atom_array, kekulize=True)
     Chem.SanitizeMol(mol)
+    if np.all(atom_array.molecule_type_id == MoleculeType.LIGAND):
+        Chem.AssignStereochemistryFrom3D(mol)
     mol.RemoveConformer(0)
 
     return processed_reference_molecule_from_mol(

--- a/openfold3/tests/core/data/primitives/structure/test_query.py
+++ b/openfold3/tests/core/data/primitives/structure/test_query.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 import pytest
+from rdkit import Chem
 
 from openfold3.core.data.primitives.structure.query import (
     structure_with_ref_mol_from_ccd_code,
@@ -48,3 +49,36 @@ def test_consistent_structure_from_smiles_and_ccd_code(smiles, ccd_code):
     assert Counter(struct_from_smiles.atom_array.element) == Counter(
         struct_from_ccd.atom_array.element
     )
+
+
+def test_ccd_tetrahedral_stereochemistry_is_preserved():
+    structure = structure_with_ref_mol_from_ccd_code("DAS", chain_id="X")
+    mol = structure.processed_reference_mols[0].mol
+    atom_names = [atom.GetProp("annot_atom_name") for atom in mol.GetAtoms()]
+
+    stereocenters = {
+        atom_names[atom_index]: orientation
+        for atom_index, orientation in Chem.FindMolChiralCenters(
+            mol, includeUnassigned=True
+        )
+    }
+
+    assert stereocenters == {"CA": "R"}
+
+
+def test_ccd_double_bond_stereochemistry_is_preserved():
+    structure = structure_with_ref_mol_from_ccd_code("FUM", chain_id="X")
+    mol = structure.processed_reference_mols[0].mol
+    atom_names = [atom.GetProp("annot_atom_name") for atom in mol.GetAtoms()]
+
+    stereo_bonds = {
+        tuple(
+            sorted(
+                (atom_names[bond.GetBeginAtomIdx()], atom_names[bond.GetEndAtomIdx()])
+            )
+        ): bond.GetStereo()
+        for bond in mol.GetBonds()
+        if bond.GetStereo() != Chem.BondStereo.STEREONONE
+    }
+
+    assert stereo_bonds == {("C4", "C5"): Chem.BondStereo.STEREOE}

--- a/openfold3/tests/core/data/primitives/structure/test_query.py
+++ b/openfold3/tests/core/data/primitives/structure/test_query.py
@@ -51,34 +51,53 @@ def test_consistent_structure_from_smiles_and_ccd_code(smiles, ccd_code):
     )
 
 
-def test_ccd_tetrahedral_stereochemistry_is_preserved():
-    structure = structure_with_ref_mol_from_ccd_code("DAS", chain_id="X")
-    mol = structure.processed_reference_mols[0].mol
-    atom_names = [atom.GetProp("annot_atom_name") for atom in mol.GetAtoms()]
-
-    stereocenters = {
-        atom_names[atom_index]: orientation
-        for atom_index, orientation in Chem.FindMolChiralCenters(
-            mol, includeUnassigned=True
-        )
-    }
-
-    assert stereocenters == {"CA": "R"}
+def _stereocenter_orientations(mol: Chem.Mol) -> list[str]:
+    return sorted(
+        orientation
+        for _, orientation in Chem.FindMolChiralCenters(mol, includeUnassigned=True)
+    )
 
 
-def test_ccd_double_bond_stereochemistry_is_preserved():
-    structure = structure_with_ref_mol_from_ccd_code("FUM", chain_id="X")
-    mol = structure.processed_reference_mols[0].mol
-    atom_names = [atom.GetProp("annot_atom_name") for atom in mol.GetAtoms()]
+def _stereo_bond_orientations(mol: Chem.Mol) -> list[Chem.BondStereo]:
+    return sorted(
+        (
+            bond.GetStereo()
+            for bond in mol.GetBonds()
+            if bond.GetStereo() != Chem.BondStereo.STEREONONE
+        ),
+        key=int,
+    )
 
-    stereo_bonds = {
-        tuple(
-            sorted(
-                (atom_names[bond.GetBeginAtomIdx()], atom_names[bond.GetEndAtomIdx()])
-            )
-        ): bond.GetStereo()
-        for bond in mol.GetBonds()
-        if bond.GetStereo() != Chem.BondStereo.STEREONONE
-    }
 
-    assert stereo_bonds == {("C4", "C5"): Chem.BondStereo.STEREOE}
+def test_ccd_tetrahedral_stereochemistry_matches_smiles():
+    ccd_structure = structure_with_ref_mol_from_ccd_code("DAS", chain_id="X")
+    smiles_structure = structure_with_ref_mol_from_smiles(
+        "N[C@H](CC(O)=O)C(O)=O", chain_id="X"
+    )
+
+    ccd_orientations = _stereocenter_orientations(
+        ccd_structure.processed_reference_mols[0].mol
+    )
+    smiles_orientations = _stereocenter_orientations(
+        smiles_structure.processed_reference_mols[0].mol
+    )
+
+    assert smiles_orientations
+    assert ccd_orientations == smiles_orientations
+
+
+def test_ccd_double_bond_stereochemistry_matches_smiles():
+    ccd_structure = structure_with_ref_mol_from_ccd_code("FUM", chain_id="X")
+    smiles_structure = structure_with_ref_mol_from_smiles(
+        "O=C(O)/C=C/C(=O)O", chain_id="X"
+    )
+
+    ccd_orientations = _stereo_bond_orientations(
+        ccd_structure.processed_reference_mols[0].mol
+    )
+    smiles_orientations = _stereo_bond_orientations(
+        smiles_structure.processed_reference_mols[0].mol
+    )
+
+    assert smiles_orientations
+    assert ccd_orientations == smiles_orientations


### PR DESCRIPTION
**Summary**

Preserves stereochemistry encoded by CCD ligand coordinates during inference.

OF3 currently converts a CCD `AtomArray` into an RDKit molecule and removes its source conformer before generating the processed reference molecule. If the molecular graph does not already contain stereo assignments, removing the conformer discards the CCD's stereochemistry. The regenerated reference conformer can then have a different stereoisomer. This change assigns stereochemistry from the CCD 3D conformer before removing it. This is restricted to ligand molecules, leaving polymer and non-canonical residue processing unchanged.

**Changes**

- Assigns tetrahedral and double-bond stereochemistry from CCD ligand coordinates before the source conformer is removed.
- Restricts the new behavior to `MoleculeType.LIGAND` atom arrays.
- Adds regression tests comparing CCD D-aspartate (`DAS`) with its stereospecified SMILES representation.
- Adds regression tests comparing CCD fumarate (`FUM`) with stereospecified trans-fumarate SMILES.

**Related Issues**

None.

**Testing**

All tests including the unit tests pass.

Benchmark testing used 12 unique CCD ligands across 13 protein-ligand cases, with five diffusion samples per case:

| Ligand (PDB) | Default OF3 | CCD-preserving OF3 |
|---|---:|---:|
| CHC (1OSV) | 44/55 | 55/55 |
| 062 (1ZRB) | 5/10 | 10/10 |
| 4CS (3FXB) | 5/5 | 5/5 |
| QNB (3UON) | 5/5 | 5/5 |
| FVQ (4AV4) | 25/25 | 25/25 |
| 1IU (4BXK) | 20/25 | 25/25 |
| 0Y7 (4HBM) | 14/20 | 20/20 |
| W81 (5IWE) | 5/10 | 10/10 |
| QNB (5ZK3) | 3/5 | 3/5 |
| DAS (6R7R) | 0/5 | 0/5 |
| GJ6 (7XK9) | 3/10 | 8/10 |
| FUM E/Z (8AJX) | 4/5 | 4/5 |
| KR9 (8H59) | 0/5 | 0/5 |

Across the tetrahedral cases, default OF3 preserved 129/180 assignments and CCD-preserving OF3 preserved 166/180. The number of unique ligands with at least one fully correct sample also increased from 4/12 to 10/12. 

The CCD-preservation change substantially improves the default reference geometry but does not guarantee that every generated structure retains the input stereochemistry.