### PR TITLE
Pytest for training integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ openfold3/resources/
 tests/test_data/sample_feats.pickle
 cutlass/
 
+# default output of scripts/datasets/generate_subset_cache.py + download_subset.py
+# (and the generate-pdb-subset/download-pdb-subset pixi tasks, which run from here)
+/datasets/
+
 # User-specific claude settings
 .claude/
 
@@ -23,6 +27,3 @@ cutlass/
 
 # uv environments
 .venv/
-
-# build testing
-test-sdist/

--- a/docs/source/debugging_how_to.md
+++ b/docs/source/debugging_how_to.md
@@ -23,6 +23,7 @@ Put this snippet at the very top of your launch script
 
 ```python
 import debugpy
+
 debugpy.listen(("0.0.0.0", 5678))
 print("Waiting for debugger to attach...")
 debugpy.wait_for_client()

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -4,7 +4,18 @@ Welcome to the training documentation for OpenFold3. This guide covers how to tr
 
 ## 1. Prerequisites
 
-- OpenFold3 Conda environment. See [OpenFold3 Installation](https://github.com/aqlaboratory/openfold-3/blob/main/docs/source/Installation.md) for instructions on how to build the environment.
+- OpenFold3 environment. See [OpenFold3 Installation](https://github.com/aqlaboratory/openfold-3/blob/main/docs/source/Installation.md) for instructions on how to build the environment.
+
+Optionally test your installation for training OpenFold3 using a small subset of the PDB dataset. The command `setup-pdb-subset`, comprised of `generate-pdb-subset` + `download-pdb-subset` will create a mini PDB training set complete with the MSAs, template files, and OpenFold cache files.
+
+```
+# Run once to generate a mini training set
+pixi run -e openfold3-cuda12 setup-pdb-subset
+
+# Invoke the training test
+pixi run -e openfold3-cuda12 pytest openfold3/tests/test_training_full.py
+```
+
 
 ## 2. Download the Dataset
 

--- a/openfold3/tests/test_training_full.py
+++ b/openfold3/tests/test_training_full.py
@@ -1,0 +1,210 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for training on the small local PDB subset.
+
+Requires the subset produced by ``scripts/datasets/generate_subset_cache.py`` +
+``scripts/datasets/download_subset.py`` to already exist locally under
+``<openfold3-directory>/datasets`` (skips otherwise -- these files are gitignored,
+not fetched by CI, and must be generated/downloaded by hand).
+
+The runner yaml (``datasets/train_pdb_subset.yaml``) already bakes in a small
+test case -- 8 train / 4 val structures, gradient checkpointing, small MSA chunk size,
+diffusion loss chunking, etc, picked by ``generate_subset_cache.py``. ``full_subset``
+runs it as checked in (only ``output_dir`` is redirected). ``smoke`` additionally trims
+epoch length/count and disables dataloader workers, for a faster opt-in sanity check.
+
+To mimic a real user's workflow (not just the internal Python API), both cases invoke
+the actual ``run_openfold train --runner-yaml ...`` console script as a subprocess --
+the same command documented in docs/source/training.md -- against a materialized copy
+of the runner yaml with the per-case overrides applied. Its output (including
+Lightning's per-step progress bar) streams live to the real terminal via
+``capsys.disabled()``, regardless of pytest's capture mode -- no need for ``-s``.
+
+Run with:
+    pytest openfold3/tests/test_training_full.py
+    pytest openfold3/tests/test_training_full.py -k smoke  # fast case only
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import yaml
+
+import openfold3
+from openfold3.core.config import config_utils
+from openfold3.entry_points.validator import TrainingExperimentConfig
+from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+# OPENFOLD_PDB_SUBSET_DIR lets CI point this at wherever the cached subset
+# lives (e.g. outside the checked-out workspace); defaults to the local dev
+# convention of <openfold3-directory>/datasets otherwise.
+DATASETS_DIR = Path(
+    os.environ.get("OPENFOLD_PDB_SUBSET_DIR")
+    or (Path(openfold3.__file__).resolve().parent.parent / "datasets")
+)
+RUNNER_YAML = DATASETS_DIR / "train_pdb_subset.yaml"
+PDB_TRAINING_SET_DIR = DATASETS_DIR / "pdb_training_set"
+
+RUN_OPENFOLD = shutil.which("run_openfold")
+
+
+@dataclass(frozen=True)
+class TrainCase:
+    name: str
+    # Deep-merged onto the checked-in yaml; empty means "run it as-is".
+    overrides: dict = field(default_factory=dict)
+    timeout_s: int = 900
+
+
+# The default runner.yaml settings can be found in
+# scripts/datasets/pdb_subset_helpers.py `build_runner_yaml_config`
+CASES = [
+    pytest.param(
+        TrainCase(
+            "smoke",
+            overrides={
+                # No dataloader worker subprocesses (each forks a copy of the dataset
+                # cache/process state -- a real contributor to memory blowups on
+                # constrained machines) and a single-batch epoch.
+                "data_module_args": {
+                    "num_workers": 0,
+                    "num_workers_validation": 0,
+                    "epoch_len": 1,
+                },
+                "pl_trainer_args": {
+                    "max_epochs": 1,
+                    "log_every_n_steps": 1,
+                },
+            },
+            timeout_s=600,
+        ),
+        marks=pytest.mark.slow,
+        id="smoke",
+    ),
+    pytest.param(
+        TrainCase("full_subset", timeout_s=1800),
+        marks=pytest.mark.slow,
+        id="full_subset",
+    ),
+]
+
+
+def _require_local_subset() -> None:
+    """Skip if the local PDB subset hasn't been generated/downloaded yet."""
+    missing = [p for p in (RUNNER_YAML, PDB_TRAINING_SET_DIR) if not p.exists()]
+    if missing:
+        pytest.skip(
+            "Local PDB training subset not found: "
+            f"{', '.join(str(p) for p in missing)}. Run "
+            "`python scripts/datasets/generate_subset_cache.py` and "
+            "`python scripts/datasets/download_subset.py` first "
+            "(see scripts/datasets/), or `pixi run setup-pdb-subset`."
+        )
+
+
+def _run_streaming(cmd: list[str], timeout_s: int, capsys) -> tuple[int, str]:
+    """Run `cmd`, printing its combined stdout/stderr live as it arrives.
+
+    Unlike `subprocess.run(capture_output=True)`, this gives real-time progress
+    visibility (e.g. Lightning's per-step progress bar) instead of a silent
+    block until the process exits. `capsys.disabled()` forces the output to
+    the real terminal regardless of pytest's capture mode, so it's visible
+    without needing to remember `-s`. A watchdog timer kills the process after
+    `timeout_s` even if it produces no output at all (a true hang), which
+    `for line in proc.stdout` alone wouldn't catch.
+
+    Returns (returncode, combined_output).
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    timed_out = threading.Event()
+
+    def _kill_on_timeout():
+        timed_out.set()
+        proc.kill()
+
+    timer = threading.Timer(timeout_s, _kill_on_timeout)
+    timer.start()
+
+    lines = []
+    try:
+        with capsys.disabled():
+            for line in proc.stdout:
+                print(line, end="", flush=True)
+                lines.append(line)
+    finally:
+        timer.cancel()
+        proc.wait()
+
+    output = "".join(lines)
+    if timed_out.is_set():
+        pytest.fail(
+            f"`{' '.join(cmd)}` timed out after {timeout_s}s and was killed.\n"
+            f"--- output (last 4000 chars) ---\n{output[-4000:]}"
+        )
+    return proc.returncode, output
+
+
+@skip_unless_cuda_available()
+@pytest.mark.training_verification
+@pytest.mark.parametrize("case", CASES)
+def test_train(case: TrainCase, tmp_path, capsys):
+    """`run_openfold train --runner-yaml ...` on the local subset writes a checkpoint."""
+    _require_local_subset()
+    if RUN_OPENFOLD is None:
+        pytest.skip("`run_openfold` console script not found on PATH")
+
+    config_dict = config_utils.load_yaml(RUNNER_YAML)
+    config_dict["experiment_settings"]["output_dir"] = str(tmp_path)
+    if case.overrides:
+        config_dict = config_utils.deep_update(config_dict, case.overrides)
+
+    # Fail fast with a clear pydantic error here rather than parsing it out of
+    # subprocess stderr, before materializing/launching the actual CLI call.
+    TrainingExperimentConfig(**config_dict)
+
+    runner_yaml = tmp_path / "runner_config.yaml"
+    runner_yaml.write_text(yaml.safe_dump(config_dict, sort_keys=False))
+
+    returncode, output = _run_streaming(
+        [RUN_OPENFOLD, "train", "--runner-yaml", str(runner_yaml)],
+        case.timeout_s,
+        capsys,
+    )
+    assert returncode == 0, (
+        f"`run_openfold train` exited {returncode}\n"
+        f"--- output (last 4000 chars) ---\n{output[-4000:]}"
+    )
+
+    checkpoints = list((tmp_path / "checkpoints").glob("*.ckpt"))
+    assert checkpoints, f"No checkpoint written to {tmp_path / 'checkpoints'}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-vv"]))

--- a/pixi.lock
+++ b/pixi.lock
@@ -399,7 +399,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -660,7 +660,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdkit-2025.09.6-py314h168f3c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sleef-3.9.0-h5bb93e2_0.conda
@@ -1033,7 +1033,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rdkit-2025.09.6-py314h86fec03_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py314hd330473_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.15.20-h1ddadc8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.16.0-hcca44e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.18.0-py314h5727af0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.9.0-h289094c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-2.0.51-py314h0b69929_0.conda
@@ -1284,7 +1284,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rdkit-2025.09.6-py314hf4561bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.20-h80928e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.16.0-h828de30_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
@@ -1449,7 +1449,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -1738,7 +1738,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-63.0-h1f0f388_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sleef-3.9.0-h5bb93e2_0.conda
@@ -2030,7 +2030,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -2319,7 +2319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-63.0-h1f0f388_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sleef-3.9.0-h5bb93e2_0.conda
@@ -2652,7 +2652,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -2998,7 +2998,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-63.0-h1f0f388_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sleef-3.9.0-h5bb93e2_0.conda
@@ -3340,7 +3340,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/86/ed/bb230dce7741f2778ba2ae3e8778fdb8bc58eee9fd95f07bf7b2d18e8081/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
@@ -3350,6 +3349,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/32/ebcb8e175f97f6d80bfed984d4823f5028d6282417320c78c7a64908c588/kalign_python-3.6.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -3550,7 +3550,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/a3/5c2b6cac9bf5d210536c26bfb1ba191c3c36883ec8188076576332a4a49f/cuequivariance_torch-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl
@@ -3567,6 +3566,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/27/e1859a6ef2330f83a4818d8f1bc6d1b21b681313f26d3d4bd4fc54f88335/gemmi-0.7.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl
@@ -3854,7 +3854,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -4202,7 +4202,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-63.0-h1f0f388_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sleef-3.9.0-h5bb93e2_0.conda
@@ -4550,7 +4550,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -4559,6 +4558,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/32/ebcb8e175f97f6d80bfed984d4823f5028d6282417320c78c7a64908c588/kalign_python-3.6.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/61/fe772eda66bb8e2ee72da2937382aa4f803ca1e41092ca8d59953e96262c/pytest_regressions-2.11.0-py3-none-any.whl
@@ -4756,7 +4756,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/a0/ef1e3b1ffa2bb7dfc9066d8d4291707c72b2e355da3dd2bcd4d70293d1fd/cuequivariance_ops_cu13-0.10.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl
@@ -4774,6 +4773,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/27/e1859a6ef2330f83a4818d8f1bc6d1b21b681313f26d3d4bd4fc54f88335/gemmi-0.7.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl
@@ -6239,7 +6239,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
@@ -6523,7 +6523,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
@@ -6807,7 +6807,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py314h13cd500_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
@@ -11517,7 +11517,7 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1108174
   timestamp: 1782912080163
@@ -12230,14 +12230,14 @@ packages:
   run_exports: {}
   size: 150041
   timestamp: 1766159514023
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
   noarch: python
-  sha256: 4c10593eb248ae3b626ebfc2991bd67df96cb98a51816939188576237c54deee
-  md5: d9b134cef9bc26a9ed9a0fba1eff3356
+  sha256: a3daa81b2ee835161e59c09efefd81673bb48ffe104f8251b4485301689c7094
+  md5: 2e2d6ede086818186c313dad438ccea5
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   constrains:
   - __glibc >=2.17
   license: MIT
@@ -12245,8 +12245,8 @@ packages:
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
   run_exports: {}
-  size: 9342178
-  timestamp: 1782428525856
+  size: 9384917
+  timestamp: 1784938279462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
   sha256: 856866fd519b812db3e092aba308248dd87b5c308186fcffe593f309373ae94c
   md5: 3f578c7d2b0bb52469340e4060d48d94
@@ -12548,7 +12548,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 118096
   timestamp: 1782133651496
@@ -17225,10 +17225,10 @@ packages:
   run_exports: {}
   size: 148495
   timestamp: 1766159541094
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.15.20-h88be79b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.16.0-hd82de44_0.conda
   noarch: python
-  sha256: 4dcde033d77e17ae8e15669177f8550ef2155ce32443ac3a4f241238f9dab4db
-  md5: 762455b53e3cd6c35c04259cfa2fa499
+  sha256: de5a3b0b95f46fb39d78209ba06af7cef2177523b1b92fd9a7962124d361458a
+  md5: 3d3636f09fe7b14be3806dbebf91a0c8
   depends:
   - python
   - libgcc >=14
@@ -17237,10 +17237,10 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=hash-mapping
+  - pkg:pypi/ruff?source=compressed-mapping
   run_exports: {}
-  size: 8974657
-  timestamp: 1782428525763
+  size: 9112931
+  timestamp: 1784938289859
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
   sha256: e94791b9a06e0bfbcef5d4b98edcc672c5ceed246f82edc8e9e4a13dfa0d5657
   md5: 5d28f677274b1d4486b3228b6a48042e
@@ -17633,7 +17633,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/absl-py?source=compressed-mapping
+  - pkg:pypi/absl-py?source=hash-mapping
   run_exports: {}
   size: 115188
   timestamp: 1783083260530
@@ -17751,8 +17751,7 @@ packages:
   depends:
   - python >=3.14
   license: BSD-3-Clause AND MIT AND EPL-2.0
-  purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 7526
   timestamp: 1781450817767
@@ -17766,7 +17765,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/beautifulsoup4?source=compressed-mapping
+  - pkg:pypi/beautifulsoup4?source=hash-mapping
   run_exports: {}
   size: 92704
   timestamp: 1780853175566
@@ -18631,7 +18630,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fsspec?source=compressed-mapping
+  - pkg:pypi/fsspec?source=hash-mapping
   run_exports: {}
   size: 149709
   timestamp: 1781615868173
@@ -19660,7 +19659,7 @@ packages:
   - python
   license: MIT
   purls:
-  - pkg:pypi/python-discovery?source=compressed-mapping
+  - pkg:pypi/python-discovery?source=hash-mapping
   run_exports: {}
   size: 35503
   timestamp: 1783111064496
@@ -19786,7 +19785,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/requests?source=compressed-mapping
+  - pkg:pypi/requests?source=hash-mapping
   run_exports: {}
   size: 68709
   timestamp: 1778851103479
@@ -19950,7 +19949,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/smmap?source=compressed-mapping
+  - pkg:pypi/smmap?source=hash-mapping
   run_exports: {}
   size: 27262
   timestamp: 1781021238494
@@ -20094,7 +20093,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/sphinxcontrib-serializinghtml?source=compressed-mapping
+  - pkg:pypi/sphinxcontrib-serializinghtml?source=hash-mapping
   run_exports: {}
   size: 30640
   timestamp: 1781260357443
@@ -20306,7 +20305,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/typing-extensions?source=compressed-mapping
+  - pkg:pypi/typing-extensions?source=hash-mapping
   run_exports: {}
   size: 52631
   timestamp: 1783002732887
@@ -20373,7 +20372,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/virtualenv?source=compressed-mapping
+  - pkg:pypi/virtualenv?source=hash-mapping
   run_exports: {}
   size: 3111990
   timestamp: 1781651033074
@@ -22199,7 +22198,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=hash-mapping
+  - pkg:pypi/matplotlib?source=compressed-mapping
   run_exports: {}
   size: 8988367
   timestamp: 1782829965885
@@ -22951,22 +22950,22 @@ packages:
   run_exports: {}
   size: 136902
   timestamp: 1766159517466
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.15.20-h1ddadc8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.16.0-hcca44e8_0.conda
   noarch: python
-  sha256: c09f4f7cb6f116fe2c37b6fe90e234beab754f223e11e7368e272fde890d7bac
-  md5: 4abaf1414e448ab88712f10a67610410
+  sha256: 23b095cb95affe06724ba1607e97b83cf3e0a3e729fc9448a4612de82dfc68f5
+  md5: 61c184c54b583905428c28edfe1b5189
   depends:
   - python
   - __osx >=11.0
   constrains:
-  - __osx >=10.13
+  - __osx >=11.0
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=hash-mapping
+  - pkg:pypi/ruff?source=compressed-mapping
   run_exports: {}
-  size: 9318935
-  timestamp: 1782428757092
+  size: 9338197
+  timestamp: 1784938409044
 - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.18.0-py314h5727af0_0.conda
   sha256: 43b9a06e25753fe503530363738741ca58edaf69e6dc8046b022fd71e92d74df
   md5: 082c776f991a6e68e4e8a0829e5041e8
@@ -25325,7 +25324,7 @@ packages:
   - lcms2 >=2.19.1,<3.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1019767
   timestamp: 1782912213683
@@ -25712,10 +25711,10 @@ packages:
   run_exports: {}
   size: 133016
   timestamp: 1766159585543
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.20-h80928e0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.16.0-h828de30_0.conda
   noarch: python
-  sha256: 49c7cb7fa8bc6ad2e3448d3ea48e4e939df69690a984e768261ddc0728e40f7f
-  md5: 60e90a1347592b61888a3f26ad93035c
+  sha256: 1da8e618123e797c11ca4e4299102a811dc2b40f2c112dfcc71a149833dab907
+  md5: 98d41831e06234de1baa14f0683b8300
   depends:
   - python
   - __osx >=11.0
@@ -25726,8 +25725,8 @@ packages:
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
   run_exports: {}
-  size: 8539333
-  timestamp: 1782428897543
+  size: 8617591
+  timestamp: 1784938415804
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
   sha256: 7ce218a4e1c55775547835d21a7ead0d50e5ac348fd638ce6ba316c48c8547b7
   md5: e55fe08bb5d43e7120672338dd129030
@@ -25894,7 +25893,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115243
   timestamp: 1782134346100
@@ -26648,11 +26647,6 @@ packages:
   - numpy ; extra == 'test'
   - pytest ; extra == 'test'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  name: ruff
-  version: 0.15.20
-  sha256: 3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl
   name: pytest-benchmark
   version: 5.2.3
@@ -26958,6 +26952,11 @@ packages:
   requires_dist:
   - nvidia-cuda-nvrtc
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  name: ruff
+  version: 0.16.0
+  sha256: 6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
   name: sphinxcontrib-serializinghtml
   version: 2.0.0
@@ -27675,11 +27674,6 @@ packages:
   version: 12.9.1.4
   sha256: 7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6
   requires_python: '>=3'
-- pypi: https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: ruff
-  version: 0.15.20
-  sha256: 309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/86/ed/bb230dce7741f2778ba2ae3e8778fdb8bc58eee9fd95f07bf7b2d18e8081/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl
   name: nvidia-nvtx-cu12
   version: 12.9.79
@@ -27936,6 +27930,11 @@ packages:
   - sphinx-rtd-theme ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: ruff
+  version: 0.16.0
+  sha256: 4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: pyyaml
   version: 6.0.3

--- a/pixi.toml
+++ b/pixi.toml
@@ -515,3 +515,16 @@ tasks.safe-but-slow-update.cmd = [
     "--concurrent-solves",
     "4"
 ]
+
+# Sample + download a small PDB training subset (see scripts/datasets/README.md).
+# Both default to writing/reading ./datasets relative to $PIXI_PROJECT_ROOT, since
+# pixi tasks run with cwd = the project root. Extra CLI args pass through, e.g.
+# `pixi run -e openfold3-cpu generate-pdb-subset -- --train-size 32 --val-size 16`.
+# `-u`: unbuffered stdout -- these scripts' progress prints (sampling/download
+# status over several minutes) would otherwise sit fully buffered and invisible
+# until the buffer fills or the process exits whenever stdout isn't a tty, e.g.
+# piped through `docker run` in CI, which is exactly how the caching workflow
+# invokes them.
+tasks.generate-pdb-subset.cmd = ["python", "-u", "scripts/datasets/generate_subset_cache.py"]
+tasks.download-pdb-subset.cmd = ["python", "-u", "scripts/datasets/download_subset.py"]
+tasks.setup-pdb-subset.depends-on = ["generate-pdb-subset", "download-pdb-subset"]

--- a/scripts/datasets/download_subset.py
+++ b/scripts/datasets/download_subset.py
@@ -2,18 +2,19 @@
 """Download the files an existing PDB subset cache references.
 
 Requires training_cache_with_templates_subset_{train_size}.json /
-validation_cache_with_templates_subset_{val_size}.json to already exist --
-run generate_subset_cache.py first if they don't.
+validation_cache_with_templates_subset_{val_size}.json to already exist
+under --target-dir -- run generate_subset_cache.py first if they don't.
 
 Downloads target structures, alignment arrays, and templates into
---output-dir, then reference-mol SDFs for only the CCD codes actually
-present in the downloaded structures (not the full ~68k-file reference_mols
-directory) -- see scripts/datasets/README.md for why.
+--output-dir (default: <target-dir>/pdb_training_set), then reference-mol
+SDFs for only the CCD codes actually present in the downloaded structures
+(not the full ~68k-file reference_mols directory) -- see
+scripts/datasets/README.md for why.
 
 Usage:
     python download_subset.py
+    python download_subset.py --target-dir /data/of3-subset
     python download_subset.py --verify           # check completeness, don't download
-    python download_subset.py --output-dir /data/foo
 """
 
 import argparse
@@ -22,12 +23,10 @@ from pathlib import Path
 
 from pdb_subset_helpers import (
     AMINO_ACID_CCD_CODES,
-    DEFAULT_OUTPUT_DIR,
-    DEFAULT_TRAIN_CACHE,
-    DEFAULT_VAL_CACHE,
     STANDARD_NUCLEOTIDE_CCD_CODES,
     build_reference_mol_manifest,
     build_structure_manifest,
+    default_target_dir,
     download_manifest,
     extract_ids_from_cache,
     scan_structure_residue_names,
@@ -46,10 +45,22 @@ def main():
         "--workers", type=int, default=8, help="Parallel download threads"
     )
     parser.add_argument(
+        "--target-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Root directory the subset cache(s) live under -- must match "
+            "whatever generate_subset_cache.py was given (default: "
+            "./datasets next to wherever this script is invoked from)."
+        ),
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
-        default=DEFAULT_OUTPUT_DIR,
-        help=f"Directory to download files into (default: {DEFAULT_OUTPUT_DIR})",
+        default=None,
+        help=(
+            "Directory to download files into (default: <target-dir>/pdb_training_set)"
+        ),
     )
     parser.add_argument(
         "--train-size", type=int, default=8, help="Train subset size (default: 8)"
@@ -60,21 +71,33 @@ def main():
     parser.add_argument(
         "--train-cache",
         type=Path,
-        default=DEFAULT_TRAIN_CACHE,
-        help="Full training cache the subset was sampled from (for naming only)",
+        default=None,
+        help=(
+            "Full training cache the subset was sampled from, for naming "
+            "only (default: <target-dir>/training_cache_with_templates.json)"
+        ),
     )
     parser.add_argument(
         "--val-cache",
         type=Path,
-        default=DEFAULT_VAL_CACHE,
-        help="Full validation cache the subset was sampled from (for naming only)",
+        default=None,
+        help=(
+            "Full validation cache the subset was sampled from, for naming "
+            "only (default: <target-dir>/validation_cache_with_templates.json)"
+        ),
     )
     args = parser.parse_args()
-    local_root = args.output_dir
+
+    target_dir = args.target_dir or default_target_dir()
+    train_cache = args.train_cache or (
+        target_dir / "training_cache_with_templates.json"
+    )
+    val_cache = args.val_cache or (target_dir / "validation_cache_with_templates.json")
+    local_root = args.output_dir or (target_dir / "pdb_training_set")
 
     cache_files = {
-        "train": subset_cache_path(args.train_cache, args.train_size),
-        "val": subset_cache_path(args.val_cache, args.val_size),
+        "train": subset_cache_path(train_cache, args.train_size, target_dir),
+        "val": subset_cache_path(val_cache, args.val_size, target_dir),
     }
     missing = [str(p) for p in cache_files.values() if not p.exists()]
     if missing:

--- a/scripts/datasets/generate_subset_cache.py
+++ b/scripts/datasets/generate_subset_cache.py
@@ -1,29 +1,32 @@
 #!/usr/bin/env python3
-"""Sample a small PDB training/validation subset cache from the full caches.
+"""Sample a small PDB training subset cache + fetch the pinned validation set.
 
 Downloads the full (un-sampled) caches from S3 first if not already present
-locally. Writes training_cache_with_templates_subset_{train_size}.json /
-validation_cache_with_templates_subset_{val_size}.json next to this script,
-plus a run_openfold training runner yaml pointed at them.
+locally. Writes training_cache_with_templates_subset_{train_size}.json
+(randomly sampled) and validation_cache_with_templates_subset_{N}.json (the
+fixed set in pdb_subset_helpers.SMOKE_VALIDATION_PDB_IDS -- see
+select_smoke_validation_set.py for how that set was chosen and why it's
+pinned rather than randomly sampled) under --target-dir (default: ./datasets
+next to wherever this is invoked from), plus a run_openfold training runner
+yaml pointed at them.
 
 Does not download any of the structure/alignment/template/reference-mol
 files the subset references -- see download_subset.py for that.
 
 Usage:
     python generate_subset_cache.py
-    python generate_subset_cache.py --train-size 32 --val-size 16 --seed 1234
-    python generate_subset_cache.py --force  # resample even if a cache already exists
+    python generate_subset_cache.py --target-dir /data/of3-subset
+    python generate_subset_cache.py --train-size 32 --seed 1234
+    python generate_subset_cache.py --force  # regenerate even if a cache already exists
 """
 
 import argparse
 from pathlib import Path
 
 from pdb_subset_helpers import (
-    DEFAULT_OUTPUT_DIR,
-    DEFAULT_RUNNER_YAML,
-    DEFAULT_TRAIN_CACHE,
-    DEFAULT_VAL_CACHE,
-    ROOT_DIR,
+    SMOKE_VALIDATION_PDB_IDS,
+    build_pinned_subset_cache,
+    default_target_dir,
     download_full_cache,
     sample_subset_cache,
     subset_cache_path,
@@ -32,83 +35,131 @@ from pdb_subset_helpers import (
 
 
 def get_or_create_subset_cache(
-    full_cache: Path, size: int, seed: int, force: bool = False
+    full_cache: Path, size: int, seed: int, target_dir: Path, force: bool = False
 ) -> Path:
-    """Return the path to a size-N subset cache, generating it if missing.
+    """Return the path to a size-N random subset cache, generating it if missing.
 
     If the full cache itself isn't present locally either, it's downloaded
     from S3 first. If `force`, the subset is resampled even if a cache for
     this size already exists.
     """
-    subset_path = subset_cache_path(full_cache, size)
+    subset_path = subset_cache_path(full_cache, size, target_dir)
     if subset_path.exists() and not force:
         return subset_path
 
     download_full_cache(full_cache)
     print(f"Sampling {size} structures from {full_cache.name} with seed={seed}...")
-    sample_subset_cache(full_cache, [size], ROOT_DIR, seed=seed)
+    sample_subset_cache(full_cache, [size], target_dir, seed=seed)
     return subset_path
+
+
+def get_or_create_pinned_validation_cache(
+    full_cache: Path, target_dir: Path, force: bool = False
+) -> Path:
+    """Return the path to the pinned validation subset cache, building it if missing.
+
+    Always the fixed set in `SMOKE_VALIDATION_PDB_IDS`, not a random sample --
+    see that constant's docstring and select_smoke_validation_set.py for why.
+    """
+    subset_path = subset_cache_path(
+        full_cache, len(SMOKE_VALIDATION_PDB_IDS), target_dir
+    )
+    if subset_path.exists() and not force:
+        return subset_path
+
+    download_full_cache(full_cache)
+    print(
+        f"Fetching pinned validation set from {full_cache.name}:"
+        f"{SMOKE_VALIDATION_PDB_IDS}"
+    )
+    return build_pinned_subset_cache(full_cache, SMOKE_VALIDATION_PDB_IDS, target_dir)
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--target-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Root directory for the subset cache(s) and runner yaml, and "
+            "(via download_subset.py) the downloaded files -- default: "
+            "./datasets next to wherever this script is invoked from."
+        ),
+    )
+    parser.add_argument(
         "--train-size", type=int, default=8, help="Train subset size (default: 8)"
     )
     parser.add_argument(
-        "--val-size", type=int, default=4, help="Validation subset size (default: 4)"
-    )
-    parser.add_argument(
-        "--seed", type=int, default=42, help="Random seed for subset sampling"
+        "--seed", type=int, default=42, help="Random seed for train subset sampling"
     )
     parser.add_argument(
         "--train-cache",
         type=Path,
-        default=DEFAULT_TRAIN_CACHE,
-        help=f"Full training cache to sample from (default: {DEFAULT_TRAIN_CACHE})",
+        default=None,
+        help=(
+            "Full training cache to sample from (default: "
+            "<target-dir>/training_cache_with_templates.json)"
+        ),
     )
     parser.add_argument(
         "--val-cache",
         type=Path,
-        default=DEFAULT_VAL_CACHE,
-        help=f"Full validation cache to sample from (default: {DEFAULT_VAL_CACHE})",
+        default=None,
+        help=(
+            "Full validation cache the pinned validation set is fetched from "
+            "(default: <target-dir>/validation_cache_with_templates.json)"
+        ),
     )
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Resample even if a cache for the requested size already exists",
+        help="Regenerate even if a cache for the requested size already exists",
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=DEFAULT_OUTPUT_DIR,
+        default=None,
         help=(
             "Directory download_subset.py will download files into -- baked "
-            f"into the generated runner yaml (default: {DEFAULT_OUTPUT_DIR})"
+            "into the generated runner yaml (default: <target-dir>/pdb_training_set)"
         ),
     )
     parser.add_argument(
         "--runner-yaml",
         type=str,
-        default=str(DEFAULT_RUNNER_YAML),
+        default=None,
         help=(
             "Where to write the run_openfold training runner yaml (default: "
-            f"{DEFAULT_RUNNER_YAML}). Pass an empty string to skip writing it."
+            "<target-dir>/train_pdb_subset.yaml). Pass an empty string to "
+            "skip writing it."
         ),
     )
     args = parser.parse_args()
 
+    target_dir = args.target_dir or default_target_dir()
+    train_cache = args.train_cache or (
+        target_dir / "training_cache_with_templates.json"
+    )
+    val_cache = args.val_cache or (target_dir / "validation_cache_with_templates.json")
+    output_dir = args.output_dir or (target_dir / "pdb_training_set")
+    runner_yaml = (
+        str(target_dir / "train_pdb_subset.yaml")
+        if args.runner_yaml is None
+        else args.runner_yaml
+    )
+
     cache_files = {
         "train": get_or_create_subset_cache(
-            args.train_cache, args.train_size, args.seed, force=args.force
+            train_cache, args.train_size, args.seed, target_dir, force=args.force
         ),
-        "val": get_or_create_subset_cache(
-            args.val_cache, args.val_size, args.seed, force=args.force
+        "val": get_or_create_pinned_validation_cache(
+            val_cache, target_dir, force=args.force
         ),
     }
 
-    if args.runner_yaml:
-        write_runner_yaml(Path(args.runner_yaml), cache_files, args.output_dir)
+    if runner_yaml:
+        write_runner_yaml(Path(runner_yaml), cache_files, output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/datasets/pdb_subset_helpers.py
+++ b/scripts/datasets/pdb_subset_helpers.py
@@ -29,11 +29,35 @@ from botocore.config import Config
 BUCKET = "openfold3-data"
 S3_PREFIX = "pdb_training_set"
 
-ROOT_DIR = Path(__file__).parent
-DEFAULT_OUTPUT_DIR = ROOT_DIR / "pdb_training_set"
-DEFAULT_TRAIN_CACHE = ROOT_DIR / "training_cache_with_templates.json"
-DEFAULT_VAL_CACHE = ROOT_DIR / "validation_cache_with_templates.json"
-DEFAULT_RUNNER_YAML = ROOT_DIR / "train_pdb_subset.yaml"
+
+def default_target_dir() -> Path:
+    """Default root directory for generated subset caches/yaml/downloads.
+
+    A `datasets/` directory next to wherever the calling script is invoked
+    from (i.e. relative to the current working directory, not this file's
+    location) -- so running from different directories/checkouts naturally
+    keeps their generated data separate.
+    """
+    return Path.cwd() / "datasets"
+
+
+# Pinned validation set for the training smoke test (see
+# test_training_full.py) -- one small, clean representative per modality
+# (DNA / RNA / protein+ligand / multimer), each well under 300 tokens, so an
+# uncropped validation pass is always cheap regardless of what large
+# structures happen to exist in the full cache. Random sampling (even with a
+# size cap applied at sampling time) was tried and rejected in favor of this:
+# no need to scan/filter the ~1700-structure full cache on every regeneration,
+# just a direct lookup of known-good IDs. Selected by, and documented in
+# detail in, select_smoke_validation_set.py -- rerun that script and update
+# this dict by hand if these ever need to change (e.g. one gets pulled from
+# the upstream cache).
+SMOKE_VALIDATION_PDB_IDS = {
+    "7ohe": "dna",  # DNA duplex, 24 tokens
+    "7kud": "rna",  # RNA, 13 tokens
+    "7vus": "protein_ligand",  # 1 protein chain + 3 ligand chains, 87 tokens
+    "7fb8": "multimer",  # protein homodimer, 53 tokens
+}
 
 AMINO_ACID_CCD_CODES = {
     "ALA",
@@ -99,7 +123,22 @@ def download_full_cache(local_path: Path) -> None:
     )
     local_path.parent.mkdir(parents=True, exist_ok=True)
     s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
-    s3.download_file(BUCKET, s3_key, str(local_path))
+
+    # Report progress every 10%
+    total_bytes = s3.head_object(Bucket=BUCKET, Key=s3_key)["ContentLength"]
+    progress = {"downloaded": 0, "last_pct": -1}
+
+    def _report_progress(bytes_transferred: int) -> None:
+        progress["downloaded"] += bytes_transferred
+        pct = int(progress["downloaded"] * 100 / total_bytes)
+        if pct >= progress["last_pct"] + 10:
+            print(
+                f"  {local_path.name}: {pct}% "
+                f"({progress['downloaded'] / 1e6:.0f}/{total_bytes / 1e6:.0f} MB)"
+            )
+            progress["last_pct"] = pct
+
+    s3.download_file(BUCKET, s3_key, str(local_path), Callback=_report_progress)
 
     # These cache files contain bare `NaN` literals (e.g. for structures with
     # no resolution data), which is invalid per RFC 8259 and breaks ijson's
@@ -108,13 +147,13 @@ def download_full_cache(local_path: Path) -> None:
     local_path.write_text(re.sub(r"\bNaN\b", "null", text))
 
 
-def subset_cache_path(full_cache: Path, size: int) -> Path:
-    """Path a size-N subset cache for `full_cache` would live at.
+def subset_cache_path(full_cache: Path, size: int, target_dir: Path) -> Path:
+    """Path a size-N subset cache for `full_cache` would live at under `target_dir`.
 
     Shared by generate_subset_cache.py (writes it) and download_subset.py
     (reads it) so the naming convention only lives in one place.
     """
-    return ROOT_DIR / f"{full_cache.stem}_subset_{size}.json"
+    return target_dir / f"{full_cache.stem}_subset_{size}.json"
 
 
 def enumerate_structure_ids(path: Path) -> list[str]:
@@ -124,6 +163,11 @@ def enumerate_structure_ids(path: Path) -> list[str]:
         for prefix, event, value in ijson.parse(f):
             if prefix == "structure_data" and event == "map_key":
                 ids.append(value)
+                # This is a full streaming pass over a ~1.6GB file (minutes, for
+                # the un-sampled training cache) -- report periodically so it
+                # doesn't read as a silent hang in CI logs.
+                if len(ids) % 20000 == 0:
+                    print(f"  ...enumerated {len(ids)} structure IDs so far")
     return ids
 
 
@@ -136,12 +180,22 @@ def stream_subset(path: Path, selected_ids: set[str]) -> tuple[dict, dict]:
                 metadata[key] = value
 
     selected_data = {}
+    scanned = 0
     with open(path, "rb") as f:
         for pdb_id, data in ijson.kvitems(f, "structure_data"):
+            scanned += 1
             if pdb_id in selected_ids:
                 selected_data[pdb_id] = data
                 if len(selected_data) == len(selected_ids):
                     break
+            # ijson.kvitems has to parse every structure's full nested record
+            # (chains, templates, ...) to check its id, even ones we discard --
+            # this scan is the slowest part of sampling. Report periodically.
+            if scanned % 20000 == 0:
+                print(
+                    f"  ...scanned {scanned} structures, found "
+                    f"{len(selected_data)}/{len(selected_ids)} targets so far"
+                )
     return metadata, selected_data
 
 
@@ -198,6 +252,36 @@ def sample_subset_cache(
             subset_metadata,
             {pid: largest_data[pid] for pid in selected_ids},
         )
+
+
+def build_pinned_subset_cache(
+    input_cache: Path, pdb_ids: dict[str, str] | list[str], output_dir: Path
+) -> Path:
+    """Write a subset cache containing exactly `pdb_ids` -- no random sampling.
+
+    Unlike `sample_subset_cache`, every id in `pdb_ids` must actually be
+    present in `input_cache`; this raises rather than silently writing a
+    smaller-than-expected subset if one goes missing (e.g. pulled from the
+    upstream cache). `pdb_ids` may be a dict (only its keys are used -- lets
+    callers pass e.g. `SMOKE_VALIDATION_PDB_IDS` directly) or a plain list.
+    """
+    ids = sorted(pdb_ids)
+    metadata, data = stream_subset(input_cache, set(ids))
+    missing = set(ids) - set(data)
+    if missing:
+        raise ValueError(
+            f"Pinned PDB ID(s) not found in {input_cache.name}: {sorted(missing)}"
+        )
+
+    stem = input_cache.stem
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{stem}_subset_{len(ids)}.json"
+    subset_metadata = {
+        **metadata,
+        "name": f"{metadata.get('name', stem)}-pinned-{len(ids)}",
+    }
+    write_subset(out_path, subset_metadata, {pid: data[pid] for pid in ids})
+    return out_path
 
 
 # --------------------------------------------------------------------------
@@ -451,11 +535,15 @@ def build_runner_yaml_config(cache_files: dict[str, Path], local_root: Path) -> 
         "data_module_args": {
             "batch_size": 1,
             "num_workers": 4,
-            "epoch_len": 32,
+            "epoch_len": 4,
         },
         "logging_config": {
             "log_lr": False,
             "wandb_config": None,
+        },
+        "checkpoint_config": {
+            "save_top_k": 0,
+            "save_last": True,
         },
         "pl_trainer_args": {
             "devices": 1,
@@ -474,7 +562,12 @@ def build_runner_yaml_config(cache_files: dict[str, Path], local_root: Path) -> 
                         "train": {
                             "msa_module": {"swiglu_seq_chunk_size": 1024},
                             "use_cueq_triangle_kernels": False,
-                            "use_deepspeed_evo_attention": True,
+                            # DeepSpeed's op-builder has failed to link
+                            # (-laio/-lcufile, missing dev packages) on at
+                            # least one machine this integration test runs
+                            # on; disabled so a build/runtime issue in that
+                            # custom kernel isn't a variable.
+                            "use_deepspeed_evo_attention": False,
                         },
                     },
                 },

--- a/scripts/datasets/select_smoke_validation_set.py
+++ b/scripts/datasets/select_smoke_validation_set.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Selection logic behind the smoke test's pinned validation set.
+
+The training integration test's "smoke" case runs validation without cropping
+(`crop.token_crop.enabled: false`, matching real validation), so a *randomly*
+sampled validation subset can happen to include a huge structure -- we hit an
+11+ minute stall on one uncropped structure with token_count=1985. Randomly
+resampling with a token_count cap was tried and rejected (see
+`git log -p -- scripts/datasets/pdb_subset_helpers.py` around this script's
+introduction): it still means scanning/filtering over the full ~1700-structure
+cache on every regeneration. Instead, this script is run *once* to pick a
+small, fixed, modality-diverse set of PDB IDs, which then get pinned directly
+in `pdb_subset_helpers.SMOKE_VALIDATION_PDB_IDS` -- no scanning/filtering at
+subset-generation time afterward, just a direct lookup of known-good IDs.
+
+Selection criteria, applied to the full `validation_cache_with_templates.json`:
+  - token_count <= 300 (small enough that an uncropped validation pass is
+    always cheap, regardless of what large structures exist elsewhere in the
+    full cache).
+  - One clean, non-overlapping representative per modality, so each pinned ID
+    exercises a distinct code path rather than accidentally covering two at
+    once:
+      - dna: has a DNA chain, no RNA chain, no ligand chain.
+      - rna: has an RNA chain, no DNA chain, no ligand chain.
+      - protein_ligand: exactly one PROTEIN chain plus >=1 LIGAND chain(s),
+        no DNA/RNA.
+      - multimer: >=2 PROTEIN chains, no DNA/RNA/ligand.
+  - Within each modality, the smallest (by token_count) candidate is picked.
+  - Manually verified against S3 (see this script's `--verify` flag) that the
+    target structure file exists for each pick. A missing *template* cache
+    file is not disqualifying by itself -- it's the expected, valid state for
+    a chain with no templates found (`template_ids: null` in the cache), not
+    a gap; the RNA pick below is one such case.
+
+Result (as of 2026-07-26, against validation_cache_with_templates.json):
+  dna:             7ohe   (24 tokens,  DNA duplex, 2 chains)
+  rna:             7kud   (13 tokens,  RNA, no templates found -- expected)
+  protein_ligand:  7vus   (87 tokens,  1 protein chain + 3 ligand chains)
+  multimer:        7fb8   (53 tokens,  protein homodimer)
+
+If these ever need to change (e.g. one gets pulled from the upstream cache, or
+the criteria change), rerun this script and update
+`pdb_subset_helpers.SMOKE_VALIDATION_PDB_IDS` by hand -- it's a plain
+dict, not derived from this script automatically.
+
+Usage:
+    python select_smoke_validation_set.py                    # rank candidates
+    python select_smoke_validation_set.py --max-token-count 500
+    python select_smoke_validation_set.py --verify 7ohe 7kud 7vus 7fb8
+"""
+
+import argparse
+from pathlib import Path
+
+import boto3
+import ijson
+from botocore import UNSIGNED
+from botocore.config import Config
+from pdb_subset_helpers import BUCKET, S3_PREFIX, default_target_dir
+
+MODALITIES = ("dna", "rna", "protein_ligand", "multimer")
+
+
+def classify(entry: dict) -> list[str]:
+    """Which of MODALITIES `entry` is a clean, non-overlapping candidate for."""
+    mol_types = [c.get("molecule_type") for c in entry.get("chains", {}).values()]
+    has_dna = "DNA" in mol_types
+    has_rna = "RNA" in mol_types
+    has_ligand = "LIGAND" in mol_types
+    protein_count = mol_types.count("PROTEIN")
+
+    hits = []
+    if has_dna and not has_rna and not has_ligand:
+        hits.append("dna")
+    if has_rna and not has_dna and not has_ligand:
+        hits.append("rna")
+    if has_ligand and protein_count == 1 and not has_dna and not has_rna:
+        hits.append("protein_ligand")
+    if protein_count >= 2 and not has_dna and not has_rna and not has_ligand:
+        hits.append("multimer")
+    return hits
+
+
+def find_candidates(val_cache: Path, max_token_count: int) -> dict[str, list]:
+    candidates = {m: [] for m in MODALITIES}
+    with open(val_cache, "rb") as f:
+        for pdb_id, entry in ijson.kvitems(f, "structure_data"):
+            token_count = entry.get("token_count")
+            if token_count is None or token_count > max_token_count:
+                continue
+            for modality in classify(entry):
+                candidates[modality].append((token_count, pdb_id))
+    for rows in candidates.values():
+        rows.sort()
+    return candidates
+
+
+def verify_s3(val_cache: Path, pdb_ids: list[str]) -> None:
+    """Check target-structure/alignment/template S3 keys for each pdb_id."""
+    s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+
+    def exists(key: str) -> bool:
+        try:
+            s3.head_object(Bucket=BUCKET, Key=key)
+            return True
+        except Exception:
+            return False
+
+    wanted = set(pdb_ids)
+    entries = {}
+    with open(val_cache, "rb") as f:
+        for pdb_id, entry in ijson.kvitems(f, "structure_data"):
+            if pdb_id in wanted:
+                entries[pdb_id] = entry
+
+    for pdb_id in pdb_ids:
+        entry = entries.get(pdb_id)
+        if entry is None:
+            print(f"{pdb_id}: NOT FOUND in {val_cache.name}")
+            continue
+        struct_key = (
+            f"{S3_PREFIX}/preprocessed_pdb_data/standard/structure_files/"
+            f"{pdb_id}/{pdb_id}.npz"
+        )
+        print(f"{pdb_id}: structure_ok={exists(struct_key)}")
+        for chain_id, chain in entry["chains"].items():
+            rep = chain.get("alignment_representative_id")
+            if not rep:
+                continue
+            aln_ok = exists(f"{S3_PREFIX}/alignment_arrays/{rep}.npz")
+            tmpl_ok = exists(f"{S3_PREFIX}/templates/val_template_cache/{rep}.npz")
+            has_templates = bool(chain.get("template_ids"))
+            print(
+                f"  chain {chain_id} ({rep}): alignment_ok={aln_ok} "
+                f"template_ok={tmpl_ok} (template_ids present: {has_templates})"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--val-cache",
+        type=Path,
+        default=None,
+        help=(
+            "Full validation cache"
+            "(default: <target-dir>/validation_cache_with_templates.json)"
+        ),
+    )
+    parser.add_argument(
+        "--max-token-count",
+        type=int,
+        default=300,
+        help="Only rank candidates at or below this token_count (default: 300)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=8,
+        help="How many ranked candidates to print per modality (default: 8)",
+    )
+    parser.add_argument(
+        "--verify",
+        nargs="+",
+        metavar="PDB_ID",
+        help="Instead of ranking, check S3 availability for these specific IDs",
+    )
+    args = parser.parse_args()
+
+    val_cache = args.val_cache or (
+        default_target_dir() / "validation_cache_with_templates.json"
+    )
+
+    if args.verify:
+        verify_s3(val_cache, args.verify)
+        return
+
+    candidates = find_candidates(val_cache, args.max_token_count)
+    for modality, rows in candidates.items():
+        print(
+            f"=== {modality}: {len(rows)} candidates "
+            f"(<= {args.max_token_count} tokens) ==="
+        )
+        for token_count, pdb_id in rows[: args.top]:
+            print(f"  {pdb_id:8s} tokens={token_count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary**
This PR is a subset of #330, focusing on the dataset generation and the pytest for training.

With these changes, it is now possible to locally run a test of the training pipeline in two steps:
```
# Run once to generate the training set
pixi run -e openfold3-cuda12 setup-pdb-subset

# Invoke the training test
pixi run -e openfold3-cuda12 pytest openfold3/tests/test_training_full.py
```

**Changes**
- Add scripts and helper functions to collect a subset of the full OpenFold3 PDB training set into a sample training set ( under `scripts/datasets/`). At this time, the training set is randomly selected, but the validation set is "hand-picked" to include only small examples that cover different modalities. The logic for selecting the validation set is here: `scripts/datasets/select_smoke_validation_set.py`. 
- Add pytest for training. This includes both a lightweight `smoke` version and a `full version`.
   - The smoketest runs for one epoch and uses 0 dataworkers. Time cutoff of 600s
   - The full version  runs for 2 epochs and uses 1 dataworker.

**Related Issues**
- Next step would be to incorporate into CI workflows. Ideally this would be run with a cache of the training datasets so that the training datasets would not need to be regenerated each time.

**Testing**
- [x] Run two-step training workflow on multiple systems
- [x] Verify that training tests are currently skipped when no training dataset is found.

**Other Notes**
