### PR TITLE
refactor: inference tests

### DIFF
--- a/openfold3/core/metrics/alignment.py
+++ b/openfold3/core/metrics/alignment.py
@@ -19,9 +19,9 @@ through :func:`~openfold3.core.metrics.quality.get_superimpose_metrics` — Kabs
 superposition followed by RMSD — so the tests measure agreement with the same primitive
 the model's own validation uses, rather than a second implementation that could drift.
 
-Everything here takes :class:`Structure`, never a path: parsing is the expensive step and
-every metric wants the same two structures, so callers parse once at the boundary and
-pass the result down.
+Everything here takes :class:`Structure`, never a path: parsing is the expensive step
+and every metric wants the same two structures, so callers parse once at the boundary
+and pass the result down.
 """
 
 import itertools
@@ -119,7 +119,10 @@ def _paired_positions(
     ref_by_chain: Mapping[str, Mapping[int, np.ndarray]],
     assignment: Sequence[tuple[str, str]],
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Stack the CAs shared by each ``(pred_chain, ref_chain)`` pair, in matching order."""
+    """Stack the CAs shared by each ``(pred_chain, ref_chain)`` pair.
+
+    The two returned arrays come back in matching order.
+    """
     pred_xyz: list[np.ndarray] = []
     ref_xyz: list[np.ndarray] = []
     for pred_chain, ref_chain in assignment:
@@ -162,16 +165,22 @@ def _best_ca_assignment(
 ) -> CaAlignment:
     """Best superposition CA-RMSD (Å) of *pred* against *ref*.
 
-    ``pred_chains`` and ``ref_chains`` are matched as sets, not pairwise: every bijection
-    between them is scored and the best is returned. That is what makes a homomer
-    meaningful — with N interchangeable copies the chain labels a prediction happens to
-    emit carry no information, so pinning a specific pairing would measure label
-    agreement rather than structural agreement.
+    ``pred_chains`` and ``ref_chains`` are matched as sets, not pairwise: every
+    bijection between them is scored and the best is returned. That is what makes a
+    homomer meaningful — with N interchangeable copies the chain labels a prediction
+    happens to emit carry no information, so pinning a specific pairing would measure
+    label agreement rather than structural agreement.
 
     ``pred_chains`` defaults to every polymer chain in *pred*, which is what a
     single-chain prediction wants: the chain id the writer emits is then irrelevant.
 
-    Returns the winning assignment's ``rmsd``/``gdt_ts``/``gdt_ha`` and its superposition.
+    Returns the winning assignment's ``rmsd``/``gdt_ts``/``gdt_ha`` and its
+    superposition.
+
+    Partial duplication with
+    ``core.utils.permutation_alignment.find_greedy_optimal_mol_permutation``: that one
+    is greedy, whereas this brute-forces every assignment, which suits post-processing
+    analysis.
     """
     pred_by_chain = pred.ca_positions_by_chain
     ref_by_chain = ref.ca_positions_by_chain
@@ -275,6 +284,10 @@ def symmetry_mappings(
     For toluene this yields the two ring flips; for a fully asymmetric ligand, one. The
     predicted ligand comes from SMILES so its atom *names* are whatever the writer chose
     — matching has to go through the graph, not the names.
+
+    Partial duplication with
+    ``core.data.primitives.structure.conformer.get_cropped_permutations``, which
+    enumerates equivalent orderings but does not hand back the matches themselves.
     """
     pred_mol = _connectivity_graph(pred_selected)
     ref_mol = _connectivity_graph(ref_selected)
@@ -293,13 +306,13 @@ def ligand_pose_metrics(
     ref_ligand_chain: str,
     pred_chains: Sequence[str] | None = None,
 ) -> dict[str, float]:
-    """Symmetry-corrected ligand pose accuracy, in the frame of the superimposed protein.
+    """Symmetry-corrected ligand pose accuracy, in the superimposed protein's frame.
 
-    The protein is superimposed first and that same transform is applied to the predicted
-    ligand — the ligand is *not* aligned to itself. That is the question worth asking of
-    a co-folding model: given the protein placed correctly, does the ligand land in the
-    right pocket in the right orientation. Aligning the ligand separately would score its
-    internal geometry and quietly forgive a pose in the wrong site.
+    The protein is superimposed first and that same transform is applied to the
+    predicted ligand — the ligand is *not* aligned to itself. That is the question worth
+    asking of a co-folding model: given the protein placed correctly, does the ligand
+    land in the right pocket in the right orientation. Aligning the ligand separately
+    would score its internal geometry and quietly forgive a pose in the wrong site.
 
     Returns ``rmsd`` (best over symmetry mappings), ``centroid_distance`` (mapping-free,
     so it separates "wrong pocket" from "right pocket, flipped"), plus ``n_atoms`` and
@@ -336,6 +349,7 @@ def ligand_pose_metrics(
     centroid_distance = float(
         np.linalg.norm(pred_xyz.mean(axis=0) - ref_xyz.mean(axis=0))
     )
+
     return {
         "rmsd": best_rmsd,
         "centroid_distance": centroid_distance,

--- a/openfold3/core/metrics/alignment.py
+++ b/openfold3/core/metrics/alignment.py
@@ -134,14 +134,48 @@ def _paired_positions(
     return np.asarray(pred_xyz, dtype=float), np.asarray(ref_xyz, dtype=float)
 
 
-def _superimpose_rmsd(pred_xyz: np.ndarray, ref_xyz: np.ndarray) -> dict[str, float]:
-    """Kabsch-superimpose *pred_xyz* onto *ref_xyz* and return rmsd/gdt_ts/gdt_ha."""
+@dataclass(frozen=True)
+class SuperpositionMetrics:
+    """How well a superimposed prediction agrees with its reference.
+
+    All in Ångström for ``rmsd``; the GDT scores are fractions in ``[0, 1]``.
+    """
+
+    rmsd: float
+    gdt_ts: float
+    gdt_ha: float
+
+
+@dataclass(frozen=True)
+class LigandPoseMetrics:
+    """How well a predicted ligand pose agrees with its reference.
+
+    ``rmsd`` is the best over the symmetry mappings, ``centroid_distance`` is
+    mapping-free and so separates "wrong pocket" from "right pocket, flipped". The two
+    counts are diagnostics: how much ligand was compared, and how much symmetry the
+    matching had to consider.
+    """
+
+    rmsd: float
+    centroid_distance: float
+    n_atoms: int
+    n_symmetry_mappings: int
+
+
+def _superimpose_rmsd(
+    pred_xyz: np.ndarray, ref_xyz: np.ndarray
+) -> SuperpositionMetrics:
+    """Kabsch-superimpose *pred_xyz* onto *ref_xyz* and score the result."""
     metrics = get_superimpose_metrics(
         all_atom_pred_pos=torch.from_numpy(pred_xyz),
         all_atom_gt_pos=torch.from_numpy(ref_xyz),
         all_atom_mask=torch.ones(len(pred_xyz), dtype=torch.float64),
     )
-    return {name: float(value) for name, value in metrics.items()}
+    return SuperpositionMetrics(
+        rmsd=float(metrics["rmsd"]),
+        gdt_ts=float(metrics["gdt_ts"]),
+        gdt_ha=float(metrics["gdt_ha"]),
+    )
 
 
 @dataclass(frozen=True)
@@ -153,7 +187,7 @@ class CaAlignment:
     once the protein has been placed.
     """
 
-    metrics: dict[str, float]
+    metrics: SuperpositionMetrics
     transformation: Transformation
 
 
@@ -209,7 +243,7 @@ def _best_ca_assignment(
                 f"it holds {sorted(available)}"
             )
 
-    best_metrics: dict[str, float] | None = None
+    best_metrics: SuperpositionMetrics | None = None
     best_positions: tuple[np.ndarray, np.ndarray] | None = None
     for permuted_ref in itertools.permutations(ref_chains):
         assignment = list(zip(pred_chains, permuted_ref, strict=True))
@@ -220,8 +254,8 @@ def _best_ca_assignment(
                 f"for assignment {assignment}"
             )
         metrics = _superimpose_rmsd(pred_xyz, ref_xyz)
-        logger.debug("assignment %s -> CA-RMSD %.2f", assignment, metrics["rmsd"])
-        if best_metrics is None or metrics["rmsd"] < best_metrics["rmsd"]:
+        logger.debug("assignment %s -> CA-RMSD %.2f", assignment, metrics.rmsd)
+        if best_metrics is None or metrics.rmsd < best_metrics.rmsd:
             best_metrics, best_positions = metrics, (pred_xyz, ref_xyz)
 
     assert best_metrics is not None  # permutations() of a non-empty seq is non-empty
@@ -242,7 +276,7 @@ def best_ca_rmsd(
     ref: Structure,
     ref_chains: Sequence[str],
     pred_chains: Sequence[str] | None = None,
-) -> dict[str, float]:
+) -> SuperpositionMetrics:
     """Best superposition CA-RMSD (Å) of *pred* against *ref*.
 
     See :func:`_best_ca_assignment`; this returns just the metrics.
@@ -305,7 +339,7 @@ def ligand_pose_metrics(
     pred_ligand_chain: str,
     ref_ligand_chain: str,
     pred_chains: Sequence[str] | None = None,
-) -> dict[str, float]:
+) -> LigandPoseMetrics:
     """Symmetry-corrected ligand pose accuracy, in the superimposed protein's frame.
 
     The protein is superimposed first and that same transform is applied to the
@@ -313,10 +347,6 @@ def ligand_pose_metrics(
     asking of a co-folding model: given the protein placed correctly, does the ligand
     land in the right pocket in the right orientation. Aligning the ligand separately
     would score its internal geometry and quietly forgive a pose in the wrong site.
-
-    Returns ``rmsd`` (best over symmetry mappings), ``centroid_distance`` (mapping-free,
-    so it separates "wrong pocket" from "right pocket, flipped"), plus ``n_atoms`` and
-    ``n_symmetry_mappings`` for diagnosis.
     """
     alignment = _best_ca_assignment(pred, ref, ref_chains, pred_chains)
 
@@ -350,9 +380,9 @@ def ligand_pose_metrics(
         np.linalg.norm(pred_xyz.mean(axis=0) - ref_xyz.mean(axis=0))
     )
 
-    return {
-        "rmsd": best_rmsd,
-        "centroid_distance": centroid_distance,
-        "n_atoms": float(len(ref_selected)),
-        "n_symmetry_mappings": float(len(mappings)),
-    }
+    return LigandPoseMetrics(
+        rmsd=best_rmsd,
+        centroid_distance=centroid_distance,
+        n_atoms=len(ref_selected),
+        n_symmetry_mappings=len(mappings),
+    )

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -208,24 +208,28 @@ def setup_biotite_ccd(*, ccd_path: Path, force_download: bool) -> bool:
     return False
 
 
+#: End-to-end smoke tests run after a successful download to verify the install. Kept to
+#: the two short queries — the template-effect test alongside it is far too slow (two
+#: multi-sample inference runs per case) to belong in setup.
+INTEGRATION_TEST_PATH = (
+    Path(__file__).parent / "tests" / "inference" / "test_inference_full.py"
+)
+
+
 def _run_integration_tests() -> None:
     logger.info("Running integration tests...")
     os.environ["OPENFOLD_SETUP_SCRIPT"] = "1"
-    import unittest
+    import pytest
 
     root_logger = logging.getLogger()
     original_level = root_logger.level
     try:
         root_logger.setLevel(logging.WARNING)
-        program = unittest.main(
-            module="openfold3.tests.inference.test_inference_full",
-            exit=False,
-            verbosity=2,
-        )
+        exit_code = pytest.main([str(INTEGRATION_TEST_PATH), "-v"])
     finally:
         root_logger.setLevel(original_level)
 
-    if not program.result.wasSuccessful():
+    if exit_code != pytest.ExitCode.OK:
         logger.error("Integration tests failed. Please check the output above.")
         sys.exit(1)
     logger.info("Integration tests passed!")

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -149,8 +149,13 @@ def _prompt_for_config() -> OpenFoldSetupConfig:
     ).strip()
     force_download_parameters = force_input.lower() in ["yes", "y"]
 
-    confirm = input("Run integration tests? (yes/no) ").strip()
-    run_integration_tests = confirm.lower() in ["yes", "y"]
+    if _pytest_is_installed():
+        confirm = input("Run integration tests? (yes/no) ").strip()
+        run_integration_tests = confirm.lower() in ["yes", "y"]
+    else:
+        # Don't ask a question whose answer could not be honoured either way.
+        logger.warning(PYTEST_MISSING_MESSAGE)
+        run_integration_tests = False
 
     return OpenFoldSetupConfig(
         openfold_cache=openfold_cache,
@@ -217,32 +222,30 @@ INTEGRATION_TEST_PATH = (
 )
 
 
-def _require_pytest() -> None:
-    """Exit with an actionable message unless pytest can be imported.
+#: Shown wherever integration tests are wanted but cannot run.
+PYTEST_MISSING_MESSAGE = (
+    "pytest is not installed, so the integration tests cannot run. Install it with "
+    "`pip install 'openfold3[dev]'` and re-run setup to verify the installation."
+)
+
+
+def _pytest_is_installed() -> bool:
+    """Whether pytest can be imported.
 
     pytest is deliberately *not* a core dependency: it is a large install and would
     bloat every downstream package that depends on openfold3, so it lives in the ``dev``
-    extra. That makes its availability a runtime question, and this is where it gets
-    asked — up front, before anything is downloaded, so a missing test dependency
-    surfaces in seconds rather than after a multi-gigabyte parameter download.
+    extra. That makes its availability a runtime question rather than a given.
 
-    Probing with ``find_spec`` rather than importing keeps this cheap and side-effect
+    Probing with ``find_spec`` instead of importing keeps this cheap and side-effect
     free; the actual import happens in :func:`_run_integration_tests`.
     """
-    if importlib.util.find_spec("pytest") is not None:
-        return
-    logger.error(
-        "Integration tests were requested but pytest is not installed. Install it "
-        "with `pip install 'openfold3[dev]'`, or re-run setup without integration "
-        "tests."
-    )
-    sys.exit(1)
+    return importlib.util.find_spec("pytest") is not None
 
 
 def _run_integration_tests() -> None:
     logger.info("Running integration tests...")
     os.environ["OPENFOLD_SETUP_SCRIPT"] = "1"
-    import pytest  # availability already established by _require_pytest
+    import pytest  # availability already established by the caller
 
     root_logger = logging.getLogger()
     original_level = root_logger.level
@@ -265,11 +268,15 @@ def _run_integration_tests() -> None:
 
 def run_setup(config: OpenFoldSetupConfig) -> None:
     """Execute the setup described by *config* without any interactive prompts."""
-    # Validated before any download so an unusable request fails immediately. Every
-    # entry point — --config, --non-interactive and the interactive prompt — reaches
-    # setup through here, so this is the one place the check has to live.
-    if config.run_integration_tests:
-        _require_pytest()
+    # Resolved before any download so the warning lands in seconds rather than after a
+    # multi-gigabyte transfer. Setting openfold3 up does not need pytest, so a missing
+    # test dependency downgrades the request instead of throwing the whole run away.
+    # Every entry point — --config, --non-interactive and the interactive prompt —
+    # reaches setup through here, so this is the one place the check has to live.
+    run_integration_tests = config.run_integration_tests
+    if run_integration_tests and not _pytest_is_installed():
+        logger.warning(PYTEST_MISSING_MESSAGE)
+        run_integration_tests = False
 
     config.openfold_cache.mkdir(parents=True, exist_ok=True)
     os.environ["OPENFOLD_CACHE"] = str(config.openfold_cache)
@@ -286,7 +293,7 @@ def run_setup(config: OpenFoldSetupConfig) -> None:
     )
     setup_biotite_ccd(ccd_path=biotite.setup_ccd.OUTPUT_CCD, force_download=False)
 
-    if config.run_integration_tests:
+    if run_integration_tests:
         _run_integration_tests()
     else:
         logger.info("Skipping integration tests.")

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -218,7 +218,7 @@ def _run_integration_tests() -> None:
     try:
         root_logger.setLevel(logging.WARNING)
         program = unittest.main(
-            module="openfold3.tests.test_inference_full",
+            module="openfold3.tests.inference.test_inference_full",
             exit=False,
             verbosity=2,
         )

--- a/openfold3/setup_openfold.py
+++ b/openfold3/setup_openfold.py
@@ -18,6 +18,7 @@ Setup script for OpenFold3 parameters.
 Downloads model parameters and runs verification tests.
 """
 
+import importlib.util
 import logging
 import os
 import sys
@@ -216,10 +217,32 @@ INTEGRATION_TEST_PATH = (
 )
 
 
+def _require_pytest() -> None:
+    """Exit with an actionable message unless pytest can be imported.
+
+    pytest is deliberately *not* a core dependency: it is a large install and would
+    bloat every downstream package that depends on openfold3, so it lives in the ``dev``
+    extra. That makes its availability a runtime question, and this is where it gets
+    asked — up front, before anything is downloaded, so a missing test dependency
+    surfaces in seconds rather than after a multi-gigabyte parameter download.
+
+    Probing with ``find_spec`` rather than importing keeps this cheap and side-effect
+    free; the actual import happens in :func:`_run_integration_tests`.
+    """
+    if importlib.util.find_spec("pytest") is not None:
+        return
+    logger.error(
+        "Integration tests were requested but pytest is not installed. Install it "
+        "with `pip install 'openfold3[dev]'`, or re-run setup without integration "
+        "tests."
+    )
+    sys.exit(1)
+
+
 def _run_integration_tests() -> None:
     logger.info("Running integration tests...")
     os.environ["OPENFOLD_SETUP_SCRIPT"] = "1"
-    import pytest
+    import pytest  # availability already established by _require_pytest
 
     root_logger = logging.getLogger()
     original_level = root_logger.level
@@ -242,6 +265,12 @@ def _run_integration_tests() -> None:
 
 def run_setup(config: OpenFoldSetupConfig) -> None:
     """Execute the setup described by *config* without any interactive prompts."""
+    # Validated before any download so an unusable request fails immediately. Every
+    # entry point — --config, --non-interactive and the interactive prompt — reaches
+    # setup through here, so this is the one place the check has to live.
+    if config.run_integration_tests:
+        _require_pytest()
+
     config.openfold_cache.mkdir(parents=True, exist_ok=True)
     os.environ["OPENFOLD_CACHE"] = str(config.openfold_cache)
 

--- a/openfold3/tests/core/metrics/test_alignment.py
+++ b/openfold3/tests/core/metrics/test_alignment.py
@@ -1,0 +1,497 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`openfold3.core.metrics.alignment`.
+
+Everything runs against committed mmCIFs under ``test_data/mmcifs/``, so the fixtures are
+real structures rather than hand-built arrays. Where a test needs a "prediction", one is
+derived from a reference by applying a known transformation — a rigid motion, a
+translation of one chain, a symmetry relabelling — which makes the expected answer exact
+and independent of the code under test.
+
+Run with:
+    pytest openfold3/tests/core/metrics/test_alignment.py
+"""
+
+import math
+from functools import cache
+from pathlib import Path
+
+import biotite.structure as struc
+import numpy as np
+import pytest
+import torch
+
+import openfold3
+from openfold3.core.metrics.alignment import (
+    MAX_PERMUTED_CHAINS,
+    Structure,
+    _best_ca_assignment,
+    best_ca_rmsd,
+    ligand_pose_metrics,
+    symmetry_mappings,
+)
+from openfold3.core.utils.geometry.kabsch_alignment import apply_transformation
+
+MMCIFS_DIR = Path(openfold3.__file__).parent / "tests" / "test_data" / "mmcifs"
+
+#: Coordinates round-trip through float32 in the mmCIF, and the superposition itself is
+#: iterative, so "exactly zero" lands around 1e-6 Å.
+ZERO_RMSD_TOL = 1e-4
+
+
+@cache
+def load(pdb_id: str) -> Structure:
+    """Parse a committed reference, once per session — parsing dominates runtime."""
+    return Structure.from_cif(MMCIFS_DIR / f"{pdb_id}.cif")
+
+
+def rotation_about_z(radians: float) -> np.ndarray:
+    cos, sin = math.cos(radians), math.sin(radians)
+    return np.array([[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]])
+
+
+def moved(
+    structure: Structure,
+    *,
+    rotation: np.ndarray | None = None,
+    translation: np.ndarray | None = None,
+) -> Structure:
+    """A copy of *structure* under a rigid motion — a perfect prediction of itself."""
+    array = structure.atom_array.copy()
+    coord = array.coord
+    if rotation is not None:
+        coord = coord @ np.asarray(rotation).T
+    if translation is not None:
+        coord = coord + np.asarray(translation)
+    array.coord = coord
+    return Structure(path=structure.path, atom_array=array)
+
+
+def with_chain_translated(
+    structure: Structure, chain: str, offset: np.ndarray
+) -> Structure:
+    """A copy with a single chain displaced, leaving every other chain in place."""
+    array = structure.atom_array.copy()
+    mask = array.chain_id == chain
+    array.coord[mask] = array.coord[mask] + np.asarray(offset)
+    return Structure(path=structure.path, atom_array=array)
+
+
+def with_chain_relabelled(
+    structure: Structure, chain: str, mapping: tuple[int, ...]
+) -> Structure:
+    """A copy whose *chain* coordinates are permuted by a graph automorphism.
+
+    The molecule is geometrically unchanged, only its atom order differs — so a
+    symmetry-aware comparison must score it as identical.
+    """
+    array = structure.atom_array.copy()
+    indices = np.where(array.chain_id == chain)[0]
+    array.coord[indices] = array.coord[indices][list(mapping)]
+    return Structure(path=structure.path, atom_array=array)
+
+
+# ---------------------------------------------------------------------------
+# Structure
+# ---------------------------------------------------------------------------
+
+CA_COUNT_CASES = [
+    pytest.param("1ubq", {"A": 76}, id="monomer"),
+    pytest.param("1hf9", {"A": 41, "B": 41}, id="homodimer"),
+    pytest.param("4i6p", {"A": 84, "B": 82}, id="dimer-with-unequal-gaps"),
+    pytest.param(
+        "1kd8",
+        {"A": 35, "B": 35, "C": 35, "D": 35, "E": 34, "F": 35},
+        id="hexamer",
+    ),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "expected"), CA_COUNT_CASES)
+def test_ca_positions_by_chain_counts(pdb_id, expected):
+    positions = load(pdb_id).ca_positions_by_chain
+    assert {chain: len(res) for chain, res in positions.items()} == expected
+
+
+def test_from_cif_keeps_the_source_path():
+    structure = load("1ubq")
+    assert structure.path == MMCIFS_DIR / "1ubq.cif"
+    assert len(structure.atom_array) > 0
+
+
+def test_ca_positions_are_cached():
+    structure = Structure.from_cif(MMCIFS_DIR / "1ubq.cif")
+    assert structure.ca_positions_by_chain is structure.ca_positions_by_chain
+
+
+def test_ca_positions_reject_duplicate_residues():
+    """Two CAs for one residue would silently drop residues, so it must raise."""
+    array = load("1ubq").atom_array
+    ca = array[(array.atom_name == "CA") & (~array.hetero)]
+    duplicated = Structure(
+        path=Path("duplicated.cif"), atom_array=struc.concatenate([ca, ca])
+    )
+    with pytest.raises(ValueError, match="more than one CA"):
+        _ = duplicated.ca_positions_by_chain
+
+
+HEAVY_ATOM_CASES = [
+    pytest.param("7l39", "D", "MBN", 7, id="toluene"),
+    pytest.param("7l39", "B", "TRS", 8, id="tris-buffer"),
+    pytest.param("7l39", "E", "BME", 4, id="mercaptoethanol"),
+    pytest.param("4zey", "B", "SO4", 5, id="sulfate"),
+    pytest.param("3u8v", "C", "NI", 1, id="nickel-ion"),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "chain", "res_name", "n_atoms"), HEAVY_ATOM_CASES)
+def test_heavy_atoms_selects_the_ligand(pdb_id, chain, res_name, n_atoms):
+    selected = load(pdb_id).heavy_atoms(chain)
+    assert len(selected) == n_atoms
+    assert set(map(str, selected.res_name)) == {res_name}
+    assert "H" not in set(map(str, selected.element))
+
+
+def test_heavy_atoms_excludes_water():
+    """7l39 chain F is solvent only, so nothing is left to compare."""
+    with pytest.raises(ValueError, match="no non-water heavy atoms"):
+        load("7l39").heavy_atoms("F")
+
+
+def test_heavy_atoms_unknown_chain_names_the_file():
+    with pytest.raises(ValueError, match="7l39.cif"):
+        load("7l39").heavy_atoms("ZZ")
+
+
+# ---------------------------------------------------------------------------
+# best_ca_rmsd
+# ---------------------------------------------------------------------------
+
+IDENTITY_CASES = [
+    pytest.param("1ubq", ("A",), id="monomer"),
+    pytest.param("1a8q", ("A",), id="long-monomer"),
+    pytest.param("1hf9", ("A", "B"), id="homodimer"),
+    pytest.param("1kd8", ("A", "B", "C", "D"), id="four-copies"),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "ref_chains"), IDENTITY_CASES)
+def test_structure_against_itself_scores_zero(pdb_id, ref_chains):
+    structure = load(pdb_id)
+    metrics = best_ca_rmsd(
+        structure, structure, ref_chains=ref_chains, pred_chains=ref_chains
+    )
+    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics["gdt_ts"] == pytest.approx(1.0)
+    assert metrics["gdt_ha"] == pytest.approx(1.0)
+
+
+RIGID_MOTION_CASES = [
+    pytest.param(None, np.array([10.0, -5.0, 3.0]), id="translation-only"),
+    pytest.param(rotation_about_z(0.7), None, id="rotation-only"),
+    pytest.param(
+        rotation_about_z(2.5),
+        np.array([-4.0, 8.0, 12.0]),
+        id="rotation-and-translation",
+    ),
+    pytest.param(
+        rotation_about_z(math.pi), np.array([100.0, 100.0, 100.0]), id="far-displaced"
+    ),
+]
+
+
+@pytest.mark.parametrize(("rotation", "translation"), RIGID_MOTION_CASES)
+def test_rmsd_is_invariant_under_rigid_motion(rotation, translation):
+    """Superposition must remove any rigid motion, however large."""
+    reference = load("1ubq")
+    prediction = moved(reference, rotation=rotation, translation=translation)
+    metrics = best_ca_rmsd(prediction, reference, ref_chains=("A",))
+    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+
+
+SCRAMBLE_CASES = [
+    pytest.param("1hf9", ("A", "B"), ("B", "A"), id="dimer-swapped"),
+    pytest.param("1kd8", ("A", "B", "C"), ("C", "A", "B"), id="trimer-rotated"),
+    pytest.param(
+        "1kd8", ("A", "B", "C", "D"), ("D", "C", "B", "A"), id="four-copies-reversed"
+    ),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "pred_chains", "ref_chains"), SCRAMBLE_CASES)
+def test_finds_the_matching_chain_assignment(pdb_id, pred_chains, ref_chains):
+    """Chains are paired as sets, so a scrambled reference order still scores zero."""
+    structure = load(pdb_id)
+    metrics = best_ca_rmsd(
+        structure, structure, ref_chains=ref_chains, pred_chains=pred_chains
+    )
+    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+
+
+def test_pred_chains_default_to_every_polymer_chain():
+    structure = load("1ubq")
+    assert best_ca_rmsd(structure, structure, ref_chains=("A",))[
+        "rmsd"
+    ] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+
+
+BIOTITE_AGREEMENT_CASES = [
+    pytest.param("1kd8", "A", "B", id="1kd8-A-vs-B"),
+    pytest.param("1kd8", "C", "D", id="1kd8-C-vs-D"),
+    pytest.param("1hf9", "A", "B", id="1hf9-A-vs-B"),
+    pytest.param("3u8v", "A", "B", id="3u8v-A-vs-B"),
+    pytest.param("4i6p", "A", "B", id="4i6p-A-vs-B"),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "pred_chain", "ref_chain"), BIOTITE_AGREEMENT_CASES)
+def test_agrees_with_biotite_superimposition(pdb_id, pred_chain, ref_chain):
+    """Cross-check the repo primitive against an independent implementation."""
+    structure = load(pdb_id)
+    array = structure.atom_array
+
+    def sorted_ca(chain):
+        selected = array[
+            (array.atom_name == "CA") & (~array.hetero) & (array.chain_id == chain)
+        ]
+        return selected[np.argsort(selected.res_id)]
+
+    pred, ref = sorted_ca(pred_chain), sorted_ca(ref_chain)
+    shared = np.intersect1d(pred.res_id, ref.res_id)
+    pred = pred[np.isin(pred.res_id, shared)]
+    ref = ref[np.isin(ref.res_id, shared)]
+    fitted, _ = struc.superimpose(fixed=ref, mobile=pred)
+    expected = float(struc.rmsd(ref, fitted))
+
+    measured = best_ca_rmsd(
+        structure, structure, ref_chains=(ref_chain,), pred_chains=(pred_chain,)
+    )["rmsd"]
+    assert measured == pytest.approx(expected, abs=1e-4)
+
+
+def test_only_residues_present_in_both_are_scored():
+    """4i6p chain B is missing two residues that chain A models; the pair still scores."""
+    structure = load("4i6p")
+    positions = structure.ca_positions_by_chain
+    shared = set(positions["A"]) & set(positions["B"])
+    assert len(shared) == 82 < len(positions["A"])
+    metrics = best_ca_rmsd(structure, structure, ref_chains=("B",), pred_chains=("A",))
+    assert metrics["rmsd"] > 0.0
+
+
+REJECTION_CASES = [
+    pytest.param(
+        "1hf9", ("A",), ("A", "B"), "Need equal chain counts", id="unequal-chain-counts"
+    ),
+    pytest.param("1ubq", ("A",), ("ZZ",), "has no chain", id="unknown-reference-chain"),
+    pytest.param("1ubq", ("ZZ",), ("A",), "has no chain", id="unknown-predicted-chain"),
+]
+
+
+@pytest.mark.parametrize(
+    ("pdb_id", "pred_chains", "ref_chains", "message"), REJECTION_CASES
+)
+def test_rejects_unusable_chain_selections(pdb_id, pred_chains, ref_chains, message):
+    structure = load(pdb_id)
+    with pytest.raises(ValueError, match=message):
+        best_ca_rmsd(
+            structure, structure, ref_chains=ref_chains, pred_chains=pred_chains
+        )
+
+
+def test_rejects_more_chains_than_brute_force_allows():
+    """5kc1 has 12 polymer chains; 12! assignments is not a search worth attempting."""
+    structure = load("5kc1")
+    assert len(structure.ca_positions_by_chain) > MAX_PERMUTED_CHAINS
+    with pytest.raises(ValueError, match="Refusing to brute-force"):
+        best_ca_rmsd(
+            structure, structure, ref_chains=tuple(structure.ca_positions_by_chain)
+        )
+
+
+def test_rejects_chains_with_no_residues_in_common():
+    """5kc1 chains A and B share no residue ids, so there is nothing to superimpose."""
+    structure = load("5kc1")
+    positions = structure.ca_positions_by_chain
+    assert not set(positions["A"]) & set(positions["B"])
+    with pytest.raises(ValueError, match="No residues in common"):
+        best_ca_rmsd(structure, structure, ref_chains=("B",), pred_chains=("A",))
+
+
+# ---------------------------------------------------------------------------
+# CaAlignment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("rotation", "translation"), RIGID_MOTION_CASES)
+def test_alignment_transformation_maps_prediction_onto_reference(rotation, translation):
+    """The returned transform is what carries a ligand into the reference frame."""
+    reference = load("1ubq")
+    prediction = moved(reference, rotation=rotation, translation=translation)
+    alignment = _best_ca_assignment(prediction, reference, ref_chains=("A",))
+
+    predicted_coords = prediction.atom_array.coord.astype(float)
+    restored = apply_transformation(
+        positions=torch.from_numpy(predicted_coords),
+        transformation=alignment.transformation,
+    ).numpy()
+    assert np.allclose(restored, reference.atom_array.coord, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# symmetry_mappings
+# ---------------------------------------------------------------------------
+
+#: Expected automorphism counts follow from the chemistry, not from running the code:
+#: a sulfate's four equivalent oxygens give 4! and nitrate's three give 3!, tris permutes
+#: its three hydroxymethyl arms, ethylene glycol and toluene each have a single 2-fold,
+#: and mercaptoethanol is asymmetric.
+SYMMETRY_CASES = [
+    pytest.param("7l39", "E", 1, id="mercaptoethanol-asymmetric"),
+    pytest.param("3u8v", "C", 1, id="single-atom-ion"),
+    pytest.param("5kc1", "GB", 2, id="ethylene-glycol-2fold"),
+    pytest.param("7l39", "D", 2, id="toluene-ring-flip"),
+    pytest.param("5kc1", "N", 6, id="nitrate-3-factorial"),
+    pytest.param("7l39", "B", 6, id="tris-three-arms"),
+    pytest.param("4zey", "B", 24, id="sulfate-4-factorial"),
+]
+
+
+@pytest.mark.parametrize(("pdb_id", "chain", "expected"), SYMMETRY_CASES)
+def test_symmetry_group_size(pdb_id, chain, expected):
+    ligand = load(pdb_id).heavy_atoms(chain)
+    assert len(symmetry_mappings(ligand, ligand)) == expected
+
+
+@pytest.mark.parametrize(("pdb_id", "chain", "expected"), SYMMETRY_CASES)
+def test_symmetry_mappings_are_bijections(pdb_id, chain, expected):
+    ligand = load(pdb_id).heavy_atoms(chain)
+    for mapping in symmetry_mappings(ligand, ligand):
+        assert sorted(mapping) == list(range(len(ligand)))
+
+
+def test_symmetry_mappings_are_empty_for_different_molecules():
+    """Toluene is not a subgraph of mercaptoethanol, so nothing matches."""
+    toluene = load("7l39").heavy_atoms("D")
+    mercaptoethanol = load("7l39").heavy_atoms("E")
+    assert symmetry_mappings(mercaptoethanol, toluene) == []
+
+
+# ---------------------------------------------------------------------------
+# ligand_pose_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_identical_pose_scores_zero():
+    structure = load("7l39")
+    metrics = ligand_pose_metrics(
+        structure,
+        structure,
+        ref_chains=("A",),
+        pred_chains=("A",),
+        pred_ligand_chain="D",
+        ref_ligand_chain="D",
+    )
+    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics["centroid_distance"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics["n_atoms"] == 7
+    assert metrics["n_symmetry_mappings"] == 2
+
+
+LIGAND_OFFSET_CASES = [
+    pytest.param(np.array([1.0, 0.0, 0.0]), 1.0, id="1A-along-x"),
+    pytest.param(np.array([0.0, 2.0, 0.0]), 2.0, id="2A-along-y"),
+    pytest.param(np.array([3.0, 4.0, 0.0]), 5.0, id="5A-diagonal"),
+    pytest.param(np.array([-6.0, 0.0, 8.0]), 10.0, id="10A-out-of-pocket"),
+]
+
+
+@pytest.mark.parametrize(("offset", "expected"), LIGAND_OFFSET_CASES)
+def test_displacing_only_the_ligand_shows_up_in_full(offset, expected):
+    """The protein still superimposes exactly, so the whole offset lands on the ligand.
+
+    Symmetry cannot absorb a rigid displacement, so both the pose RMSD and the
+    mapping-free centroid distance must equal the displacement exactly.
+    """
+    reference = load("7l39")
+    prediction = with_chain_translated(reference, "D", offset)
+    metrics = ligand_pose_metrics(
+        prediction,
+        reference,
+        ref_chains=("A",),
+        pred_chains=("A",),
+        pred_ligand_chain="D",
+        ref_ligand_chain="D",
+    )
+    assert metrics["rmsd"] == pytest.approx(expected, abs=1e-3)
+    assert metrics["centroid_distance"] == pytest.approx(expected, abs=1e-3)
+
+
+def test_symmetry_equivalent_relabelling_scores_zero():
+    """A ring-flipped toluene is the same pose; only the atom order differs."""
+    reference = load("7l39")
+    ligand = reference.heavy_atoms("D")
+    flip = next(
+        mapping
+        for mapping in symmetry_mappings(ligand, ligand)
+        if list(mapping) != sorted(mapping)
+    )
+    prediction = with_chain_relabelled(reference, "D", flip)
+
+    naive = float(
+        np.sqrt(
+            ((prediction.heavy_atoms("D").coord - ligand.coord) ** 2).sum(-1).mean()
+        )
+    )
+    assert naive > 1.0, (
+        "the relabelling must actually move atoms for this to prove anything"
+    )
+
+    metrics = ligand_pose_metrics(
+        prediction,
+        reference,
+        ref_chains=("A",),
+        pred_chains=("A",),
+        pred_ligand_chain="D",
+        ref_ligand_chain="D",
+    )
+    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+
+
+def test_rejects_ligands_of_different_size():
+    structure = load("7l39")
+    with pytest.raises(ValueError, match="Ligand atom count mismatch"):
+        ligand_pose_metrics(
+            structure,
+            structure,
+            ref_chains=("A",),
+            pred_chains=("A",),
+            pred_ligand_chain="B",
+            ref_ligand_chain="D",
+        )
+
+
+def test_rejects_ligands_that_do_not_match_as_graphs():
+    """Same atom count, unrelated topology: EDO (C2O2) against NO3 (NO3)."""
+    structure = load("5kc1")
+    with pytest.raises(ValueError, match="No graph match"):
+        ligand_pose_metrics(
+            structure,
+            structure,
+            ref_chains=("A",),
+            pred_chains=("A",),
+            pred_ligand_chain="GB",
+            ref_ligand_chain="N",
+        )

--- a/openfold3/tests/core/metrics/test_alignment.py
+++ b/openfold3/tests/core/metrics/test_alignment.py
@@ -52,7 +52,7 @@ ZERO_RMSD_TOL = 1e-4
 
 
 @cache
-def load(pdb_id: str) -> Structure:
+def load_structure(pdb_id: str) -> Structure:
     """Parse a committed reference, once per session — parsing dominates runtime."""
     return Structure.from_cif(MMCIFS_DIR / f"{pdb_id}.cif")
 
@@ -121,12 +121,12 @@ CA_COUNT_CASES = [
 
 @pytest.mark.parametrize(("pdb_id", "expected"), CA_COUNT_CASES)
 def test_ca_positions_by_chain_counts(pdb_id, expected):
-    positions = load(pdb_id).ca_positions_by_chain
+    positions = load_structure(pdb_id).ca_positions_by_chain
     assert {chain: len(res) for chain, res in positions.items()} == expected
 
 
 def test_from_cif_keeps_the_source_path():
-    structure = load("1ubq")
+    structure = load_structure("1ubq")
     assert structure.path == MMCIFS_DIR / "1ubq.cif"
     assert len(structure.atom_array) > 0
 
@@ -138,7 +138,7 @@ def test_ca_positions_are_cached():
 
 def test_ca_positions_reject_duplicate_residues():
     """Two CAs for one residue would silently drop residues, so it must raise."""
-    array = load("1ubq").atom_array
+    array = load_structure("1ubq").atom_array
     ca = array[(array.atom_name == "CA") & (~array.hetero)]
     duplicated = Structure(
         path=Path("duplicated.cif"), atom_array=struc.concatenate([ca, ca])
@@ -158,7 +158,7 @@ HEAVY_ATOM_CASES = [
 
 @pytest.mark.parametrize(("pdb_id", "chain", "res_name", "n_atoms"), HEAVY_ATOM_CASES)
 def test_heavy_atoms_selects_the_ligand(pdb_id, chain, res_name, n_atoms):
-    selected = load(pdb_id).heavy_atoms(chain)
+    selected = load_structure(pdb_id).heavy_atoms(chain)
     assert len(selected) == n_atoms
     assert set(map(str, selected.res_name)) == {res_name}
     assert "H" not in set(map(str, selected.element))
@@ -167,12 +167,12 @@ def test_heavy_atoms_selects_the_ligand(pdb_id, chain, res_name, n_atoms):
 def test_heavy_atoms_excludes_water():
     """7l39 chain F is solvent only, so nothing is left to compare."""
     with pytest.raises(ValueError, match="no non-water heavy atoms"):
-        load("7l39").heavy_atoms("F")
+        load_structure("7l39").heavy_atoms("F")
 
 
 def test_heavy_atoms_unknown_chain_names_the_file():
     with pytest.raises(ValueError, match="7l39.cif"):
-        load("7l39").heavy_atoms("ZZ")
+        load_structure("7l39").heavy_atoms("ZZ")
 
 
 # ---------------------------------------------------------------------------
@@ -189,13 +189,13 @@ IDENTITY_CASES = [
 
 @pytest.mark.parametrize(("pdb_id", "ref_chains"), IDENTITY_CASES)
 def test_structure_against_itself_scores_zero(pdb_id, ref_chains):
-    structure = load(pdb_id)
+    structure = load_structure(pdb_id)
     metrics = best_ca_rmsd(
         structure, structure, ref_chains=ref_chains, pred_chains=ref_chains
     )
-    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
-    assert metrics["gdt_ts"] == pytest.approx(1.0)
-    assert metrics["gdt_ha"] == pytest.approx(1.0)
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.gdt_ts == pytest.approx(1.0)
+    assert metrics.gdt_ha == pytest.approx(1.0)
 
 
 RIGID_MOTION_CASES = [
@@ -215,10 +215,10 @@ RIGID_MOTION_CASES = [
 @pytest.mark.parametrize(("rotation", "translation"), RIGID_MOTION_CASES)
 def test_rmsd_is_invariant_under_rigid_motion(rotation, translation):
     """Superposition must remove any rigid motion, however large."""
-    reference = load("1ubq")
+    reference = load_structure("1ubq")
     prediction = moved(reference, rotation=rotation, translation=translation)
     metrics = best_ca_rmsd(prediction, reference, ref_chains=("A",))
-    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
 
 
 SCRAMBLE_CASES = [
@@ -233,18 +233,17 @@ SCRAMBLE_CASES = [
 @pytest.mark.parametrize(("pdb_id", "pred_chains", "ref_chains"), SCRAMBLE_CASES)
 def test_finds_the_matching_chain_assignment(pdb_id, pred_chains, ref_chains):
     """Chains are paired as sets, so a scrambled reference order still scores zero."""
-    structure = load(pdb_id)
+    structure = load_structure(pdb_id)
     metrics = best_ca_rmsd(
         structure, structure, ref_chains=ref_chains, pred_chains=pred_chains
     )
-    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
 
 
 def test_pred_chains_default_to_every_polymer_chain():
-    structure = load("1ubq")
-    assert best_ca_rmsd(structure, structure, ref_chains=("A",))[
-        "rmsd"
-    ] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    structure = load_structure("1ubq")
+    metrics = best_ca_rmsd(structure, structure, ref_chains=("A",))
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
 
 
 BIOTITE_AGREEMENT_CASES = [
@@ -259,7 +258,7 @@ BIOTITE_AGREEMENT_CASES = [
 @pytest.mark.parametrize(("pdb_id", "pred_chain", "ref_chain"), BIOTITE_AGREEMENT_CASES)
 def test_agrees_with_biotite_superimposition(pdb_id, pred_chain, ref_chain):
     """Cross-check the repo primitive against an independent implementation."""
-    structure = load(pdb_id)
+    structure = load_structure(pdb_id)
     array = structure.atom_array
 
     def sorted_ca(chain):
@@ -277,18 +276,18 @@ def test_agrees_with_biotite_superimposition(pdb_id, pred_chain, ref_chain):
 
     measured = best_ca_rmsd(
         structure, structure, ref_chains=(ref_chain,), pred_chains=(pred_chain,)
-    )["rmsd"]
+    ).rmsd
     assert measured == pytest.approx(expected, abs=1e-4)
 
 
 def test_only_residues_present_in_both_are_scored():
     """4i6p chain B is missing two residues that chain A models; the pair still scores."""
-    structure = load("4i6p")
+    structure = load_structure("4i6p")
     positions = structure.ca_positions_by_chain
     shared = set(positions["A"]) & set(positions["B"])
     assert len(shared) == 82 < len(positions["A"])
     metrics = best_ca_rmsd(structure, structure, ref_chains=("B",), pred_chains=("A",))
-    assert metrics["rmsd"] > 0.0
+    assert metrics.rmsd > 0.0
 
 
 REJECTION_CASES = [
@@ -304,7 +303,7 @@ REJECTION_CASES = [
     ("pdb_id", "pred_chains", "ref_chains", "message"), REJECTION_CASES
 )
 def test_rejects_unusable_chain_selections(pdb_id, pred_chains, ref_chains, message):
-    structure = load(pdb_id)
+    structure = load_structure(pdb_id)
     with pytest.raises(ValueError, match=message):
         best_ca_rmsd(
             structure, structure, ref_chains=ref_chains, pred_chains=pred_chains
@@ -313,7 +312,7 @@ def test_rejects_unusable_chain_selections(pdb_id, pred_chains, ref_chains, mess
 
 def test_rejects_more_chains_than_brute_force_allows():
     """5kc1 has 12 polymer chains; 12! assignments is not a search worth attempting."""
-    structure = load("5kc1")
+    structure = load_structure("5kc1")
     assert len(structure.ca_positions_by_chain) > MAX_PERMUTED_CHAINS
     with pytest.raises(ValueError, match="Refusing to brute-force"):
         best_ca_rmsd(
@@ -323,7 +322,7 @@ def test_rejects_more_chains_than_brute_force_allows():
 
 def test_rejects_chains_with_no_residues_in_common():
     """5kc1 chains A and B share no residue ids, so there is nothing to superimpose."""
-    structure = load("5kc1")
+    structure = load_structure("5kc1")
     positions = structure.ca_positions_by_chain
     assert not set(positions["A"]) & set(positions["B"])
     with pytest.raises(ValueError, match="No residues in common"):
@@ -338,7 +337,7 @@ def test_rejects_chains_with_no_residues_in_common():
 @pytest.mark.parametrize(("rotation", "translation"), RIGID_MOTION_CASES)
 def test_alignment_transformation_maps_prediction_onto_reference(rotation, translation):
     """The returned transform is what carries a ligand into the reference frame."""
-    reference = load("1ubq")
+    reference = load_structure("1ubq")
     prediction = moved(reference, rotation=rotation, translation=translation)
     alignment = _best_ca_assignment(prediction, reference, ref_chains=("A",))
 
@@ -371,21 +370,21 @@ SYMMETRY_CASES = [
 
 @pytest.mark.parametrize(("pdb_id", "chain", "expected"), SYMMETRY_CASES)
 def test_symmetry_group_size(pdb_id, chain, expected):
-    ligand = load(pdb_id).heavy_atoms(chain)
+    ligand = load_structure(pdb_id).heavy_atoms(chain)
     assert len(symmetry_mappings(ligand, ligand)) == expected
 
 
 @pytest.mark.parametrize(("pdb_id", "chain", "expected"), SYMMETRY_CASES)
 def test_symmetry_mappings_are_bijections(pdb_id, chain, expected):
-    ligand = load(pdb_id).heavy_atoms(chain)
+    ligand = load_structure(pdb_id).heavy_atoms(chain)
     for mapping in symmetry_mappings(ligand, ligand):
         assert sorted(mapping) == list(range(len(ligand)))
 
 
 def test_symmetry_mappings_are_empty_for_different_molecules():
     """Toluene is not a subgraph of mercaptoethanol, so nothing matches."""
-    toluene = load("7l39").heavy_atoms("D")
-    mercaptoethanol = load("7l39").heavy_atoms("E")
+    toluene = load_structure("7l39").heavy_atoms("D")
+    mercaptoethanol = load_structure("7l39").heavy_atoms("E")
     assert symmetry_mappings(mercaptoethanol, toluene) == []
 
 
@@ -395,7 +394,7 @@ def test_symmetry_mappings_are_empty_for_different_molecules():
 
 
 def test_identical_pose_scores_zero():
-    structure = load("7l39")
+    structure = load_structure("7l39")
     metrics = ligand_pose_metrics(
         structure,
         structure,
@@ -404,10 +403,10 @@ def test_identical_pose_scores_zero():
         pred_ligand_chain="D",
         ref_ligand_chain="D",
     )
-    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
-    assert metrics["centroid_distance"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
-    assert metrics["n_atoms"] == 7
-    assert metrics["n_symmetry_mappings"] == 2
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.centroid_distance == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.n_atoms == 7
+    assert metrics.n_symmetry_mappings == 2
 
 
 LIGAND_OFFSET_CASES = [
@@ -425,7 +424,7 @@ def test_displacing_only_the_ligand_shows_up_in_full(offset, expected):
     Symmetry cannot absorb a rigid displacement, so both the pose RMSD and the
     mapping-free centroid distance must equal the displacement exactly.
     """
-    reference = load("7l39")
+    reference = load_structure("7l39")
     prediction = with_chain_translated(reference, "D", offset)
     metrics = ligand_pose_metrics(
         prediction,
@@ -435,13 +434,13 @@ def test_displacing_only_the_ligand_shows_up_in_full(offset, expected):
         pred_ligand_chain="D",
         ref_ligand_chain="D",
     )
-    assert metrics["rmsd"] == pytest.approx(expected, abs=1e-3)
-    assert metrics["centroid_distance"] == pytest.approx(expected, abs=1e-3)
+    assert metrics.rmsd == pytest.approx(expected, abs=1e-3)
+    assert metrics.centroid_distance == pytest.approx(expected, abs=1e-3)
 
 
 def test_symmetry_equivalent_relabelling_scores_zero():
     """A ring-flipped toluene is the same pose; only the atom order differs."""
-    reference = load("7l39")
+    reference = load_structure("7l39")
     ligand = reference.heavy_atoms("D")
     flip = next(
         mapping
@@ -467,11 +466,11 @@ def test_symmetry_equivalent_relabelling_scores_zero():
         pred_ligand_chain="D",
         ref_ligand_chain="D",
     )
-    assert metrics["rmsd"] == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
 
 
 def test_rejects_ligands_of_different_size():
-    structure = load("7l39")
+    structure = load_structure("7l39")
     with pytest.raises(ValueError, match="Ligand atom count mismatch"):
         ligand_pose_metrics(
             structure,
@@ -485,7 +484,7 @@ def test_rejects_ligands_of_different_size():
 
 def test_rejects_ligands_that_do_not_match_as_graphs():
     """Same atom count, unrelated topology: EDO (C2O2) against NO3 (NO3)."""
-    structure = load("5kc1")
+    structure = load_structure("5kc1")
     with pytest.raises(ValueError, match="No graph match"):
         ligand_pose_metrics(
             structure,

--- a/openfold3/tests/core/metrics/test_alignment.py
+++ b/openfold3/tests/core/metrics/test_alignment.py
@@ -256,18 +256,20 @@ BIOTITE_AGREEMENT_CASES = [
 
 
 @pytest.mark.parametrize(("pdb_id", "pred_chain", "ref_chain"), BIOTITE_AGREEMENT_CASES)
-def test_agrees_with_biotite_superimposition(pdb_id, pred_chain, ref_chain):
+def test_best_ca_rmsd_agrees_with_biotite_superimposition(
+    pdb_id, pred_chain, ref_chain
+):
     """Cross-check the repo primitive against an independent implementation."""
     structure = load_structure(pdb_id)
     array = structure.atom_array
 
-    def sorted_ca(chain):
+    def _sorted_ca(chain):
         selected = array[
             (array.atom_name == "CA") & (~array.hetero) & (array.chain_id == chain)
         ]
         return selected[np.argsort(selected.res_id)]
 
-    pred, ref = sorted_ca(pred_chain), sorted_ca(ref_chain)
+    pred, ref = _sorted_ca(pred_chain), _sorted_ca(ref_chain)
     shared = np.intersect1d(pred.res_id, ref.res_id)
     pred = pred[np.isin(pred.res_id, shared)]
     ref = ref[np.isin(ref.res_id, shared)]

--- a/openfold3/tests/core/metrics/test_alignment.py
+++ b/openfold3/tests/core/metrics/test_alignment.py
@@ -440,25 +440,91 @@ def test_displacing_only_the_ligand_shows_up_in_full(offset, expected):
     assert metrics.centroid_distance == pytest.approx(expected, abs=1e-3)
 
 
-def test_symmetry_equivalent_relabelling_scores_zero():
-    """A ring-flipped toluene is the same pose; only the atom order differs."""
+#: Toluene (MBN), 7l39 chain D, in file order: a methyl carbon ``C`` on a benzene ring
+#: whose carbons run ``C1`` (the one bearing the methyl) round to ``C6``.
+TOLUENE_ATOM_ORDER = ("C", "C1", "C2", "C3", "C4", "C5", "C6")
+
+#: The same molecule with the ring read the other way round. ``C``, ``C1`` and the para
+#: carbon ``C4`` lie on the mirror axis and stay put; the two pairs either side of it
+#: swap — ``C2``<->``C6`` and ``C3``<->``C5``. This is toluene's only non-trivial
+#: automorphism.
+TOLUENE_RING_FLIP = ("C", "C1", "C6", "C5", "C4", "C3", "C2")
+
+#: Smallest atom movement among the non-symmetry relabellings below (~0.74 Å). Scoring
+#: any of them near zero would mean a genuine mismatch had been wrongly forgiven.
+MIN_MISMATCH_RMSD = 0.5
+
+
+def toluene_indices(atom_order: tuple[str, ...]) -> tuple[int, ...]:
+    """An atom order as indices into ``TOLUENE_ATOM_ORDER``.
+
+    That index form is what :func:`with_chain_relabelled` and :func:`symmetry_mappings`
+    both speak; names are used above because a flip is legible and ``(0, 1, 6, 5, 4, 3,
+    2)`` is not.
+    """
+    return tuple(TOLUENE_ATOM_ORDER.index(name) for name in atom_order)
+
+
+def test_symmetry_mappings_finds_the_ring_flip():
+    """Toluene has exactly two automorphisms: the identity and the mirror.
+
+    Pins the atom order the constants above are written against, so they cannot quietly
+    drift out of step with the committed cif.
+    """
+    ligand = load_structure("7l39").heavy_atoms("D")
+    assert tuple(str(name) for name in ligand.atom_name) == TOLUENE_ATOM_ORDER
+
+    found = {
+        tuple(TOLUENE_ATOM_ORDER[index] for index in mapping)
+        for mapping in symmetry_mappings(ligand, ligand)
+    }
+    assert found == {TOLUENE_ATOM_ORDER, TOLUENE_RING_FLIP}
+
+
+RELABELLING_CASES = [
+    pytest.param(TOLUENE_ATOM_ORDER, True, id="unchanged"),
+    pytest.param(TOLUENE_RING_FLIP, True, id="ring-flip"),
+    # Ortho and meta carbons are not interchangeable with each other, so swapping a
+    # neighbouring pair is a real error however the molecule is read.
+    pytest.param(
+        ("C", "C1", "C3", "C2", "C4", "C5", "C6"), False, id="adjacent-carbons-swapped"
+    ),
+    # Benzene alone would be invariant under this; the methyl is what breaks it.
+    pytest.param(
+        ("C", "C2", "C3", "C4", "C5", "C6", "C1"), False, id="ring-rotated-under-methyl"
+    ),
+    pytest.param(
+        ("C4", "C1", "C2", "C3", "C", "C5", "C6"), False, id="methyl-swapped-into-ring"
+    ),
+    # Reversed about the wrong axis: close enough to the true mirror that the symmetry
+    # search cuts the error roughly in half, but it never reaches zero.
+    pytest.param(
+        ("C", "C6", "C5", "C4", "C3", "C2", "C1"), False, id="ring-reversed-wrong-axis"
+    ),
+]
+
+
+@pytest.mark.parametrize(("atom_order", "is_symmetry"), RELABELLING_CASES)
+def test_relabelling_is_forgiven_only_when_it_is_a_symmetry(atom_order, is_symmetry):
+    """Reordering a ligand's atoms is free exactly when the reordering is a symmetry.
+
+    Each case rewrites chain D's coordinates into ``atom_order`` — the pose is untouched,
+    only which atom sits where changes. Toluene's mirror must score zero; anything else
+    must not, or the metric would forgive genuinely misplaced atoms.
+    """
     reference = load_structure("7l39")
     ligand = reference.heavy_atoms("D")
-    flip = next(
-        mapping
-        for mapping in symmetry_mappings(ligand, ligand)
-        if list(mapping) != sorted(mapping)
-    )
-    prediction = with_chain_relabelled(reference, "D", flip)
+    prediction = with_chain_relabelled(reference, "D", toluene_indices(atom_order))
 
     naive = float(
         np.sqrt(
             ((prediction.heavy_atoms("D").coord - ligand.coord) ** 2).sum(-1).mean()
         )
     )
-    assert naive > 1.0, (
-        "the relabelling must actually move atoms for this to prove anything"
-    )
+    if atom_order != TOLUENE_ATOM_ORDER:
+        assert naive > MIN_MISMATCH_RMSD, (
+            "the relabelling must actually move atoms for this to prove anything"
+        )
 
     metrics = ligand_pose_metrics(
         prediction,
@@ -468,7 +534,18 @@ def test_symmetry_equivalent_relabelling_scores_zero():
         pred_ligand_chain="D",
         ref_ligand_chain="D",
     )
-    assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+
+    if is_symmetry:
+        assert metrics.rmsd == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    else:
+        assert metrics.rmsd > MIN_MISMATCH_RMSD
+
+    # Reordering atoms cannot move their centre of mass, so the mapping-free half of the
+    # metric stays at zero throughout: every case above is the right pocket, and the RMSD
+    # signal is purely about which atom went where.
+    assert metrics.centroid_distance == pytest.approx(0.0, abs=ZERO_RMSD_TOL)
+    # Searching symmetries can only ever improve the score, never worsen it.
+    assert metrics.rmsd <= naive + ZERO_RMSD_TOL
 
 
 def test_rejects_ligands_of_different_size():

--- a/openfold3/tests/inference/analysis.py
+++ b/openfold3/tests/inference/analysis.py
@@ -19,18 +19,21 @@ through :func:`~openfold3.core.metrics.quality.get_superimpose_metrics` — Kabs
 superposition followed by RMSD — so the tests measure agreement with the same primitive
 the model's own validation uses, rather than a second implementation that could drift.
 
-Only protein CA-RMSD lives here for now; ligand RMSD needs symmetry-aware atom matching
-and is deliberately left out.
+Everything here takes :class:`Structure`, never a path: parsing is the expensive step and
+every metric wants the same two structures, so callers parse once at the boundary and
+pass the result down.
 """
 
 import itertools
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 
 import numpy as np
 import torch
+from biotite.structure import AtomArray
 
 from openfold3.core.data.io.structure.cif import parse_mmcif
 from openfold3.core.metrics.quality import get_superimpose_metrics
@@ -48,27 +51,67 @@ logger = logging.getLogger(__name__)
 MAX_PERMUTED_CHAINS = 6
 
 
-def ca_positions_by_chain(cif_path: Path) -> dict[str, dict[int, np.ndarray]]:
-    """Map ``chain_id -> {res_id: CA position}`` over the polymer CAs in *cif_path*.
+@dataclass(frozen=True, eq=False)
+class Structure:
+    """A parsed mmCIF, carrying the path it came from so errors can name the file.
 
-    Keying by residue id (rather than returning a flat array) is what lets a prediction
-    be compared against a reference with unmodelled gaps: only residues present in both
-    are scored.
+    Holding the parsed array rather than re-reading a path matters here: a single scored
+    query superimposes the protein, then reuses that same superposition for the ligand,
+    and each of those steps needs both structures. Passing paths made that four or five
+    parses of the same two files per query.
     """
-    atom_array = parse_mmcif(cif_path).atom_array
-    ca = atom_array[(atom_array.atom_name == "CA") & (~atom_array.hetero)]
-    by_chain: dict[str, dict[int, np.ndarray]] = {}
-    for chain_id, res_id, coord in zip(ca.chain_id, ca.res_id, ca.coord, strict=True):
-        residues = by_chain.setdefault(str(chain_id), {})
-        if int(res_id) in residues:
-            # Insertion codes or altlocs would otherwise silently overwrite, quietly
-            # dropping residues from the comparison instead of failing.
+
+    path: Path
+    atom_array: AtomArray
+
+    @classmethod
+    def from_cif(cls, path: Path) -> "Structure":
+        return cls(path=path, atom_array=parse_mmcif(path).atom_array)
+
+    @cached_property
+    def ca_positions_by_chain(self) -> dict[str, dict[int, np.ndarray]]:
+        """Map ``chain_id -> {res_id: CA position}`` over the polymer CAs.
+
+        Keying by residue id (rather than a flat array) is what lets a prediction be
+        compared against a reference with unmodelled gaps: only residues present in both
+        are scored. Cached because the chain-assignment search reads it repeatedly.
+        """
+        array = self.atom_array
+        ca = array[(array.atom_name == "CA") & (~array.hetero)]
+        by_chain: dict[str, dict[int, np.ndarray]] = {}
+        for chain_id, res_id, coord in zip(
+            ca.chain_id, ca.res_id, ca.coord, strict=True
+        ):
+            residues = by_chain.setdefault(str(chain_id), {})
+            if int(res_id) in residues:
+                # Insertion codes or altlocs would otherwise silently overwrite, quietly
+                # dropping residues from the comparison instead of failing.
+                raise ValueError(
+                    f"{self.path}: chain {chain_id} has more than one CA for residue "
+                    f"{res_id}"
+                )
+            residues[int(res_id)] = coord
+        return by_chain
+
+    def heavy_atoms(self, chain: str) -> AtomArray:
+        """Non-water heavy atoms of one chain, with the intra-chain bond graph kept."""
+        array = self.atom_array
+        selected = array[
+            (array.chain_id == chain)
+            & (array.res_name != "HOH")
+            & (array.element != "H")
+        ]
+        if not len(selected):
             raise ValueError(
-                f"{cif_path}: chain {chain_id} has more than one CA for residue "
-                f"{res_id}"
+                f"{self.path}: chain {chain} holds no non-water heavy atoms; chains "
+                f"present are {sorted(set(map(str, array.chain_id)))}"
             )
-        residues[int(res_id)] = coord
-    return by_chain
+        if selected.bonds is None:
+            raise ValueError(
+                f"{self.path}: chain {chain} carries no bond graph, so ligand atoms "
+                "cannot be matched up by connectivity"
+            )
+        return selected
 
 
 def _paired_positions(
@@ -112,12 +155,12 @@ class CaAlignment:
 
 
 def _best_ca_assignment(
-    pred_cif: Path,
-    ref_cif: Path,
+    pred: Structure,
+    ref: Structure,
     ref_chains: Sequence[str],
     pred_chains: Sequence[str] | None = None,
 ) -> CaAlignment:
-    """Best superposition CA-RMSD (Å) of *pred_cif* against *ref_cif*.
+    """Best superposition CA-RMSD (Å) of *pred* against *ref*.
 
     ``pred_chains`` and ``ref_chains`` are matched as sets, not pairwise: every bijection
     between them is scored and the best is returned. That is what makes a homomer
@@ -125,13 +168,16 @@ def _best_ca_assignment(
     emit carry no information, so pinning a specific pairing would measure label
     agreement rather than structural agreement.
 
-    ``pred_chains`` defaults to every polymer chain in *pred_cif*, which is what a
+    ``pred_chains`` defaults to every polymer chain in *pred*, which is what a
     single-chain prediction wants: the chain id the writer emits is then irrelevant.
 
     Returns the winning assignment's ``rmsd``/``gdt_ts``/``gdt_ha`` and its superposition.
     """
+    pred_by_chain = pred.ca_positions_by_chain
+    ref_by_chain = ref.ca_positions_by_chain
+
     if pred_chains is None:
-        pred_chains = sorted(ca_positions_by_chain(pred_cif))
+        pred_chains = sorted(pred_by_chain)
     if len(pred_chains) != len(ref_chains):
         raise ValueError(
             f"Need equal chain counts to pair up, got predicted {list(pred_chains)} "
@@ -143,17 +189,15 @@ def _best_ca_assignment(
             f"limit is {MAX_PERMUTED_CHAINS}"
         )
 
-    pred_by_chain = ca_positions_by_chain(pred_cif)
-    ref_by_chain = ca_positions_by_chain(ref_cif)
-    for label, wanted, available in (
-        ("predicted", pred_chains, pred_by_chain),
-        ("reference", ref_chains, ref_by_chain),
+    for structure, wanted, available in (
+        (pred, pred_chains, pred_by_chain),
+        (ref, ref_chains, ref_by_chain),
     ):
         missing = sorted(set(wanted) - set(available))
         if missing:
             raise ValueError(
-                f"{label} structure {pred_cif if label == 'predicted' else ref_cif} "
-                f"has no chain(s) {missing}; it holds {sorted(available)}"
+                f"{structure.path} has no chain(s) {missing}; "
+                f"it holds {sorted(available)}"
             )
 
     best_metrics: dict[str, float] | None = None
@@ -163,7 +207,7 @@ def _best_ca_assignment(
         pred_xyz, ref_xyz = _paired_positions(pred_by_chain, ref_by_chain, assignment)
         if not len(pred_xyz):
             raise ValueError(
-                f"No residues in common between {pred_cif} and {ref_cif} "
+                f"No residues in common between {pred.path} and {ref.path} "
                 f"for assignment {assignment}"
             )
         metrics = _superimpose_rmsd(pred_xyz, ref_xyz)
@@ -185,16 +229,16 @@ def _best_ca_assignment(
 
 
 def best_ca_rmsd(
-    pred_cif: Path,
-    ref_cif: Path,
+    pred: Structure,
+    ref: Structure,
     ref_chains: Sequence[str],
     pred_chains: Sequence[str] | None = None,
 ) -> dict[str, float]:
-    """Best superposition CA-RMSD (Å) of *pred_cif* against *ref_cif*.
+    """Best superposition CA-RMSD (Å) of *pred* against *ref*.
 
     See :func:`_best_ca_assignment`; this returns just the metrics.
     """
-    return _best_ca_assignment(pred_cif, ref_cif, ref_chains, pred_chains).metrics
+    return _best_ca_assignment(pred, ref, ref_chains, pred_chains).metrics
 
 
 # ---------------------------------------------------------------------------
@@ -202,28 +246,7 @@ def best_ca_rmsd(
 # ---------------------------------------------------------------------------
 
 
-def _heavy_atoms(cif_path: Path, chain: str):
-    """Non-water heavy atoms of one chain, with the intra-chain bond graph retained."""
-    atom_array = parse_mmcif(cif_path).atom_array
-    selected = atom_array[
-        (atom_array.chain_id == chain)
-        & (atom_array.res_name != "HOH")
-        & (atom_array.element != "H")
-    ]
-    if not len(selected):
-        raise ValueError(
-            f"{cif_path}: chain {chain} holds no non-water heavy atoms; chains present "
-            f"are {sorted(set(map(str, atom_array.chain_id)))}"
-        )
-    if selected.bonds is None:
-        raise ValueError(
-            f"{cif_path}: chain {chain} carries no bond graph, so ligand atoms cannot "
-            "be matched up by connectivity"
-        )
-    return selected
-
-
-def _connectivity_graph(selected):
+def _connectivity_graph(selected: AtomArray):
     """An RDKit molecule holding *only* element identity and connectivity.
 
     Bond orders are dropped deliberately. A prediction built from SMILES and a reference
@@ -244,7 +267,9 @@ def _connectivity_graph(selected):
     return mol
 
 
-def symmetry_mappings(pred_selected, ref_selected) -> list[tuple[int, ...]]:
+def symmetry_mappings(
+    pred_selected: AtomArray, ref_selected: AtomArray
+) -> list[tuple[int, ...]]:
     """Every element- and connectivity-preserving map from reference to predicted atoms.
 
     For toluene this yields the two ring flips; for a fully asymmetric ligand, one. The
@@ -260,8 +285,8 @@ def symmetry_mappings(pred_selected, ref_selected) -> list[tuple[int, ...]]:
 
 
 def ligand_pose_metrics(
-    pred_cif: Path,
-    ref_cif: Path,
+    pred: Structure,
+    ref: Structure,
     *,
     ref_chains: Sequence[str],
     pred_ligand_chain: str,
@@ -280,10 +305,10 @@ def ligand_pose_metrics(
     so it separates "wrong pocket" from "right pocket, flipped"), plus ``n_atoms`` and
     ``n_symmetry_mappings`` for diagnosis.
     """
-    alignment = _best_ca_assignment(pred_cif, ref_cif, ref_chains, pred_chains)
+    alignment = _best_ca_assignment(pred, ref, ref_chains, pred_chains)
 
-    pred_selected = _heavy_atoms(pred_cif, pred_ligand_chain)
-    ref_selected = _heavy_atoms(ref_cif, ref_ligand_chain)
+    pred_selected = pred.heavy_atoms(pred_ligand_chain)
+    ref_selected = ref.heavy_atoms(ref_ligand_chain)
     if len(pred_selected) != len(ref_selected):
         raise ValueError(
             f"Ligand atom count mismatch: predicted chain {pred_ligand_chain} has "

--- a/openfold3/tests/inference/analysis.py
+++ b/openfold3/tests/inference/analysis.py
@@ -1,0 +1,155 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scoring predicted structures against experimental references.
+
+Answers "is this consistent with experiment?" rather than "did it run". Scoring goes
+through :func:`~openfold3.core.metrics.quality.get_superimpose_metrics` — Kabsch
+superposition followed by RMSD — so the tests measure agreement with the same primitive
+the model's own validation uses, rather than a second implementation that could drift.
+
+Only protein CA-RMSD lives here for now; ligand RMSD needs symmetry-aware atom matching
+and is deliberately left out.
+"""
+
+import itertools
+import logging
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from openfold3.core.data.io.structure.cif import parse_mmcif
+from openfold3.core.metrics.quality import get_superimpose_metrics
+
+logger = logging.getLogger(__name__)
+
+#: Guard on the chain-assignment search below, which is factorial in the number of
+#: interchangeable copies. Six covers every example query; beyond that the caller wants
+#: real permutation alignment, not brute force.
+MAX_PERMUTED_CHAINS = 6
+
+
+def ca_positions_by_chain(cif_path: Path) -> dict[str, dict[int, np.ndarray]]:
+    """Map ``chain_id -> {res_id: CA position}`` over the polymer CAs in *cif_path*.
+
+    Keying by residue id (rather than returning a flat array) is what lets a prediction
+    be compared against a reference with unmodelled gaps: only residues present in both
+    are scored.
+    """
+    atom_array = parse_mmcif(cif_path).atom_array
+    ca = atom_array[(atom_array.atom_name == "CA") & (~atom_array.hetero)]
+    by_chain: dict[str, dict[int, np.ndarray]] = {}
+    for chain_id, res_id, coord in zip(ca.chain_id, ca.res_id, ca.coord, strict=True):
+        residues = by_chain.setdefault(str(chain_id), {})
+        if int(res_id) in residues:
+            # Insertion codes or altlocs would otherwise silently overwrite, quietly
+            # dropping residues from the comparison instead of failing.
+            raise ValueError(
+                f"{cif_path}: chain {chain_id} has more than one CA for residue "
+                f"{res_id}"
+            )
+        residues[int(res_id)] = coord
+    return by_chain
+
+
+def _paired_positions(
+    pred_by_chain: Mapping[str, Mapping[int, np.ndarray]],
+    ref_by_chain: Mapping[str, Mapping[int, np.ndarray]],
+    assignment: Sequence[tuple[str, str]],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Stack the CAs shared by each ``(pred_chain, ref_chain)`` pair, in matching order."""
+    pred_xyz: list[np.ndarray] = []
+    ref_xyz: list[np.ndarray] = []
+    for pred_chain, ref_chain in assignment:
+        pred_residues = pred_by_chain[pred_chain]
+        ref_residues = ref_by_chain[ref_chain]
+        for res_id in sorted(set(pred_residues) & set(ref_residues)):
+            pred_xyz.append(pred_residues[res_id])
+            ref_xyz.append(ref_residues[res_id])
+    return np.asarray(pred_xyz, dtype=float), np.asarray(ref_xyz, dtype=float)
+
+
+def _superimpose_rmsd(pred_xyz: np.ndarray, ref_xyz: np.ndarray) -> dict[str, float]:
+    """Kabsch-superimpose *pred_xyz* onto *ref_xyz* and return rmsd/gdt_ts/gdt_ha."""
+    metrics = get_superimpose_metrics(
+        all_atom_pred_pos=torch.from_numpy(pred_xyz),
+        all_atom_gt_pos=torch.from_numpy(ref_xyz),
+        all_atom_mask=torch.ones(len(pred_xyz), dtype=torch.float64),
+    )
+    return {name: float(value) for name, value in metrics.items()}
+
+
+def best_ca_rmsd(
+    pred_cif: Path,
+    ref_cif: Path,
+    ref_chains: Sequence[str],
+    pred_chains: Sequence[str] | None = None,
+) -> dict[str, float]:
+    """Best superposition CA-RMSD (Å) of *pred_cif* against *ref_cif*.
+
+    ``pred_chains`` and ``ref_chains`` are matched as sets, not pairwise: every bijection
+    between them is scored and the best is returned. That is what makes a homomer
+    meaningful — with N interchangeable copies the chain labels a prediction happens to
+    emit carry no information, so pinning a specific pairing would measure label
+    agreement rather than structural agreement.
+
+    ``pred_chains`` defaults to every polymer chain in *pred_cif*, which is what a
+    single-chain prediction wants: the chain id the writer emits is then irrelevant.
+
+    Returns the ``rmsd``/``gdt_ts``/``gdt_ha`` of the winning assignment.
+    """
+    if pred_chains is None:
+        pred_chains = sorted(ca_positions_by_chain(pred_cif))
+    if len(pred_chains) != len(ref_chains):
+        raise ValueError(
+            f"Need equal chain counts to pair up, got predicted {list(pred_chains)} "
+            f"vs reference {list(ref_chains)}"
+        )
+    if len(pred_chains) > MAX_PERMUTED_CHAINS:
+        raise ValueError(
+            f"Refusing to brute-force {len(pred_chains)}! chain assignments; "
+            f"limit is {MAX_PERMUTED_CHAINS}"
+        )
+
+    pred_by_chain = ca_positions_by_chain(pred_cif)
+    ref_by_chain = ca_positions_by_chain(ref_cif)
+    for label, wanted, available in (
+        ("predicted", pred_chains, pred_by_chain),
+        ("reference", ref_chains, ref_by_chain),
+    ):
+        missing = sorted(set(wanted) - set(available))
+        if missing:
+            raise ValueError(
+                f"{label} structure {pred_cif if label == 'predicted' else ref_cif} "
+                f"has no chain(s) {missing}; it holds {sorted(available)}"
+            )
+
+    best: dict[str, float] | None = None
+    for permuted_ref in itertools.permutations(ref_chains):
+        assignment = list(zip(pred_chains, permuted_ref, strict=True))
+        pred_xyz, ref_xyz = _paired_positions(pred_by_chain, ref_by_chain, assignment)
+        if not len(pred_xyz):
+            raise ValueError(
+                f"No residues in common between {pred_cif} and {ref_cif} "
+                f"for assignment {assignment}"
+            )
+        metrics = _superimpose_rmsd(pred_xyz, ref_xyz)
+        logger.debug("assignment %s -> CA-RMSD %.2f", assignment, metrics["rmsd"])
+        if best is None or metrics["rmsd"] < best["rmsd"]:
+            best = metrics
+
+    assert best is not None  # permutations() of a non-empty sequence is non-empty
+    return best

--- a/openfold3/tests/inference/analysis.py
+++ b/openfold3/tests/inference/analysis.py
@@ -26,6 +26,7 @@ and is deliberately left out.
 import itertools
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -33,6 +34,11 @@ import torch
 
 from openfold3.core.data.io.structure.cif import parse_mmcif
 from openfold3.core.metrics.quality import get_superimpose_metrics
+from openfold3.core.utils.geometry.kabsch_alignment import (
+    Transformation,
+    apply_transformation,
+    get_optimal_transformation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +98,25 @@ def _superimpose_rmsd(pred_xyz: np.ndarray, ref_xyz: np.ndarray) -> dict[str, fl
     return {name: float(value) for name, value in metrics.items()}
 
 
-def best_ca_rmsd(
+@dataclass(frozen=True)
+class CaAlignment:
+    """The chain assignment that won, and the superposition it implies.
+
+    ``transformation`` maps predicted coordinates onto the reference frame, so it can be
+    applied to anything else in the prediction — a ligand, say — to ask where it lands
+    once the protein has been placed.
+    """
+
+    metrics: dict[str, float]
+    transformation: Transformation
+
+
+def _best_ca_assignment(
     pred_cif: Path,
     ref_cif: Path,
     ref_chains: Sequence[str],
     pred_chains: Sequence[str] | None = None,
-) -> dict[str, float]:
+) -> CaAlignment:
     """Best superposition CA-RMSD (Å) of *pred_cif* against *ref_cif*.
 
     ``pred_chains`` and ``ref_chains`` are matched as sets, not pairwise: every bijection
@@ -109,7 +128,7 @@ def best_ca_rmsd(
     ``pred_chains`` defaults to every polymer chain in *pred_cif*, which is what a
     single-chain prediction wants: the chain id the writer emits is then irrelevant.
 
-    Returns the ``rmsd``/``gdt_ts``/``gdt_ha`` of the winning assignment.
+    Returns the winning assignment's ``rmsd``/``gdt_ts``/``gdt_ha`` and its superposition.
     """
     if pred_chains is None:
         pred_chains = sorted(ca_positions_by_chain(pred_cif))
@@ -137,7 +156,8 @@ def best_ca_rmsd(
                 f"has no chain(s) {missing}; it holds {sorted(available)}"
             )
 
-    best: dict[str, float] | None = None
+    best_metrics: dict[str, float] | None = None
+    best_positions: tuple[np.ndarray, np.ndarray] | None = None
     for permuted_ref in itertools.permutations(ref_chains):
         assignment = list(zip(pred_chains, permuted_ref, strict=True))
         pred_xyz, ref_xyz = _paired_positions(pred_by_chain, ref_by_chain, assignment)
@@ -148,8 +168,152 @@ def best_ca_rmsd(
             )
         metrics = _superimpose_rmsd(pred_xyz, ref_xyz)
         logger.debug("assignment %s -> CA-RMSD %.2f", assignment, metrics["rmsd"])
-        if best is None or metrics["rmsd"] < best["rmsd"]:
-            best = metrics
+        if best_metrics is None or metrics["rmsd"] < best_metrics["rmsd"]:
+            best_metrics, best_positions = metrics, (pred_xyz, ref_xyz)
 
-    assert best is not None  # permutations() of a non-empty sequence is non-empty
-    return best
+    assert best_metrics is not None  # permutations() of a non-empty seq is non-empty
+    assert best_positions is not None
+    # Only the winner's transform is needed, so it is derived once here rather than for
+    # every candidate assignment.
+    pred_xyz, ref_xyz = best_positions
+    transformation = get_optimal_transformation(
+        mobile_positions=torch.from_numpy(pred_xyz),
+        target_positions=torch.from_numpy(ref_xyz),
+        positions_mask=torch.ones(len(pred_xyz), dtype=torch.float64),
+    )
+    return CaAlignment(metrics=best_metrics, transformation=transformation)
+
+
+def best_ca_rmsd(
+    pred_cif: Path,
+    ref_cif: Path,
+    ref_chains: Sequence[str],
+    pred_chains: Sequence[str] | None = None,
+) -> dict[str, float]:
+    """Best superposition CA-RMSD (Å) of *pred_cif* against *ref_cif*.
+
+    See :func:`_best_ca_assignment`; this returns just the metrics.
+    """
+    return _best_ca_assignment(pred_cif, ref_cif, ref_chains, pred_chains).metrics
+
+
+# ---------------------------------------------------------------------------
+# Ligand pose
+# ---------------------------------------------------------------------------
+
+
+def _heavy_atoms(cif_path: Path, chain: str):
+    """Non-water heavy atoms of one chain, with the intra-chain bond graph retained."""
+    atom_array = parse_mmcif(cif_path).atom_array
+    selected = atom_array[
+        (atom_array.chain_id == chain)
+        & (atom_array.res_name != "HOH")
+        & (atom_array.element != "H")
+    ]
+    if not len(selected):
+        raise ValueError(
+            f"{cif_path}: chain {chain} holds no non-water heavy atoms; chains present "
+            f"are {sorted(set(map(str, atom_array.chain_id)))}"
+        )
+    if selected.bonds is None:
+        raise ValueError(
+            f"{cif_path}: chain {chain} carries no bond graph, so ligand atoms cannot "
+            "be matched up by connectivity"
+        )
+    return selected
+
+
+def _connectivity_graph(selected):
+    """An RDKit molecule holding *only* element identity and connectivity.
+
+    Bond orders are dropped deliberately. A prediction built from SMILES and a reference
+    built from a CCD definition need not agree on kekulisation or aromatic perception,
+    and none of that changes which atoms are interchangeable by symmetry. Comparing
+    topology alone is the standard basis for a symmetry-corrected RMSD.
+    """
+    from rdkit import Chem
+
+    mol = Chem.RWMol()
+    for element in selected.element:
+        mol.AddAtom(Chem.Atom(str(element).capitalize()))
+    for i, j, _bond_order in selected.bonds.as_array():
+        mol.AddBond(int(i), int(j), Chem.BondType.SINGLE)
+    mol = mol.GetMol()
+    mol.UpdatePropertyCache(strict=False)
+    Chem.FastFindRings(mol)  # substructure matching needs ring perception
+    return mol
+
+
+def symmetry_mappings(pred_selected, ref_selected) -> list[tuple[int, ...]]:
+    """Every element- and connectivity-preserving map from reference to predicted atoms.
+
+    For toluene this yields the two ring flips; for a fully asymmetric ligand, one. The
+    predicted ligand comes from SMILES so its atom *names* are whatever the writer chose
+    — matching has to go through the graph, not the names.
+    """
+    pred_mol = _connectivity_graph(pred_selected)
+    ref_mol = _connectivity_graph(ref_selected)
+    matches = pred_mol.GetSubstructMatches(
+        ref_mol, uniquify=False, useChirality=False, maxMatches=10_000
+    )
+    return [tuple(int(i) for i in match) for match in matches]
+
+
+def ligand_pose_metrics(
+    pred_cif: Path,
+    ref_cif: Path,
+    *,
+    ref_chains: Sequence[str],
+    pred_ligand_chain: str,
+    ref_ligand_chain: str,
+    pred_chains: Sequence[str] | None = None,
+) -> dict[str, float]:
+    """Symmetry-corrected ligand pose accuracy, in the frame of the superimposed protein.
+
+    The protein is superimposed first and that same transform is applied to the predicted
+    ligand — the ligand is *not* aligned to itself. That is the question worth asking of
+    a co-folding model: given the protein placed correctly, does the ligand land in the
+    right pocket in the right orientation. Aligning the ligand separately would score its
+    internal geometry and quietly forgive a pose in the wrong site.
+
+    Returns ``rmsd`` (best over symmetry mappings), ``centroid_distance`` (mapping-free,
+    so it separates "wrong pocket" from "right pocket, flipped"), plus ``n_atoms`` and
+    ``n_symmetry_mappings`` for diagnosis.
+    """
+    alignment = _best_ca_assignment(pred_cif, ref_cif, ref_chains, pred_chains)
+
+    pred_selected = _heavy_atoms(pred_cif, pred_ligand_chain)
+    ref_selected = _heavy_atoms(ref_cif, ref_ligand_chain)
+    if len(pred_selected) != len(ref_selected):
+        raise ValueError(
+            f"Ligand atom count mismatch: predicted chain {pred_ligand_chain} has "
+            f"{len(pred_selected)} heavy atoms, reference chain {ref_ligand_chain} has "
+            f"{len(ref_selected)}"
+        )
+
+    pred_xyz = apply_transformation(
+        positions=torch.from_numpy(pred_selected.coord.astype(float)),
+        transformation=alignment.transformation,
+    ).numpy()
+    ref_xyz = ref_selected.coord.astype(float)
+
+    mappings = symmetry_mappings(pred_selected, ref_selected)
+    if not mappings:
+        raise ValueError(
+            f"No graph match between predicted ligand (chain {pred_ligand_chain}) and "
+            f"reference ligand (chain {ref_ligand_chain}) — different molecules?"
+        )
+
+    best_rmsd = min(
+        float(np.sqrt(((pred_xyz[list(mapping)] - ref_xyz) ** 2).sum(axis=-1).mean()))
+        for mapping in mappings
+    )
+    centroid_distance = float(
+        np.linalg.norm(pred_xyz.mean(axis=0) - ref_xyz.mean(axis=0))
+    )
+    return {
+        "rmsd": best_rmsd,
+        "centroid_distance": centroid_distance,
+        "n_atoms": float(len(ref_selected)),
+        "n_symmetry_mappings": float(len(mappings)),
+    }

--- a/openfold3/tests/inference/helpers.py
+++ b/openfold3/tests/inference/helpers.py
@@ -22,18 +22,100 @@ accelerator and downloaded model weights; the test modules gate on that with
 import logging
 import os
 import textwrap
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import openfold3
 from openfold3.core.config import config_utils
 from openfold3.entry_points.experiment_runner import InferenceExperimentRunner
 from openfold3.entry_points.validator import (
     InferenceExperimentConfig,
 )
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
+)
 
 logger = logging.getLogger(__name__)
+
+#: Committed experimental structures, used both as template inputs and RMSD references.
+MMCIFS_DIR = Path(openfold3.__file__).parent / "tests" / "test_data" / "mmcifs"
+
+#: Seed the outputs are written under. Comes from ``ExperimentSettings.seeds`` (default
+#: ``[42]``), which the runner yaml in :func:`run_inference` does not override — *not*
+#: from ``InferenceQuerySet.seeds``, which the runner ignores.
+SEED = 42
+
+
+@dataclass(frozen=True)
+class Mode:
+    """One inference feature combination.
+
+    These are the two independent branches of the data module's ``prepare_data``, and
+    each materially changes how close a prediction lands to the experimental structure:
+    with neither, the model runs single-sequence and for most targets misses the native
+    fold entirely. So this is the axis accuracy expectations are keyed on — a single
+    RMSD ceiling per target would be meaningless across all four.
+
+    Frozen (and therefore hashable) so it can key a per-mode threshold table.
+    """
+
+    use_msa_server: bool
+    use_templates: bool
+
+    @property
+    def id(self) -> str:
+        """Short label used for the pytest parameter id."""
+        msa = "msa" if self.use_msa_server else "no_msa"
+        templates = "templates" if self.use_templates else "no_templates"
+        return f"{msa}-{templates}"
+
+
+#: Every combination — the axis inference cases are parametrized over.
+MODES = tuple(
+    Mode(use_msa_server=use_msa_server, use_templates=use_templates)
+    for use_msa_server in (False, True)
+    for use_templates in (False, True)
+)
+
+
+def query_set_from_chains(query_name: str, *chains: Mapping) -> InferenceQuerySet:
+    """Build a single-query :class:`InferenceQuerySet` from raw chain dicts."""
+    return InferenceQuerySet.model_validate(
+        {"queries": {query_name: {"chains": list(chains)}}}
+    )
+
+
+def prediction_dir(output_dir: Path, query_name: str, *, seed: int = SEED) -> Path:
+    """Directory the runner writes one query's predictions into.
+
+    Mirrors ``InferenceExperimentRunner``: ``<output_dir>/<query>/seed_<seed>/``.
+    """
+    return output_dir / query_name / f"seed_{seed}"
+
+
+def prediction_stem(query_name: str, sample: int, *, seed: int = SEED) -> str:
+    """Filename prefix shared by one diffusion sample's output files."""
+    return f"{query_name}_seed_{seed}_sample_{sample}"
+
+
+def predicted_structure_cifs(
+    output_dir: Path, query_name: str, *, seed: int = SEED
+) -> list[Path]:
+    """Predicted model cifs for one query, ordered by diffusion sample number.
+
+    Sorted numerically rather than lexicographically so sample 10 does not land between
+    1 and 2.
+    """
+    directory = prediction_dir(output_dir, query_name, seed=seed)
+    return sorted(
+        directory.glob(f"{query_name}_seed_{seed}_sample_*_model.cif"),
+        key=lambda path: int(path.stem.rsplit("_sample_", 1)[1].split("_")[0]),
+    )
+
 
 inference_test_yaml_str = textwrap.dedent("""\
     model_update:

--- a/openfold3/tests/inference/helpers.py
+++ b/openfold3/tests/inference/helpers.py
@@ -14,9 +14,9 @@
 
 """Shared helpers for the end-to-end inference tests in this package.
 
-Everything here drives a real ``InferenceExperimentRunner``, so it requires a GPU and
-downloaded model weights; the test modules gate on that with
-``skip_unless_cuda_available``.
+Everything here drives a real ``InferenceExperimentRunner``, so it requires an
+accelerator and downloaded model weights; the test modules gate on that with
+``skip_unless_accelerator_available``.
 """
 
 import logging

--- a/openfold3/tests/inference/helpers.py
+++ b/openfold3/tests/inference/helpers.py
@@ -1,0 +1,107 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for the end-to-end inference tests in this package.
+
+Everything here drives a real ``InferenceExperimentRunner``, so it requires a GPU and
+downloaded model weights; the test modules gate on that with
+``skip_unless_cuda_available``.
+"""
+
+import logging
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openfold3.core.config import config_utils
+from openfold3.entry_points.experiment_runner import InferenceExperimentRunner
+from openfold3.entry_points.validator import (
+    InferenceExperimentConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+inference_test_yaml_str = textwrap.dedent("""\
+    model_update:
+      presets:
+        - predict
+        - low_mem
+    """)
+
+
+def run_inference(
+    query_set,
+    output_dir: Path,
+    *,
+    use_msa_server: bool,
+    use_templates: bool,
+    num_diffusion_samples: int = 1,
+    template_output_dir: Path | None = None,
+) -> Path:
+    """Run one inference job into ``output_dir`` and return it.
+
+    Skips (``pytest.skip``) if no model checkpoint is available (escalated to a hard
+    failure when ``OPENFOLD_SETUP_SCRIPT=1``). ``template_output_dir`` isolates the
+    template cache per run (otherwise it lands in a persistent ``/tmp`` dir shared across
+    runs and same-sequence queries).
+    """
+    runner_yaml = output_dir / "runner_config.yaml"
+    yaml_str = inference_test_yaml_str
+    if template_output_dir is not None:
+        yaml_str += textwrap.dedent(f"""\
+            template_preprocessor_settings:
+              output_directory: {template_output_dir}
+            """)
+    runner_yaml.write_text(yaml_str)
+
+    with patch("builtins.input", return_value="no"):
+        experiment_config = InferenceExperimentConfig(
+            **config_utils.load_yaml(runner_yaml)
+        )
+    runner = InferenceExperimentRunner(
+        experiment_config,
+        num_diffusion_samples=num_diffusion_samples,
+        output_dir=output_dir,
+        use_msa_server=use_msa_server,
+        use_templates=use_templates,
+    )
+    try:
+        runner.setup()
+    except ValueError as e:
+        if "is not a valid file or directory" in str(e):
+            if os.environ.get("OPENFOLD_SETUP_SCRIPT") == "1":
+                raise AssertionError(
+                    "No checkpoint files found after running setup script. "
+                    "Please check that the download completed successfully."
+                ) from None
+            logger.warning(
+                "No checkpoint files found, skipping. Use the setup script to "
+                "download the weights."
+            )
+            pytest.skip("No checkpoint files available")
+        raise
+
+    runner.run(query_set)
+    runner.cleanup()
+
+    err_log_dir = output_dir / "logs"
+    if err_log_dir.exists():
+        raise RuntimeError(
+            f"Found error logs in directory {err_log_dir}, "
+            "check for errors in inference."
+        )
+    return output_dir

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -47,7 +47,11 @@ import openfold3
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
-from openfold3.tests.inference.analysis import best_ca_rmsd, ligand_pose_metrics
+from openfold3.tests.inference.analysis import (
+    Structure,
+    best_ca_rmsd,
+    ligand_pose_metrics,
+)
 from openfold3.tests.inference.helpers import (
     MMCIFS_DIR,
     MODES,
@@ -332,13 +336,18 @@ def _assert_within_ceiling(
 
 
 def _assert_protein(
-    expectation: Expectation, query_name: str, mode: Mode, *, pred_cif: Path
+    expectation: Expectation,
+    query_name: str,
+    mode: Mode,
+    *,
+    pred: Structure,
+    ref: Structure,
 ) -> None:
     """Score the protein fold against the reference."""
     protein = expectation.protein
     metrics = best_ca_rmsd(
-        pred_cif=pred_cif,
-        ref_cif=expectation.ref_cif,
+        pred=pred,
+        ref=ref,
         ref_chains=protein.ref_chains,
         pred_chains=protein.pred_chains,
     )
@@ -360,14 +369,19 @@ def _assert_protein(
 
 
 def _assert_ligand(
-    expectation: Expectation, query_name: str, mode: Mode, *, pred_cif: Path
+    expectation: Expectation,
+    query_name: str,
+    mode: Mode,
+    *,
+    pred: Structure,
+    ref: Structure,
 ) -> None:
     """Score the ligand pose in the frame of the superimposed protein."""
     ligand = expectation.ligand
     assert ligand is not None  # guarded by the caller
     metrics = ligand_pose_metrics(
-        pred_cif=pred_cif,
-        ref_cif=expectation.ref_cif,
+        pred=pred,
+        ref=ref,
         ref_chains=expectation.protein.ref_chains,
         pred_chains=expectation.protein.pred_chains,
         pred_ligand_chain=ligand.pred_chain,
@@ -407,9 +421,13 @@ def _maybe_assert_accuracy(
     expectation = case.expectations.get(query_name)
     if expectation is None:
         return
-    _assert_protein(expectation, query_name, mode, pred_cif=pred_cif)
+    # Parsed once here and handed down: the protein and the ligand both need both
+    # structures, and the ligand reuses the protein's superposition.
+    pred = Structure.from_cif(pred_cif)
+    ref = Structure.from_cif(expectation.ref_cif)
+    _assert_protein(expectation, query_name, mode, pred=pred, ref=ref)
     if expectation.ligand is not None:
-        _assert_ligand(expectation, query_name, mode, pred_cif=pred_cif)
+        _assert_ligand(expectation, query_name, mode, pred=pred, ref=ref)
 
 
 @skip_unless_accelerator_available()

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -355,12 +355,12 @@ def _assert_protein(
         "%s [%s] CA-RMSD %.2f Å (gdt_ts %.3f) vs %s",
         query_name,
         mode.id,
-        metrics["rmsd"],
-        metrics["gdt_ts"],
+        metrics.rmsd,
+        metrics.gdt_ts,
         expectation.ref_cif.name,
     )
     _assert_within_ceiling(
-        metrics["rmsd"],
+        metrics.rmsd,
         protein.rmsd_max.get(mode),
         what=f"CA-RMSD against {expectation.ref_cif.name}",
         query_name=query_name,
@@ -392,15 +392,15 @@ def _assert_ligand(
         "vs %s chain %s",
         query_name,
         mode.id,
-        metrics["rmsd"],
-        metrics["centroid_distance"],
-        int(metrics["n_atoms"]),
-        int(metrics["n_symmetry_mappings"]),
+        metrics.rmsd,
+        metrics.centroid_distance,
+        metrics.n_atoms,
+        metrics.n_symmetry_mappings,
         expectation.ref_cif.name,
         ligand.ref_chain,
     )
     _assert_within_ceiling(
-        metrics["rmsd"],
+        metrics.rmsd,
         ligand.rmsd_max.get(mode),
         what=(
             f"ligand RMSD against {expectation.ref_cif.name} chain {ligand.ref_chain}"

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -29,6 +29,8 @@ Run with:
 """
 
 import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 
@@ -38,7 +40,15 @@ import openfold3
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
-from openfold3.tests.inference.helpers import run_inference
+from openfold3.tests.inference.analysis import best_ca_rmsd
+from openfold3.tests.inference.helpers import (
+    MODES,
+    Mode,
+    prediction_dir,
+    prediction_stem,
+    query_set_from_chains,
+    run_inference,
+)
 from openfold3.tests.utils.compare_utils import skip_unless_accelerator_available
 
 logging.basicConfig(level=logging.WARNING)
@@ -55,17 +65,14 @@ requires_examples = pytest.mark.skipif(
     not EXAMPLES_DIR.is_dir(), reason=f"No examples directory at {EXAMPLES_DIR}"
 )
 
-#: Seed the outputs are written under. Comes from ``ExperimentSettings.seeds`` (default
-#: ``[42]``), which the runner yaml in :func:`run_inference` does not override — *not*
-#: from ``InferenceQuerySet.seeds``, which the runner ignores.
-SEED = 42
-
+# Leucine zipper protein fragment
 PROTEIN_CHAIN = {
     "molecule_type": "protein",
     "chain_ids": ["A", "B"],
     "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
 }
 
+# Phenol
 LIGAND_CHAIN = {
     "molecule_type": "ligand",
     "chain_ids": ["C"],
@@ -73,59 +80,148 @@ LIGAND_CHAIN = {
 }
 
 
-def _inline_query_set(*chains: dict) -> InferenceQuerySet:
-    """Build a single-query set named ``query1`` from raw chain dicts."""
-    return InferenceQuerySet.model_validate(
-        {"queries": {"query1": {"chains": list(chains)}}}
-    )
-
-
 def _example_query_set(filename: str) -> InferenceQuerySet:
     """Load an example query JSON through the same loader ``run_openfold`` uses."""
     return InferenceQuerySet.from_json(EXAMPLES_DIR / filename)
 
 
+@dataclass(frozen=True)
+class Expectation:
+    """How closely one query's prediction must match an experimental structure.
+
+    ``ca_rmsd_max`` maps a :class:`Mode` to an Ångström ceiling on the protein CA-RMSD.
+    A mode *absent* from it is run but not scored — the outputs are still checked, the
+    test just makes no accuracy claim there. That absence is the point of keying on
+    ``Mode``: how close a prediction lands depends strongly on whether it had an MSA and
+    a template, so no single ceiling per target is right across all four, and a ceiling
+    is only worth asserting once it has been *measured* in that mode.
+
+    ``pred_chains``/``ref_chains`` are matched as sets by :func:`best_ca_rmsd`, so
+    interchangeable copies need no particular order.
+
+    To score a query: commit its experimental structure under ``test_data/mmcifs/``,
+    then run the case in the mode you want to pin and read the measured CA-RMSD off the
+    log line in :func:`_maybe_assert_ca_rmsd`, leaving margin for hardware variance::
+
+        from openfold3.tests.inference.helpers import MMCIFS_DIR
+
+        Expectation(
+            ref_cif=MMCIFS_DIR / "1ubq.cif",
+            pred_chains=("A",),
+            ref_chains=("A",),
+            ca_rmsd_max={Mode(use_msa_server=True, use_templates=True): 2.0},
+        )
+    """
+
+    ref_cif: Path
+    pred_chains: tuple[str, ...]
+    ref_chains: tuple[str, ...]
+    ca_rmsd_max: Mapping[Mode, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class InferenceCase:
+    """A query set to run, plus optional per-query accuracy expectations.
+
+    ``build_query_set`` is deferred behind a callable so a missing examples directory
+    skips the case instead of breaking collection.
+    """
+
+    id: str
+    build_query_set: Callable[[], InferenceQuerySet]
+    #: Query name -> expectation. Queries absent are run but not scored — the default,
+    #: since scoring one needs a reference structure committed under
+    #: ``test_data/mmcifs/`` and a ceiling measured per mode.
+    expectations: Mapping[str, Expectation] = field(default_factory=dict)
+    marks: tuple = ()
+
+
 #: Each case builds an :class:`InferenceQuerySet`, either in memory or from a file in
-#: ``examples/example_inference_inputs``. Construction is deferred behind a callable so
-#: that a missing examples directory skips the case instead of breaking collection.
-#: Expected outputs are derived from the query names, so a case may hold any number of
-#: queries — adding another example is one row.
+#: ``examples/example_inference_inputs``. Expected outputs are derived from the query
+#: names, so a case may hold any number of queries — adding another example is one row,
+#: and costs one inference run per mode.
 CASES = [
-    pytest.param(partial(_inline_query_set, PROTEIN_CHAIN), id="protein_only"),
-    pytest.param(
-        partial(_inline_query_set, PROTEIN_CHAIN, LIGAND_CHAIN),
-        id="protein_and_ligand",
+    InferenceCase(
+        id="protein_only",
+        build_query_set=partial(query_set_from_chains, "query1", PROTEIN_CHAIN),
     ),
-    pytest.param(
-        partial(_example_query_set, "query_protein_ligand_multiple.json"),
+    InferenceCase(
+        id="protein_and_ligand",
+        build_query_set=partial(
+            query_set_from_chains, "query1", PROTEIN_CHAIN, LIGAND_CHAIN
+        ),
+    ),
+    InferenceCase(
+        id="ubiquitin",
+        build_query_set=partial(_example_query_set, "query_ubiquitin.json"),
+        marks=(requires_examples,),
+    ),
+    InferenceCase(
         id="protein_ligand_multiple",
-        marks=requires_examples,
+        build_query_set=partial(
+            _example_query_set, "query_protein_ligand_multiple.json"
+        ),
+        marks=(requires_examples,),
     ),
 ]
 
+CASE_PARAMS = [pytest.param(case, id=case.id, marks=case.marks) for case in CASES]
+MODE_PARAMS = [pytest.param(mode, id=mode.id) for mode in MODES]
+
+
+def _maybe_assert_ca_rmsd(
+    case: InferenceCase, query_name: str, mode: Mode, *, pred_cif: Path
+) -> None:
+    """Score one prediction against its reference, when the case declares one.
+
+    Always logs the measured CA-RMSD when a reference exists, so a run in an unscored
+    mode still tells you what ceiling to record for it.
+    """
+    expectation = case.expectations.get(query_name)
+    if expectation is None:
+        return
+
+    metrics = best_ca_rmsd(
+        pred_cif=pred_cif,
+        ref_cif=expectation.ref_cif,
+        pred_chains=expectation.pred_chains,
+        ref_chains=expectation.ref_chains,
+    )
+    logger.info(
+        "%s [%s] CA-RMSD %.2f Å (gdt_ts %.3f) vs %s",
+        query_name,
+        mode.id,
+        metrics["rmsd"],
+        metrics["gdt_ts"],
+        expectation.ref_cif.name,
+    )
+
+    ceiling = expectation.ca_rmsd_max.get(mode)
+    if ceiling is None:
+        return
+    assert metrics["rmsd"] < ceiling, (
+        f"{query_name} [{mode.id}]: CA-RMSD {metrics['rmsd']:.2f} Å against "
+        f"{expectation.ref_cif.name} exceeds the {ceiling} Å ceiling for this mode"
+    )
+
 
 @skip_unless_accelerator_available()
-@pytest.mark.parametrize("build_query_set", CASES)
-@pytest.mark.parametrize(
-    "use_templates", [False, True], ids=["no_templates", "templates"]
-)
-@pytest.mark.parametrize("use_msa_server", [False, True], ids=["no_msa", "msa"])
-def test_inference_writes_outputs(
-    build_query_set, use_msa_server, use_templates, tmp_path
-):
+@pytest.mark.parametrize("case", CASE_PARAMS)
+@pytest.mark.parametrize("mode", MODE_PARAMS)
+def test_inference_writes_outputs(case, mode, tmp_path):
     """Every query in the set writes the expected per-sample files, in every mode.
 
-    The two feature flags are independent branches of ``prepare_data``: without the MSA
-    server the query sequence is used single-sequence, and template preprocessing runs
-    on its own flag. Stacking the three parametrize marks gives the full cartesian
-    product, so each query set is exercised in all four modes.
+    Then, where the case declares an :class:`Expectation` for that query *and* that
+    mode, the prediction is scored against the experimental structure. Without that the
+    suite only shows inference ran, not that it produced something consistent with
+    experiment.
     """
-    query_set = build_query_set()
+    query_set = case.build_query_set()
     run_inference(
         query_set,
         tmp_path,
-        use_msa_server=use_msa_server,
-        use_templates=use_templates,
+        use_msa_server=mode.use_msa_server,
+        use_templates=mode.use_templates,
         num_diffusion_samples=1,
         # Isolate the template cache: without this it lands in a persistent /tmp dir
         # shared across runs, and the template-enabled cases here would see each
@@ -134,8 +230,8 @@ def test_inference_writes_outputs(
     )
     logger.info("Checking output contents at %s", tmp_path)
     for query_name in query_set.queries:
-        seed_dir = tmp_path / query_name / f"seed_{SEED}"
-        stem = f"{query_name}_seed_{SEED}_sample_1"
+        seed_dir = prediction_dir(tmp_path, query_name)
+        stem = prediction_stem(query_name, sample=1)
         expected_files = [
             f"{stem}_confidences.json",
             f"{stem}_confidences_aggregated.json",
@@ -146,6 +242,9 @@ def test_inference_writes_outputs(
             assert (seed_dir / name).exists(), (
                 f"Expected output file not found: {seed_dir / name}"
             )
+        _maybe_assert_ca_rmsd(
+            case, query_name, mode, pred_cif=seed_dir / f"{stem}_model.cif"
+        )
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -26,6 +26,13 @@ otherwise.
 
 Run with:
     pytest openfold3/tests/inference/test_inference_full.py
+
+To calibrate a case's ``ca_rmsd_max`` — run just that case in all four modes and read
+the measured CA-RMSDs off the log (``log_cli_level`` is WARNING by default, so INFO has
+to be asked for):
+
+    pytest openfold3/tests/inference/test_inference_full.py -k ubiquitin \\
+        -v --log-cli-level=INFO
 """
 
 import logging
@@ -42,6 +49,7 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
 )
 from openfold3.tests.inference.analysis import best_ca_rmsd
 from openfold3.tests.inference.helpers import (
+    MMCIFS_DIR,
     MODES,
     Mode,
     prediction_dir,
@@ -103,19 +111,19 @@ class Expectation:
     then run the case in the mode you want to pin and read the measured CA-RMSD off the
     log line in :func:`_maybe_assert_ca_rmsd`, leaving margin for hardware variance::
 
-        from openfold3.tests.inference.helpers import MMCIFS_DIR
-
         Expectation(
             ref_cif=MMCIFS_DIR / "1ubq.cif",
-            pred_chains=("A",),
             ref_chains=("A",),
             ca_rmsd_max={Mode(use_msa_server=True, use_templates=True): 2.0},
         )
     """
 
     ref_cif: Path
-    pred_chains: tuple[str, ...]
     ref_chains: tuple[str, ...]
+    #: Predicted chains to pair with ``ref_chains``. ``None`` discovers every polymer
+    #: chain in the prediction, which is what a single-chain query wants — the chain id
+    #: the writer emits then carries no weight.
+    pred_chains: tuple[str, ...] | None = None
     ca_rmsd_max: Mapping[Mode, float] = field(default_factory=dict)
 
 
@@ -154,6 +162,18 @@ CASES = [
     InferenceCase(
         id="ubiquitin",
         build_query_set=partial(_example_query_set, "query_ubiquitin.json"),
+        expectations={
+            # 1ubq chain A is 76 contiguous residues whose sequence is byte-identical
+            # to the query, so every residue takes part in the comparison.
+            "ubiquitin": Expectation(
+                ref_cif=MMCIFS_DIR / "1ubq.cif",
+                ref_chains=("A",),
+                # Deliberately unpinned: run the case (see the module docstring) and
+                # record the logged CA-RMSD per mode here, with margin. Until then the
+                # RMSD is measured and logged but nothing is asserted.
+                ca_rmsd_max={},
+            )
+        },
         marks=(requires_examples,),
     ),
     InferenceCase(
@@ -184,8 +204,8 @@ def _maybe_assert_ca_rmsd(
     metrics = best_ca_rmsd(
         pred_cif=pred_cif,
         ref_cif=expectation.ref_cif,
-        pred_chains=expectation.pred_chains,
         ref_chains=expectation.ref_chains,
+        pred_chains=expectation.pred_chains,
     )
     logger.info(
         "%s [%s] CA-RMSD %.2f Å (gdt_ts %.3f) vs %s",

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -47,7 +47,7 @@ import openfold3
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
-from openfold3.tests.inference.analysis import best_ca_rmsd
+from openfold3.tests.inference.analysis import best_ca_rmsd, ligand_pose_metrics
 from openfold3.tests.inference.helpers import (
     MMCIFS_DIR,
     MODES,
@@ -94,37 +94,70 @@ def _example_query_set(filename: str) -> InferenceQuerySet:
 
 
 @dataclass(frozen=True)
-class Expectation:
-    """How closely one query's prediction must match an experimental structure.
+class ProteinExpectation:
+    """Which protein chains to score, and how closely they must match.
 
-    ``ca_rmsd_max`` maps a :class:`Mode` to an Ångström ceiling on the protein CA-RMSD.
-    A mode *absent* from it is run but not scored — the outputs are still checked, the
-    test just makes no accuracy claim there. That absence is the point of keying on
-    ``Mode``: how close a prediction lands depends strongly on whether it had an MSA and
-    a template, so no single ceiling per target is right across all four, and a ceiling
-    is only worth asserting once it has been *measured* in that mode.
+    ``rmsd_max`` bounds the superposition CA-RMSD in Ångström, keyed by :class:`Mode`.
+    A mode *absent* from it is measured and logged but not asserted — that absence is
+    the point of keying on ``Mode``: how close a prediction lands depends strongly on
+    whether it had an MSA and a template, so no single ceiling is right across all four,
+    and a ceiling is only worth asserting once it has been *measured* in that mode.
 
-    ``pred_chains``/``ref_chains`` are matched as sets by :func:`best_ca_rmsd`, so
+    ``ref_chains`` and ``pred_chains`` are matched as sets by :func:`best_ca_rmsd`, so
     interchangeable copies need no particular order.
-
-    To score a query: commit its experimental structure under ``test_data/mmcifs/``,
-    then run the case in the mode you want to pin and read the measured CA-RMSD off the
-    log line in :func:`_maybe_assert_ca_rmsd`, leaving margin for hardware variance::
-
-        Expectation(
-            ref_cif=MMCIFS_DIR / "1ubq.cif",
-            ref_chains=("A",),
-            ca_rmsd_max={Mode(use_msa_server=True, use_templates=True): 2.0},
-        )
     """
 
-    ref_cif: Path
     ref_chains: tuple[str, ...]
     #: Predicted chains to pair with ``ref_chains``. ``None`` discovers every polymer
     #: chain in the prediction, which is what a single-chain query wants — the chain id
     #: the writer emits then carries no weight.
     pred_chains: tuple[str, ...] | None = None
-    ca_rmsd_max: Mapping[Mode, float] = field(default_factory=dict)
+    rmsd_max: Mapping[Mode, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LigandExpectation:
+    """Which ligand to score, and how close its pose must be.
+
+    ``rmsd_max`` follows the same measured-before-pinned rule as
+    :class:`ProteinExpectation`, but bounds the ligand pose RMSD: measured in the frame
+    of the superimposed protein, so it asks whether the ligand landed in the right pocket
+    the right way round, not merely whether its internal geometry is sane.
+
+    Chains are named rather than discovered: a prediction may carry several ligands, and
+    a reference typically carries buffer components and ions too, so which pair is meant
+    has to be stated.
+    """
+
+    ref_chain: str
+    pred_chain: str
+    rmsd_max: Mapping[Mode, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Expectation:
+    """One query's experimental reference, and what about the prediction must match it.
+
+    The protein is always scored; the ligand only when the query has one with a real
+    counterpart in the reference. Both sub-expectations name chains within the same
+    ``ref_cif``.
+
+    To score a query: commit its experimental structure under ``test_data/mmcifs/``, then
+    run the case in the mode you want to pin and read the measurement off the log line in
+    :func:`_maybe_assert_accuracy`, leaving margin for hardware variance::
+
+        Expectation(
+            ref_cif=MMCIFS_DIR / "1ubq.cif",
+            protein=ProteinExpectation(
+                ref_chains=("A",),
+                rmsd_max={Mode(use_msa_server=True, use_templates=True): 2.0},
+            ),
+        )
+    """
+
+    ref_cif: Path
+    protein: ProteinExpectation
+    ligand: LigandExpectation | None = None
 
 
 @dataclass(frozen=True)
@@ -167,27 +200,29 @@ CASES = [
             # to the query, so every residue takes part in the comparison.
             "ubiquitin": Expectation(
                 ref_cif=MMCIFS_DIR / "1ubq.cif",
-                ref_chains=("A",),
-                # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42.
-                # Pinned just above each measurement rather than at a loose common
-                # bound: ubiquitin is easy enough that every mode lands under 1 Å, so a
-                # generous ceiling would accept a real degradation without complaining.
-                ca_rmsd_max={
-                    # measured 0.87 Å (gdt_ts 0.974)
-                    Mode(use_msa_server=False, use_templates=False): 0.9,
-                    # measured 0.87 Å (gdt_ts 0.974) — same numbers as the row above:
-                    # without the MSA server template search has nothing to draw on
-                    # (preprocessing returns within the same second), so both no_msa
-                    # modes are the same computation. They are not bit-identical though
-                    # — 7L39 measures 15.29 vs 15.78 Å across this same pair — they
-                    # agree here because a converged prediction is stable.
-                    Mode(use_msa_server=False, use_templates=True): 0.9,
-                    # measured 0.75 Å (gdt_ts 0.967)
-                    Mode(use_msa_server=True, use_templates=False): 0.8,
-                    # measured 0.79 Å (gdt_ts 0.967) — only 0.01 Å of headroom, the
-                    # first ceiling to revisit if this goes flaky on other hardware
-                    Mode(use_msa_server=True, use_templates=True): 0.8,
-                },
+                protein=ProteinExpectation(
+                    ref_chains=("A",),
+                    # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42.
+                    # Pinned just above each measurement rather than at a loose common
+                    # bound: ubiquitin is easy enough that every mode lands under 1 Å, so
+                    # a generous ceiling would accept a real degradation unnoticed.
+                    rmsd_max={
+                        # measured 0.87 Å (gdt_ts 0.974)
+                        Mode(use_msa_server=False, use_templates=False): 0.9,
+                        # measured 0.87 Å (gdt_ts 0.974) — same numbers as the row
+                        # above: without the MSA server template search has nothing to
+                        # draw on (preprocessing returns within the same second), so
+                        # both no_msa modes are the same computation. Not bit-identical
+                        # though — 7L39 moves between runs across this same pair — they
+                        # agree here because a converged prediction is stable.
+                        Mode(use_msa_server=False, use_templates=True): 0.9,
+                        # measured 0.75 Å (gdt_ts 0.967)
+                        Mode(use_msa_server=True, use_templates=False): 0.8,
+                        # measured 0.79 Å (gdt_ts 0.967) — only 0.01 Å of headroom, the
+                        # first ceiling to revisit if this goes flaky on other hardware
+                        Mode(use_msa_server=True, use_templates=True): 0.8,
+                    },
+                ),
             )
         },
         marks=(requires_examples,),
@@ -211,33 +246,65 @@ CASES = [
                 # precision we assert at — pairwise CA-RMSD among the three runs
                 # 0.24–0.46 Å — so a ceiling recorded here is tied to this reference.
                 ref_cif=MMCIFS_DIR / "7l39.cif",
-                ref_chains=("A",),
-                # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42:
-                #   no_msa-no_templates  15.29 Å (gdt_ts 0.032)
-                #   no_msa-templates     15.78 Å (gdt_ts 0.039)
-                #   msa-no_templates      0.22 Å (gdt_ts 1.000)
-                #   msa-templates         0.20 Å (gdt_ts 1.000)
-                # Unlike ubiquitin, this target lives or dies on the MSA: single-sequence
-                # the model does not find the fold at all (gdt_ts 0.03), with an MSA it
-                # is essentially exact. Which is the case the per-mode encoding exists
-                # for — one ceiling across all four would have to be ~16 Å and would
-                # then wave through a total collapse of the MSA path.
-                ca_rmsd_max={
-                    # Only the converged modes are pinned, and pinned tight. gdt_ts is
-                    # 1.000 in both, i.e. the prediction is locked onto the reference,
-                    # so the number is reproducible.
-                    Mode(use_msa_server=True, use_templates=False): 0.3,
-                    Mode(use_msa_server=True, use_templates=True): 0.3,
-                    # The two no_msa modes are deliberately left unpinned. Their RMSD is
-                    # the distance to a fold the model never found, which is not a stable
-                    # quantity: the two runs above differ by 0.5 Å despite being the same
-                    # computation (template search finds nothing without the MSA server —
-                    # its preprocessing returns within the same second). Pinning a tight
-                    # ceiling there would buy flakiness and no signal. Asserting these
-                    # properly needs a *floor* — "must be worse than 8 Å without an MSA",
-                    # the way test_templates.py proves its template effect — which
-                    # Expectation cannot express yet.
-                },
+                protein=ProteinExpectation(
+                    ref_chains=("A",),
+                    # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42,
+                    # over two separate runs:
+                    #   no_msa-no_templates  15.29 / 14.85 Å (gdt_ts 0.032 / 0.054)
+                    #   no_msa-templates     15.78 / 15.91 Å (gdt_ts 0.039 / 0.039)
+                    #   msa-no_templates      0.22 /  0.22 Å (gdt_ts 1.000)
+                    #   msa-templates         0.20 /  0.20 Å (gdt_ts 1.000)
+                    # The repeat is the evidence for how these are pinned: the converged
+                    # modes reproduced to the last printed digit, while the failed ones
+                    # moved by up to 0.44 Å between runs.
+                    #
+                    # Unlike ubiquitin, this target lives or dies on the MSA:
+                    # single-sequence the model does not find the fold at all (gdt_ts
+                    # 0.03), with an MSA it is essentially exact. Which is the case the
+                    # per-mode encoding exists for — one ceiling across all four would
+                    # have to be ~16 Å and would then wave through a total collapse of
+                    # the MSA path.
+                    rmsd_max={
+                        # Only the converged modes are pinned, and pinned tight. gdt_ts
+                        # is 1.000 in both, i.e. the prediction is locked onto the
+                        # reference, so the number is reproducible.
+                        Mode(use_msa_server=True, use_templates=False): 0.3,
+                        Mode(use_msa_server=True, use_templates=True): 0.3,
+                        # The two no_msa modes are deliberately left unpinned. Their
+                        # RMSD is the distance to a fold the model never found, which is
+                        # not a stable quantity — see the run-to-run spread above.
+                        # Pinning a tight ceiling there would buy flakiness and no
+                        # signal. Asserting these properly needs a *floor* — "must be
+                        # worse than 8 Å without an MSA", the way test_templates.py
+                        # proves its template effect — which ProteinExpectation cannot
+                        # express yet.
+                    },
+                ),
+                # Toluene (CCD MBN), 7 heavy atoms, sitting in the engineered L99A
+                # cavity. The query supplies it as SMILES, so the prediction's atom
+                # names are the writer's invention and matching goes through the bond
+                # graph; the methyl leaves the ring with a 2-fold flip, which the
+                # symmetry search covers. In the reference it is chain D — chain A is
+                # the protein, and the other hetero chains are buffer (TRS, BME, Cl).
+                ligand=LigandExpectation(
+                    ref_chain="D",
+                    pred_chain="X",
+                    # Measured 2026-07-28, same runs as the CA-RMSD above:
+                    #   no_msa-no_templates  25.76 Å (centroid 25.65)
+                    #   no_msa-templates     16.45 Å (centroid 16.35)
+                    #   msa-no_templates      0.30 Å (centroid  0.27)
+                    #   msa-templates         0.27 Å (centroid  0.26)
+                    # The pose tracks the fold exactly as expected: with an MSA the
+                    # ligand sits sub-Ångström in the cavity, far inside the 2 Å that
+                    # normally counts as a correct pose; without one the centroid alone
+                    # is 16-26 Å off, i.e. the ligand is not in a pocket at all because
+                    # there is no pocket. Only the converged modes are pinned, for the
+                    # same reason as the protein.
+                    rmsd_max={
+                        Mode(use_msa_server=True, use_templates=False): 0.4,
+                        Mode(use_msa_server=True, use_templates=True): 0.4,
+                    },
+                ),
             )
         },
         marks=(requires_examples,),
@@ -248,23 +315,32 @@ CASE_PARAMS = [pytest.param(case, id=case.id, marks=case.marks) for case in CASE
 MODE_PARAMS = [pytest.param(mode, id=mode.id) for mode in MODES]
 
 
-def _maybe_assert_ca_rmsd(
-    case: InferenceCase, query_name: str, mode: Mode, *, pred_cif: Path
+def _assert_within_ceiling(
+    measured: float, ceiling: float | None, *, what: str, query_name: str, mode: Mode
 ) -> None:
-    """Score one prediction against its reference, when the case declares one.
+    """Enforce one ceiling, when this mode has one pinned.
 
-    Always logs the measured CA-RMSD when a reference exists, so a run in an unscored
-    mode still tells you what ceiling to record for it.
+    ``None`` means the mode is measured but makes no accuracy claim, which is the
+    default until a number has actually been observed for it.
     """
-    expectation = case.expectations.get(query_name)
-    if expectation is None:
+    if ceiling is None:
         return
+    assert measured < ceiling, (
+        f"{query_name} [{mode.id}]: {what} {measured:.2f} Å exceeds the "
+        f"{ceiling} Å ceiling for this mode"
+    )
 
+
+def _assert_protein(
+    expectation: Expectation, query_name: str, mode: Mode, *, pred_cif: Path
+) -> None:
+    """Score the protein fold against the reference."""
+    protein = expectation.protein
     metrics = best_ca_rmsd(
         pred_cif=pred_cif,
         ref_cif=expectation.ref_cif,
-        ref_chains=expectation.ref_chains,
-        pred_chains=expectation.pred_chains,
+        ref_chains=protein.ref_chains,
+        pred_chains=protein.pred_chains,
     )
     logger.info(
         "%s [%s] CA-RMSD %.2f Å (gdt_ts %.3f) vs %s",
@@ -274,14 +350,66 @@ def _maybe_assert_ca_rmsd(
         metrics["gdt_ts"],
         expectation.ref_cif.name,
     )
-
-    ceiling = expectation.ca_rmsd_max.get(mode)
-    if ceiling is None:
-        return
-    assert metrics["rmsd"] < ceiling, (
-        f"{query_name} [{mode.id}]: CA-RMSD {metrics['rmsd']:.2f} Å against "
-        f"{expectation.ref_cif.name} exceeds the {ceiling} Å ceiling for this mode"
+    _assert_within_ceiling(
+        metrics["rmsd"],
+        protein.rmsd_max.get(mode),
+        what=f"CA-RMSD against {expectation.ref_cif.name}",
+        query_name=query_name,
+        mode=mode,
     )
+
+
+def _assert_ligand(
+    expectation: Expectation, query_name: str, mode: Mode, *, pred_cif: Path
+) -> None:
+    """Score the ligand pose in the frame of the superimposed protein."""
+    ligand = expectation.ligand
+    assert ligand is not None  # guarded by the caller
+    metrics = ligand_pose_metrics(
+        pred_cif=pred_cif,
+        ref_cif=expectation.ref_cif,
+        ref_chains=expectation.protein.ref_chains,
+        pred_chains=expectation.protein.pred_chains,
+        pred_ligand_chain=ligand.pred_chain,
+        ref_ligand_chain=ligand.ref_chain,
+    )
+    logger.info(
+        "%s [%s] ligand RMSD %.2f Å (centroid %.2f Å, %d atoms, %d symmetry mappings) "
+        "vs %s chain %s",
+        query_name,
+        mode.id,
+        metrics["rmsd"],
+        metrics["centroid_distance"],
+        int(metrics["n_atoms"]),
+        int(metrics["n_symmetry_mappings"]),
+        expectation.ref_cif.name,
+        ligand.ref_chain,
+    )
+    _assert_within_ceiling(
+        metrics["rmsd"],
+        ligand.rmsd_max.get(mode),
+        what=(
+            f"ligand RMSD against {expectation.ref_cif.name} chain {ligand.ref_chain}"
+        ),
+        query_name=query_name,
+        mode=mode,
+    )
+
+
+def _maybe_assert_accuracy(
+    case: InferenceCase, query_name: str, mode: Mode, *, pred_cif: Path
+) -> None:
+    """Score one prediction against its reference, when the case declares one.
+
+    Always logs what it measures, whether or not a ceiling is pinned for this mode, so a
+    run in an unscored mode still tells you what to record for it.
+    """
+    expectation = case.expectations.get(query_name)
+    if expectation is None:
+        return
+    _assert_protein(expectation, query_name, mode, pred_cif=pred_cif)
+    if expectation.ligand is not None:
+        _assert_ligand(expectation, query_name, mode, pred_cif=pred_cif)
 
 
 @skip_unless_accelerator_available()
@@ -321,7 +449,7 @@ def test_inference_writes_outputs(case, mode, tmp_path):
             assert (seed_dir / name).exists(), (
                 f"Expected output file not found: {seed_dir / name}"
             )
-        _maybe_assert_ca_rmsd(
+        _maybe_assert_accuracy(
             case, query_name, mode, pred_cif=seed_dir / f"{stem}_model.cif"
         )
 

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -168,10 +168,23 @@ CASES = [
             "ubiquitin": Expectation(
                 ref_cif=MMCIFS_DIR / "1ubq.cif",
                 ref_chains=("A",),
-                # Deliberately unpinned: run the case (see the module docstring) and
-                # record the logged CA-RMSD per mode here, with margin. Until then the
-                # RMSD is measured and logged but nothing is asserted.
-                ca_rmsd_max={},
+                # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42.
+                # Pinned just above each measurement rather than at a loose common
+                # bound: ubiquitin is easy enough that every mode lands under 1 Å, so a
+                # generous ceiling would accept a real degradation without complaining.
+                ca_rmsd_max={
+                    # measured 0.87 Å (gdt_ts 0.974)
+                    Mode(use_msa_server=False, use_templates=False): 0.9,
+                    # measured 0.87 Å (gdt_ts 0.974) — the same numbers as the row
+                    # above, because without the MSA server template search has nothing
+                    # to draw on, so on a fixed seed this run reduces to that one
+                    Mode(use_msa_server=False, use_templates=True): 0.9,
+                    # measured 0.75 Å (gdt_ts 0.967)
+                    Mode(use_msa_server=True, use_templates=False): 0.8,
+                    # measured 0.79 Å (gdt_ts 0.967) — only 0.01 Å of headroom, the
+                    # first ceiling to revisit if this goes flaky on other hardware
+                    Mode(use_msa_server=True, use_templates=True): 0.8,
+                },
             )
         },
         marks=(requires_examples,),

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -14,11 +14,12 @@
 
 """Smoke tests for inference: small queries run end-to-end.
 
-``test_inference_writes_outputs`` runs each case in ``CASES`` with MSA server + templates
-and checks the expected output files are written for every query it contains. Cases mix
-in-memory query sets with the query JSONs under ``examples/example_inference_inputs``,
-so adding either kind is one row. See ``test_templates.py`` for the functional check that
-a supplied template actually steers the prediction.
+``test_inference_writes_outputs`` runs every case in ``CASES`` against every combination
+of ``use_msa_server`` and ``use_templates``, checking the expected output files are
+written for each query the case contains. Cases mix in-memory query sets with the query
+JSONs under ``examples/example_inference_inputs``, so adding either kind is one row —
+and costs four inference runs. See ``test_templates.py`` for the functional check that a
+supplied template actually steers the prediction.
 
 These require an accelerator (CUDA, ROCm or MPS) and downloaded model weights; they skip
 otherwise.
@@ -46,7 +47,9 @@ logger = logging.getLogger(__name__)
 #: Repo-root ``examples/`` — present in a source checkout, but not shipped in the wheel
 #: (``packages.find`` only picks up ``openfold3*``), so file-backed cases must tolerate
 #: its absence when the suite runs from an install.
-EXAMPLES_DIR = Path(openfold3.__file__).parent / "examples" / "example_inference_inputs"
+EXAMPLES_DIR = (
+    Path(openfold3.__file__).parent.parent / "examples" / "example_inference_inputs"
+)
 
 requires_examples = pytest.mark.skipif(
     not EXAMPLES_DIR.is_dir(), reason=f"No examples directory at {EXAMPLES_DIR}"
@@ -103,15 +106,31 @@ CASES = [
 
 @skip_unless_accelerator_available()
 @pytest.mark.parametrize("build_query_set", CASES)
-def test_inference_writes_outputs(build_query_set, tmp_path):
-    """Every query in the set runs end-to-end and writes the expected per-sample files."""
+@pytest.mark.parametrize(
+    "use_templates", [False, True], ids=["no_templates", "templates"]
+)
+@pytest.mark.parametrize("use_msa_server", [False, True], ids=["no_msa", "msa"])
+def test_inference_writes_outputs(
+    build_query_set, use_msa_server, use_templates, tmp_path
+):
+    """Every query in the set writes the expected per-sample files, in every mode.
+
+    The two feature flags are independent branches of ``prepare_data``: without the MSA
+    server the query sequence is used single-sequence, and template preprocessing runs
+    on its own flag. Stacking the three parametrize marks gives the full cartesian
+    product, so each query set is exercised in all four modes.
+    """
     query_set = build_query_set()
     run_inference(
         query_set,
         tmp_path,
-        use_msa_server=True,
-        use_templates=True,
+        use_msa_server=use_msa_server,
+        use_templates=use_templates,
         num_diffusion_samples=1,
+        # Isolate the template cache: without this it lands in a persistent /tmp dir
+        # shared across runs, and the template-enabled cases here would see each
+        # other's leftovers.
+        template_output_dir=tmp_path / "template_data",
     )
     logger.info("Checking output contents at %s", tmp_path)
     for query_name in query_set.queries:

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -15,9 +15,10 @@
 """Smoke tests for inference: small queries run end-to-end.
 
 ``test_inference_writes_outputs`` runs each case in ``CASES`` with MSA server + templates
-and checks the expected output files are written; adding a molecule-type combination is
-one row. See ``test_templates.py`` for the functional check that a supplied template
-actually steers the prediction.
+and checks the expected output files are written for every query it contains. Cases mix
+in-memory query sets with the query JSONs under ``examples/example_inference_inputs``,
+so adding either kind is one row. See ``test_templates.py`` for the functional check that
+a supplied template actually steers the prediction.
 
 These require an accelerator (CUDA, ROCm or MPS) and downloaded model weights; they skip
 otherwise.
@@ -27,9 +28,12 @@ Run with:
 """
 
 import logging
+from functools import partial
+from pathlib import Path
 
 import pytest
 
+import openfold3
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
@@ -38,6 +42,20 @@ from openfold3.tests.utils.compare_utils import skip_unless_accelerator_availabl
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
+
+#: Repo-root ``examples/`` — present in a source checkout, but not shipped in the wheel
+#: (``packages.find`` only picks up ``openfold3*``), so file-backed cases must tolerate
+#: its absence when the suite runs from an install.
+EXAMPLES_DIR = Path(openfold3.__file__).parent / "examples" / "example_inference_inputs"
+
+requires_examples = pytest.mark.skipif(
+    not EXAMPLES_DIR.is_dir(), reason=f"No examples directory at {EXAMPLES_DIR}"
+)
+
+#: Seed the outputs are written under. Comes from ``ExperimentSettings.seeds`` (default
+#: ``[42]``), which the runner yaml in :func:`run_inference` does not override — *not*
+#: from ``InferenceQuerySet.seeds``, which the runner ignores.
+SEED = 42
 
 PROTEIN_CHAIN = {
     "molecule_type": "protein",
@@ -51,28 +69,43 @@ LIGAND_CHAIN = {
     "smiles": "c1ccccc1O",
 }
 
-#: Chain sets to run, all under the query name ``query1`` so they share one expected
-#: output listing. Cases differ only in which molecule types the query contains.
-CASES = [
-    pytest.param([PROTEIN_CHAIN], id="protein_only"),
-    pytest.param([PROTEIN_CHAIN, LIGAND_CHAIN], id="protein_and_ligand"),
-]
 
-EXPECTED_OUTPUT_FILES = [
-    "query1_seed_42_sample_1_confidences.json",
-    "query1_seed_42_sample_1_confidences_aggregated.json",
-    "query1_seed_42_sample_1_model.cif",
-    "timing.json",
+def _inline_query_set(*chains: dict) -> InferenceQuerySet:
+    """Build a single-query set named ``query1`` from raw chain dicts."""
+    return InferenceQuerySet.model_validate(
+        {"queries": {"query1": {"chains": list(chains)}}}
+    )
+
+
+def _example_query_set(filename: str) -> InferenceQuerySet:
+    """Load an example query JSON through the same loader ``run_openfold`` uses."""
+    return InferenceQuerySet.from_json(EXAMPLES_DIR / filename)
+
+
+#: Each case builds an :class:`InferenceQuerySet`, either in memory or from a file in
+#: ``examples/example_inference_inputs``. Construction is deferred behind a callable so
+#: that a missing examples directory skips the case instead of breaking collection.
+#: Expected outputs are derived from the query names, so a case may hold any number of
+#: queries — adding another example is one row.
+CASES = [
+    pytest.param(partial(_inline_query_set, PROTEIN_CHAIN), id="protein_only"),
+    pytest.param(
+        partial(_inline_query_set, PROTEIN_CHAIN, LIGAND_CHAIN),
+        id="protein_and_ligand",
+    ),
+    pytest.param(
+        partial(_example_query_set, "query_protein_ligand_multiple.json"),
+        id="protein_ligand_multiple",
+        marks=requires_examples,
+    ),
 ]
 
 
 @skip_unless_accelerator_available()
-@pytest.mark.parametrize("chains", CASES)
-def test_inference_writes_outputs(chains, tmp_path):
-    """Each query runs end-to-end and writes the expected per-sample outputs."""
-    query_set = InferenceQuerySet.model_validate(
-        {"queries": {"query1": {"chains": chains}}}
-    )
+@pytest.mark.parametrize("build_query_set", CASES)
+def test_inference_writes_outputs(build_query_set, tmp_path):
+    """Every query in the set runs end-to-end and writes the expected per-sample files."""
+    query_set = build_query_set()
     run_inference(
         query_set,
         tmp_path,
@@ -81,11 +114,19 @@ def test_inference_writes_outputs(chains, tmp_path):
         num_diffusion_samples=1,
     )
     logger.info("Checking output contents at %s", tmp_path)
-    seed_dir = tmp_path / "query1" / "seed_42"
-    for name in EXPECTED_OUTPUT_FILES:
-        assert (seed_dir / name).exists(), (
-            f"Expected output file not found: {seed_dir / name}"
-        )
+    for query_name in query_set.queries:
+        seed_dir = tmp_path / query_name / f"seed_{SEED}"
+        stem = f"{query_name}_seed_{SEED}_sample_1"
+        expected_files = [
+            f"{stem}_confidences.json",
+            f"{stem}_confidences_aggregated.json",
+            f"{stem}_model.cif",
+            "timing.json",
+        ]
+        for name in expected_files:
+            assert (seed_dir / name).exists(), (
+                f"Expected output file not found: {seed_dir / name}"
+            )
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Smoke tests for inference: two small queries run end-to-end.
+"""Smoke tests for inference: small queries run end-to-end.
 
-``test_protein_only`` / ``test_protein_and_ligand`` run with MSA server + templates and
-check the expected output files are written. See ``test_templates.py`` for the functional
-check that a supplied template actually steers the prediction.
+``test_inference_writes_outputs`` runs each case in ``CASES`` with MSA server + templates
+and checks the expected output files are written; adding a molecule-type combination is
+one row. See ``test_templates.py`` for the functional check that a supplied template
+actually steers the prediction.
 
-Both require a GPU and downloaded model weights; they skip otherwise.
+These require a GPU and downloaded model weights; they skip otherwise.
 
 Run with:
     pytest openfold3/tests/inference/test_inference_full.py
@@ -37,45 +38,40 @@ from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
-protein_only_query = InferenceQuerySet.model_validate(
-    {
-        "queries": {
-            "query1": {
-                "chains": [
-                    {
-                        "molecule_type": "protein",
-                        "chain_ids": ["A", "B"],
-                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
-                    }
-                ]
-            }
-        }
-    }
-)
+PROTEIN_CHAIN = {
+    "molecule_type": "protein",
+    "chain_ids": ["A", "B"],
+    "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
+}
 
-protein_and_ligand_query = InferenceQuerySet.model_validate(
-    {
-        "queries": {
-            "query1": {
-                "chains": [
-                    {
-                        "molecule_type": "protein",
-                        "chain_ids": ["A", "B"],
-                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
-                    },
-                    {
-                        "molecule_type": "ligand",
-                        "chain_ids": ["C"],
-                        "smiles": "c1ccccc1O",
-                    },
-                ]
-            }
-        }
-    }
-)
+LIGAND_CHAIN = {
+    "molecule_type": "ligand",
+    "chain_ids": ["C"],
+    "smiles": "c1ccccc1O",
+}
+
+#: Chain sets to run, all under the query name ``query1`` so they share one expected
+#: output listing. Cases differ only in which molecule types the query contains.
+CASES = [
+    pytest.param([PROTEIN_CHAIN], id="protein_only"),
+    pytest.param([PROTEIN_CHAIN, LIGAND_CHAIN], id="protein_and_ligand"),
+]
+
+EXPECTED_OUTPUT_FILES = [
+    "query1_seed_42_sample_1_confidences.json",
+    "query1_seed_42_sample_1_confidences_aggregated.json",
+    "query1_seed_42_sample_1_model.cif",
+    "timing.json",
+]
 
 
-def _assert_inference_writes_outputs(query_set, tmp_path):
+@skip_unless_cuda_available()
+@pytest.mark.parametrize("chains", CASES)
+def test_inference_writes_outputs(chains, tmp_path):
+    """Each query runs end-to-end and writes the expected per-sample outputs."""
+    query_set = InferenceQuerySet.model_validate(
+        {"queries": {"query1": {"chains": chains}}}
+    )
     run_inference(
         query_set,
         tmp_path,
@@ -85,26 +81,10 @@ def _assert_inference_writes_outputs(query_set, tmp_path):
     )
     logger.info("Checking output contents at %s", tmp_path)
     seed_dir = tmp_path / "query1" / "seed_42"
-    expected_files = [
-        "query1_seed_42_sample_1_confidences.json",
-        "query1_seed_42_sample_1_confidences_aggregated.json",
-        "query1_seed_42_sample_1_model.cif",
-        "timing.json",
-    ]
-    for name in expected_files:
+    for name in EXPECTED_OUTPUT_FILES:
         assert (seed_dir / name).exists(), (
             f"Expected output file not found: {seed_dir / name}"
         )
-
-
-@skip_unless_cuda_available()
-def test_protein_only(tmp_path):
-    _assert_inference_writes_outputs(protein_only_query, tmp_path)
-
-
-@skip_unless_cuda_available()
-def test_protein_and_ligand(tmp_path):
-    _assert_inference_writes_outputs(protein_and_ligand_query, tmp_path)
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -175,9 +175,12 @@ CASES = [
                 ca_rmsd_max={
                     # measured 0.87 Å (gdt_ts 0.974)
                     Mode(use_msa_server=False, use_templates=False): 0.9,
-                    # measured 0.87 Å (gdt_ts 0.974) — the same numbers as the row
-                    # above, because without the MSA server template search has nothing
-                    # to draw on, so on a fixed seed this run reduces to that one
+                    # measured 0.87 Å (gdt_ts 0.974) — same numbers as the row above:
+                    # without the MSA server template search has nothing to draw on
+                    # (preprocessing returns within the same second), so both no_msa
+                    # modes are the same computation. They are not bit-identical though
+                    # — 7L39 measures 15.29 vs 15.78 Å across this same pair — they
+                    # agree here because a converged prediction is stable.
                     Mode(use_msa_server=False, use_templates=True): 0.9,
                     # measured 0.75 Å (gdt_ts 0.967)
                     Mode(use_msa_server=True, use_templates=False): 0.8,
@@ -190,10 +193,53 @@ CASES = [
         marks=(requires_examples,),
     ),
     InferenceCase(
-        id="protein_ligand_multiple",
+        id="query_single_protein_single_ligand",
         build_query_set=partial(
-            _example_query_set, "query_protein_ligand_multiple.json"
+            _example_query_set, "query_single_protein_single_ligand.json"
         ),
+        expectations={
+            "pdb_7L39": Expectation(
+                # T4 lysozyme L99A with toluene. The query encodes the L99A mutation
+                # itself (position 99 is A), and 7l39 chain A matches the query sequence
+                # residue-for-residue over all 162 modelled positions — no stray point
+                # mutants, which is the hazard with T4 lysozyme.
+                #
+                # Two equally exact alternatives exist, both also monomeric with toluene
+                # (MBN) bound: 4W53 (1.56 Å, all 164 residues modelled) and 7L3A (1.11 Å,
+                # cryo, toluene the only non-water heteroatom). 7L39 is used because the
+                # query names itself after it. They are not interchangeable to the
+                # precision we assert at — pairwise CA-RMSD among the three runs
+                # 0.24–0.46 Å — so a ceiling recorded here is tied to this reference.
+                ref_cif=MMCIFS_DIR / "7l39.cif",
+                ref_chains=("A",),
+                # Measured 2026-07-28 on of3-p2-155k, one diffusion sample, seed 42:
+                #   no_msa-no_templates  15.29 Å (gdt_ts 0.032)
+                #   no_msa-templates     15.78 Å (gdt_ts 0.039)
+                #   msa-no_templates      0.22 Å (gdt_ts 1.000)
+                #   msa-templates         0.20 Å (gdt_ts 1.000)
+                # Unlike ubiquitin, this target lives or dies on the MSA: single-sequence
+                # the model does not find the fold at all (gdt_ts 0.03), with an MSA it
+                # is essentially exact. Which is the case the per-mode encoding exists
+                # for — one ceiling across all four would have to be ~16 Å and would
+                # then wave through a total collapse of the MSA path.
+                ca_rmsd_max={
+                    # Only the converged modes are pinned, and pinned tight. gdt_ts is
+                    # 1.000 in both, i.e. the prediction is locked onto the reference,
+                    # so the number is reproducible.
+                    Mode(use_msa_server=True, use_templates=False): 0.3,
+                    Mode(use_msa_server=True, use_templates=True): 0.3,
+                    # The two no_msa modes are deliberately left unpinned. Their RMSD is
+                    # the distance to a fold the model never found, which is not a stable
+                    # quantity: the two runs above differ by 0.5 Å despite being the same
+                    # computation (template search finds nothing without the MSA server —
+                    # its preprocessing returns within the same second). Pinning a tight
+                    # ceiling there would buy flakiness and no signal. Asserting these
+                    # properly needs a *floor* — "must be worse than 8 Å without an MSA",
+                    # the way test_templates.py proves its template effect — which
+                    # Expectation cannot express yet.
+                },
+            )
+        },
         marks=(requires_examples,),
     ),
 ]

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -1,0 +1,111 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for inference: two small queries run end-to-end.
+
+``test_protein_only`` / ``test_protein_and_ligand`` run with MSA server + templates and
+check the expected output files are written. See ``test_templates.py`` for the functional
+check that a supplied template actually steers the prediction.
+
+Both require a GPU and downloaded model weights; they skip otherwise.
+
+Run with:
+    pytest openfold3/tests/inference/test_inference_full.py
+"""
+
+import logging
+
+import pytest
+
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
+)
+from openfold3.tests.inference.helpers import run_inference
+from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+protein_only_query = InferenceQuerySet.model_validate(
+    {
+        "queries": {
+            "query1": {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A", "B"],
+                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
+                    }
+                ]
+            }
+        }
+    }
+)
+
+protein_and_ligand_query = InferenceQuerySet.model_validate(
+    {
+        "queries": {
+            "query1": {
+                "chains": [
+                    {
+                        "molecule_type": "protein",
+                        "chain_ids": ["A", "B"],
+                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
+                    },
+                    {
+                        "molecule_type": "ligand",
+                        "chain_ids": ["C"],
+                        "smiles": "c1ccccc1O",
+                    },
+                ]
+            }
+        }
+    }
+)
+
+
+def _assert_inference_writes_outputs(query_set, tmp_path):
+    run_inference(
+        query_set,
+        tmp_path,
+        use_msa_server=True,
+        use_templates=True,
+        num_diffusion_samples=1,
+    )
+    logger.info("Checking output contents at %s", tmp_path)
+    seed_dir = tmp_path / "query1" / "seed_42"
+    expected_files = [
+        "query1_seed_42_sample_1_confidences.json",
+        "query1_seed_42_sample_1_confidences_aggregated.json",
+        "query1_seed_42_sample_1_model.cif",
+        "timing.json",
+    ]
+    for name in expected_files:
+        assert (seed_dir / name).exists(), (
+            f"Expected output file not found: {seed_dir / name}"
+        )
+
+
+@skip_unless_cuda_available()
+def test_protein_only(tmp_path):
+    _assert_inference_writes_outputs(protein_only_query, tmp_path)
+
+
+@skip_unless_cuda_available()
+def test_protein_and_ligand(tmp_path):
+    _assert_inference_writes_outputs(protein_and_ligand_query, tmp_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-vv"]))

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -19,7 +19,8 @@ and checks the expected output files are written; adding a molecule-type combina
 one row. See ``test_templates.py`` for the functional check that a supplied template
 actually steers the prediction.
 
-These require a GPU and downloaded model weights; they skip otherwise.
+These require an accelerator (CUDA, ROCm or MPS) and downloaded model weights; they skip
+otherwise.
 
 Run with:
     pytest openfold3/tests/inference/test_inference_full.py
@@ -33,7 +34,7 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
 from openfold3.tests.inference.helpers import run_inference
-from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
+from openfold3.tests.utils.compare_utils import skip_unless_accelerator_available
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -65,7 +66,7 @@ EXPECTED_OUTPUT_FILES = [
 ]
 
 
-@skip_unless_cuda_available()
+@skip_unless_accelerator_available()
 @pytest.mark.parametrize("chains", CASES)
 def test_inference_writes_outputs(chains, tmp_path):
     """Each query runs end-to-end and writes the expected per-sample outputs."""

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -44,13 +44,13 @@ from pathlib import Path
 import pytest
 
 import openfold3
-from openfold3.projects.of3_all_atom.config.inference_query_format import (
-    InferenceQuerySet,
-)
-from openfold3.tests.inference.analysis import (
+from openfold3.core.metrics.alignment import (
     Structure,
     best_ca_rmsd,
     ligand_pose_metrics,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
 )
 from openfold3.tests.inference.helpers import (
     MMCIFS_DIR,

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -139,9 +139,7 @@ def _mean_ca_rmsd(case: TemplateRmsdCase, *, mode: Mode, tmp_path: Path) -> floa
     # no information here.
     reference = Structure.from_cif(_ref_cif(case))
     rmsds = [
-        best_ca_rmsd(Structure.from_cif(cif), reference, ref_chains=(case.chain,))[
-            "rmsd"
-        ]
+        best_ca_rmsd(Structure.from_cif(cif), reference, ref_chains=(case.chain,)).rmsd
         for cif in sample_cifs
     ]
     logger.info("%s [%s] per-sample RMSDs: %s", key, mode.id, rmsds)

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -33,7 +33,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from openfold3.tests.inference.analysis import Structure, best_ca_rmsd
+from openfold3.core.metrics.alignment import Structure, best_ca_rmsd
 from openfold3.tests.inference.helpers import (
     MMCIFS_DIR,
     Mode,

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -30,27 +30,31 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-import biotite.structure as struc
 import numpy as np
 import pytest
 
-import openfold3
-from openfold3.core.data.io.structure.cif import parse_mmcif
-from openfold3.projects.of3_all_atom.config.inference_query_format import (
-    InferenceQuerySet,
+from openfold3.tests.inference.analysis import best_ca_rmsd
+from openfold3.tests.inference.helpers import (
+    MMCIFS_DIR,
+    Mode,
+    predicted_structure_cifs,
+    query_set_from_chains,
+    run_inference,
 )
-from openfold3.tests.inference.helpers import run_inference
 from openfold3.tests.utils.compare_utils import skip_unless_accelerator_available
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
-MMCIFS_DIR = Path(openfold3.__file__).parent / "tests" / "test_data" / "mmcifs"
-
 # Number of diffusion samples per condition. The user's experiments show the samples
 # cluster (all near the reference with a template, all far without), so the mean over
 # samples is representative and robust.
 NUM_DIFFUSION_SAMPLES = 5
+
+#: The two conditions compared. Both run single-sequence, so the template flag is the
+#: only difference between them — that is what makes the RMSD gap attributable to it.
+TEMPLATE_OFF = Mode(use_msa_server=False, use_templates=False)
+TEMPLATE_ON = Mode(use_msa_server=False, use_templates=True)
 
 
 @dataclass(frozen=True)
@@ -100,67 +104,43 @@ def _ref_cif(case: TemplateRmsdCase) -> Path:
     return MMCIFS_DIR / f"{case.pdb_id}.cif"
 
 
-def _ca(atom_array, chain: str | None = None):
-    """Sorted-by-res_id CA atoms of a chain (or all non-hetero CA if chain is None)."""
-    mask = (atom_array.atom_name == "CA") & (~atom_array.hetero)
-    if chain is not None:
-        mask &= atom_array.chain_id == chain
-    ca = atom_array[mask]
-    return ca[np.argsort(ca.res_id)]
-
-
-def _ca_rmsd(pred_cif: Path, ref_cif: Path, ref_chain: str) -> float:
-    """Superposition CA-RMSD (Angstroms) of a predicted monomer vs a reference chain."""
-    pred = _ca(parse_mmcif(pred_cif).atom_array)  # monomer -> single chain
-    ref = _ca(parse_mmcif(ref_cif).atom_array, ref_chain)
-    common = np.intersect1d(pred.res_id, ref.res_id)
-    pred = pred[np.isin(pred.res_id, common)]
-    ref = ref[np.isin(ref.res_id, common)]
-    assert len(pred) == len(ref) == len(common), (
-        f"CA correspondence mismatch: pred={len(pred)} ref={len(ref)} "
-        f"common={len(common)} (duplicate res_ids / unexpected chains?)"
-    )
-    fitted, _ = struc.superimpose(fixed=ref, mobile=pred)
-    return float(struc.rmsd(ref, fitted))
-
-
-def _make_query(case: TemplateRmsdCase, *, with_template: bool) -> tuple[object, str]:
+def _make_query(case: TemplateRmsdCase, *, mode: Mode) -> tuple[object, str]:
+    """Build the query for one condition, attaching the template only when it is on."""
     chain = {
         "molecule_type": "protein",
         "chain_ids": [case.chain],
         "sequence": case.sequence,
     }
-    if with_template:
+    if mode.use_templates:
         chain["template_cif_paths"] = [str(_ref_cif(case))]
         chain["template_cif_chain_ids"] = [case.chain]
-    key = f"{case.pdb_id}_template_{'on' if with_template else 'off'}"
-    query_set = InferenceQuerySet.model_validate(
-        {"queries": {key: {"chains": [chain]}}}
-    )
-    return query_set, key
+    key = f"{case.pdb_id}_template_{'on' if mode.use_templates else 'off'}"
+    return query_set_from_chains(key, chain), key
 
 
-def _mean_ca_rmsd(
-    case: TemplateRmsdCase, *, with_template: bool, tmp_path: Path
-) -> float:
-    """Run one condition (no MSA, template on/off) and return mean CA-RMSD over samples."""
-    query_set, key = _make_query(case, with_template=with_template)
+def _mean_ca_rmsd(case: TemplateRmsdCase, *, mode: Mode, tmp_path: Path) -> float:
+    """Run one condition and return the mean CA-RMSD over diffusion samples."""
+    query_set, key = _make_query(case, mode=mode)
     out_dir = tmp_path / key
     out_dir.mkdir(parents=True, exist_ok=True)
     run_inference(
         query_set,
         out_dir,
-        use_msa_server=False,
-        use_templates=with_template,
+        use_msa_server=mode.use_msa_server,
+        use_templates=mode.use_templates,
         num_diffusion_samples=NUM_DIFFUSION_SAMPLES,
         template_output_dir=out_dir / "template_data",
     )
 
-    seed_dir = out_dir / key / "seed_42"
-    sample_cifs = sorted(seed_dir.glob(f"{key}_seed_42_sample_*_model.cif"))
-    assert sample_cifs, f"No predicted structures found in {seed_dir}"
-    rmsds = [_ca_rmsd(cif, _ref_cif(case), case.chain) for cif in sample_cifs]
-    logger.info("%s template=%s per-sample RMSDs: %s", key, with_template, rmsds)
+    sample_cifs = predicted_structure_cifs(out_dir, key)
+    assert sample_cifs, f"No predicted structures found under {out_dir / key}"
+    # The prediction is a monomer, so let its chains be discovered: the chain id the
+    # writer emits carries no information here.
+    rmsds = [
+        best_ca_rmsd(cif, _ref_cif(case), ref_chains=(case.chain,))["rmsd"]
+        for cif in sample_cifs
+    ]
+    logger.info("%s [%s] per-sample RMSDs: %s", key, mode.id, rmsds)
     return float(np.mean(rmsds))
 
 
@@ -169,8 +149,8 @@ def _mean_ca_rmsd(
 @pytest.mark.parametrize("case", CASES, ids=lambda c: c.pdb_id)
 def test_template_lowers_rmsd(case, tmp_path):
     """Without MSA, a supplied template must lower CA-RMSD to the native fold (PR #306)."""
-    rmsd_off = _mean_ca_rmsd(case, with_template=False, tmp_path=tmp_path)
-    rmsd_on = _mean_ca_rmsd(case, with_template=True, tmp_path=tmp_path)
+    rmsd_off = _mean_ca_rmsd(case, mode=TEMPLATE_OFF, tmp_path=tmp_path)
+    rmsd_on = _mean_ca_rmsd(case, mode=TEMPLATE_ON, tmp_path=tmp_path)
     logger.info("%s mean RMSD off=%.2f on=%.2f", case.pdb_id, rmsd_off, rmsd_on)
 
     assert rmsd_off > case.no_template_rmsd_min_angstrom, (

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -12,190 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for inference.
+"""Template-effect RMSD test (PR #306).
 
-- ``test_protein_only`` / ``test_protein_and_ligand``: two small queries run end-to-end
-  (with MSA server + templates), checking the expected output files are written.
-- ``test_template_lowers_rmsd``: functional check for PR #306 — with no MSA, supplying a
-  template must pull the prediction onto the native fold (low CA-RMSD to the reference),
-  whereas without a template the single-sequence model can't find it (high CA-RMSD).
-  Parametrized over ``CASES`` so adding a PDB is one row + committing its cif.
+``test_template_lowers_rmsd``: with no MSA, supplying a template must pull the prediction
+onto the native fold (low CA-RMSD to the reference), whereas without a template the
+single-sequence model can't find it (high CA-RMSD). Parametrized over ``CASES`` so adding
+a PDB is one row + committing its cif.
 
-All of these require a GPU and downloaded model weights; they skip otherwise.
+Requires a GPU and downloaded model weights; skips otherwise.
 
 Run with:
-    pytest openfold3/tests/test_inference_full.py
+    pytest openfold3/tests/inference/test_templates.py
 """
 
 import logging
-import os
-import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import patch
 
 import biotite.structure as struc
 import numpy as np
 import pytest
 
-from openfold3.core.config import config_utils
+import openfold3
 from openfold3.core.data.io.structure.cif import parse_mmcif
-from openfold3.entry_points.experiment_runner import InferenceExperimentRunner
-from openfold3.entry_points.validator import (
-    InferenceExperimentConfig,
-)
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
+from openfold3.tests.inference.helpers import run_inference
 from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
-MMCIFS_DIR = Path(__file__).parent / "test_data" / "mmcifs"
-
-protein_only_query = InferenceQuerySet.model_validate(
-    {
-        "queries": {
-            "query1": {
-                "chains": [
-                    {
-                        "molecule_type": "protein",
-                        "chain_ids": ["A", "B"],
-                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
-                    }
-                ]
-            }
-        }
-    }
-)
-
-protein_and_ligand_query = InferenceQuerySet.model_validate(
-    {
-        "queries": {
-            "query1": {
-                "chains": [
-                    {
-                        "molecule_type": "protein",
-                        "chain_ids": ["A", "B"],
-                        "sequence": "XRMKQLEDKVEELLSKNYHLENEVARLKKLVGER",
-                    },
-                    {
-                        "molecule_type": "ligand",
-                        "chain_ids": ["C"],
-                        "smiles": "c1ccccc1O",
-                    },
-                ]
-            }
-        }
-    }
-)
-
-inference_test_yaml_str = textwrap.dedent("""\
-    model_update:
-      presets:
-        - predict
-        - low_mem
-    """)
-
-
-def _run_inference_helper(
-    query_set,
-    output_dir: Path,
-    *,
-    use_msa_server: bool,
-    use_templates: bool,
-    num_diffusion_samples: int = 1,
-    template_output_dir: Path | None = None,
-) -> Path:
-    """Run one inference job into ``output_dir`` and return it.
-
-    Skips (``pytest.skip``) if no model checkpoint is available (escalated to a hard
-    failure when ``OPENFOLD_SETUP_SCRIPT=1``). ``template_output_dir`` isolates the
-    template cache per run (otherwise it lands in a persistent ``/tmp`` dir shared across
-    runs and same-sequence queries).
-    """
-    runner_yaml = output_dir / "runner_config.yaml"
-    yaml_str = inference_test_yaml_str
-    if template_output_dir is not None:
-        yaml_str += textwrap.dedent(f"""\
-            template_preprocessor_settings:
-              output_directory: {template_output_dir}
-            """)
-    runner_yaml.write_text(yaml_str)
-
-    with patch("builtins.input", return_value="no"):
-        experiment_config = InferenceExperimentConfig(
-            **config_utils.load_yaml(runner_yaml)
-        )
-    runner = InferenceExperimentRunner(
-        experiment_config,
-        num_diffusion_samples=num_diffusion_samples,
-        output_dir=output_dir,
-        use_msa_server=use_msa_server,
-        use_templates=use_templates,
-    )
-    try:
-        runner.setup()
-    except ValueError as e:
-        if "is not a valid file or directory" in str(e):
-            if os.environ.get("OPENFOLD_SETUP_SCRIPT") == "1":
-                raise AssertionError(
-                    "No checkpoint files found after running setup script. "
-                    "Please check that the download completed successfully."
-                ) from None
-            logger.warning(
-                "No checkpoint files found, skipping. Use the setup script to "
-                "download the weights."
-            )
-            pytest.skip("No checkpoint files available")
-        raise
-
-    runner.run(query_set)
-    runner.cleanup()
-
-    err_log_dir = output_dir / "logs"
-    if err_log_dir.exists():
-        raise RuntimeError(
-            f"Found error logs in directory {err_log_dir}, "
-            "check for errors in inference."
-        )
-    return output_dir
-
-
-def _assert_inference_writes_outputs(query_set, tmp_path):
-    _run_inference_helper(
-        query_set,
-        tmp_path,
-        use_msa_server=True,
-        use_templates=True,
-        num_diffusion_samples=1,
-    )
-    logger.info("Checking output contents at %s", tmp_path)
-    seed_dir = tmp_path / "query1" / "seed_42"
-    expected_files = [
-        "query1_seed_42_sample_1_confidences.json",
-        "query1_seed_42_sample_1_confidences_aggregated.json",
-        "query1_seed_42_sample_1_model.cif",
-        "timing.json",
-    ]
-    for name in expected_files:
-        assert (seed_dir / name).exists(), (
-            f"Expected output file not found: {seed_dir / name}"
-        )
-
-
-@skip_unless_cuda_available()
-def test_protein_only(tmp_path):
-    _assert_inference_writes_outputs(protein_only_query, tmp_path)
-
-
-@skip_unless_cuda_available()
-def test_protein_and_ligand(tmp_path):
-    _assert_inference_writes_outputs(protein_and_ligand_query, tmp_path)
-
-
-# --- Template-effect RMSD test (PR #306) -----------------------------------------------
+MMCIFS_DIR = Path(openfold3.__file__).parent / "tests" / "test_data" / "mmcifs"
 
 # Number of diffusion samples per condition. The user's experiments show the samples
 # cluster (all near the reference with a template, all far without), so the mean over
@@ -297,7 +146,7 @@ def _mean_ca_rmsd(
     query_set, key = _make_query(case, with_template=with_template)
     out_dir = tmp_path / key
     out_dir.mkdir(parents=True, exist_ok=True)
-    _run_inference_helper(
+    run_inference(
         query_set,
         out_dir,
         use_msa_server=False,

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -19,7 +19,8 @@ onto the native fold (low CA-RMSD to the reference), whereas without a template 
 single-sequence model can't find it (high CA-RMSD). Parametrized over ``CASES`` so adding
 a PDB is one row + committing its cif.
 
-Requires a GPU and downloaded model weights; skips otherwise.
+Requires an accelerator (CUDA, ROCm or MPS) and downloaded model weights; skips
+otherwise.
 
 Run with:
     pytest openfold3/tests/inference/test_templates.py
@@ -39,7 +40,7 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
 from openfold3.tests.inference.helpers import run_inference
-from openfold3.tests.utils.compare_utils import skip_unless_cuda_available
+from openfold3.tests.utils.compare_utils import skip_unless_accelerator_available
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -163,7 +164,7 @@ def _mean_ca_rmsd(
     return float(np.mean(rmsds))
 
 
-@skip_unless_cuda_available()
+@skip_unless_accelerator_available()
 @pytest.mark.inference_verification
 @pytest.mark.parametrize("case", CASES, ids=lambda c: c.pdb_id)
 def test_template_lowers_rmsd(case, tmp_path):

--- a/openfold3/tests/inference/test_templates.py
+++ b/openfold3/tests/inference/test_templates.py
@@ -33,7 +33,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from openfold3.tests.inference.analysis import best_ca_rmsd
+from openfold3.tests.inference.analysis import Structure, best_ca_rmsd
 from openfold3.tests.inference.helpers import (
     MMCIFS_DIR,
     Mode,
@@ -134,10 +134,14 @@ def _mean_ca_rmsd(case: TemplateRmsdCase, *, mode: Mode, tmp_path: Path) -> floa
 
     sample_cifs = predicted_structure_cifs(out_dir, key)
     assert sample_cifs, f"No predicted structures found under {out_dir / key}"
-    # The prediction is a monomer, so let its chains be discovered: the chain id the
-    # writer emits carries no information here.
+    # The reference is parsed once for the whole batch of samples; the prediction is a
+    # monomer, so let its chains be discovered — the chain id the writer emits carries
+    # no information here.
+    reference = Structure.from_cif(_ref_cif(case))
     rmsds = [
-        best_ca_rmsd(cif, _ref_cif(case), ref_chains=(case.chain,))["rmsd"]
+        best_ca_rmsd(Structure.from_cif(cif), reference, ref_chains=(case.chain,))[
+            "rmsd"
+        ]
         for cif in sample_cifs
     ]
     logger.info("%s [%s] per-sample RMSDs: %s", key, mode.id, rmsds)

--- a/openfold3/tests/test_data/mmcifs/1ubq.cif
+++ b/openfold3/tests/test_data/mmcifs/1ubq.cif
@@ -1,0 +1,2237 @@
+data_1UBQ
+# 
+_entry.id   1UBQ 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.386 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+_database_2.pdbx_database_accession 
+_database_2.pdbx_DOI 
+PDB   1UBQ         pdb_00001ubq 10.2210/pdb1ubq/pdb 
+WWPDB D_1000176905 ?            ?                   
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1987-04-16 
+2 'Structure model' 1 1 2008-03-24 
+3 'Structure model' 1 2 2011-07-13 
+4 'Structure model' 1 3 2024-02-14 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+_pdbx_audit_revision_details.details             ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Version format compliance' 
+3 4 'Structure model' 'Data collection'           
+4 4 'Structure model' 'Database references'       
+5 4 'Structure model' Other                       
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1 4 'Structure model' chem_comp_atom       
+2 4 'Structure model' chem_comp_bond       
+3 4 'Structure model' database_2           
+4 4 'Structure model' pdbx_database_status 
+# 
+loop_
+_pdbx_audit_revision_item.ordinal 
+_pdbx_audit_revision_item.revision_ordinal 
+_pdbx_audit_revision_item.data_content_type 
+_pdbx_audit_revision_item.item 
+1 4 'Structure model' '_database_2.pdbx_DOI'                
+2 4 'Structure model' '_database_2.pdbx_database_accession' 
+3 4 'Structure model' '_pdbx_database_status.process_site'  
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1UBQ 
+_pdbx_database_status.recvd_initial_deposition_date   1987-01-02 
+_pdbx_database_status.deposit_site                    ? 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_nmr_data            ? 
+_pdbx_database_status.methods_development_category    ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Vijay-Kumar, S.' 1 
+'Bugg, C.E.'      2 
+'Cook, W.J.'      3 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Structure of ubiquitin refined at 1.8 A resolution.'                                                 J.Mol.Biol. 194 531  
+544 1987 JMOBAK UK 0022-2836 0070 ? 3041007 '10.1016/0022-2836(87)90679-6' 
+1       'Comparison of the Three-Dimensional Structures of Human, Yeast, and Oat Ubiquitin'                   J.Biol.Chem. 262 
+6396 ?   1987 JBCHA3 US 0021-9258 0071 ? ?       ?                              
+2       'Three-Dimensional Structure of Ubiquitin at 2.8 Angstroms Resolution'                                
+Proc.Natl.Acad.Sci.USA 82  3582 ?   1985 PNASA6 US 0027-8424 0040 ? ?       ?                              
+3       'Crystallization and Preliminary X-Ray Investigation of Ubiquitin, a Non-Histone Chromosomal Protein' J.Mol.Biol. 130 353  
+?   1979 JMOBAK UK 0022-2836 0070 ? ?       ?                              
+4       'Molecular Conservation of 74 Amino Acid Sequence of Ubiquitin between Cattle and Man'                Nature 255 423  ?   
+1975 NATUAS UK 0028-0836 0006 ? ?       ?                              
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+_citation_author.identifier_ORCID 
+primary 'Vijay-Kumar, S.'   1  ? 
+primary 'Bugg, C.E.'        2  ? 
+primary 'Cook, W.J.'        3  ? 
+1       'Vijay-Kumar, S.'   4  ? 
+1       'Bugg, C.E.'        5  ? 
+1       'Wilkinson, K.D.'   6  ? 
+1       'Vierstra, R.D.'    7  ? 
+1       'Hatfield, P.M.'    8  ? 
+1       'Cook, W.J.'        9  ? 
+2       'Vijay-Kumar, S.'   10 ? 
+2       'Bugg, C.E.'        11 ? 
+2       'Wilkinson, K.D.'   12 ? 
+2       'Cook, W.J.'        13 ? 
+3       'Cook, W.J.'        14 ? 
+3       'Suddath, F.L.'     15 ? 
+3       'Bugg, C.E.'        16 ? 
+3       'Goldstein, G.'     17 ? 
+4       'Schlesinger, D.H.' 18 ? 
+4       'Goldstein, G.'     19 ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer man UBIQUITIN 8576.831 1  ? ? ? ? 
+2 water   nat water     18.015   58 ? ? ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_entity_poly.pdbx_seq_one_letter_code_can   MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+_pdbx_entity_nonpoly.entity_id   2 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  MET n 
+1 2  GLN n 
+1 3  ILE n 
+1 4  PHE n 
+1 5  VAL n 
+1 6  LYS n 
+1 7  THR n 
+1 8  LEU n 
+1 9  THR n 
+1 10 GLY n 
+1 11 LYS n 
+1 12 THR n 
+1 13 ILE n 
+1 14 THR n 
+1 15 LEU n 
+1 16 GLU n 
+1 17 VAL n 
+1 18 GLU n 
+1 19 PRO n 
+1 20 SER n 
+1 21 ASP n 
+1 22 THR n 
+1 23 ILE n 
+1 24 GLU n 
+1 25 ASN n 
+1 26 VAL n 
+1 27 LYS n 
+1 28 ALA n 
+1 29 LYS n 
+1 30 ILE n 
+1 31 GLN n 
+1 32 ASP n 
+1 33 LYS n 
+1 34 GLU n 
+1 35 GLY n 
+1 36 ILE n 
+1 37 PRO n 
+1 38 PRO n 
+1 39 ASP n 
+1 40 GLN n 
+1 41 GLN n 
+1 42 ARG n 
+1 43 LEU n 
+1 44 ILE n 
+1 45 PHE n 
+1 46 ALA n 
+1 47 GLY n 
+1 48 LYS n 
+1 49 GLN n 
+1 50 LEU n 
+1 51 GLU n 
+1 52 ASP n 
+1 53 GLY n 
+1 54 ARG n 
+1 55 THR n 
+1 56 LEU n 
+1 57 SER n 
+1 58 ASP n 
+1 59 TYR n 
+1 60 ASN n 
+1 61 ILE n 
+1 62 GLN n 
+1 63 LYS n 
+1 64 GLU n 
+1 65 SER n 
+1 66 THR n 
+1 67 LEU n 
+1 68 HIS n 
+1 69 LEU n 
+1 70 VAL n 
+1 71 LEU n 
+1 72 ARG n 
+1 73 LEU n 
+1 74 ARG n 
+1 75 GLY n 
+1 76 GLY n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               human 
+_entity_src_gen.gene_src_genus                     Homo 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Homo sapiens' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     9606 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      ? 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     ? 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE         ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE        ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking' y ASPARAGINE      ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'     133.103 
+GLN 'L-peptide linking' y GLUTAMINE       ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE         ? 'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking' y HISTIDINE       ? 'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer         . WATER           ? 'H2 O'           18.015  
+ILE 'L-peptide linking' y ISOLEUCINE      ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE         ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking' y LYSINE          ? 'C6 H15 N2 O2 1' 147.195 
+MET 'L-peptide linking' y METHIONINE      ? 'C5 H11 N O2 S'  149.211 
+PHE 'L-peptide linking' y PHENYLALANINE   ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE         ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE          ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE       ? 'C4 H9 N O3'     119.119 
+TYR 'L-peptide linking' y TYROSINE        ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE          ? 'C5 H11 N O2'    117.146 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  MET 1  1  1  MET MET A . n 
+A 1 2  GLN 2  2  2  GLN GLN A . n 
+A 1 3  ILE 3  3  3  ILE ILE A . n 
+A 1 4  PHE 4  4  4  PHE PHE A . n 
+A 1 5  VAL 5  5  5  VAL VAL A . n 
+A 1 6  LYS 6  6  6  LYS LYS A . n 
+A 1 7  THR 7  7  7  THR THR A . n 
+A 1 8  LEU 8  8  8  LEU LEU A . n 
+A 1 9  THR 9  9  9  THR THR A . n 
+A 1 10 GLY 10 10 10 GLY GLY A . n 
+A 1 11 LYS 11 11 11 LYS LYS A . n 
+A 1 12 THR 12 12 12 THR THR A . n 
+A 1 13 ILE 13 13 13 ILE ILE A . n 
+A 1 14 THR 14 14 14 THR THR A . n 
+A 1 15 LEU 15 15 15 LEU LEU A . n 
+A 1 16 GLU 16 16 16 GLU GLU A . n 
+A 1 17 VAL 17 17 17 VAL VAL A . n 
+A 1 18 GLU 18 18 18 GLU GLU A . n 
+A 1 19 PRO 19 19 19 PRO PRO A . n 
+A 1 20 SER 20 20 20 SER SER A . n 
+A 1 21 ASP 21 21 21 ASP ASP A . n 
+A 1 22 THR 22 22 22 THR THR A . n 
+A 1 23 ILE 23 23 23 ILE ILE A . n 
+A 1 24 GLU 24 24 24 GLU GLU A . n 
+A 1 25 ASN 25 25 25 ASN ASN A . n 
+A 1 26 VAL 26 26 26 VAL VAL A . n 
+A 1 27 LYS 27 27 27 LYS LYS A . n 
+A 1 28 ALA 28 28 28 ALA ALA A . n 
+A 1 29 LYS 29 29 29 LYS LYS A . n 
+A 1 30 ILE 30 30 30 ILE ILE A . n 
+A 1 31 GLN 31 31 31 GLN GLN A . n 
+A 1 32 ASP 32 32 32 ASP ASP A . n 
+A 1 33 LYS 33 33 33 LYS LYS A . n 
+A 1 34 GLU 34 34 34 GLU GLU A . n 
+A 1 35 GLY 35 35 35 GLY GLY A . n 
+A 1 36 ILE 36 36 36 ILE ILE A . n 
+A 1 37 PRO 37 37 37 PRO PRO A . n 
+A 1 38 PRO 38 38 38 PRO PRO A . n 
+A 1 39 ASP 39 39 39 ASP ASP A . n 
+A 1 40 GLN 40 40 40 GLN GLN A . n 
+A 1 41 GLN 41 41 41 GLN GLN A . n 
+A 1 42 ARG 42 42 42 ARG ARG A . n 
+A 1 43 LEU 43 43 43 LEU LEU A . n 
+A 1 44 ILE 44 44 44 ILE ILE A . n 
+A 1 45 PHE 45 45 45 PHE PHE A . n 
+A 1 46 ALA 46 46 46 ALA ALA A . n 
+A 1 47 GLY 47 47 47 GLY GLY A . n 
+A 1 48 LYS 48 48 48 LYS LYS A . n 
+A 1 49 GLN 49 49 49 GLN GLN A . n 
+A 1 50 LEU 50 50 50 LEU LEU A . n 
+A 1 51 GLU 51 51 51 GLU GLU A . n 
+A 1 52 ASP 52 52 52 ASP ASP A . n 
+A 1 53 GLY 53 53 53 GLY GLY A . n 
+A 1 54 ARG 54 54 54 ARG ARG A . n 
+A 1 55 THR 55 55 55 THR THR A . n 
+A 1 56 LEU 56 56 56 LEU LEU A . n 
+A 1 57 SER 57 57 57 SER SER A . n 
+A 1 58 ASP 58 58 58 ASP ASP A . n 
+A 1 59 TYR 59 59 59 TYR TYR A . n 
+A 1 60 ASN 60 60 60 ASN ASN A . n 
+A 1 61 ILE 61 61 61 ILE ILE A . n 
+A 1 62 GLN 62 62 62 GLN GLN A . n 
+A 1 63 LYS 63 63 63 LYS LYS A . n 
+A 1 64 GLU 64 64 64 GLU GLU A . n 
+A 1 65 SER 65 65 65 SER SER A . n 
+A 1 66 THR 66 66 66 THR THR A . n 
+A 1 67 LEU 67 67 67 LEU LEU A . n 
+A 1 68 HIS 68 68 68 HIS HIS A . n 
+A 1 69 LEU 69 69 69 LEU LEU A . n 
+A 1 70 VAL 70 70 70 VAL VAL A . n 
+A 1 71 LEU 71 71 71 LEU LEU A . n 
+A 1 72 ARG 72 72 72 ARG ARG A . n 
+A 1 73 LEU 73 73 73 LEU LEU A . n 
+A 1 74 ARG 74 74 74 ARG ARG A . n 
+A 1 75 GLY 75 75 75 GLY GLY A . n 
+A 1 76 GLY 76 76 76 GLY GLY A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 HOH 1  77  1  HOH HOH A . 
+B 2 HOH 2  78  2  HOH HOH A . 
+B 2 HOH 3  79  3  HOH HOH A . 
+B 2 HOH 4  80  4  HOH HOH A . 
+B 2 HOH 5  81  5  HOH HOH A . 
+B 2 HOH 6  82  6  HOH HOH A . 
+B 2 HOH 7  83  7  HOH HOH A . 
+B 2 HOH 8  84  8  HOH HOH A . 
+B 2 HOH 9  85  9  HOH HOH A . 
+B 2 HOH 10 86  10 HOH HOH A . 
+B 2 HOH 11 87  11 HOH HOH A . 
+B 2 HOH 12 88  12 HOH HOH A . 
+B 2 HOH 13 89  13 HOH HOH A . 
+B 2 HOH 14 90  14 HOH HOH A . 
+B 2 HOH 15 91  15 HOH HOH A . 
+B 2 HOH 16 92  16 HOH HOH A . 
+B 2 HOH 17 93  17 HOH HOH A . 
+B 2 HOH 18 94  18 HOH HOH A . 
+B 2 HOH 19 95  19 HOH HOH A . 
+B 2 HOH 20 96  20 HOH HOH A . 
+B 2 HOH 21 97  21 HOH HOH A . 
+B 2 HOH 22 98  22 HOH HOH A . 
+B 2 HOH 23 99  23 HOH HOH A . 
+B 2 HOH 24 100 24 HOH HOH A . 
+B 2 HOH 25 101 25 HOH HOH A . 
+B 2 HOH 26 102 26 HOH HOH A . 
+B 2 HOH 27 103 27 HOH HOH A . 
+B 2 HOH 28 104 28 HOH HOH A . 
+B 2 HOH 29 105 29 HOH HOH A . 
+B 2 HOH 30 106 30 HOH HOH A . 
+B 2 HOH 31 107 31 HOH HOH A . 
+B 2 HOH 32 108 32 HOH HOH A . 
+B 2 HOH 33 109 33 HOH HOH A . 
+B 2 HOH 34 110 34 HOH HOH A . 
+B 2 HOH 35 111 35 HOH HOH A . 
+B 2 HOH 36 112 36 HOH HOH A . 
+B 2 HOH 37 113 37 HOH HOH A . 
+B 2 HOH 38 114 38 HOH HOH A . 
+B 2 HOH 39 115 39 HOH HOH A . 
+B 2 HOH 40 116 40 HOH HOH A . 
+B 2 HOH 41 117 41 HOH HOH A . 
+B 2 HOH 42 118 42 HOH HOH A . 
+B 2 HOH 43 119 43 HOH HOH A . 
+B 2 HOH 44 120 44 HOH HOH A . 
+B 2 HOH 45 121 45 HOH HOH A . 
+B 2 HOH 46 122 46 HOH HOH A . 
+B 2 HOH 47 123 47 HOH HOH A . 
+B 2 HOH 48 124 48 HOH HOH A . 
+B 2 HOH 49 125 49 HOH HOH A . 
+B 2 HOH 50 126 50 HOH HOH A . 
+B 2 HOH 51 127 51 HOH HOH A . 
+B 2 HOH 52 128 52 HOH HOH A . 
+B 2 HOH 53 129 53 HOH HOH A . 
+B 2 HOH 54 130 54 HOH HOH A . 
+B 2 HOH 55 131 55 HOH HOH A . 
+B 2 HOH 56 132 56 HOH HOH A . 
+B 2 HOH 57 133 57 HOH HOH A . 
+B 2 HOH 58 134 58 HOH HOH A . 
+# 
+_software.name             PROLSQ 
+_software.classification   refinement 
+_software.version          . 
+_software.citation_id      ? 
+_software.pdbx_ordinal     1 
+# 
+_cell.entry_id           1UBQ 
+_cell.length_a           50.840 
+_cell.length_b           42.770 
+_cell.length_c           28.950 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              4 
+_cell.pdbx_unique_axis   ? 
+_cell.length_a_esd       ? 
+_cell.length_b_esd       ? 
+_cell.length_c_esd       ? 
+_cell.angle_alpha_esd    ? 
+_cell.angle_beta_esd     ? 
+_cell.angle_gamma_esd    ? 
+# 
+_symmetry.entry_id                         1UBQ 
+_symmetry.space_group_name_H-M             'P 21 21 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                19 
+_symmetry.space_group_name_Hall            ? 
+# 
+_exptl.entry_id          1UBQ 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   ? 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      1.83 
+_exptl_crystal.density_percent_sol   32.94 
+_exptl_crystal.description           ? 
+_exptl_crystal.F_000                 ? 
+_exptl_crystal.preparation           ? 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           ? 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   ? 
+_diffrn_radiation.pdbx_diffrn_protocol             ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   . 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_refine.entry_id                                 1UBQ 
+_refine.ls_number_reflns_obs                     ? 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             ? 
+_refine.ls_d_res_high                            1.8 
+_refine.ls_percent_reflns_obs                    ? 
+_refine.ls_R_factor_obs                          0.1760000 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       ? 
+_refine.ls_R_factor_R_free                       ? 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.B_iso_min                                ? 
+_refine.B_iso_max                                ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        602 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         0 
+_refine_hist.number_atoms_solvent             58 
+_refine_hist.number_atoms_total               660 
+_refine_hist.d_res_high                       1.8 
+_refine_hist.d_res_low                        . 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+p_bond_d    0.016 ? ? ? 'X-RAY DIFFRACTION' ? 
+p_angle_deg 1.5   ? ? ? 'X-RAY DIFFRACTION' ? 
+# 
+_database_PDB_matrix.entry_id          1UBQ 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_struct.entry_id                  1UBQ 
+_struct.title                     'STRUCTURE OF UBIQUITIN REFINED AT 1.8 ANGSTROMS RESOLUTION' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1UBQ 
+_struct_keywords.pdbx_keywords   'CHROMOSOMAL PROTEIN' 
+_struct_keywords.text            'CHROMOSOMAL PROTEIN' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    UBIQ_HUMAN 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          P62988 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_seq_one_letter_code   MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              1UBQ 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 76 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P62988 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  76 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       76 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+_struct_biol.id        1 
+_struct_biol.details   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 H1 ILE A 23 ? GLU A 34 ? ILE A 23 GLU A 34 1 ? 12 
+HELX_P HELX_P2 H2 LEU A 56 ? TYR A 59 ? LEU A 56 TYR A 59 5 ? 4  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+_struct_sheet.id               BET 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   5 
+_struct_sheet.details          ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+BET 1 2 ? anti-parallel 
+BET 2 3 ? parallel      
+BET 3 4 ? anti-parallel 
+BET 4 5 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+BET 1 GLY A 10 ? VAL A 17 ? GLY A 10 VAL A 17 
+BET 2 MET A 1  ? THR A 7  ? MET A 1  THR A 7  
+BET 3 GLU A 64 ? ARG A 72 ? GLU A 64 ARG A 72 
+BET 4 GLN A 40 ? PHE A 45 ? GLN A 40 PHE A 45 
+BET 5 LYS A 48 ? LEU A 50 ? LYS A 48 LEU A 50 
+# 
+loop_
+_pdbx_validate_symm_contact.id 
+_pdbx_validate_symm_contact.PDB_model_num 
+_pdbx_validate_symm_contact.auth_atom_id_1 
+_pdbx_validate_symm_contact.auth_asym_id_1 
+_pdbx_validate_symm_contact.auth_comp_id_1 
+_pdbx_validate_symm_contact.auth_seq_id_1 
+_pdbx_validate_symm_contact.PDB_ins_code_1 
+_pdbx_validate_symm_contact.label_alt_id_1 
+_pdbx_validate_symm_contact.site_symmetry_1 
+_pdbx_validate_symm_contact.auth_atom_id_2 
+_pdbx_validate_symm_contact.auth_asym_id_2 
+_pdbx_validate_symm_contact.auth_comp_id_2 
+_pdbx_validate_symm_contact.auth_seq_id_2 
+_pdbx_validate_symm_contact.PDB_ins_code_2 
+_pdbx_validate_symm_contact.label_alt_id_2 
+_pdbx_validate_symm_contact.site_symmetry_2 
+_pdbx_validate_symm_contact.dist 
+1 1 OE2 A GLU 16 ? ? 1_555 NH1 A ARG 72 ? ? 1_554 2.02 
+2 1 NZ  A LYS 48 ? ? 1_555 OXT A GLY 76 ? ? 4_467 2.16 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 CA A LEU 15 ? ? CB A LEU 15 ? ? CG  A LEU 15 ? ? 129.31 115.30 14.01 2.30 N 
+2 1 CD A ARG 54 ? ? NE A ARG 54 ? ? CZ  A ARG 54 ? ? 135.97 123.60 12.37 1.40 N 
+3 1 NE A ARG 54 ? ? CZ A ARG 54 ? ? NH1 A ARG 54 ? ? 125.77 120.30 5.47  0.50 N 
+# 
+loop_
+_chem_comp_atom.comp_id 
+_chem_comp_atom.atom_id 
+_chem_comp_atom.type_symbol 
+_chem_comp_atom.pdbx_aromatic_flag 
+_chem_comp_atom.pdbx_stereo_config 
+_chem_comp_atom.pdbx_ordinal 
+ALA N    N N N 1   
+ALA CA   C N S 2   
+ALA C    C N N 3   
+ALA O    O N N 4   
+ALA CB   C N N 5   
+ALA OXT  O N N 6   
+ALA H    H N N 7   
+ALA H2   H N N 8   
+ALA HA   H N N 9   
+ALA HB1  H N N 10  
+ALA HB2  H N N 11  
+ALA HB3  H N N 12  
+ALA HXT  H N N 13  
+ARG N    N N N 14  
+ARG CA   C N S 15  
+ARG C    C N N 16  
+ARG O    O N N 17  
+ARG CB   C N N 18  
+ARG CG   C N N 19  
+ARG CD   C N N 20  
+ARG NE   N N N 21  
+ARG CZ   C N N 22  
+ARG NH1  N N N 23  
+ARG NH2  N N N 24  
+ARG OXT  O N N 25  
+ARG H    H N N 26  
+ARG H2   H N N 27  
+ARG HA   H N N 28  
+ARG HB2  H N N 29  
+ARG HB3  H N N 30  
+ARG HG2  H N N 31  
+ARG HG3  H N N 32  
+ARG HD2  H N N 33  
+ARG HD3  H N N 34  
+ARG HE   H N N 35  
+ARG HH11 H N N 36  
+ARG HH12 H N N 37  
+ARG HH21 H N N 38  
+ARG HH22 H N N 39  
+ARG HXT  H N N 40  
+ASN N    N N N 41  
+ASN CA   C N S 42  
+ASN C    C N N 43  
+ASN O    O N N 44  
+ASN CB   C N N 45  
+ASN CG   C N N 46  
+ASN OD1  O N N 47  
+ASN ND2  N N N 48  
+ASN OXT  O N N 49  
+ASN H    H N N 50  
+ASN H2   H N N 51  
+ASN HA   H N N 52  
+ASN HB2  H N N 53  
+ASN HB3  H N N 54  
+ASN HD21 H N N 55  
+ASN HD22 H N N 56  
+ASN HXT  H N N 57  
+ASP N    N N N 58  
+ASP CA   C N S 59  
+ASP C    C N N 60  
+ASP O    O N N 61  
+ASP CB   C N N 62  
+ASP CG   C N N 63  
+ASP OD1  O N N 64  
+ASP OD2  O N N 65  
+ASP OXT  O N N 66  
+ASP H    H N N 67  
+ASP H2   H N N 68  
+ASP HA   H N N 69  
+ASP HB2  H N N 70  
+ASP HB3  H N N 71  
+ASP HD2  H N N 72  
+ASP HXT  H N N 73  
+GLN N    N N N 74  
+GLN CA   C N S 75  
+GLN C    C N N 76  
+GLN O    O N N 77  
+GLN CB   C N N 78  
+GLN CG   C N N 79  
+GLN CD   C N N 80  
+GLN OE1  O N N 81  
+GLN NE2  N N N 82  
+GLN OXT  O N N 83  
+GLN H    H N N 84  
+GLN H2   H N N 85  
+GLN HA   H N N 86  
+GLN HB2  H N N 87  
+GLN HB3  H N N 88  
+GLN HG2  H N N 89  
+GLN HG3  H N N 90  
+GLN HE21 H N N 91  
+GLN HE22 H N N 92  
+GLN HXT  H N N 93  
+GLU N    N N N 94  
+GLU CA   C N S 95  
+GLU C    C N N 96  
+GLU O    O N N 97  
+GLU CB   C N N 98  
+GLU CG   C N N 99  
+GLU CD   C N N 100 
+GLU OE1  O N N 101 
+GLU OE2  O N N 102 
+GLU OXT  O N N 103 
+GLU H    H N N 104 
+GLU H2   H N N 105 
+GLU HA   H N N 106 
+GLU HB2  H N N 107 
+GLU HB3  H N N 108 
+GLU HG2  H N N 109 
+GLU HG3  H N N 110 
+GLU HE2  H N N 111 
+GLU HXT  H N N 112 
+GLY N    N N N 113 
+GLY CA   C N N 114 
+GLY C    C N N 115 
+GLY O    O N N 116 
+GLY OXT  O N N 117 
+GLY H    H N N 118 
+GLY H2   H N N 119 
+GLY HA2  H N N 120 
+GLY HA3  H N N 121 
+GLY HXT  H N N 122 
+HIS N    N N N 123 
+HIS CA   C N S 124 
+HIS C    C N N 125 
+HIS O    O N N 126 
+HIS CB   C N N 127 
+HIS CG   C Y N 128 
+HIS ND1  N Y N 129 
+HIS CD2  C Y N 130 
+HIS CE1  C Y N 131 
+HIS NE2  N Y N 132 
+HIS OXT  O N N 133 
+HIS H    H N N 134 
+HIS H2   H N N 135 
+HIS HA   H N N 136 
+HIS HB2  H N N 137 
+HIS HB3  H N N 138 
+HIS HD1  H N N 139 
+HIS HD2  H N N 140 
+HIS HE1  H N N 141 
+HIS HE2  H N N 142 
+HIS HXT  H N N 143 
+HOH O    O N N 144 
+HOH H1   H N N 145 
+HOH H2   H N N 146 
+ILE N    N N N 147 
+ILE CA   C N S 148 
+ILE C    C N N 149 
+ILE O    O N N 150 
+ILE CB   C N S 151 
+ILE CG1  C N N 152 
+ILE CG2  C N N 153 
+ILE CD1  C N N 154 
+ILE OXT  O N N 155 
+ILE H    H N N 156 
+ILE H2   H N N 157 
+ILE HA   H N N 158 
+ILE HB   H N N 159 
+ILE HG12 H N N 160 
+ILE HG13 H N N 161 
+ILE HG21 H N N 162 
+ILE HG22 H N N 163 
+ILE HG23 H N N 164 
+ILE HD11 H N N 165 
+ILE HD12 H N N 166 
+ILE HD13 H N N 167 
+ILE HXT  H N N 168 
+LEU N    N N N 169 
+LEU CA   C N S 170 
+LEU C    C N N 171 
+LEU O    O N N 172 
+LEU CB   C N N 173 
+LEU CG   C N N 174 
+LEU CD1  C N N 175 
+LEU CD2  C N N 176 
+LEU OXT  O N N 177 
+LEU H    H N N 178 
+LEU H2   H N N 179 
+LEU HA   H N N 180 
+LEU HB2  H N N 181 
+LEU HB3  H N N 182 
+LEU HG   H N N 183 
+LEU HD11 H N N 184 
+LEU HD12 H N N 185 
+LEU HD13 H N N 186 
+LEU HD21 H N N 187 
+LEU HD22 H N N 188 
+LEU HD23 H N N 189 
+LEU HXT  H N N 190 
+LYS N    N N N 191 
+LYS CA   C N S 192 
+LYS C    C N N 193 
+LYS O    O N N 194 
+LYS CB   C N N 195 
+LYS CG   C N N 196 
+LYS CD   C N N 197 
+LYS CE   C N N 198 
+LYS NZ   N N N 199 
+LYS OXT  O N N 200 
+LYS H    H N N 201 
+LYS H2   H N N 202 
+LYS HA   H N N 203 
+LYS HB2  H N N 204 
+LYS HB3  H N N 205 
+LYS HG2  H N N 206 
+LYS HG3  H N N 207 
+LYS HD2  H N N 208 
+LYS HD3  H N N 209 
+LYS HE2  H N N 210 
+LYS HE3  H N N 211 
+LYS HZ1  H N N 212 
+LYS HZ2  H N N 213 
+LYS HZ3  H N N 214 
+LYS HXT  H N N 215 
+MET N    N N N 216 
+MET CA   C N S 217 
+MET C    C N N 218 
+MET O    O N N 219 
+MET CB   C N N 220 
+MET CG   C N N 221 
+MET SD   S N N 222 
+MET CE   C N N 223 
+MET OXT  O N N 224 
+MET H    H N N 225 
+MET H2   H N N 226 
+MET HA   H N N 227 
+MET HB2  H N N 228 
+MET HB3  H N N 229 
+MET HG2  H N N 230 
+MET HG3  H N N 231 
+MET HE1  H N N 232 
+MET HE2  H N N 233 
+MET HE3  H N N 234 
+MET HXT  H N N 235 
+PHE N    N N N 236 
+PHE CA   C N S 237 
+PHE C    C N N 238 
+PHE O    O N N 239 
+PHE CB   C N N 240 
+PHE CG   C Y N 241 
+PHE CD1  C Y N 242 
+PHE CD2  C Y N 243 
+PHE CE1  C Y N 244 
+PHE CE2  C Y N 245 
+PHE CZ   C Y N 246 
+PHE OXT  O N N 247 
+PHE H    H N N 248 
+PHE H2   H N N 249 
+PHE HA   H N N 250 
+PHE HB2  H N N 251 
+PHE HB3  H N N 252 
+PHE HD1  H N N 253 
+PHE HD2  H N N 254 
+PHE HE1  H N N 255 
+PHE HE2  H N N 256 
+PHE HZ   H N N 257 
+PHE HXT  H N N 258 
+PRO N    N N N 259 
+PRO CA   C N S 260 
+PRO C    C N N 261 
+PRO O    O N N 262 
+PRO CB   C N N 263 
+PRO CG   C N N 264 
+PRO CD   C N N 265 
+PRO OXT  O N N 266 
+PRO H    H N N 267 
+PRO HA   H N N 268 
+PRO HB2  H N N 269 
+PRO HB3  H N N 270 
+PRO HG2  H N N 271 
+PRO HG3  H N N 272 
+PRO HD2  H N N 273 
+PRO HD3  H N N 274 
+PRO HXT  H N N 275 
+SER N    N N N 276 
+SER CA   C N S 277 
+SER C    C N N 278 
+SER O    O N N 279 
+SER CB   C N N 280 
+SER OG   O N N 281 
+SER OXT  O N N 282 
+SER H    H N N 283 
+SER H2   H N N 284 
+SER HA   H N N 285 
+SER HB2  H N N 286 
+SER HB3  H N N 287 
+SER HG   H N N 288 
+SER HXT  H N N 289 
+THR N    N N N 290 
+THR CA   C N S 291 
+THR C    C N N 292 
+THR O    O N N 293 
+THR CB   C N R 294 
+THR OG1  O N N 295 
+THR CG2  C N N 296 
+THR OXT  O N N 297 
+THR H    H N N 298 
+THR H2   H N N 299 
+THR HA   H N N 300 
+THR HB   H N N 301 
+THR HG1  H N N 302 
+THR HG21 H N N 303 
+THR HG22 H N N 304 
+THR HG23 H N N 305 
+THR HXT  H N N 306 
+TYR N    N N N 307 
+TYR CA   C N S 308 
+TYR C    C N N 309 
+TYR O    O N N 310 
+TYR CB   C N N 311 
+TYR CG   C Y N 312 
+TYR CD1  C Y N 313 
+TYR CD2  C Y N 314 
+TYR CE1  C Y N 315 
+TYR CE2  C Y N 316 
+TYR CZ   C Y N 317 
+TYR OH   O N N 318 
+TYR OXT  O N N 319 
+TYR H    H N N 320 
+TYR H2   H N N 321 
+TYR HA   H N N 322 
+TYR HB2  H N N 323 
+TYR HB3  H N N 324 
+TYR HD1  H N N 325 
+TYR HD2  H N N 326 
+TYR HE1  H N N 327 
+TYR HE2  H N N 328 
+TYR HH   H N N 329 
+TYR HXT  H N N 330 
+VAL N    N N N 331 
+VAL CA   C N S 332 
+VAL C    C N N 333 
+VAL O    O N N 334 
+VAL CB   C N N 335 
+VAL CG1  C N N 336 
+VAL CG2  C N N 337 
+VAL OXT  O N N 338 
+VAL H    H N N 339 
+VAL H2   H N N 340 
+VAL HA   H N N 341 
+VAL HB   H N N 342 
+VAL HG11 H N N 343 
+VAL HG12 H N N 344 
+VAL HG13 H N N 345 
+VAL HG21 H N N 346 
+VAL HG22 H N N 347 
+VAL HG23 H N N 348 
+VAL HXT  H N N 349 
+# 
+loop_
+_chem_comp_bond.comp_id 
+_chem_comp_bond.atom_id_1 
+_chem_comp_bond.atom_id_2 
+_chem_comp_bond.value_order 
+_chem_comp_bond.pdbx_aromatic_flag 
+_chem_comp_bond.pdbx_stereo_config 
+_chem_comp_bond.pdbx_ordinal 
+ALA N   CA   sing N N 1   
+ALA N   H    sing N N 2   
+ALA N   H2   sing N N 3   
+ALA CA  C    sing N N 4   
+ALA CA  CB   sing N N 5   
+ALA CA  HA   sing N N 6   
+ALA C   O    doub N N 7   
+ALA C   OXT  sing N N 8   
+ALA CB  HB1  sing N N 9   
+ALA CB  HB2  sing N N 10  
+ALA CB  HB3  sing N N 11  
+ALA OXT HXT  sing N N 12  
+ARG N   CA   sing N N 13  
+ARG N   H    sing N N 14  
+ARG N   H2   sing N N 15  
+ARG CA  C    sing N N 16  
+ARG CA  CB   sing N N 17  
+ARG CA  HA   sing N N 18  
+ARG C   O    doub N N 19  
+ARG C   OXT  sing N N 20  
+ARG CB  CG   sing N N 21  
+ARG CB  HB2  sing N N 22  
+ARG CB  HB3  sing N N 23  
+ARG CG  CD   sing N N 24  
+ARG CG  HG2  sing N N 25  
+ARG CG  HG3  sing N N 26  
+ARG CD  NE   sing N N 27  
+ARG CD  HD2  sing N N 28  
+ARG CD  HD3  sing N N 29  
+ARG NE  CZ   sing N N 30  
+ARG NE  HE   sing N N 31  
+ARG CZ  NH1  sing N N 32  
+ARG CZ  NH2  doub N N 33  
+ARG NH1 HH11 sing N N 34  
+ARG NH1 HH12 sing N N 35  
+ARG NH2 HH21 sing N N 36  
+ARG NH2 HH22 sing N N 37  
+ARG OXT HXT  sing N N 38  
+ASN N   CA   sing N N 39  
+ASN N   H    sing N N 40  
+ASN N   H2   sing N N 41  
+ASN CA  C    sing N N 42  
+ASN CA  CB   sing N N 43  
+ASN CA  HA   sing N N 44  
+ASN C   O    doub N N 45  
+ASN C   OXT  sing N N 46  
+ASN CB  CG   sing N N 47  
+ASN CB  HB2  sing N N 48  
+ASN CB  HB3  sing N N 49  
+ASN CG  OD1  doub N N 50  
+ASN CG  ND2  sing N N 51  
+ASN ND2 HD21 sing N N 52  
+ASN ND2 HD22 sing N N 53  
+ASN OXT HXT  sing N N 54  
+ASP N   CA   sing N N 55  
+ASP N   H    sing N N 56  
+ASP N   H2   sing N N 57  
+ASP CA  C    sing N N 58  
+ASP CA  CB   sing N N 59  
+ASP CA  HA   sing N N 60  
+ASP C   O    doub N N 61  
+ASP C   OXT  sing N N 62  
+ASP CB  CG   sing N N 63  
+ASP CB  HB2  sing N N 64  
+ASP CB  HB3  sing N N 65  
+ASP CG  OD1  doub N N 66  
+ASP CG  OD2  sing N N 67  
+ASP OD2 HD2  sing N N 68  
+ASP OXT HXT  sing N N 69  
+GLN N   CA   sing N N 70  
+GLN N   H    sing N N 71  
+GLN N   H2   sing N N 72  
+GLN CA  C    sing N N 73  
+GLN CA  CB   sing N N 74  
+GLN CA  HA   sing N N 75  
+GLN C   O    doub N N 76  
+GLN C   OXT  sing N N 77  
+GLN CB  CG   sing N N 78  
+GLN CB  HB2  sing N N 79  
+GLN CB  HB3  sing N N 80  
+GLN CG  CD   sing N N 81  
+GLN CG  HG2  sing N N 82  
+GLN CG  HG3  sing N N 83  
+GLN CD  OE1  doub N N 84  
+GLN CD  NE2  sing N N 85  
+GLN NE2 HE21 sing N N 86  
+GLN NE2 HE22 sing N N 87  
+GLN OXT HXT  sing N N 88  
+GLU N   CA   sing N N 89  
+GLU N   H    sing N N 90  
+GLU N   H2   sing N N 91  
+GLU CA  C    sing N N 92  
+GLU CA  CB   sing N N 93  
+GLU CA  HA   sing N N 94  
+GLU C   O    doub N N 95  
+GLU C   OXT  sing N N 96  
+GLU CB  CG   sing N N 97  
+GLU CB  HB2  sing N N 98  
+GLU CB  HB3  sing N N 99  
+GLU CG  CD   sing N N 100 
+GLU CG  HG2  sing N N 101 
+GLU CG  HG3  sing N N 102 
+GLU CD  OE1  doub N N 103 
+GLU CD  OE2  sing N N 104 
+GLU OE2 HE2  sing N N 105 
+GLU OXT HXT  sing N N 106 
+GLY N   CA   sing N N 107 
+GLY N   H    sing N N 108 
+GLY N   H2   sing N N 109 
+GLY CA  C    sing N N 110 
+GLY CA  HA2  sing N N 111 
+GLY CA  HA3  sing N N 112 
+GLY C   O    doub N N 113 
+GLY C   OXT  sing N N 114 
+GLY OXT HXT  sing N N 115 
+HIS N   CA   sing N N 116 
+HIS N   H    sing N N 117 
+HIS N   H2   sing N N 118 
+HIS CA  C    sing N N 119 
+HIS CA  CB   sing N N 120 
+HIS CA  HA   sing N N 121 
+HIS C   O    doub N N 122 
+HIS C   OXT  sing N N 123 
+HIS CB  CG   sing N N 124 
+HIS CB  HB2  sing N N 125 
+HIS CB  HB3  sing N N 126 
+HIS CG  ND1  sing Y N 127 
+HIS CG  CD2  doub Y N 128 
+HIS ND1 CE1  doub Y N 129 
+HIS ND1 HD1  sing N N 130 
+HIS CD2 NE2  sing Y N 131 
+HIS CD2 HD2  sing N N 132 
+HIS CE1 NE2  sing Y N 133 
+HIS CE1 HE1  sing N N 134 
+HIS NE2 HE2  sing N N 135 
+HIS OXT HXT  sing N N 136 
+HOH O   H1   sing N N 137 
+HOH O   H2   sing N N 138 
+ILE N   CA   sing N N 139 
+ILE N   H    sing N N 140 
+ILE N   H2   sing N N 141 
+ILE CA  C    sing N N 142 
+ILE CA  CB   sing N N 143 
+ILE CA  HA   sing N N 144 
+ILE C   O    doub N N 145 
+ILE C   OXT  sing N N 146 
+ILE CB  CG1  sing N N 147 
+ILE CB  CG2  sing N N 148 
+ILE CB  HB   sing N N 149 
+ILE CG1 CD1  sing N N 150 
+ILE CG1 HG12 sing N N 151 
+ILE CG1 HG13 sing N N 152 
+ILE CG2 HG21 sing N N 153 
+ILE CG2 HG22 sing N N 154 
+ILE CG2 HG23 sing N N 155 
+ILE CD1 HD11 sing N N 156 
+ILE CD1 HD12 sing N N 157 
+ILE CD1 HD13 sing N N 158 
+ILE OXT HXT  sing N N 159 
+LEU N   CA   sing N N 160 
+LEU N   H    sing N N 161 
+LEU N   H2   sing N N 162 
+LEU CA  C    sing N N 163 
+LEU CA  CB   sing N N 164 
+LEU CA  HA   sing N N 165 
+LEU C   O    doub N N 166 
+LEU C   OXT  sing N N 167 
+LEU CB  CG   sing N N 168 
+LEU CB  HB2  sing N N 169 
+LEU CB  HB3  sing N N 170 
+LEU CG  CD1  sing N N 171 
+LEU CG  CD2  sing N N 172 
+LEU CG  HG   sing N N 173 
+LEU CD1 HD11 sing N N 174 
+LEU CD1 HD12 sing N N 175 
+LEU CD1 HD13 sing N N 176 
+LEU CD2 HD21 sing N N 177 
+LEU CD2 HD22 sing N N 178 
+LEU CD2 HD23 sing N N 179 
+LEU OXT HXT  sing N N 180 
+LYS N   CA   sing N N 181 
+LYS N   H    sing N N 182 
+LYS N   H2   sing N N 183 
+LYS CA  C    sing N N 184 
+LYS CA  CB   sing N N 185 
+LYS CA  HA   sing N N 186 
+LYS C   O    doub N N 187 
+LYS C   OXT  sing N N 188 
+LYS CB  CG   sing N N 189 
+LYS CB  HB2  sing N N 190 
+LYS CB  HB3  sing N N 191 
+LYS CG  CD   sing N N 192 
+LYS CG  HG2  sing N N 193 
+LYS CG  HG3  sing N N 194 
+LYS CD  CE   sing N N 195 
+LYS CD  HD2  sing N N 196 
+LYS CD  HD3  sing N N 197 
+LYS CE  NZ   sing N N 198 
+LYS CE  HE2  sing N N 199 
+LYS CE  HE3  sing N N 200 
+LYS NZ  HZ1  sing N N 201 
+LYS NZ  HZ2  sing N N 202 
+LYS NZ  HZ3  sing N N 203 
+LYS OXT HXT  sing N N 204 
+MET N   CA   sing N N 205 
+MET N   H    sing N N 206 
+MET N   H2   sing N N 207 
+MET CA  C    sing N N 208 
+MET CA  CB   sing N N 209 
+MET CA  HA   sing N N 210 
+MET C   O    doub N N 211 
+MET C   OXT  sing N N 212 
+MET CB  CG   sing N N 213 
+MET CB  HB2  sing N N 214 
+MET CB  HB3  sing N N 215 
+MET CG  SD   sing N N 216 
+MET CG  HG2  sing N N 217 
+MET CG  HG3  sing N N 218 
+MET SD  CE   sing N N 219 
+MET CE  HE1  sing N N 220 
+MET CE  HE2  sing N N 221 
+MET CE  HE3  sing N N 222 
+MET OXT HXT  sing N N 223 
+PHE N   CA   sing N N 224 
+PHE N   H    sing N N 225 
+PHE N   H2   sing N N 226 
+PHE CA  C    sing N N 227 
+PHE CA  CB   sing N N 228 
+PHE CA  HA   sing N N 229 
+PHE C   O    doub N N 230 
+PHE C   OXT  sing N N 231 
+PHE CB  CG   sing N N 232 
+PHE CB  HB2  sing N N 233 
+PHE CB  HB3  sing N N 234 
+PHE CG  CD1  doub Y N 235 
+PHE CG  CD2  sing Y N 236 
+PHE CD1 CE1  sing Y N 237 
+PHE CD1 HD1  sing N N 238 
+PHE CD2 CE2  doub Y N 239 
+PHE CD2 HD2  sing N N 240 
+PHE CE1 CZ   doub Y N 241 
+PHE CE1 HE1  sing N N 242 
+PHE CE2 CZ   sing Y N 243 
+PHE CE2 HE2  sing N N 244 
+PHE CZ  HZ   sing N N 245 
+PHE OXT HXT  sing N N 246 
+PRO N   CA   sing N N 247 
+PRO N   CD   sing N N 248 
+PRO N   H    sing N N 249 
+PRO CA  C    sing N N 250 
+PRO CA  CB   sing N N 251 
+PRO CA  HA   sing N N 252 
+PRO C   O    doub N N 253 
+PRO C   OXT  sing N N 254 
+PRO CB  CG   sing N N 255 
+PRO CB  HB2  sing N N 256 
+PRO CB  HB3  sing N N 257 
+PRO CG  CD   sing N N 258 
+PRO CG  HG2  sing N N 259 
+PRO CG  HG3  sing N N 260 
+PRO CD  HD2  sing N N 261 
+PRO CD  HD3  sing N N 262 
+PRO OXT HXT  sing N N 263 
+SER N   CA   sing N N 264 
+SER N   H    sing N N 265 
+SER N   H2   sing N N 266 
+SER CA  C    sing N N 267 
+SER CA  CB   sing N N 268 
+SER CA  HA   sing N N 269 
+SER C   O    doub N N 270 
+SER C   OXT  sing N N 271 
+SER CB  OG   sing N N 272 
+SER CB  HB2  sing N N 273 
+SER CB  HB3  sing N N 274 
+SER OG  HG   sing N N 275 
+SER OXT HXT  sing N N 276 
+THR N   CA   sing N N 277 
+THR N   H    sing N N 278 
+THR N   H2   sing N N 279 
+THR CA  C    sing N N 280 
+THR CA  CB   sing N N 281 
+THR CA  HA   sing N N 282 
+THR C   O    doub N N 283 
+THR C   OXT  sing N N 284 
+THR CB  OG1  sing N N 285 
+THR CB  CG2  sing N N 286 
+THR CB  HB   sing N N 287 
+THR OG1 HG1  sing N N 288 
+THR CG2 HG21 sing N N 289 
+THR CG2 HG22 sing N N 290 
+THR CG2 HG23 sing N N 291 
+THR OXT HXT  sing N N 292 
+TYR N   CA   sing N N 293 
+TYR N   H    sing N N 294 
+TYR N   H2   sing N N 295 
+TYR CA  C    sing N N 296 
+TYR CA  CB   sing N N 297 
+TYR CA  HA   sing N N 298 
+TYR C   O    doub N N 299 
+TYR C   OXT  sing N N 300 
+TYR CB  CG   sing N N 301 
+TYR CB  HB2  sing N N 302 
+TYR CB  HB3  sing N N 303 
+TYR CG  CD1  doub Y N 304 
+TYR CG  CD2  sing Y N 305 
+TYR CD1 CE1  sing Y N 306 
+TYR CD1 HD1  sing N N 307 
+TYR CD2 CE2  doub Y N 308 
+TYR CD2 HD2  sing N N 309 
+TYR CE1 CZ   doub Y N 310 
+TYR CE1 HE1  sing N N 311 
+TYR CE2 CZ   sing Y N 312 
+TYR CE2 HE2  sing N N 313 
+TYR CZ  OH   sing N N 314 
+TYR OH  HH   sing N N 315 
+TYR OXT HXT  sing N N 316 
+VAL N   CA   sing N N 317 
+VAL N   H    sing N N 318 
+VAL N   H2   sing N N 319 
+VAL CA  C    sing N N 320 
+VAL CA  CB   sing N N 321 
+VAL CA  HA   sing N N 322 
+VAL C   O    doub N N 323 
+VAL C   OXT  sing N N 324 
+VAL CB  CG1  sing N N 325 
+VAL CB  CG2  sing N N 326 
+VAL CB  HB   sing N N 327 
+VAL CG1 HG11 sing N N 328 
+VAL CG1 HG12 sing N N 329 
+VAL CG1 HG13 sing N N 330 
+VAL CG2 HG21 sing N N 331 
+VAL CG2 HG22 sing N N 332 
+VAL CG2 HG23 sing N N 333 
+VAL OXT HXT  sing N N 334 
+# 
+_atom_sites.entry_id                    1UBQ 
+_atom_sites.fract_transf_matrix[1][1]   .019670 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   .023381 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   .034542 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1   N N   . MET A 1 1  ? 27.340 24.430 2.614  1.00 9.67  ? 1   MET A N   1 
+ATOM   2   C CA  . MET A 1 1  ? 26.266 25.413 2.842  1.00 10.38 ? 1   MET A CA  1 
+ATOM   3   C C   . MET A 1 1  ? 26.913 26.639 3.531  1.00 9.62  ? 1   MET A C   1 
+ATOM   4   O O   . MET A 1 1  ? 27.886 26.463 4.263  1.00 9.62  ? 1   MET A O   1 
+ATOM   5   C CB  . MET A 1 1  ? 25.112 24.880 3.649  1.00 13.77 ? 1   MET A CB  1 
+ATOM   6   C CG  . MET A 1 1  ? 25.353 24.860 5.134  1.00 16.29 ? 1   MET A CG  1 
+ATOM   7   S SD  . MET A 1 1  ? 23.930 23.959 5.904  1.00 17.17 ? 1   MET A SD  1 
+ATOM   8   C CE  . MET A 1 1  ? 24.447 23.984 7.620  1.00 16.11 ? 1   MET A CE  1 
+ATOM   9   N N   . GLN A 1 2  ? 26.335 27.770 3.258  1.00 9.27  ? 2   GLN A N   1 
+ATOM   10  C CA  . GLN A 1 2  ? 26.850 29.021 3.898  1.00 9.07  ? 2   GLN A CA  1 
+ATOM   11  C C   . GLN A 1 2  ? 26.100 29.253 5.202  1.00 8.72  ? 2   GLN A C   1 
+ATOM   12  O O   . GLN A 1 2  ? 24.865 29.024 5.330  1.00 8.22  ? 2   GLN A O   1 
+ATOM   13  C CB  . GLN A 1 2  ? 26.733 30.148 2.905  1.00 14.46 ? 2   GLN A CB  1 
+ATOM   14  C CG  . GLN A 1 2  ? 26.882 31.546 3.409  1.00 17.01 ? 2   GLN A CG  1 
+ATOM   15  C CD  . GLN A 1 2  ? 26.786 32.562 2.270  1.00 20.10 ? 2   GLN A CD  1 
+ATOM   16  O OE1 . GLN A 1 2  ? 27.783 33.160 1.870  1.00 21.89 ? 2   GLN A OE1 1 
+ATOM   17  N NE2 . GLN A 1 2  ? 25.562 32.733 1.806  1.00 19.49 ? 2   GLN A NE2 1 
+ATOM   18  N N   . ILE A 1 3  ? 26.849 29.656 6.217  1.00 5.87  ? 3   ILE A N   1 
+ATOM   19  C CA  . ILE A 1 3  ? 26.235 30.058 7.497  1.00 5.07  ? 3   ILE A CA  1 
+ATOM   20  C C   . ILE A 1 3  ? 26.882 31.428 7.862  1.00 4.01  ? 3   ILE A C   1 
+ATOM   21  O O   . ILE A 1 3  ? 27.906 31.711 7.264  1.00 4.61  ? 3   ILE A O   1 
+ATOM   22  C CB  . ILE A 1 3  ? 26.344 29.050 8.645  1.00 6.55  ? 3   ILE A CB  1 
+ATOM   23  C CG1 . ILE A 1 3  ? 27.810 28.748 8.999  1.00 4.72  ? 3   ILE A CG1 1 
+ATOM   24  C CG2 . ILE A 1 3  ? 25.491 27.771 8.287  1.00 5.58  ? 3   ILE A CG2 1 
+ATOM   25  C CD1 . ILE A 1 3  ? 27.967 28.087 10.417 1.00 10.83 ? 3   ILE A CD1 1 
+ATOM   26  N N   . PHE A 1 4  ? 26.214 32.097 8.771  1.00 4.55  ? 4   PHE A N   1 
+ATOM   27  C CA  . PHE A 1 4  ? 26.772 33.436 9.197  1.00 4.68  ? 4   PHE A CA  1 
+ATOM   28  C C   . PHE A 1 4  ? 27.151 33.362 10.650 1.00 5.30  ? 4   PHE A C   1 
+ATOM   29  O O   . PHE A 1 4  ? 26.350 32.778 11.395 1.00 5.58  ? 4   PHE A O   1 
+ATOM   30  C CB  . PHE A 1 4  ? 25.695 34.498 8.946  1.00 4.83  ? 4   PHE A CB  1 
+ATOM   31  C CG  . PHE A 1 4  ? 25.288 34.609 7.499  1.00 7.97  ? 4   PHE A CG  1 
+ATOM   32  C CD1 . PHE A 1 4  ? 24.147 33.966 7.038  1.00 6.69  ? 4   PHE A CD1 1 
+ATOM   33  C CD2 . PHE A 1 4  ? 26.136 35.346 6.640  1.00 8.34  ? 4   PHE A CD2 1 
+ATOM   34  C CE1 . PHE A 1 4  ? 23.812 34.031 5.677  1.00 9.10  ? 4   PHE A CE1 1 
+ATOM   35  C CE2 . PHE A 1 4  ? 25.810 35.392 5.267  1.00 10.61 ? 4   PHE A CE2 1 
+ATOM   36  C CZ  . PHE A 1 4  ? 24.620 34.778 4.853  1.00 8.90  ? 4   PHE A CZ  1 
+ATOM   37  N N   . VAL A 1 5  ? 28.260 33.943 11.096 1.00 4.44  ? 5   VAL A N   1 
+ATOM   38  C CA  . VAL A 1 5  ? 28.605 33.965 12.503 1.00 3.87  ? 5   VAL A CA  1 
+ATOM   39  C C   . VAL A 1 5  ? 28.638 35.461 12.900 1.00 4.93  ? 5   VAL A C   1 
+ATOM   40  O O   . VAL A 1 5  ? 29.522 36.103 12.320 1.00 6.84  ? 5   VAL A O   1 
+ATOM   41  C CB  . VAL A 1 5  ? 29.963 33.317 12.814 1.00 2.99  ? 5   VAL A CB  1 
+ATOM   42  C CG1 . VAL A 1 5  ? 30.211 33.394 14.304 1.00 5.28  ? 5   VAL A CG1 1 
+ATOM   43  C CG2 . VAL A 1 5  ? 29.957 31.838 12.352 1.00 9.13  ? 5   VAL A CG2 1 
+ATOM   44  N N   . LYS A 1 6  ? 27.751 35.867 13.740 1.00 6.04  ? 6   LYS A N   1 
+ATOM   45  C CA  . LYS A 1 6  ? 27.691 37.315 14.143 1.00 6.12  ? 6   LYS A CA  1 
+ATOM   46  C C   . LYS A 1 6  ? 28.469 37.475 15.420 1.00 6.57  ? 6   LYS A C   1 
+ATOM   47  O O   . LYS A 1 6  ? 28.213 36.753 16.411 1.00 5.76  ? 6   LYS A O   1 
+ATOM   48  C CB  . LYS A 1 6  ? 26.219 37.684 14.307 1.00 7.45  ? 6   LYS A CB  1 
+ATOM   49  C CG  . LYS A 1 6  ? 25.884 39.139 14.615 1.00 11.12 ? 6   LYS A CG  1 
+ATOM   50  C CD  . LYS A 1 6  ? 24.348 39.296 14.642 1.00 14.54 ? 6   LYS A CD  1 
+ATOM   51  C CE  . LYS A 1 6  ? 23.865 40.723 14.749 1.00 18.84 ? 6   LYS A CE  1 
+ATOM   52  N NZ  . LYS A 1 6  ? 22.375 40.720 14.907 1.00 20.55 ? 6   LYS A NZ  1 
+ATOM   53  N N   . THR A 1 7  ? 29.426 38.430 15.446 1.00 7.41  ? 7   THR A N   1 
+ATOM   54  C CA  . THR A 1 7  ? 30.225 38.643 16.662 1.00 7.48  ? 7   THR A CA  1 
+ATOM   55  C C   . THR A 1 7  ? 29.664 39.839 17.434 1.00 8.75  ? 7   THR A C   1 
+ATOM   56  O O   . THR A 1 7  ? 28.850 40.565 16.859 1.00 8.58  ? 7   THR A O   1 
+ATOM   57  C CB  . THR A 1 7  ? 31.744 38.879 16.299 1.00 9.61  ? 7   THR A CB  1 
+ATOM   58  O OG1 . THR A 1 7  ? 31.737 40.257 15.824 1.00 11.78 ? 7   THR A OG1 1 
+ATOM   59  C CG2 . THR A 1 7  ? 32.260 37.969 15.171 1.00 9.17  ? 7   THR A CG2 1 
+ATOM   60  N N   . LEU A 1 8  ? 30.132 40.069 18.642 1.00 9.84  ? 8   LEU A N   1 
+ATOM   61  C CA  . LEU A 1 8  ? 29.607 41.180 19.467 1.00 14.15 ? 8   LEU A CA  1 
+ATOM   62  C C   . LEU A 1 8  ? 30.075 42.538 18.984 1.00 17.37 ? 8   LEU A C   1 
+ATOM   63  O O   . LEU A 1 8  ? 29.586 43.570 19.483 1.00 17.01 ? 8   LEU A O   1 
+ATOM   64  C CB  . LEU A 1 8  ? 29.919 40.890 20.938 1.00 16.63 ? 8   LEU A CB  1 
+ATOM   65  C CG  . LEU A 1 8  ? 29.183 39.722 21.581 1.00 18.88 ? 8   LEU A CG  1 
+ATOM   66  C CD1 . LEU A 1 8  ? 29.308 39.750 23.095 1.00 19.31 ? 8   LEU A CD1 1 
+ATOM   67  C CD2 . LEU A 1 8  ? 27.700 39.721 21.228 1.00 18.59 ? 8   LEU A CD2 1 
+ATOM   68  N N   . THR A 1 9  ? 30.991 42.571 17.998 1.00 18.33 ? 9   THR A N   1 
+ATOM   69  C CA  . THR A 1 9  ? 31.422 43.940 17.553 1.00 19.24 ? 9   THR A CA  1 
+ATOM   70  C C   . THR A 1 9  ? 30.755 44.351 16.277 1.00 19.48 ? 9   THR A C   1 
+ATOM   71  O O   . THR A 1 9  ? 31.207 45.268 15.566 1.00 23.14 ? 9   THR A O   1 
+ATOM   72  C CB  . THR A 1 9  ? 32.979 43.918 17.445 1.00 18.97 ? 9   THR A CB  1 
+ATOM   73  O OG1 . THR A 1 9  ? 33.174 43.067 16.265 1.00 20.24 ? 9   THR A OG1 1 
+ATOM   74  C CG2 . THR A 1 9  ? 33.657 43.319 18.672 1.00 19.70 ? 9   THR A CG2 1 
+ATOM   75  N N   . GLY A 1 10 ? 29.721 43.673 15.885 1.00 19.43 ? 10  GLY A N   1 
+ATOM   76  C CA  . GLY A 1 10 ? 28.978 43.960 14.678 1.00 18.74 ? 10  GLY A CA  1 
+ATOM   77  C C   . GLY A 1 10 ? 29.604 43.507 13.393 1.00 17.62 ? 10  GLY A C   1 
+ATOM   78  O O   . GLY A 1 10 ? 29.219 43.981 12.301 1.00 19.74 ? 10  GLY A O   1 
+ATOM   79  N N   . LYS A 1 11 ? 30.563 42.623 13.495 1.00 13.56 ? 11  LYS A N   1 
+ATOM   80  C CA  . LYS A 1 11 ? 31.191 42.012 12.331 1.00 11.91 ? 11  LYS A CA  1 
+ATOM   81  C C   . LYS A 1 11 ? 30.459 40.666 12.130 1.00 10.18 ? 11  LYS A C   1 
+ATOM   82  O O   . LYS A 1 11 ? 30.253 39.991 13.133 1.00 9.10  ? 11  LYS A O   1 
+ATOM   83  C CB  . LYS A 1 11 ? 32.672 41.717 12.505 1.00 13.43 ? 11  LYS A CB  1 
+ATOM   84  C CG  . LYS A 1 11 ? 33.280 41.086 11.227 1.00 16.69 ? 11  LYS A CG  1 
+ATOM   85  C CD  . LYS A 1 11 ? 34.762 40.799 11.470 1.00 17.92 ? 11  LYS A CD  1 
+ATOM   86  C CE  . LYS A 1 11 ? 35.614 40.847 10.240 1.00 20.81 ? 11  LYS A CE  1 
+ATOM   87  N NZ  . LYS A 1 11 ? 35.100 40.073 9.101  1.00 21.93 ? 11  LYS A NZ  1 
+ATOM   88  N N   . THR A 1 12 ? 30.163 40.338 10.886 1.00 9.63  ? 12  THR A N   1 
+ATOM   89  C CA  . THR A 1 12 ? 29.542 39.020 10.653 1.00 9.85  ? 12  THR A CA  1 
+ATOM   90  C C   . THR A 1 12 ? 30.494 38.261 9.729  1.00 11.66 ? 12  THR A C   1 
+ATOM   91  O O   . THR A 1 12 ? 30.849 38.850 8.706  1.00 12.33 ? 12  THR A O   1 
+ATOM   92  C CB  . THR A 1 12 ? 28.113 39.049 10.015 1.00 10.85 ? 12  THR A CB  1 
+ATOM   93  O OG1 . THR A 1 12 ? 27.280 39.722 10.996 1.00 10.91 ? 12  THR A OG1 1 
+ATOM   94  C CG2 . THR A 1 12 ? 27.588 37.635 9.715  1.00 9.63  ? 12  THR A CG2 1 
+ATOM   95  N N   . ILE A 1 13 ? 30.795 37.015 10.095 1.00 10.42 ? 13  ILE A N   1 
+ATOM   96  C CA  . ILE A 1 13 ? 31.720 36.289 9.176  1.00 11.84 ? 13  ILE A CA  1 
+ATOM   97  C C   . ILE A 1 13 ? 30.955 35.211 8.459  1.00 10.55 ? 13  ILE A C   1 
+ATOM   98  O O   . ILE A 1 13 ? 30.025 34.618 9.040  1.00 11.92 ? 13  ILE A O   1 
+ATOM   99  C CB  . ILE A 1 13 ? 32.995 35.883 9.934  1.00 14.86 ? 13  ILE A CB  1 
+ATOM   100 C CG1 . ILE A 1 13 ? 33.306 34.381 9.840  1.00 14.87 ? 13  ILE A CG1 1 
+ATOM   101 C CG2 . ILE A 1 13 ? 33.109 36.381 11.435 1.00 17.08 ? 13  ILE A CG2 1 
+ATOM   102 C CD1 . ILE A 1 13 ? 34.535 34.028 10.720 1.00 16.46 ? 13  ILE A CD1 1 
+ATOM   103 N N   . THR A 1 14 ? 31.244 34.986 7.197  1.00 9.39  ? 14  THR A N   1 
+ATOM   104 C CA  . THR A 1 14 ? 30.505 33.884 6.512  1.00 9.63  ? 14  THR A CA  1 
+ATOM   105 C C   . THR A 1 14 ? 31.409 32.680 6.446  1.00 11.20 ? 14  THR A C   1 
+ATOM   106 O O   . THR A 1 14 ? 32.619 32.812 6.125  1.00 11.63 ? 14  THR A O   1 
+ATOM   107 C CB  . THR A 1 14 ? 30.091 34.393 5.078  1.00 10.38 ? 14  THR A CB  1 
+ATOM   108 O OG1 . THR A 1 14 ? 31.440 34.513 4.487  1.00 16.30 ? 14  THR A OG1 1 
+ATOM   109 C CG2 . THR A 1 14 ? 29.420 35.756 5.119  1.00 11.66 ? 14  THR A CG2 1 
+ATOM   110 N N   . LEU A 1 15 ? 30.884 31.485 6.666  1.00 8.29  ? 15  LEU A N   1 
+ATOM   111 C CA  . LEU A 1 15 ? 31.677 30.275 6.639  1.00 9.03  ? 15  LEU A CA  1 
+ATOM   112 C C   . LEU A 1 15 ? 31.022 29.288 5.665  1.00 8.59  ? 15  LEU A C   1 
+ATOM   113 O O   . LEU A 1 15 ? 29.809 29.395 5.545  1.00 7.79  ? 15  LEU A O   1 
+ATOM   114 C CB  . LEU A 1 15 ? 31.562 29.686 8.045  1.00 11.08 ? 15  LEU A CB  1 
+ATOM   115 C CG  . LEU A 1 15 ? 32.631 29.444 9.060  1.00 15.79 ? 15  LEU A CG  1 
+ATOM   116 C CD1 . LEU A 1 15 ? 33.814 30.390 9.030  1.00 15.88 ? 15  LEU A CD1 1 
+ATOM   117 C CD2 . LEU A 1 15 ? 31.945 29.449 10.436 1.00 15.27 ? 15  LEU A CD2 1 
+ATOM   118 N N   . GLU A 1 16 ? 31.834 28.412 5.125  1.00 11.04 ? 16  GLU A N   1 
+ATOM   119 C CA  . GLU A 1 16 ? 31.220 27.341 4.275  1.00 11.50 ? 16  GLU A CA  1 
+ATOM   120 C C   . GLU A 1 16 ? 31.440 26.079 5.080  1.00 10.13 ? 16  GLU A C   1 
+ATOM   121 O O   . GLU A 1 16 ? 32.576 25.802 5.461  1.00 9.83  ? 16  GLU A O   1 
+ATOM   122 C CB  . GLU A 1 16 ? 31.827 27.262 2.894  1.00 17.22 ? 16  GLU A CB  1 
+ATOM   123 C CG  . GLU A 1 16 ? 31.363 28.410 1.962  1.00 23.33 ? 16  GLU A CG  1 
+ATOM   124 C CD  . GLU A 1 16 ? 31.671 28.291 0.498  1.00 26.99 ? 16  GLU A CD  1 
+ATOM   125 O OE1 . GLU A 1 16 ? 30.869 28.621 -0.366 1.00 28.86 ? 16  GLU A OE1 1 
+ATOM   126 O OE2 . GLU A 1 16 ? 32.835 27.861 0.278  1.00 28.90 ? 16  GLU A OE2 1 
+ATOM   127 N N   . VAL A 1 17 ? 30.310 25.458 5.384  1.00 8.99  ? 17  VAL A N   1 
+ATOM   128 C CA  . VAL A 1 17 ? 30.288 24.245 6.193  1.00 8.85  ? 17  VAL A CA  1 
+ATOM   129 C C   . VAL A 1 17 ? 29.279 23.227 5.641  1.00 8.04  ? 17  VAL A C   1 
+ATOM   130 O O   . VAL A 1 17 ? 28.478 23.522 4.725  1.00 8.99  ? 17  VAL A O   1 
+ATOM   131 C CB  . VAL A 1 17 ? 29.903 24.590 7.665  1.00 9.78  ? 17  VAL A CB  1 
+ATOM   132 C CG1 . VAL A 1 17 ? 30.862 25.496 8.389  1.00 12.05 ? 17  VAL A CG1 1 
+ATOM   133 C CG2 . VAL A 1 17 ? 28.476 25.135 7.705  1.00 10.54 ? 17  VAL A CG2 1 
+ATOM   134 N N   . GLU A 1 18 ? 29.380 22.057 6.232  1.00 7.29  ? 18  GLU A N   1 
+ATOM   135 C CA  . GLU A 1 18 ? 28.468 20.940 5.980  1.00 7.08  ? 18  GLU A CA  1 
+ATOM   136 C C   . GLU A 1 18 ? 27.819 20.609 7.316  1.00 6.45  ? 18  GLU A C   1 
+ATOM   137 O O   . GLU A 1 18 ? 28.449 20.674 8.360  1.00 5.28  ? 18  GLU A O   1 
+ATOM   138 C CB  . GLU A 1 18 ? 29.213 19.697 5.506  1.00 10.28 ? 18  GLU A CB  1 
+ATOM   139 C CG  . GLU A 1 18 ? 29.728 19.755 4.060  1.00 12.65 ? 18  GLU A CG  1 
+ATOM   140 C CD  . GLU A 1 18 ? 28.754 20.061 2.978  1.00 14.15 ? 18  GLU A CD  1 
+ATOM   141 O OE1 . GLU A 1 18 ? 27.546 19.992 2.985  1.00 14.33 ? 18  GLU A OE1 1 
+ATOM   142 O OE2 . GLU A 1 18 ? 29.336 20.423 1.904  1.00 18.17 ? 18  GLU A OE2 1 
+ATOM   143 N N   . PRO A 1 19 ? 26.559 20.220 7.288  1.00 7.24  ? 19  PRO A N   1 
+ATOM   144 C CA  . PRO A 1 19 ? 25.829 19.825 8.494  1.00 7.07  ? 19  PRO A CA  1 
+ATOM   145 C C   . PRO A 1 19 ? 26.541 18.732 9.251  1.00 6.65  ? 19  PRO A C   1 
+ATOM   146 O O   . PRO A 1 19 ? 26.333 18.536 10.457 1.00 6.37  ? 19  PRO A O   1 
+ATOM   147 C CB  . PRO A 1 19 ? 24.469 19.332 7.952  1.00 7.61  ? 19  PRO A CB  1 
+ATOM   148 C CG  . PRO A 1 19 ? 24.299 20.134 6.704  1.00 8.16  ? 19  PRO A CG  1 
+ATOM   149 C CD  . PRO A 1 19 ? 25.714 20.108 6.073  1.00 7.49  ? 19  PRO A CD  1 
+ATOM   150 N N   . SER A 1 20 ? 27.361 17.959 8.559  1.00 6.80  ? 20  SER A N   1 
+ATOM   151 C CA  . SER A 1 20 ? 28.054 16.835 9.210  1.00 6.28  ? 20  SER A CA  1 
+ATOM   152 C C   . SER A 1 20 ? 29.258 17.318 9.984  1.00 8.45  ? 20  SER A C   1 
+ATOM   153 O O   . SER A 1 20 ? 29.930 16.477 10.606 1.00 7.26  ? 20  SER A O   1 
+ATOM   154 C CB  . SER A 1 20 ? 28.523 15.820 8.182  1.00 8.57  ? 20  SER A CB  1 
+ATOM   155 O OG  . SER A 1 20 ? 28.946 16.445 6.967  1.00 11.13 ? 20  SER A OG  1 
+ATOM   156 N N   . ASP A 1 21 ? 29.599 18.599 9.828  1.00 7.50  ? 21  ASP A N   1 
+ATOM   157 C CA  . ASP A 1 21 ? 30.796 19.083 10.566 1.00 7.70  ? 21  ASP A CA  1 
+ATOM   158 C C   . ASP A 1 21 ? 30.491 19.162 12.040 1.00 7.08  ? 21  ASP A C   1 
+ATOM   159 O O   . ASP A 1 21 ? 29.367 19.523 12.441 1.00 8.11  ? 21  ASP A O   1 
+ATOM   160 C CB  . ASP A 1 21 ? 31.155 20.515 10.048 1.00 11.00 ? 21  ASP A CB  1 
+ATOM   161 C CG  . ASP A 1 21 ? 31.923 20.436 8.755  1.00 15.32 ? 21  ASP A CG  1 
+ATOM   162 O OD1 . ASP A 1 21 ? 32.493 19.374 8.456  1.00 18.03 ? 21  ASP A OD1 1 
+ATOM   163 O OD2 . ASP A 1 21 ? 31.838 21.402 7.968  1.00 14.36 ? 21  ASP A OD2 1 
+ATOM   164 N N   . THR A 1 22 ? 31.510 18.936 12.852 1.00 5.37  ? 22  THR A N   1 
+ATOM   165 C CA  . THR A 1 22 ? 31.398 19.064 14.286 1.00 6.01  ? 22  THR A CA  1 
+ATOM   166 C C   . THR A 1 22 ? 31.593 20.553 14.655 1.00 8.01  ? 22  THR A C   1 
+ATOM   167 O O   . THR A 1 22 ? 32.159 21.311 13.861 1.00 8.11  ? 22  THR A O   1 
+ATOM   168 C CB  . THR A 1 22 ? 32.492 18.193 14.995 1.00 8.92  ? 22  THR A CB  1 
+ATOM   169 O OG1 . THR A 1 22 ? 33.778 18.739 14.516 1.00 10.22 ? 22  THR A OG1 1 
+ATOM   170 C CG2 . THR A 1 22 ? 32.352 16.700 14.630 1.00 9.65  ? 22  THR A CG2 1 
+ATOM   171 N N   . ILE A 1 23 ? 31.113 20.863 15.860 1.00 8.32  ? 23  ILE A N   1 
+ATOM   172 C CA  . ILE A 1 23 ? 31.288 22.201 16.417 1.00 9.92  ? 23  ILE A CA  1 
+ATOM   173 C C   . ILE A 1 23 ? 32.776 22.519 16.577 1.00 10.01 ? 23  ILE A C   1 
+ATOM   174 O O   . ILE A 1 23 ? 33.233 23.659 16.384 1.00 8.71  ? 23  ILE A O   1 
+ATOM   175 C CB  . ILE A 1 23 ? 30.520 22.300 17.764 1.00 10.78 ? 23  ILE A CB  1 
+ATOM   176 C CG1 . ILE A 1 23 ? 29.006 22.043 17.442 1.00 11.38 ? 23  ILE A CG1 1 
+ATOM   177 C CG2 . ILE A 1 23 ? 30.832 23.699 18.358 1.00 10.90 ? 23  ILE A CG2 1 
+ATOM   178 C CD1 . ILE A 1 23 ? 28.407 22.948 16.366 1.00 12.30 ? 23  ILE A CD1 1 
+ATOM   179 N N   . GLU A 1 24 ? 33.548 21.526 16.950 1.00 9.54  ? 24  GLU A N   1 
+ATOM   180 C CA  . GLU A 1 24 ? 35.031 21.722 17.069 1.00 11.81 ? 24  GLU A CA  1 
+ATOM   181 C C   . GLU A 1 24 ? 35.615 22.190 15.759 1.00 11.14 ? 24  GLU A C   1 
+ATOM   182 O O   . GLU A 1 24 ? 36.532 23.046 15.724 1.00 10.62 ? 24  GLU A O   1 
+ATOM   183 C CB  . GLU A 1 24 ? 35.667 20.383 17.447 1.00 19.24 ? 24  GLU A CB  1 
+ATOM   184 C CG  . GLU A 1 24 ? 37.128 20.293 17.872 1.00 27.76 ? 24  GLU A CG  1 
+ATOM   185 C CD  . GLU A 1 24 ? 37.561 18.851 18.082 1.00 32.92 ? 24  GLU A CD  1 
+ATOM   186 O OE1 . GLU A 1 24 ? 37.758 18.024 17.195 1.00 34.80 ? 24  GLU A OE1 1 
+ATOM   187 O OE2 . GLU A 1 24 ? 37.628 18.599 19.313 1.00 36.51 ? 24  GLU A OE2 1 
+ATOM   188 N N   . ASN A 1 25 ? 35.139 21.624 14.662 1.00 9.43  ? 25  ASN A N   1 
+ATOM   189 C CA  . ASN A 1 25 ? 35.590 21.945 13.302 1.00 10.96 ? 25  ASN A CA  1 
+ATOM   190 C C   . ASN A 1 25 ? 35.238 23.382 12.920 1.00 9.68  ? 25  ASN A C   1 
+ATOM   191 O O   . ASN A 1 25 ? 36.066 24.109 12.333 1.00 9.33  ? 25  ASN A O   1 
+ATOM   192 C CB  . ASN A 1 25 ? 35.064 20.957 12.255 1.00 16.78 ? 25  ASN A CB  1 
+ATOM   193 C CG  . ASN A 1 25 ? 35.541 21.418 10.871 1.00 22.31 ? 25  ASN A CG  1 
+ATOM   194 O OD1 . ASN A 1 25 ? 36.772 21.623 10.676 1.00 25.66 ? 25  ASN A OD1 1 
+ATOM   195 N ND2 . ASN A 1 25 ? 34.628 21.595 9.920  1.00 24.70 ? 25  ASN A ND2 1 
+ATOM   196 N N   . VAL A 1 26 ? 34.007 23.745 13.250 1.00 6.52  ? 26  VAL A N   1 
+ATOM   197 C CA  . VAL A 1 26 ? 33.533 25.097 12.978 1.00 5.53  ? 26  VAL A CA  1 
+ATOM   198 C C   . VAL A 1 26 ? 34.441 26.099 13.684 1.00 4.42  ? 26  VAL A C   1 
+ATOM   199 O O   . VAL A 1 26 ? 34.883 27.090 13.093 1.00 3.40  ? 26  VAL A O   1 
+ATOM   200 C CB  . VAL A 1 26 ? 32.060 25.257 13.364 1.00 3.86  ? 26  VAL A CB  1 
+ATOM   201 C CG1 . VAL A 1 26 ? 31.684 26.749 13.342 1.00 7.25  ? 26  VAL A CG1 1 
+ATOM   202 C CG2 . VAL A 1 26 ? 31.152 24.421 12.477 1.00 8.12  ? 26  VAL A CG2 1 
+ATOM   203 N N   . LYS A 1 27 ? 34.734 25.822 14.949 1.00 2.64  ? 27  LYS A N   1 
+ATOM   204 C CA  . LYS A 1 27 ? 35.596 26.715 15.736 1.00 4.14  ? 27  LYS A CA  1 
+ATOM   205 C C   . LYS A 1 27 ? 36.975 26.826 15.107 1.00 5.58  ? 27  LYS A C   1 
+ATOM   206 O O   . LYS A 1 27 ? 37.579 27.926 15.159 1.00 4.11  ? 27  LYS A O   1 
+ATOM   207 C CB  . LYS A 1 27 ? 35.715 26.203 17.172 1.00 3.97  ? 27  LYS A CB  1 
+ATOM   208 C CG  . LYS A 1 27 ? 34.343 26.445 17.898 1.00 7.45  ? 27  LYS A CG  1 
+ATOM   209 C CD  . LYS A 1 27 ? 34.509 26.077 19.360 1.00 9.02  ? 27  LYS A CD  1 
+ATOM   210 C CE  . LYS A 1 27 ? 33.206 26.311 20.122 1.00 12.90 ? 27  LYS A CE  1 
+ATOM   211 N NZ  . LYS A 1 27 ? 33.455 25.910 21.546 1.00 15.47 ? 27  LYS A NZ  1 
+ATOM   212 N N   . ALA A 1 28 ? 37.499 25.743 14.571 1.00 6.61  ? 28  ALA A N   1 
+ATOM   213 C CA  . ALA A 1 28 ? 38.794 25.761 13.880 1.00 7.74  ? 28  ALA A CA  1 
+ATOM   214 C C   . ALA A 1 28 ? 38.728 26.591 12.611 1.00 9.17  ? 28  ALA A C   1 
+ATOM   215 O O   . ALA A 1 28 ? 39.704 27.346 12.277 1.00 11.45 ? 28  ALA A O   1 
+ATOM   216 C CB  . ALA A 1 28 ? 39.285 24.336 13.566 1.00 7.68  ? 28  ALA A CB  1 
+ATOM   217 N N   . LYS A 1 29 ? 37.633 26.543 11.867 1.00 8.96  ? 29  LYS A N   1 
+ATOM   218 C CA  . LYS A 1 29 ? 37.471 27.391 10.668 1.00 7.90  ? 29  LYS A CA  1 
+ATOM   219 C C   . LYS A 1 29 ? 37.441 28.882 11.052 1.00 6.92  ? 29  LYS A C   1 
+ATOM   220 O O   . LYS A 1 29 ? 38.020 29.772 10.382 1.00 6.87  ? 29  LYS A O   1 
+ATOM   221 C CB  . LYS A 1 29 ? 36.193 27.058 9.911  1.00 10.28 ? 29  LYS A CB  1 
+ATOM   222 C CG  . LYS A 1 29 ? 36.153 25.620 9.409  1.00 14.94 ? 29  LYS A CG  1 
+ATOM   223 C CD  . LYS A 1 29 ? 34.758 25.280 8.900  1.00 19.69 ? 29  LYS A CD  1 
+ATOM   224 C CE  . LYS A 1 29 ? 34.793 24.264 7.767  1.00 22.63 ? 29  LYS A CE  1 
+ATOM   225 N NZ  . LYS A 1 29 ? 34.914 24.944 6.441  1.00 24.98 ? 29  LYS A NZ  1 
+ATOM   226 N N   . ILE A 1 30 ? 36.811 29.170 12.192 1.00 4.57  ? 30  ILE A N   1 
+ATOM   227 C CA  . ILE A 1 30 ? 36.731 30.570 12.645 1.00 5.58  ? 30  ILE A CA  1 
+ATOM   228 C C   . ILE A 1 30 ? 38.148 30.981 13.069 1.00 7.26  ? 30  ILE A C   1 
+ATOM   229 O O   . ILE A 1 30 ? 38.544 32.150 12.856 1.00 9.46  ? 30  ILE A O   1 
+ATOM   230 C CB  . ILE A 1 30 ? 35.708 30.776 13.806 1.00 5.36  ? 30  ILE A CB  1 
+ATOM   231 C CG1 . ILE A 1 30 ? 34.228 30.630 13.319 1.00 2.94  ? 30  ILE A CG1 1 
+ATOM   232 C CG2 . ILE A 1 30 ? 35.874 32.138 14.512 1.00 2.78  ? 30  ILE A CG2 1 
+ATOM   233 C CD1 . ILE A 1 30 ? 33.284 30.504 14.552 1.00 2.00  ? 30  ILE A CD1 1 
+ATOM   234 N N   . GLN A 1 31 ? 38.883 30.110 13.713 1.00 7.06  ? 31  GLN A N   1 
+ATOM   235 C CA  . GLN A 1 31 ? 40.269 30.508 14.115 1.00 8.67  ? 31  GLN A CA  1 
+ATOM   236 C C   . GLN A 1 31 ? 41.092 30.808 12.851 1.00 10.90 ? 31  GLN A C   1 
+ATOM   237 O O   . GLN A 1 31 ? 41.828 31.808 12.681 1.00 9.63  ? 31  GLN A O   1 
+ATOM   238 C CB  . GLN A 1 31 ? 40.996 29.399 14.865 1.00 9.12  ? 31  GLN A CB  1 
+ATOM   239 C CG  . GLN A 1 31 ? 42.445 29.848 15.182 1.00 10.76 ? 31  GLN A CG  1 
+ATOM   240 C CD  . GLN A 1 31 ? 43.090 28.828 16.095 1.00 13.78 ? 31  GLN A CD  1 
+ATOM   241 O OE1 . GLN A 1 31 ? 42.770 27.655 15.906 1.00 14.48 ? 31  GLN A OE1 1 
+ATOM   242 N NE2 . GLN A 1 31 ? 43.898 29.252 17.050 1.00 14.76 ? 31  GLN A NE2 1 
+ATOM   243 N N   . ASP A 1 32 ? 41.001 29.878 11.931 1.00 10.93 ? 32  ASP A N   1 
+ATOM   244 C CA  . ASP A 1 32 ? 41.718 30.022 10.643 1.00 14.01 ? 32  ASP A CA  1 
+ATOM   245 C C   . ASP A 1 32 ? 41.399 31.338 9.967  1.00 14.04 ? 32  ASP A C   1 
+ATOM   246 O O   . ASP A 1 32 ? 42.260 32.036 9.381  1.00 13.39 ? 32  ASP A O   1 
+ATOM   247 C CB  . ASP A 1 32 ? 41.398 28.780 9.810  1.00 18.01 ? 32  ASP A CB  1 
+ATOM   248 C CG  . ASP A 1 32 ? 42.626 28.557 8.928  1.00 24.33 ? 32  ASP A CG  1 
+ATOM   249 O OD1 . ASP A 1 32 ? 43.666 28.262 9.539  1.00 26.29 ? 32  ASP A OD1 1 
+ATOM   250 O OD2 . ASP A 1 32 ? 42.430 28.812 7.728  1.00 25.17 ? 32  ASP A OD2 1 
+ATOM   251 N N   . LYS A 1 33 ? 40.117 31.750 9.988  1.00 14.22 ? 33  LYS A N   1 
+ATOM   252 C CA  . LYS A 1 33 ? 39.808 32.994 9.233  1.00 14.00 ? 33  LYS A CA  1 
+ATOM   253 C C   . LYS A 1 33 ? 39.837 34.271 9.995  1.00 12.37 ? 33  LYS A C   1 
+ATOM   254 O O   . LYS A 1 33 ? 40.164 35.323 9.345  1.00 12.17 ? 33  LYS A O   1 
+ATOM   255 C CB  . LYS A 1 33 ? 38.615 32.801 8.320  1.00 18.62 ? 33  LYS A CB  1 
+ATOM   256 C CG  . LYS A 1 33 ? 37.220 32.822 8.827  1.00 24.00 ? 33  LYS A CG  1 
+ATOM   257 C CD  . LYS A 1 33 ? 36.351 33.613 7.838  1.00 27.61 ? 33  LYS A CD  1 
+ATOM   258 C CE  . LYS A 1 33 ? 36.322 32.944 6.477  1.00 27.64 ? 33  LYS A CE  1 
+ATOM   259 N NZ  . LYS A 1 33 ? 35.768 33.945 5.489  1.00 30.06 ? 33  LYS A NZ  1 
+ATOM   260 N N   . GLU A 1 34 ? 39.655 34.335 11.285 1.00 10.11 ? 34  GLU A N   1 
+ATOM   261 C CA  . GLU A 1 34 ? 39.676 35.547 12.072 1.00 10.07 ? 34  GLU A CA  1 
+ATOM   262 C C   . GLU A 1 34 ? 40.675 35.527 13.200 1.00 9.32  ? 34  GLU A C   1 
+ATOM   263 O O   . GLU A 1 34 ? 40.814 36.528 13.911 1.00 11.61 ? 34  GLU A O   1 
+ATOM   264 C CB  . GLU A 1 34 ? 38.290 35.814 12.698 1.00 14.77 ? 34  GLU A CB  1 
+ATOM   265 C CG  . GLU A 1 34 ? 37.156 35.985 11.688 1.00 18.75 ? 34  GLU A CG  1 
+ATOM   266 C CD  . GLU A 1 34 ? 37.192 37.361 11.033 1.00 22.28 ? 34  GLU A CD  1 
+ATOM   267 O OE1 . GLU A 1 34 ? 37.519 38.360 11.645 1.00 21.95 ? 34  GLU A OE1 1 
+ATOM   268 O OE2 . GLU A 1 34 ? 36.861 37.320 9.822  1.00 25.19 ? 34  GLU A OE2 1 
+ATOM   269 N N   . GLY A 1 35 ? 41.317 34.393 13.432 1.00 7.22  ? 35  GLY A N   1 
+ATOM   270 C CA  . GLY A 1 35 ? 42.345 34.269 14.431 1.00 6.29  ? 35  GLY A CA  1 
+ATOM   271 C C   . GLY A 1 35 ? 41.949 34.076 15.842 1.00 6.93  ? 35  GLY A C   1 
+ATOM   272 O O   . GLY A 1 35 ? 42.829 34.000 16.739 1.00 7.41  ? 35  GLY A O   1 
+ATOM   273 N N   . ILE A 1 36 ? 40.642 33.916 16.112 1.00 5.86  ? 36  ILE A N   1 
+ATOM   274 C CA  . ILE A 1 36 ? 40.226 33.716 17.509 1.00 6.07  ? 36  ILE A CA  1 
+ATOM   275 C C   . ILE A 1 36 ? 40.449 32.278 17.945 1.00 6.36  ? 36  ILE A C   1 
+ATOM   276 O O   . ILE A 1 36 ? 39.936 31.336 17.315 1.00 6.18  ? 36  ILE A O   1 
+ATOM   277 C CB  . ILE A 1 36 ? 38.693 34.106 17.595 1.00 7.47  ? 36  ILE A CB  1 
+ATOM   278 C CG1 . ILE A 1 36 ? 38.471 35.546 17.045 1.00 8.52  ? 36  ILE A CG1 1 
+ATOM   279 C CG2 . ILE A 1 36 ? 38.146 33.932 19.027 1.00 7.36  ? 36  ILE A CG2 1 
+ATOM   280 C CD1 . ILE A 1 36 ? 36.958 35.746 16.680 1.00 9.49  ? 36  ILE A CD1 1 
+ATOM   281 N N   . PRO A 1 37 ? 41.189 32.085 19.031 1.00 8.65  ? 37  PRO A N   1 
+ATOM   282 C CA  . PRO A 1 37 ? 41.461 30.751 19.594 1.00 9.18  ? 37  PRO A CA  1 
+ATOM   283 C C   . PRO A 1 37 ? 40.168 30.026 19.918 1.00 9.85  ? 37  PRO A C   1 
+ATOM   284 O O   . PRO A 1 37 ? 39.264 30.662 20.521 1.00 8.51  ? 37  PRO A O   1 
+ATOM   285 C CB  . PRO A 1 37 ? 42.195 31.142 20.913 1.00 11.42 ? 37  PRO A CB  1 
+ATOM   286 C CG  . PRO A 1 37 ? 42.904 32.414 20.553 1.00 9.27  ? 37  PRO A CG  1 
+ATOM   287 C CD  . PRO A 1 37 ? 41.822 33.188 19.813 1.00 8.33  ? 37  PRO A CD  1 
+ATOM   288 N N   . PRO A 1 38 ? 40.059 28.758 19.607 1.00 8.71  ? 38  PRO A N   1 
+ATOM   289 C CA  . PRO A 1 38 ? 38.817 28.020 19.889 1.00 9.08  ? 38  PRO A CA  1 
+ATOM   290 C C   . PRO A 1 38 ? 38.421 28.048 21.341 1.00 9.28  ? 38  PRO A C   1 
+ATOM   291 O O   . PRO A 1 38 ? 37.213 28.036 21.704 1.00 6.50  ? 38  PRO A O   1 
+ATOM   292 C CB  . PRO A 1 38 ? 39.090 26.629 19.325 1.00 10.31 ? 38  PRO A CB  1 
+ATOM   293 C CG  . PRO A 1 38 ? 40.082 26.904 18.198 1.00 10.81 ? 38  PRO A CG  1 
+ATOM   294 C CD  . PRO A 1 38 ? 41.035 27.909 18.879 1.00 12.00 ? 38  PRO A CD  1 
+ATOM   295 N N   . ASP A 1 39 ? 39.374 28.090 22.240 1.00 11.20 ? 39  ASP A N   1 
+ATOM   296 C CA  . ASP A 1 39 ? 39.063 28.063 23.695 1.00 14.96 ? 39  ASP A CA  1 
+ATOM   297 C C   . ASP A 1 39 ? 38.365 29.335 24.159 1.00 13.99 ? 39  ASP A C   1 
+ATOM   298 O O   . ASP A 1 39 ? 37.684 29.390 25.221 1.00 13.75 ? 39  ASP A O   1 
+ATOM   299 C CB  . ASP A 1 39 ? 40.340 27.692 24.468 1.00 24.16 ? 39  ASP A CB  1 
+ATOM   300 C CG  . ASP A 1 39 ? 40.559 28.585 25.675 1.00 31.06 ? 39  ASP A CG  1 
+ATOM   301 O OD1 . ASP A 1 39 ? 40.716 29.809 25.456 1.00 35.55 ? 39  ASP A OD1 1 
+ATOM   302 O OD2 . ASP A 1 39 ? 40.549 28.090 26.840 1.00 34.22 ? 39  ASP A OD2 1 
+ATOM   303 N N   . GLN A 1 40 ? 38.419 30.373 23.341 1.00 11.60 ? 40  GLN A N   1 
+ATOM   304 C CA  . GLN A 1 40 ? 37.738 31.637 23.712 1.00 10.76 ? 40  GLN A CA  1 
+ATOM   305 C C   . GLN A 1 40 ? 36.334 31.742 23.087 1.00 8.01  ? 40  GLN A C   1 
+ATOM   306 O O   . GLN A 1 40 ? 35.574 32.618 23.483 1.00 8.96  ? 40  GLN A O   1 
+ATOM   307 C CB  . GLN A 1 40 ? 38.528 32.854 23.182 1.00 11.14 ? 40  GLN A CB  1 
+ATOM   308 C CG  . GLN A 1 40 ? 39.919 32.854 23.840 1.00 14.85 ? 40  GLN A CG  1 
+ATOM   309 C CD  . GLN A 1 40 ? 40.760 34.036 23.394 1.00 16.11 ? 40  GLN A CD  1 
+ATOM   310 O OE1 . GLN A 1 40 ? 41.975 34.008 23.624 1.00 20.52 ? 40  GLN A OE1 1 
+ATOM   311 N NE2 . GLN A 1 40 ? 40.140 35.007 22.775 1.00 18.16 ? 40  GLN A NE2 1 
+ATOM   312 N N   . GLN A 1 41 ? 36.000 30.860 22.172 1.00 6.52  ? 41  GLN A N   1 
+ATOM   313 C CA  . GLN A 1 41 ? 34.738 30.875 21.473 1.00 3.87  ? 41  GLN A CA  1 
+ATOM   314 C C   . GLN A 1 41 ? 33.589 30.189 22.181 1.00 4.79  ? 41  GLN A C   1 
+ATOM   315 O O   . GLN A 1 41 ? 33.580 29.009 22.499 1.00 6.34  ? 41  GLN A O   1 
+ATOM   316 C CB  . GLN A 1 41 ? 34.876 30.237 20.066 1.00 4.20  ? 41  GLN A CB  1 
+ATOM   317 C CG  . GLN A 1 41 ? 36.012 30.860 19.221 1.00 3.20  ? 41  GLN A CG  1 
+ATOM   318 C CD  . GLN A 1 41 ? 36.083 30.194 17.875 1.00 4.89  ? 41  GLN A CD  1 
+ATOM   319 O OE1 . GLN A 1 41 ? 35.048 29.702 17.393 1.00 5.21  ? 41  GLN A OE1 1 
+ATOM   320 N NE2 . GLN A 1 41 ? 37.228 30.126 17.233 1.00 7.13  ? 41  GLN A NE2 1 
+ATOM   321 N N   . ARG A 1 42 ? 32.478 30.917 22.269 1.00 5.73  ? 42  ARG A N   1 
+ATOM   322 C CA  . ARG A 1 42 ? 31.200 30.329 22.780 1.00 6.97  ? 42  ARG A CA  1 
+ATOM   323 C C   . ARG A 1 42 ? 30.210 30.509 21.650 1.00 7.15  ? 42  ARG A C   1 
+ATOM   324 O O   . ARG A 1 42 ? 29.978 31.726 21.269 1.00 7.33  ? 42  ARG A O   1 
+ATOM   325 C CB  . ARG A 1 42 ? 30.847 30.931 24.118 1.00 13.23 ? 42  ARG A CB  1 
+ATOM   326 C CG  . ARG A 1 42 ? 29.412 30.796 24.598 1.00 21.27 ? 42  ARG A CG  1 
+ATOM   327 C CD  . ARG A 1 42 ? 29.271 31.314 26.016 1.00 26.14 ? 42  ARG A CD  1 
+ATOM   328 N NE  . ARG A 1 42 ? 27.875 31.317 26.443 1.00 32.26 ? 42  ARG A NE  1 
+ATOM   329 C CZ  . ARG A 1 42 ? 27.132 32.423 26.574 1.00 34.32 ? 42  ARG A CZ  1 
+ATOM   330 N NH1 . ARG A 1 42 ? 27.630 33.656 26.461 1.00 35.30 ? 42  ARG A NH1 1 
+ATOM   331 N NH2 . ARG A 1 42 ? 25.810 32.299 26.732 1.00 36.39 ? 42  ARG A NH2 1 
+ATOM   332 N N   . LEU A 1 43 ? 29.694 29.436 21.054 1.00 4.65  ? 43  LEU A N   1 
+ATOM   333 C CA  . LEU A 1 43 ? 28.762 29.573 19.906 1.00 3.51  ? 43  LEU A CA  1 
+ATOM   334 C C   . LEU A 1 43 ? 27.331 29.317 20.364 1.00 5.56  ? 43  LEU A C   1 
+ATOM   335 O O   . LEU A 1 43 ? 27.101 28.346 21.097 1.00 4.19  ? 43  LEU A O   1 
+ATOM   336 C CB  . LEU A 1 43 ? 29.151 28.655 18.755 1.00 3.74  ? 43  LEU A CB  1 
+ATOM   337 C CG  . LEU A 1 43 ? 30.416 28.912 17.980 1.00 6.32  ? 43  LEU A CG  1 
+ATOM   338 C CD1 . LEU A 1 43 ? 30.738 27.693 17.122 1.00 9.55  ? 43  LEU A CD1 1 
+ATOM   339 C CD2 . LEU A 1 43 ? 30.205 30.168 17.129 1.00 6.41  ? 43  LEU A CD2 1 
+ATOM   340 N N   . ILE A 1 44 ? 26.436 30.232 20.004 1.00 4.58  ? 44  ILE A N   1 
+ATOM   341 C CA  . ILE A 1 44 ? 25.034 30.170 20.401 1.00 5.55  ? 44  ILE A CA  1 
+ATOM   342 C C   . ILE A 1 44 ? 24.101 30.149 19.196 1.00 5.46  ? 44  ILE A C   1 
+ATOM   343 O O   . ILE A 1 44 ? 24.196 30.948 18.287 1.00 6.04  ? 44  ILE A O   1 
+ATOM   344 C CB  . ILE A 1 44 ? 24.639 31.426 21.286 1.00 6.80  ? 44  ILE A CB  1 
+ATOM   345 C CG1 . ILE A 1 44 ? 25.646 31.670 22.421 1.00 10.31 ? 44  ILE A CG1 1 
+ATOM   346 C CG2 . ILE A 1 44 ? 23.181 31.309 21.824 1.00 7.39  ? 44  ILE A CG2 1 
+ATOM   347 C CD1 . ILE A 1 44 ? 25.778 30.436 23.356 1.00 13.90 ? 44  ILE A CD1 1 
+ATOM   348 N N   . PHE A 1 45 ? 23.141 29.187 19.241 1.00 6.75  ? 45  PHE A N   1 
+ATOM   349 C CA  . PHE A 1 45 ? 22.126 29.062 18.183 1.00 4.70  ? 45  PHE A CA  1 
+ATOM   350 C C   . PHE A 1 45 ? 20.835 28.629 18.904 1.00 6.34  ? 45  PHE A C   1 
+ATOM   351 O O   . PHE A 1 45 ? 20.821 27.734 19.749 1.00 5.45  ? 45  PHE A O   1 
+ATOM   352 C CB  . PHE A 1 45 ? 22.494 28.057 17.109 1.00 5.51  ? 45  PHE A CB  1 
+ATOM   353 C CG  . PHE A 1 45 ? 21.447 27.869 16.026 1.00 5.98  ? 45  PHE A CG  1 
+ATOM   354 C CD1 . PHE A 1 45 ? 21.325 28.813 15.005 1.00 6.86  ? 45  PHE A CD1 1 
+ATOM   355 C CD2 . PHE A 1 45 ? 20.638 26.735 16.053 1.00 5.87  ? 45  PHE A CD2 1 
+ATOM   356 C CE1 . PHE A 1 45 ? 20.369 28.648 14.001 1.00 6.68  ? 45  PHE A CE1 1 
+ATOM   357 C CE2 . PHE A 1 45 ? 19.677 26.539 15.051 1.00 6.64  ? 45  PHE A CE2 1 
+ATOM   358 C CZ  . PHE A 1 45 ? 19.593 27.465 14.021 1.00 6.84  ? 45  PHE A CZ  1 
+ATOM   359 N N   . ALA A 1 46 ? 19.810 29.378 18.578 1.00 6.53  ? 46  ALA A N   1 
+ATOM   360 C CA  . ALA A 1 46 ? 18.443 29.143 19.083 1.00 7.15  ? 46  ALA A CA  1 
+ATOM   361 C C   . ALA A 1 46 ? 18.453 28.941 20.591 1.00 9.00  ? 46  ALA A C   1 
+ATOM   362 O O   . ALA A 1 46 ? 17.860 27.994 21.128 1.00 11.15 ? 46  ALA A O   1 
+ATOM   363 C CB  . ALA A 1 46 ? 17.864 27.977 18.346 1.00 8.99  ? 46  ALA A CB  1 
+ATOM   364 N N   . GLY A 1 47 ? 19.172 29.808 21.243 1.00 9.35  ? 47  GLY A N   1 
+ATOM   365 C CA  . GLY A 1 47 ? 19.399 29.894 22.655 1.00 11.68 ? 47  GLY A CA  1 
+ATOM   366 C C   . GLY A 1 47 ? 20.083 28.729 23.321 1.00 11.14 ? 47  GLY A C   1 
+ATOM   367 O O   . GLY A 1 47 ? 19.991 28.584 24.561 1.00 13.93 ? 47  GLY A O   1 
+ATOM   368 N N   . LYS A 1 48 ? 20.801 27.931 22.578 1.00 10.47 ? 48  LYS A N   1 
+ATOM   369 C CA  . LYS A 1 48 ? 21.550 26.796 23.133 1.00 8.82  ? 48  LYS A CA  1 
+ATOM   370 C C   . LYS A 1 48 ? 23.046 27.087 22.913 1.00 7.68  ? 48  LYS A C   1 
+ATOM   371 O O   . LYS A 1 48 ? 23.383 27.627 21.870 1.00 6.47  ? 48  LYS A O   1 
+ATOM   372 C CB  . LYS A 1 48 ? 21.242 25.519 22.391 1.00 9.74  ? 48  LYS A CB  1 
+ATOM   373 C CG  . LYS A 1 48 ? 19.762 25.077 22.455 1.00 14.14 ? 48  LYS A CG  1 
+ATOM   374 C CD  . LYS A 1 48 ? 19.634 23.885 21.531 1.00 16.32 ? 48  LYS A CD  1 
+ATOM   375 C CE  . LYS A 1 48 ? 18.791 24.221 20.313 1.00 20.04 ? 48  LYS A CE  1 
+ATOM   376 N NZ  . LYS A 1 48 ? 17.440 24.655 20.827 1.00 23.92 ? 48  LYS A NZ  1 
+ATOM   377 N N   . GLN A 1 49 ? 23.880 26.727 23.851 1.00 8.89  ? 49  GLN A N   1 
+ATOM   378 C CA  . GLN A 1 49 ? 25.349 26.872 23.643 1.00 7.18  ? 49  GLN A CA  1 
+ATOM   379 C C   . GLN A 1 49 ? 25.743 25.586 22.922 1.00 8.23  ? 49  GLN A C   1 
+ATOM   380 O O   . GLN A 1 49 ? 25.325 24.489 23.378 1.00 9.70  ? 49  GLN A O   1 
+ATOM   381 C CB  . GLN A 1 49 ? 26.070 27.025 24.960 1.00 11.67 ? 49  GLN A CB  1 
+ATOM   382 C CG  . GLN A 1 49 ? 27.553 27.356 24.695 1.00 15.82 ? 49  GLN A CG  1 
+ATOM   383 C CD  . GLN A 1 49 ? 28.262 27.576 26.020 1.00 20.21 ? 49  GLN A CD  1 
+ATOM   384 O OE1 . GLN A 1 49 ? 29.189 26.840 26.335 1.00 23.23 ? 49  GLN A OE1 1 
+ATOM   385 N NE2 . GLN A 1 49 ? 27.777 28.585 26.739 1.00 20.67 ? 49  GLN A NE2 1 
+ATOM   386 N N   . LEU A 1 50 ? 26.465 25.689 21.833 1.00 6.51  ? 50  LEU A N   1 
+ATOM   387 C CA  . LEU A 1 50 ? 26.826 24.521 21.012 1.00 7.41  ? 50  LEU A CA  1 
+ATOM   388 C C   . LEU A 1 50 ? 27.994 23.781 21.643 1.00 8.27  ? 50  LEU A C   1 
+ATOM   389 O O   . LEU A 1 50 ? 28.904 24.444 22.098 1.00 8.34  ? 50  LEU A O   1 
+ATOM   390 C CB  . LEU A 1 50 ? 27.043 24.992 19.571 1.00 7.13  ? 50  LEU A CB  1 
+ATOM   391 C CG  . LEU A 1 50 ? 25.931 25.844 18.959 1.00 7.53  ? 50  LEU A CG  1 
+ATOM   392 C CD1 . LEU A 1 50 ? 26.203 26.083 17.471 1.00 8.14  ? 50  LEU A CD1 1 
+ATOM   393 C CD2 . LEU A 1 50 ? 24.577 25.190 19.079 1.00 9.11  ? 50  LEU A CD2 1 
+ATOM   394 N N   . GLU A 1 51 ? 27.942 22.448 21.648 1.00 9.43  ? 51  GLU A N   1 
+ATOM   395 C CA  . GLU A 1 51 ? 29.015 21.657 22.288 1.00 11.90 ? 51  GLU A CA  1 
+ATOM   396 C C   . GLU A 1 51 ? 29.942 21.106 21.240 1.00 11.49 ? 51  GLU A C   1 
+ATOM   397 O O   . GLU A 1 51 ? 29.470 20.677 20.190 1.00 9.88  ? 51  GLU A O   1 
+ATOM   398 C CB  . GLU A 1 51 ? 28.348 20.540 23.066 1.00 16.56 ? 51  GLU A CB  1 
+ATOM   399 C CG  . GLU A 1 51 ? 29.247 19.456 23.705 1.00 26.06 ? 51  GLU A CG  1 
+ATOM   400 C CD  . GLU A 1 51 ? 28.722 19.047 25.066 1.00 29.86 ? 51  GLU A CD  1 
+ATOM   401 O OE1 . GLU A 1 51 ? 29.139 18.132 25.746 1.00 32.13 ? 51  GLU A OE1 1 
+ATOM   402 O OE2 . GLU A 1 51 ? 27.777 19.842 25.367 1.00 33.44 ? 51  GLU A OE2 1 
+ATOM   403 N N   . ASP A 1 52 ? 31.233 21.090 21.459 1.00 12.71 ? 52  ASP A N   1 
+ATOM   404 C CA  . ASP A 1 52 ? 32.262 20.670 20.514 1.00 16.56 ? 52  ASP A CA  1 
+ATOM   405 C C   . ASP A 1 52 ? 32.128 19.364 19.750 1.00 15.83 ? 52  ASP A C   1 
+ATOM   406 O O   . ASP A 1 52 ? 32.546 19.317 18.558 1.00 17.21 ? 52  ASP A O   1 
+ATOM   407 C CB  . ASP A 1 52 ? 33.638 20.716 21.242 1.00 21.05 ? 52  ASP A CB  1 
+ATOM   408 C CG  . ASP A 1 52 ? 34.174 22.129 21.354 1.00 25.12 ? 52  ASP A CG  1 
+ATOM   409 O OD1 . ASP A 1 52 ? 35.252 22.322 21.958 1.00 28.37 ? 52  ASP A OD1 1 
+ATOM   410 O OD2 . ASP A 1 52 ? 33.544 23.086 20.883 1.00 25.82 ? 52  ASP A OD2 1 
+ATOM   411 N N   . GLY A 1 53 ? 31.697 18.311 20.406 1.00 15.00 ? 53  GLY A N   1 
+ATOM   412 C CA  . GLY A 1 53 ? 31.568 16.962 19.825 1.00 11.77 ? 53  GLY A CA  1 
+ATOM   413 C C   . GLY A 1 53 ? 30.320 16.698 19.051 1.00 11.10 ? 53  GLY A C   1 
+ATOM   414 O O   . GLY A 1 53 ? 30.198 15.657 18.366 1.00 11.25 ? 53  GLY A O   1 
+ATOM   415 N N   . ARG A 1 54 ? 29.340 17.594 19.076 1.00 8.53  ? 54  ARG A N   1 
+ATOM   416 C CA  . ARG A 1 54 ? 28.108 17.439 18.276 1.00 9.05  ? 54  ARG A CA  1 
+ATOM   417 C C   . ARG A 1 54 ? 28.375 17.999 16.887 1.00 8.96  ? 54  ARG A C   1 
+ATOM   418 O O   . ARG A 1 54 ? 29.326 18.786 16.690 1.00 11.60 ? 54  ARG A O   1 
+ATOM   419 C CB  . ARG A 1 54 ? 26.926 18.191 18.892 1.00 7.97  ? 54  ARG A CB  1 
+ATOM   420 C CG  . ARG A 1 54 ? 26.621 17.799 20.352 1.00 9.62  ? 54  ARG A CG  1 
+ATOM   421 C CD  . ARG A 1 54 ? 26.010 16.370 20.280 1.00 12.20 ? 54  ARG A CD  1 
+ATOM   422 N NE  . ARG A 1 54 ? 26.975 15.521 20.942 1.00 18.23 ? 54  ARG A NE  1 
+ATOM   423 C CZ  . ARG A 1 54 ? 27.603 14.423 20.655 1.00 22.08 ? 54  ARG A CZ  1 
+ATOM   424 N NH1 . ARG A 1 54 ? 27.479 13.733 19.537 1.00 23.38 ? 54  ARG A NH1 1 
+ATOM   425 N NH2 . ARG A 1 54 ? 28.519 13.967 21.550 1.00 25.50 ? 54  ARG A NH2 1 
+ATOM   426 N N   . THR A 1 55 ? 27.510 17.689 15.954 1.00 9.05  ? 55  THR A N   1 
+ATOM   427 C CA  . THR A 1 55 ? 27.574 18.192 14.563 1.00 9.03  ? 55  THR A CA  1 
+ATOM   428 C C   . THR A 1 55 ? 26.482 19.280 14.432 1.00 8.15  ? 55  THR A C   1 
+ATOM   429 O O   . THR A 1 55 ? 25.609 19.388 15.287 1.00 5.91  ? 55  THR A O   1 
+ATOM   430 C CB  . THR A 1 55 ? 27.299 17.055 13.533 1.00 11.15 ? 55  THR A CB  1 
+ATOM   431 O OG1 . THR A 1 55 ? 25.925 16.611 13.913 1.00 11.95 ? 55  THR A OG1 1 
+ATOM   432 C CG2 . THR A 1 55 ? 28.236 15.864 13.558 1.00 11.71 ? 55  THR A CG2 1 
+ATOM   433 N N   . LEU A 1 56 ? 26.585 20.063 13.378 1.00 6.91  ? 56  LEU A N   1 
+ATOM   434 C CA  . LEU A 1 56 ? 25.594 21.109 13.072 1.00 8.29  ? 56  LEU A CA  1 
+ATOM   435 C C   . LEU A 1 56 ? 24.241 20.436 12.857 1.00 8.05  ? 56  LEU A C   1 
+ATOM   436 O O   . LEU A 1 56 ? 23.264 20.951 13.329 1.00 10.17 ? 56  LEU A O   1 
+ATOM   437 C CB  . LEU A 1 56 ? 26.084 21.888 11.833 1.00 6.60  ? 56  LEU A CB  1 
+ATOM   438 C CG  . LEU A 1 56 ? 27.426 22.616 11.902 1.00 7.73  ? 56  LEU A CG  1 
+ATOM   439 C CD1 . LEU A 1 56 ? 27.718 23.341 10.578 1.00 9.85  ? 56  LEU A CD1 1 
+ATOM   440 C CD2 . LEU A 1 56 ? 27.380 23.721 12.955 1.00 8.64  ? 56  LEU A CD2 1 
+ATOM   441 N N   . SER A 1 57 ? 24.240 19.233 12.246 1.00 8.92  ? 57  SER A N   1 
+ATOM   442 C CA  . SER A 1 57 ? 22.924 18.583 12.025 1.00 9.00  ? 57  SER A CA  1 
+ATOM   443 C C   . SER A 1 57 ? 22.229 18.244 13.325 1.00 9.44  ? 57  SER A C   1 
+ATOM   444 O O   . SER A 1 57 ? 20.963 18.253 13.395 1.00 10.91 ? 57  SER A O   1 
+ATOM   445 C CB  . SER A 1 57 ? 23.059 17.326 11.154 1.00 10.32 ? 57  SER A CB  1 
+ATOM   446 O OG  . SER A 1 57 ? 23.914 16.395 11.755 1.00 13.59 ? 57  SER A OG  1 
+ATOM   447 N N   . ASP A 1 58 ? 22.997 17.978 14.366 1.00 9.11  ? 58  ASP A N   1 
+ATOM   448 C CA  . ASP A 1 58 ? 22.418 17.638 15.693 1.00 7.91  ? 58  ASP A CA  1 
+ATOM   449 C C   . ASP A 1 58 ? 21.460 18.737 16.163 1.00 9.12  ? 58  ASP A C   1 
+ATOM   450 O O   . ASP A 1 58 ? 20.497 18.506 16.900 1.00 8.61  ? 58  ASP A O   1 
+ATOM   451 C CB  . ASP A 1 58 ? 23.461 17.331 16.741 1.00 8.41  ? 58  ASP A CB  1 
+ATOM   452 C CG  . ASP A 1 58 ? 24.184 16.016 16.619 1.00 11.50 ? 58  ASP A CG  1 
+ATOM   453 O OD1 . ASP A 1 58 ? 25.303 15.894 17.152 1.00 10.05 ? 58  ASP A OD1 1 
+ATOM   454 O OD2 . ASP A 1 58 ? 23.572 15.107 15.975 1.00 11.70 ? 58  ASP A OD2 1 
+ATOM   455 N N   . TYR A 1 59 ? 21.846 19.954 15.905 1.00 7.97  ? 59  TYR A N   1 
+ATOM   456 C CA  . TYR A 1 59 ? 21.079 21.149 16.251 1.00 8.45  ? 59  TYR A CA  1 
+ATOM   457 C C   . TYR A 1 59 ? 20.142 21.590 15.149 1.00 10.98 ? 59  TYR A C   1 
+ATOM   458 O O   . TYR A 1 59 ? 19.499 22.645 15.321 1.00 12.95 ? 59  TYR A O   1 
+ATOM   459 C CB  . TYR A 1 59 ? 22.085 22.254 16.581 1.00 7.94  ? 59  TYR A CB  1 
+ATOM   460 C CG  . TYR A 1 59 ? 22.945 21.951 17.785 1.00 6.91  ? 59  TYR A CG  1 
+ATOM   461 C CD1 . TYR A 1 59 ? 24.272 21.544 17.644 1.00 4.59  ? 59  TYR A CD1 1 
+ATOM   462 C CD2 . TYR A 1 59 ? 22.437 22.157 19.065 1.00 6.98  ? 59  TYR A CD2 1 
+ATOM   463 C CE1 . TYR A 1 59 ? 25.052 21.285 18.776 1.00 5.39  ? 59  TYR A CE1 1 
+ATOM   464 C CE2 . TYR A 1 59 ? 23.204 21.907 20.192 1.00 6.52  ? 59  TYR A CE2 1 
+ATOM   465 C CZ  . TYR A 1 59 ? 24.517 21.470 20.030 1.00 6.76  ? 59  TYR A CZ  1 
+ATOM   466 O OH  . TYR A 1 59 ? 25.248 21.302 21.191 1.00 7.63  ? 59  TYR A OH  1 
+ATOM   467 N N   . ASN A 1 60 ? 19.993 20.884 14.049 1.00 12.38 ? 60  ASN A N   1 
+ATOM   468 C CA  . ASN A 1 60 ? 19.065 21.352 12.999 1.00 13.94 ? 60  ASN A CA  1 
+ATOM   469 C C   . ASN A 1 60 ? 19.442 22.745 12.510 1.00 14.16 ? 60  ASN A C   1 
+ATOM   470 O O   . ASN A 1 60 ? 18.571 23.610 12.289 1.00 14.26 ? 60  ASN A O   1 
+ATOM   471 C CB  . ASN A 1 60 ? 17.586 21.282 13.461 1.00 19.23 ? 60  ASN A CB  1 
+ATOM   472 C CG  . ASN A 1 60 ? 16.576 21.258 12.315 1.00 22.65 ? 60  ASN A CG  1 
+ATOM   473 O OD1 . ASN A 1 60 ? 15.440 21.819 12.378 1.00 25.45 ? 60  ASN A OD1 1 
+ATOM   474 N ND2 . ASN A 1 60 ? 16.924 20.586 11.216 1.00 24.09 ? 60  ASN A ND2 1 
+ATOM   475 N N   . ILE A 1 61 ? 20.717 22.964 12.260 1.00 11.08 ? 61  ILE A N   1 
+ATOM   476 C CA  . ILE A 1 61 ? 21.184 24.263 11.690 1.00 11.78 ? 61  ILE A CA  1 
+ATOM   477 C C   . ILE A 1 61 ? 21.110 24.111 10.173 1.00 13.74 ? 61  ILE A C   1 
+ATOM   478 O O   . ILE A 1 61 ? 21.841 23.198 9.686  1.00 14.60 ? 61  ILE A O   1 
+ATOM   479 C CB  . ILE A 1 61 ? 22.650 24.516 12.172 1.00 11.80 ? 61  ILE A CB  1 
+ATOM   480 C CG1 . ILE A 1 61 ? 22.662 24.819 13.699 1.00 11.56 ? 61  ILE A CG1 1 
+ATOM   481 C CG2 . ILE A 1 61 ? 23.376 25.645 11.409 1.00 13.29 ? 61  ILE A CG2 1 
+ATOM   482 C CD1 . ILE A 1 61 ? 24.123 24.981 14.195 1.00 11.42 ? 61  ILE A CD1 1 
+ATOM   483 N N   . GLN A 1 62 ? 20.291 24.875 9.507  1.00 13.97 ? 62  GLN A N   1 
+ATOM   484 C CA  . GLN A 1 62 ? 20.081 24.773 8.033  1.00 15.52 ? 62  GLN A CA  1 
+ATOM   485 C C   . GLN A 1 62 ? 20.822 25.914 7.332  1.00 13.94 ? 62  GLN A C   1 
+ATOM   486 O O   . GLN A 1 62 ? 21.323 26.830 8.008  1.00 12.15 ? 62  GLN A O   1 
+ATOM   487 C CB  . GLN A 1 62 ? 18.599 24.736 7.727  1.00 19.53 ? 62  GLN A CB  1 
+ATOM   488 C CG  . GLN A 1 62 ? 17.819 23.434 7.900  1.00 26.38 ? 62  GLN A CG  1 
+ATOM   489 C CD  . GLN A 1 62 ? 16.509 23.529 7.116  1.00 30.61 ? 62  GLN A CD  1 
+ATOM   490 O OE1 . GLN A 1 62 ? 15.446 22.980 7.433  1.00 33.23 ? 62  GLN A OE1 1 
+ATOM   491 N NE2 . GLN A 1 62 ? 16.539 24.293 6.009  1.00 32.71 ? 62  GLN A NE2 1 
+ATOM   492 N N   . LYS A 1 63 ? 20.924 25.862 6.006  1.00 11.73 ? 63  LYS A N   1 
+ATOM   493 C CA  . LYS A 1 63 ? 21.656 26.847 5.240  1.00 11.97 ? 63  LYS A CA  1 
+ATOM   494 C C   . LYS A 1 63 ? 21.127 28.240 5.574  1.00 10.41 ? 63  LYS A C   1 
+ATOM   495 O O   . LYS A 1 63 ? 19.958 28.465 5.842  1.00 9.59  ? 63  LYS A O   1 
+ATOM   496 C CB  . LYS A 1 63 ? 21.631 26.642 3.731  1.00 13.73 ? 63  LYS A CB  1 
+ATOM   497 C CG  . LYS A 1 63 ? 20.210 26.423 3.175  1.00 16.98 ? 63  LYS A CG  1 
+ATOM   498 C CD  . LYS A 1 63 ? 20.268 26.589 1.656  1.00 20.19 ? 63  LYS A CD  1 
+ATOM   499 C CE  . LYS A 1 63 ? 19.202 25.857 0.891  1.00 23.42 ? 63  LYS A CE  1 
+ATOM   500 N NZ  . LYS A 1 63 ? 17.884 26.544 1.075  1.00 25.97 ? 63  LYS A NZ  1 
+ATOM   501 N N   . GLU A 1 64 ? 22.099 29.163 5.605  1.00 10.04 ? 64  GLU A N   1 
+ATOM   502 C CA  . GLU A 1 64 ? 21.907 30.563 5.881  1.00 10.94 ? 64  GLU A CA  1 
+ATOM   503 C C   . GLU A 1 64 ? 21.466 30.953 7.261  1.00 9.74  ? 64  GLU A C   1 
+ATOM   504 O O   . GLU A 1 64 ? 21.066 32.112 7.533  1.00 9.42  ? 64  GLU A O   1 
+ATOM   505 C CB  . GLU A 1 64 ? 21.023 31.223 4.784  1.00 18.31 ? 64  GLU A CB  1 
+ATOM   506 C CG  . GLU A 1 64 ? 21.861 31.342 3.474  1.00 24.16 ? 64  GLU A CG  1 
+ATOM   507 C CD  . GLU A 1 64 ? 21.156 30.726 2.311  1.00 29.00 ? 64  GLU A CD  1 
+ATOM   508 O OE1 . GLU A 1 64 ? 19.942 30.793 2.170  1.00 31.72 ? 64  GLU A OE1 1 
+ATOM   509 O OE2 . GLU A 1 64 ? 21.954 30.152 1.535  1.00 32.61 ? 64  GLU A OE2 1 
+ATOM   510 N N   . SER A 1 65 ? 21.674 30.034 8.191  1.00 6.85  ? 65  SER A N   1 
+ATOM   511 C CA  . SER A 1 65 ? 21.419 30.253 9.620  1.00 6.90  ? 65  SER A CA  1 
+ATOM   512 C C   . SER A 1 65 ? 22.504 31.228 10.136 1.00 4.72  ? 65  SER A C   1 
+ATOM   513 O O   . SER A 1 65 ? 23.579 31.321 9.554  1.00 3.91  ? 65  SER A O   1 
+ATOM   514 C CB  . SER A 1 65 ? 21.637 28.923 10.353 1.00 7.28  ? 65  SER A CB  1 
+ATOM   515 O OG  . SER A 1 65 ? 20.544 28.047 10.059 1.00 10.56 ? 65  SER A OG  1 
+ATOM   516 N N   . THR A 1 66 ? 22.241 31.873 11.241 1.00 4.48  ? 66  THR A N   1 
+ATOM   517 C CA  . THR A 1 66 ? 23.212 32.762 11.891 1.00 3.80  ? 66  THR A CA  1 
+ATOM   518 C C   . THR A 1 66 ? 23.509 32.224 13.290 1.00 4.60  ? 66  THR A C   1 
+ATOM   519 O O   . THR A 1 66 ? 22.544 31.942 14.034 1.00 5.33  ? 66  THR A O   1 
+ATOM   520 C CB  . THR A 1 66 ? 22.699 34.267 11.985 1.00 2.85  ? 66  THR A CB  1 
+ATOM   521 O OG1 . THR A 1 66 ? 22.495 34.690 10.589 1.00 2.15  ? 66  THR A OG1 1 
+ATOM   522 C CG2 . THR A 1 66 ? 23.727 35.131 12.722 1.00 3.40  ? 66  THR A CG2 1 
+ATOM   523 N N   . LEU A 1 67 ? 24.790 32.021 13.618 1.00 4.17  ? 67  LEU A N   1 
+ATOM   524 C CA  . LEU A 1 67 ? 25.149 31.609 14.980 1.00 3.85  ? 67  LEU A CA  1 
+ATOM   525 C C   . LEU A 1 67 ? 25.698 32.876 15.669 1.00 3.80  ? 67  LEU A C   1 
+ATOM   526 O O   . LEU A 1 67 ? 26.158 33.730 14.894 1.00 5.54  ? 67  LEU A O   1 
+ATOM   527 C CB  . LEU A 1 67 ? 26.310 30.594 14.967 1.00 7.18  ? 67  LEU A CB  1 
+ATOM   528 C CG  . LEU A 1 67 ? 26.290 29.480 13.960 1.00 9.67  ? 67  LEU A CG  1 
+ATOM   529 C CD1 . LEU A 1 67 ? 27.393 28.442 14.229 1.00 8.12  ? 67  LEU A CD1 1 
+ATOM   530 C CD2 . LEU A 1 67 ? 24.942 28.807 13.952 1.00 11.66 ? 67  LEU A CD2 1 
+ATOM   531 N N   . HIS A 1 68 ? 25.621 32.945 16.950 1.00 2.94  ? 68  HIS A N   1 
+ATOM   532 C CA  . HIS A 1 68 ? 26.179 34.127 17.650 1.00 4.17  ? 68  HIS A CA  1 
+ATOM   533 C C   . HIS A 1 68 ? 27.475 33.651 18.304 1.00 5.32  ? 68  HIS A C   1 
+ATOM   534 O O   . HIS A 1 68 ? 27.507 32.587 18.958 1.00 7.70  ? 68  HIS A O   1 
+ATOM   535 C CB  . HIS A 1 68 ? 25.214 34.565 18.780 1.00 5.57  ? 68  HIS A CB  1 
+ATOM   536 C CG  . HIS A 1 68 ? 23.978 35.121 18.126 1.00 9.95  ? 68  HIS A CG  1 
+ATOM   537 N ND1 . HIS A 1 68 ? 23.853 36.432 17.781 1.00 13.74 ? 68  HIS A ND1 1 
+ATOM   538 C CD2 . HIS A 1 68 ? 22.824 34.514 17.782 1.00 12.79 ? 68  HIS A CD2 1 
+ATOM   539 C CE1 . HIS A 1 68 ? 22.674 36.627 17.200 1.00 14.75 ? 68  HIS A CE1 1 
+ATOM   540 N NE2 . HIS A 1 68 ? 22.045 35.455 17.173 1.00 16.30 ? 68  HIS A NE2 1 
+ATOM   541 N N   . LEU A 1 69 ? 28.525 34.447 18.189 1.00 5.29  ? 69  LEU A N   1 
+ATOM   542 C CA  . LEU A 1 69 ? 29.801 34.145 18.829 1.00 3.97  ? 69  LEU A CA  1 
+ATOM   543 C C   . LEU A 1 69 ? 30.052 35.042 20.004 1.00 5.07  ? 69  LEU A C   1 
+ATOM   544 O O   . LEU A 1 69 ? 30.105 36.305 19.788 1.00 4.34  ? 69  LEU A O   1 
+ATOM   545 C CB  . LEU A 1 69 ? 30.925 34.304 17.753 1.00 6.08  ? 69  LEU A CB  1 
+ATOM   546 C CG  . LEU A 1 69 ? 32.345 34.183 18.358 1.00 7.37  ? 69  LEU A CG  1 
+ATOM   547 C CD1 . LEU A 1 69 ? 32.555 32.783 18.870 1.00 6.87  ? 69  LEU A CD1 1 
+ATOM   548 C CD2 . LEU A 1 69 ? 33.361 34.491 17.245 1.00 9.96  ? 69  LEU A CD2 1 
+ATOM   549 N N   . VAL A 1 70 ? 30.124 34.533 21.191 1.00 4.29  ? 70  VAL A N   1 
+ATOM   550 C CA  . VAL A 1 70 ? 30.479 35.369 22.374 1.00 6.26  ? 70  VAL A CA  1 
+ATOM   551 C C   . VAL A 1 70 ? 31.901 34.910 22.728 1.00 9.22  ? 70  VAL A C   1 
+ATOM   552 O O   . VAL A 1 70 ? 32.190 33.696 22.635 1.00 9.36  ? 70  VAL A O   1 
+ATOM   553 C CB  . VAL A 1 70 ? 29.472 35.181 23.498 1.00 8.69  ? 70  VAL A CB  1 
+ATOM   554 C CG1 . VAL A 1 70 ? 29.821 35.957 24.765 1.00 9.76  ? 70  VAL A CG1 1 
+ATOM   555 C CG2 . VAL A 1 70 ? 28.049 35.454 23.071 1.00 8.54  ? 70  VAL A CG2 1 
+ATOM   556 N N   . LEU A 1 71 ? 32.763 35.831 23.090 1.00 12.71 ? 71  LEU A N   1 
+ATOM   557 C CA  . LEU A 1 71 ? 34.145 35.472 23.481 1.00 16.06 ? 71  LEU A CA  1 
+ATOM   558 C C   . LEU A 1 71 ? 34.239 35.353 24.979 1.00 18.09 ? 71  LEU A C   1 
+ATOM   559 O O   . LEU A 1 71 ? 33.707 36.197 25.728 1.00 19.26 ? 71  LEU A O   1 
+ATOM   560 C CB  . LEU A 1 71 ? 35.114 36.564 22.907 1.00 17.10 ? 71  LEU A CB  1 
+ATOM   561 C CG  . LEU A 1 71 ? 35.926 35.979 21.737 1.00 19.37 ? 71  LEU A CG  1 
+ATOM   562 C CD1 . LEU A 1 71 ? 35.003 35.084 20.920 1.00 17.51 ? 71  LEU A CD1 1 
+ATOM   563 C CD2 . LEU A 1 71 ? 36.533 37.087 20.917 1.00 19.57 ? 71  LEU A CD2 1 
+ATOM   564 N N   . ARG A 1 72 ? 34.930 34.384 25.451 1.00 21.47 ? 72  ARG A N   1 
+ATOM   565 C CA  . ARG A 1 72 ? 35.161 34.174 26.896 1.00 25.83 ? 72  ARG A CA  1 
+ATOM   566 C C   . ARG A 1 72 ? 36.671 34.296 27.089 1.00 27.74 ? 72  ARG A C   1 
+ATOM   567 O O   . ARG A 1 72 ? 37.305 33.233 26.795 1.00 30.65 ? 72  ARG A O   1 
+ATOM   568 C CB  . ARG A 1 72 ? 34.717 32.760 27.286 1.00 28.49 ? 72  ARG A CB  1 
+ATOM   569 C CG  . ARG A 1 72 ? 35.752 32.054 28.160 1.00 31.79 ? 72  ARG A CG  1 
+ATOM   570 C CD  . ARG A 1 72 ? 35.612 30.577 28.044 1.00 34.05 ? 72  ARG A CD  1 
+ATOM   571 N NE  . ARG A 1 72 ? 35.040 30.252 26.730 1.00 35.08 ? 72  ARG A NE  1 
+ATOM   572 C CZ  . ARG A 1 72 ? 34.338 29.103 26.650 1.00 34.67 ? 72  ARG A CZ  1 
+ATOM   573 N NH1 . ARG A 1 72 ? 34.110 28.437 27.768 1.00 35.02 ? 72  ARG A NH1 1 
+ATOM   574 N NH2 . ARG A 1 72 ? 34.014 28.657 25.457 1.00 34.97 ? 72  ARG A NH2 1 
+ATOM   575 N N   . LEU A 1 73 ? 37.197 35.397 27.513 0.45 28.93 ? 73  LEU A N   1 
+ATOM   576 C CA  . LEU A 1 73 ? 38.668 35.502 27.680 0.45 30.76 ? 73  LEU A CA  1 
+ATOM   577 C C   . LEU A 1 73 ? 39.076 34.931 29.031 0.45 32.18 ? 73  LEU A C   1 
+ATOM   578 O O   . LEU A 1 73 ? 38.297 34.946 29.996 0.45 32.31 ? 73  LEU A O   1 
+ATOM   579 C CB  . LEU A 1 73 ? 39.080 36.941 27.406 0.45 30.53 ? 73  LEU A CB  1 
+ATOM   580 C CG  . LEU A 1 73 ? 39.502 37.340 26.002 0.45 30.16 ? 73  LEU A CG  1 
+ATOM   581 C CD1 . LEU A 1 73 ? 38.684 36.647 24.923 0.45 29.57 ? 73  LEU A CD1 1 
+ATOM   582 C CD2 . LEU A 1 73 ? 39.337 38.854 25.862 0.45 29.11 ? 73  LEU A CD2 1 
+ATOM   583 N N   . ARG A 1 74 ? 40.294 34.412 29.045 0.45 33.82 ? 74  ARG A N   1 
+ATOM   584 C CA  . ARG A 1 74 ? 40.873 33.802 30.253 0.45 35.33 ? 74  ARG A CA  1 
+ATOM   585 C C   . ARG A 1 74 ? 41.765 34.829 30.944 0.45 36.22 ? 74  ARG A C   1 
+ATOM   586 O O   . ARG A 1 74 ? 42.945 34.994 30.583 0.45 36.70 ? 74  ARG A O   1 
+ATOM   587 C CB  . ARG A 1 74 ? 41.651 32.529 29.923 0.45 36.91 ? 74  ARG A CB  1 
+ATOM   588 C CG  . ARG A 1 74 ? 41.608 31.444 30.989 0.45 38.62 ? 74  ARG A CG  1 
+ATOM   589 C CD  . ARG A 1 74 ? 41.896 30.080 30.456 0.45 39.75 ? 74  ARG A CD  1 
+ATOM   590 N NE  . ARG A 1 74 ? 43.311 29.735 30.563 0.45 41.13 ? 74  ARG A NE  1 
+ATOM   591 C CZ  . ARG A 1 74 ? 44.174 29.905 29.554 0.45 41.91 ? 74  ARG A CZ  1 
+ATOM   592 N NH1 . ARG A 1 74 ? 43.754 30.312 28.356 0.45 42.75 ? 74  ARG A NH1 1 
+ATOM   593 N NH2 . ARG A 1 74 ? 45.477 29.726 29.763 0.45 41.93 ? 74  ARG A NH2 1 
+ATOM   594 N N   . GLY A 1 75 ? 41.165 35.531 31.898 0.25 36.31 ? 75  GLY A N   1 
+ATOM   595 C CA  . GLY A 1 75 ? 41.845 36.550 32.686 0.25 36.07 ? 75  GLY A CA  1 
+ATOM   596 C C   . GLY A 1 75 ? 41.251 37.941 32.588 0.25 36.16 ? 75  GLY A C   1 
+ATOM   597 O O   . GLY A 1 75 ? 41.102 38.523 31.500 0.25 36.26 ? 75  GLY A O   1 
+ATOM   598 N N   . GLY A 1 76 ? 40.946 38.472 33.757 0.25 36.05 ? 76  GLY A N   1 
+ATOM   599 C CA  . GLY A 1 76 ? 40.373 39.813 33.944 0.25 36.19 ? 76  GLY A CA  1 
+ATOM   600 C C   . GLY A 1 76 ? 40.031 39.992 35.432 0.25 36.20 ? 76  GLY A C   1 
+ATOM   601 O O   . GLY A 1 76 ? 38.933 40.525 35.687 0.25 36.13 ? 76  GLY A O   1 
+ATOM   602 O OXT . GLY A 1 76 ? 40.862 39.575 36.251 0.25 36.27 ? 76  GLY A OXT 1 
+HETATM 603 O O   . HOH B 2 .  ? 45.747 30.081 19.708 1.00 12.43 ? 77  HOH A O   1 
+HETATM 604 O O   . HOH B 2 .  ? 19.168 31.868 17.050 1.00 12.65 ? 78  HOH A O   1 
+HETATM 605 O O   . HOH B 2 .  ? 32.010 38.387 19.636 1.00 12.83 ? 79  HOH A O   1 
+HETATM 606 O O   . HOH B 2 .  ? 42.084 27.361 21.953 1.00 22.27 ? 80  HOH A O   1 
+HETATM 607 O O   . HOH B 2 .  ? 21.314 20.644 8.719  1.00 18.33 ? 81  HOH A O   1 
+HETATM 608 O O   . HOH B 2 .  ? 31.965 38.637 3.699  1.00 31.69 ? 82  HOH A O   1 
+HETATM 609 O O   . HOH B 2 .  ? 27.707 15.908 4.653  1.00 20.30 ? 83  HOH A O   1 
+HETATM 610 O O   . HOH B 2 .  ? 19.969 32.720 14.769 1.00 10.14 ? 84  HOH A O   1 
+HETATM 611 O O   . HOH B 2 .  ? 29.847 13.577 10.864 1.00 29.65 ? 85  HOH A O   1 
+HETATM 612 O O   . HOH B 2 .  ? 23.893 27.864 1.501  1.00 23.48 ? 86  HOH A O   1 
+HETATM 613 O O   . HOH B 2 .  ? 19.638 23.312 4.775  1.00 18.40 ? 87  HOH A O   1 
+HETATM 614 O O   . HOH B 2 .  ? 34.628 29.369 4.779  1.00 26.17 ? 88  HOH A O   1 
+HETATM 615 O O   . HOH B 2 .  ? 42.240 24.744 25.707 1.00 31.34 ? 89  HOH A O   1 
+HETATM 616 O O   . HOH B 2 .  ? 30.290 42.500 8.820  1.00 16.49 ? 90  HOH A O   1 
+HETATM 617 O O   . HOH B 2 .  ? 24.512 39.162 10.841 1.00 13.14 ? 91  HOH A O   1 
+HETATM 618 O O   . HOH B 2 .  ? 26.557 43.450 19.940 1.00 19.38 ? 92  HOH A O   1 
+HETATM 619 O O   . HOH B 2 .  ? 42.535 22.385 13.872 1.00 29.35 ? 93  HOH A O   1 
+HETATM 620 O O   . HOH B 2 .  ? 42.440 26.381 12.686 1.00 29.46 ? 94  HOH A O   1 
+HETATM 621 O O   . HOH B 2 .  ? 22.651 14.457 13.085 1.00 22.07 ? 95  HOH A O   1 
+HETATM 622 O O   . HOH B 2 .  ? 35.325 26.551 23.202 1.00 15.20 ? 96  HOH A O   1 
+HETATM 623 O O   . HOH B 2 .  ? 23.629 20.940 3.146  1.00 15.45 ? 97  HOH A O   1 
+HETATM 624 O O   . HOH B 2 .  ? 25.928 21.774 2.325  1.00 13.70 ? 98  HOH A O   1 
+HETATM 625 O O   . HOH B 2 .  ? 33.388 21.973 5.659  1.00 24.89 ? 99  HOH A O   1 
+HETATM 626 O O   . HOH B 2 .  ? 18.326 23.911 17.697 1.00 24.10 ? 100 HOH A O   1 
+HETATM 627 O O   . HOH B 2 .  ? 18.160 27.072 10.662 1.00 20.76 ? 101 HOH A O   1 
+HETATM 628 O O   . HOH B 2 .  ? 34.746 17.167 18.219 1.00 32.86 ? 102 HOH A O   1 
+HETATM 629 O O   . HOH B 2 .  ? 19.801 32.364 20.210 1.00 21.09 ? 103 HOH A O   1 
+HETATM 630 O O   . HOH B 2 .  ? 30.285 26.829 22.191 1.00 8.56  ? 104 HOH A O   1 
+HETATM 631 O O   . HOH B 2 .  ? 44.612 32.306 16.961 1.00 7.69  ? 105 HOH A O   1 
+HETATM 632 O O   . HOH B 2 .  ? 16.287 25.999 13.142 0.78 28.90 ? 106 HOH A O   1 
+HETATM 633 O O   . HOH B 2 .  ? 27.101 42.135 15.494 0.51 23.36 ? 107 HOH A O   1 
+HETATM 634 O O   . HOH B 2 .  ? 37.209 23.795 21.367 0.74 27.88 ? 108 HOH A O   1 
+HETATM 635 O O   . HOH B 2 .  ? 19.582 32.034 -0.685 0.49 22.24 ? 109 HOH A O   1 
+HETATM 636 O O   . HOH B 2 .  ? 28.824 25.094 0.886  0.77 36.99 ? 110 HOH A O   1 
+HETATM 637 O O   . HOH B 2 .  ? 25.146 19.162 25.323 0.87 36.70 ? 111 HOH A O   1 
+HETATM 638 O O   . HOH B 2 .  ? 20.747 37.769 14.674 0.85 29.64 ? 112 HOH A O   1 
+HETATM 639 O O   . HOH B 2 .  ? 16.035 17.841 8.765  0.61 23.89 ? 113 HOH A O   1 
+HETATM 640 O O   . HOH B 2 .  ? 35.712 46.814 12.926 0.48 27.11 ? 114 HOH A O   1 
+HETATM 641 O O   . HOH B 2 .  ? 15.570 27.475 7.482  0.51 24.18 ? 115 HOH A O   1 
+HETATM 642 O O   . HOH B 2 .  ? 33.447 21.075 2.918  0.59 26.03 ? 116 HOH A O   1 
+HETATM 643 O O   . HOH B 2 .  ? 41.116 39.021 13.061 0.63 22.39 ? 117 HOH A O   1 
+HETATM 644 O O   . HOH B 2 .  ? 32.346 13.689 18.912 0.48 24.09 ? 118 HOH A O   1 
+HETATM 645 O O   . HOH B 2 .  ? 31.197 13.048 7.920  0.71 29.54 ? 119 HOH A O   1 
+HETATM 646 O O   . HOH B 2 .  ? 42.853 39.375 29.308 0.64 46.90 ? 120 HOH A O   1 
+HETATM 647 O O   . HOH B 2 .  ? 39.646 23.959 9.699  0.41 18.25 ? 121 HOH A O   1 
+HETATM 648 O O   . HOH B 2 .  ? 34.405 45.181 13.420 0.87 26.13 ? 122 HOH A O   1 
+HETATM 649 O O   . HOH B 2 .  ? 26.517 24.300 27.592 0.41 21.02 ? 123 HOH A O   1 
+HETATM 650 O O   . HOH B 2 .  ? 40.740 38.734 9.602  0.45 16.60 ? 124 HOH A O   1 
+HETATM 651 O O   . HOH B 2 .  ? 31.494 18.276 23.170 0.67 26.53 ? 125 HOH A O   1 
+HETATM 652 O O   . HOH B 2 .  ? 37.752 30.947 1.059  0.87 32.52 ? 126 HOH A O   1 
+HETATM 653 O O   . HOH B 2 .  ? 31.771 16.941 7.511  0.64 15.94 ? 127 HOH A O   1 
+HETATM 654 O O   . HOH B 2 .  ? 41.628 24.537 10.145 0.57 22.53 ? 128 HOH A O   1 
+HETATM 655 O O   . HOH B 2 .  ? 28.988 22.175 -1.744 0.56 29.32 ? 129 HOH A O   1 
+HETATM 656 O O   . HOH B 2 .  ? 14.882 16.539 10.692 0.53 24.82 ? 130 HOH A O   1 
+HETATM 657 O O   . HOH B 2 .  ? 32.589 40.385 7.523  0.36 26.01 ? 131 HOH A O   1 
+HETATM 658 O O   . HOH B 2 .  ? 38.363 30.369 5.579  0.49 35.45 ? 132 HOH A O   1 
+HETATM 659 O O   . HOH B 2 .  ? 27.841 46.062 17.589 0.81 32.15 ? 133 HOH A O   1 
+HETATM 660 O O   . HOH B 2 .  ? 37.667 43.421 17.000 0.50 33.32 ? 134 HOH A O   1 
+# 

--- a/openfold3/tests/test_data/mmcifs/7l39.cif
+++ b/openfold3/tests/test_data/mmcifs/7l39.cif
@@ -1,0 +1,5553 @@
+data_7L39
+# 
+_entry.id   7L39 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.380 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+_database_2.pdbx_database_accession 
+_database_2.pdbx_DOI 
+PDB   7L39         pdb_00007l39 10.2210/pdb7l39/pdb 
+WWPDB D_1000253633 ?            ?                   
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.entry_id                        7L39 
+_pdbx_database_status.recvd_initial_deposition_date   2020-12-17 
+_pdbx_database_status.SG_entry                        N 
+_pdbx_database_status.deposit_site                    RCSB 
+_pdbx_database_status.process_site                    RCSB 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.status_code_nmr_data            ? 
+_pdbx_database_status.methods_development_category    ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+_audit_author.identifier_ORCID 
+'Fischer, M.'      1 0000-0002-7179-2581 
+'Bradford, S.Y.C.' 2 0000-0002-5639-549X 
+# 
+_citation.abstract                  ? 
+_citation.abstract_id_CAS           ? 
+_citation.book_id_ISBN              ? 
+_citation.book_publisher            ? 
+_citation.book_publisher_city       ? 
+_citation.book_title                ? 
+_citation.coordinate_linkage        ? 
+_citation.country                   UK 
+_citation.database_id_Medline       ? 
+_citation.details                   ? 
+_citation.id                        primary 
+_citation.journal_abbrev            'Chem Sci' 
+_citation.journal_id_ASTM           ? 
+_citation.journal_id_CSD            ? 
+_citation.journal_id_ISSN           2041-6520 
+_citation.journal_full              ? 
+_citation.journal_issue             ? 
+_citation.journal_volume            12 
+_citation.language                  ? 
+_citation.page_first                11275 
+_citation.page_last                 11293 
+_citation.title                     'Temperature artifacts in protein structures bias ligand-binding predictions.' 
+_citation.year                      2021 
+_citation.database_id_CSD           ? 
+_citation.pdbx_database_id_DOI      10.1039/d1sc02751d 
+_citation.pdbx_database_id_PubMed   34667539 
+_citation.unpublished_flag          ? 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+_citation_author.identifier_ORCID 
+primary 'Bradford, S.Y.C.' 1 0000-0002-5639-549X 
+primary 'El Khoury, L.'    2 0000-0003-3157-9425 
+primary 'Ge, Y.'           3 0000-0002-3946-1440 
+primary 'Osato, M.'        4 0000-0002-2732-457X 
+primary 'Mobley, D.L.'     5 0000-0002-1083-5533 
+primary 'Fischer, M.'      6 0000-0002-7179-2581 
+# 
+_cell.angle_alpha                  90.000 
+_cell.angle_alpha_esd              ? 
+_cell.angle_beta                   90.000 
+_cell.angle_beta_esd               ? 
+_cell.angle_gamma                  120.000 
+_cell.angle_gamma_esd              ? 
+_cell.entry_id                     7L39 
+_cell.details                      ? 
+_cell.formula_units_Z              ? 
+_cell.length_a                     61.016 
+_cell.length_a_esd                 ? 
+_cell.length_b                     61.016 
+_cell.length_b_esd                 ? 
+_cell.length_c                     98.051 
+_cell.length_c_esd                 ? 
+_cell.volume                       ? 
+_cell.volume_esd                   ? 
+_cell.Z_PDB                        6 
+_cell.reciprocal_angle_alpha       ? 
+_cell.reciprocal_angle_beta        ? 
+_cell.reciprocal_angle_gamma       ? 
+_cell.reciprocal_angle_alpha_esd   ? 
+_cell.reciprocal_angle_beta_esd    ? 
+_cell.reciprocal_angle_gamma_esd   ? 
+_cell.reciprocal_length_a          ? 
+_cell.reciprocal_length_b          ? 
+_cell.reciprocal_length_c          ? 
+_cell.reciprocal_length_a_esd      ? 
+_cell.reciprocal_length_b_esd      ? 
+_cell.reciprocal_length_c_esd      ? 
+_cell.pdbx_unique_axis             ? 
+# 
+_symmetry.entry_id                         7L39 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                154 
+_symmetry.space_group_name_Hall            ? 
+_symmetry.space_group_name_H-M             'P 32 2 1' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     man Endolysin                                18620.387 1  3.2.1.17 R12G/I137R/L99A ? ? 
+2 non-polymer syn 2-AMINO-2-HYDROXYMETHYL-PROPANE-1,3-DIOL 122.143   1  ?        ?               ? ? 
+3 non-polymer syn 'CHLORIDE ION'                           35.453    1  ?        ?               ? ? 
+4 non-polymer syn TOLUENE                                  92.138    1  ?        ?               ? ? 
+5 non-polymer syn BETA-MERCAPTOETHANOL                     78.133    1  ?        ?               ? ? 
+6 water       nat water                                    18.015    90 ?        ?               ? ? 
+# 
+_entity_name_com.entity_id   1 
+_entity_name_com.name        'Lysis protein,Lysozyme,Muramidase' 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;MNIFEMLRIDEGLRLKIYKDTEGYYTIGIGHLLTKSPSLNAAKSELDKAIGRNCNGVITKDEAEKLFNQDVDAAVRGILR
+NAKLKPVYDSLDAVRRCAAINMVFQMGETGVAGFTNSLRMLQQKRWDEAAVNLAKSRWYNQTPNRAKRVITTFRTGTWDA
+YKNL
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;MNIFEMLRIDEGLRLKIYKDTEGYYTIGIGHLLTKSPSLNAAKSELDKAIGRNCNGVITKDEAEKLFNQDVDAAVRGILR
+NAKLKPVYDSLDAVRRCAAINMVFQMGETGVAGFTNSLRMLQQKRWDEAAVNLAKSRWYNQTPNRAKRVITTFRTGTWDA
+YKNL
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   MET n 
+1 2   ASN n 
+1 3   ILE n 
+1 4   PHE n 
+1 5   GLU n 
+1 6   MET n 
+1 7   LEU n 
+1 8   ARG n 
+1 9   ILE n 
+1 10  ASP n 
+1 11  GLU n 
+1 12  GLY n 
+1 13  LEU n 
+1 14  ARG n 
+1 15  LEU n 
+1 16  LYS n 
+1 17  ILE n 
+1 18  TYR n 
+1 19  LYS n 
+1 20  ASP n 
+1 21  THR n 
+1 22  GLU n 
+1 23  GLY n 
+1 24  TYR n 
+1 25  TYR n 
+1 26  THR n 
+1 27  ILE n 
+1 28  GLY n 
+1 29  ILE n 
+1 30  GLY n 
+1 31  HIS n 
+1 32  LEU n 
+1 33  LEU n 
+1 34  THR n 
+1 35  LYS n 
+1 36  SER n 
+1 37  PRO n 
+1 38  SER n 
+1 39  LEU n 
+1 40  ASN n 
+1 41  ALA n 
+1 42  ALA n 
+1 43  LYS n 
+1 44  SER n 
+1 45  GLU n 
+1 46  LEU n 
+1 47  ASP n 
+1 48  LYS n 
+1 49  ALA n 
+1 50  ILE n 
+1 51  GLY n 
+1 52  ARG n 
+1 53  ASN n 
+1 54  CYS n 
+1 55  ASN n 
+1 56  GLY n 
+1 57  VAL n 
+1 58  ILE n 
+1 59  THR n 
+1 60  LYS n 
+1 61  ASP n 
+1 62  GLU n 
+1 63  ALA n 
+1 64  GLU n 
+1 65  LYS n 
+1 66  LEU n 
+1 67  PHE n 
+1 68  ASN n 
+1 69  GLN n 
+1 70  ASP n 
+1 71  VAL n 
+1 72  ASP n 
+1 73  ALA n 
+1 74  ALA n 
+1 75  VAL n 
+1 76  ARG n 
+1 77  GLY n 
+1 78  ILE n 
+1 79  LEU n 
+1 80  ARG n 
+1 81  ASN n 
+1 82  ALA n 
+1 83  LYS n 
+1 84  LEU n 
+1 85  LYS n 
+1 86  PRO n 
+1 87  VAL n 
+1 88  TYR n 
+1 89  ASP n 
+1 90  SER n 
+1 91  LEU n 
+1 92  ASP n 
+1 93  ALA n 
+1 94  VAL n 
+1 95  ARG n 
+1 96  ARG n 
+1 97  CYS n 
+1 98  ALA n 
+1 99  ALA n 
+1 100 ILE n 
+1 101 ASN n 
+1 102 MET n 
+1 103 VAL n 
+1 104 PHE n 
+1 105 GLN n 
+1 106 MET n 
+1 107 GLY n 
+1 108 GLU n 
+1 109 THR n 
+1 110 GLY n 
+1 111 VAL n 
+1 112 ALA n 
+1 113 GLY n 
+1 114 PHE n 
+1 115 THR n 
+1 116 ASN n 
+1 117 SER n 
+1 118 LEU n 
+1 119 ARG n 
+1 120 MET n 
+1 121 LEU n 
+1 122 GLN n 
+1 123 GLN n 
+1 124 LYS n 
+1 125 ARG n 
+1 126 TRP n 
+1 127 ASP n 
+1 128 GLU n 
+1 129 ALA n 
+1 130 ALA n 
+1 131 VAL n 
+1 132 ASN n 
+1 133 LEU n 
+1 134 ALA n 
+1 135 LYS n 
+1 136 SER n 
+1 137 ARG n 
+1 138 TRP n 
+1 139 TYR n 
+1 140 ASN n 
+1 141 GLN n 
+1 142 THR n 
+1 143 PRO n 
+1 144 ASN n 
+1 145 ARG n 
+1 146 ALA n 
+1 147 LYS n 
+1 148 ARG n 
+1 149 VAL n 
+1 150 ILE n 
+1 151 THR n 
+1 152 THR n 
+1 153 PHE n 
+1 154 ARG n 
+1 155 THR n 
+1 156 GLY n 
+1 157 THR n 
+1 158 TRP n 
+1 159 ASP n 
+1 160 ALA n 
+1 161 TYR n 
+1 162 LYS n 
+1 163 ASN n 
+1 164 LEU n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      'Biological sequence' 
+_entity_src_gen.pdbx_beg_seq_num                   1 
+_entity_src_gen.pdbx_end_seq_num                   164 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     ? 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Enterobacteria phage T4' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     10665 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Escherichia coli' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     562 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    ENLYS_BPT4 
+_struct_ref.pdbx_db_accession          P00720 
+_struct_ref.pdbx_db_isoform            ? 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_seq_one_letter_code   
+;MNIFEMLRIDERLRLKIYKDTEGYYTIGIGHLLTKSPSLNAAKSELDKAIGRNCNGVITKDEAEKLFNQDVDAAVRGILR
+NAKLKPVYDSLDAVRRCALINMVFQMGETGVAGFTNSLRMLQQKRWDEAAVNLAKSIWYNQTPNRAKRVITTFRTGTWDA
+YKNL
+;
+_struct_ref.pdbx_align_begin           1 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              7L39 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 164 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P00720 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  164 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       164 
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 7L39 GLY A 12  ? UNP P00720 ARG 12  'engineered mutation' 12  1 
+1 7L39 ALA A 99  ? UNP P00720 LEU 99  'engineered mutation' 99  2 
+1 7L39 ARG A 137 ? UNP P00720 ILE 137 'engineered mutation' 137 3 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE                                  ?             'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE                                 ?             'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking' y ASPARAGINE                               ?             'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID'                          ?             'C4 H7 N O4'     133.103 
+BME non-polymer         . BETA-MERCAPTOETHANOL                     ?             'C2 H6 O S'      78.133  
+CL  non-polymer         . 'CHLORIDE ION'                           ?             'Cl -1'          35.453  
+CYS 'L-peptide linking' y CYSTEINE                                 ?             'C3 H7 N O2 S'   121.158 
+GLN 'L-peptide linking' y GLUTAMINE                                ?             'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID'                          ?             'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE                                  ?             'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking' y HISTIDINE                                ?             'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer         . WATER                                    ?             'H2 O'           18.015  
+ILE 'L-peptide linking' y ISOLEUCINE                               ?             'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE                                  ?             'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking' y LYSINE                                   ?             'C6 H15 N2 O2 1' 147.195 
+MBN non-polymer         . TOLUENE                                  ?             'C7 H8'          92.138  
+MET 'L-peptide linking' y METHIONINE                               ?             'C5 H11 N O2 S'  149.211 
+PHE 'L-peptide linking' y PHENYLALANINE                            ?             'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE                                  ?             'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE                                   ?             'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE                                ?             'C4 H9 N O3'     119.119 
+TRP 'L-peptide linking' y TRYPTOPHAN                               ?             'C11 H12 N2 O2'  204.225 
+TRS non-polymer         . 2-AMINO-2-HYDROXYMETHYL-PROPANE-1,3-DIOL 'TRIS BUFFER' 'C4 H12 N O3 1'  122.143 
+TYR 'L-peptide linking' y TYROSINE                                 ?             'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE                                   ?             'C5 H11 N O2'    117.146 
+# 
+_exptl.absorpt_coefficient_mu     ? 
+_exptl.absorpt_correction_T_max   ? 
+_exptl.absorpt_correction_T_min   ? 
+_exptl.absorpt_correction_type    ? 
+_exptl.absorpt_process_details    ? 
+_exptl.entry_id                   7L39 
+_exptl.crystals_number            1 
+_exptl.details                    ? 
+_exptl.method                     'X-RAY DIFFRACTION' 
+_exptl.method_details             ? 
+# 
+_exptl_crystal.colour                      ? 
+_exptl_crystal.density_diffrn              ? 
+_exptl_crystal.density_Matthews            2.83 
+_exptl_crystal.density_method              ? 
+_exptl_crystal.density_percent_sol         56.53 
+_exptl_crystal.description                 ? 
+_exptl_crystal.F_000                       ? 
+_exptl_crystal.id                          1 
+_exptl_crystal.preparation                 ? 
+_exptl_crystal.size_max                    ? 
+_exptl_crystal.size_mid                    ? 
+_exptl_crystal.size_min                    ? 
+_exptl_crystal.size_rad                    ? 
+_exptl_crystal.colour_lustre               ? 
+_exptl_crystal.colour_modifier             ? 
+_exptl_crystal.colour_primary              ? 
+_exptl_crystal.density_meas                ? 
+_exptl_crystal.density_meas_esd            ? 
+_exptl_crystal.density_meas_gt             ? 
+_exptl_crystal.density_meas_lt             ? 
+_exptl_crystal.density_meas_temp           ? 
+_exptl_crystal.density_meas_temp_esd       ? 
+_exptl_crystal.density_meas_temp_gt        ? 
+_exptl_crystal.density_meas_temp_lt        ? 
+_exptl_crystal.pdbx_crystal_image_url      ? 
+_exptl_crystal.pdbx_crystal_image_format   ? 
+_exptl_crystal.pdbx_mosaicity              ? 
+_exptl_crystal.pdbx_mosaicity_esd          ? 
+# 
+_exptl_crystal_grow.apparatus       ? 
+_exptl_crystal_grow.atmosphere      ? 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.details         ? 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, HANGING DROP' 
+_exptl_crystal_grow.method_ref      ? 
+_exptl_crystal_grow.pH              ? 
+_exptl_crystal_grow.pressure        ? 
+_exptl_crystal_grow.pressure_esd    ? 
+_exptl_crystal_grow.seeding         ? 
+_exptl_crystal_grow.seeding_ref     ? 
+_exptl_crystal_grow.temp            291 
+_exptl_crystal_grow.temp_details    291-293 
+_exptl_crystal_grow.temp_esd        ? 
+_exptl_crystal_grow.time            ? 
+_exptl_crystal_grow.pdbx_details    
+;Crystals were grown from a 10 mg/mL frozen protein solution by the hanging drop method at 291-293K, with a 1:1 drop ratio of protein to solution and over a well solution of 0.1 M Tris-hydrochloride (pH 8), 20%-26% (w/v) PEG 4000, 70-170 mM lithium citrate, 8%-18% 2-propanol, 50 mM 2-mercaptoethanol, and 50 mM 2-hydroxyethyl disulfide
+;
+_exptl_crystal_grow.pdbx_pH_range   ? 
+# 
+_diffrn.ambient_environment              ? 
+_diffrn.ambient_temp                     278 
+_diffrn.ambient_temp_details             RT 
+_diffrn.ambient_temp_esd                 ? 
+_diffrn.crystal_id                       1 
+_diffrn.crystal_support                  ? 
+_diffrn.crystal_treatment                ? 
+_diffrn.details                          ? 
+_diffrn.id                               1 
+_diffrn.ambient_pressure                 ? 
+_diffrn.ambient_pressure_esd             ? 
+_diffrn.ambient_pressure_gt              ? 
+_diffrn.ambient_pressure_lt              ? 
+_diffrn.ambient_temp_gt                  ? 
+_diffrn.ambient_temp_lt                  ? 
+_diffrn.pdbx_serial_crystal_experiment   N 
+# 
+_diffrn_detector.details                      ? 
+_diffrn_detector.detector                     PIXEL 
+_diffrn_detector.diffrn_id                    1 
+_diffrn_detector.type                         'DECTRIS EIGER X 16M' 
+_diffrn_detector.area_resol_mean              ? 
+_diffrn_detector.dtime                        ? 
+_diffrn_detector.pdbx_frames_total            ? 
+_diffrn_detector.pdbx_collection_time_total   ? 
+_diffrn_detector.pdbx_collection_date         2018-03-15 
+_diffrn_detector.pdbx_frequency               ? 
+# 
+_diffrn_radiation.collimation                      ? 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.filter_edge                      ? 
+_diffrn_radiation.inhomogeneity                    ? 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.polarisn_norm                    ? 
+_diffrn_radiation.polarisn_ratio                   ? 
+_diffrn_radiation.probe                            ? 
+_diffrn_radiation.type                             ? 
+_diffrn_radiation.xray_symbol                      ? 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.pdbx_wavelength_list             ? 
+_diffrn_radiation.pdbx_wavelength                  ? 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_analyzer                    ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   1 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.current                     ? 
+_diffrn_source.details                     ? 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.power                       ? 
+_diffrn_source.size                        ? 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.target                      ? 
+_diffrn_source.type                        'APS BEAMLINE 22-ID' 
+_diffrn_source.voltage                     ? 
+_diffrn_source.take-off_angle              ? 
+_diffrn_source.pdbx_wavelength_list        1 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_synchrotron_beamline   22-ID 
+_diffrn_source.pdbx_synchrotron_site       APS 
+# 
+_reflns.B_iso_Wilson_estimate            ? 
+_reflns.entry_id                         7L39 
+_reflns.data_reduction_details           ? 
+_reflns.data_reduction_method            ? 
+_reflns.d_resolution_high                1.350 
+_reflns.d_resolution_low                 46.520 
+_reflns.details                          ? 
+_reflns.limit_h_max                      ? 
+_reflns.limit_h_min                      ? 
+_reflns.limit_k_max                      ? 
+_reflns.limit_k_min                      ? 
+_reflns.limit_l_max                      ? 
+_reflns.limit_l_min                      ? 
+_reflns.number_all                       ? 
+_reflns.number_obs                       47088 
+_reflns.observed_criterion               ? 
+_reflns.observed_criterion_F_max         ? 
+_reflns.observed_criterion_F_min         ? 
+_reflns.observed_criterion_I_max         ? 
+_reflns.observed_criterion_I_min         ? 
+_reflns.observed_criterion_sigma_F       ? 
+_reflns.observed_criterion_sigma_I       ? 
+_reflns.percent_possible_obs             100.000 
+_reflns.R_free_details                   ? 
+_reflns.Rmerge_F_all                     ? 
+_reflns.Rmerge_F_obs                     ? 
+_reflns.Friedel_coverage                 ? 
+_reflns.number_gt                        ? 
+_reflns.threshold_expression             ? 
+_reflns.pdbx_redundancy                  6.600 
+_reflns.pdbx_Rmerge_I_obs                0.055 
+_reflns.pdbx_Rmerge_I_all                ? 
+_reflns.pdbx_Rsym_value                  ? 
+_reflns.pdbx_netI_over_av_sigmaI         ? 
+_reflns.pdbx_netI_over_sigmaI            13.2 
+_reflns.pdbx_res_netI_over_av_sigmaI_2   ? 
+_reflns.pdbx_res_netI_over_sigmaI_2      ? 
+_reflns.pdbx_chi_squared                 ? 
+_reflns.pdbx_scaling_rejects             ? 
+_reflns.pdbx_d_res_high_opt              ? 
+_reflns.pdbx_d_res_low_opt               ? 
+_reflns.pdbx_d_res_opt_method            ? 
+_reflns.phase_calculation_details        ? 
+_reflns.pdbx_Rrim_I_all                  ? 
+_reflns.pdbx_Rpim_I_all                  ? 
+_reflns.pdbx_d_opt                       ? 
+_reflns.pdbx_number_measured_all         ? 
+_reflns.pdbx_diffrn_id                   1 
+_reflns.pdbx_ordinal                     1 
+_reflns.pdbx_CC_half                     ? 
+_reflns.pdbx_CC_star                     ? 
+_reflns.pdbx_R_split                     ? 
+# 
+loop_
+_reflns_shell.d_res_high 
+_reflns_shell.d_res_low 
+_reflns_shell.meanI_over_sigI_all 
+_reflns_shell.meanI_over_sigI_obs 
+_reflns_shell.number_measured_all 
+_reflns_shell.number_measured_obs 
+_reflns_shell.number_possible 
+_reflns_shell.number_unique_all 
+_reflns_shell.number_unique_obs 
+_reflns_shell.percent_possible_all 
+_reflns_shell.percent_possible_obs 
+_reflns_shell.Rmerge_F_all 
+_reflns_shell.Rmerge_F_obs 
+_reflns_shell.Rmerge_I_all 
+_reflns_shell.Rmerge_I_obs 
+_reflns_shell.meanI_over_sigI_gt 
+_reflns_shell.meanI_over_uI_all 
+_reflns_shell.meanI_over_uI_gt 
+_reflns_shell.number_measured_gt 
+_reflns_shell.number_unique_gt 
+_reflns_shell.percent_possible_gt 
+_reflns_shell.Rmerge_F_gt 
+_reflns_shell.Rmerge_I_gt 
+_reflns_shell.pdbx_redundancy 
+_reflns_shell.pdbx_Rsym_value 
+_reflns_shell.pdbx_chi_squared 
+_reflns_shell.pdbx_netI_over_sigmaI_all 
+_reflns_shell.pdbx_netI_over_sigmaI_obs 
+_reflns_shell.pdbx_Rrim_I_all 
+_reflns_shell.pdbx_Rpim_I_all 
+_reflns_shell.pdbx_rejects 
+_reflns_shell.pdbx_ordinal 
+_reflns_shell.pdbx_diffrn_id 
+_reflns_shell.pdbx_CC_half 
+_reflns_shell.pdbx_CC_star 
+_reflns_shell.pdbx_R_split 
+1.350 1.390  ? ? ? ? ? ? 2283 100.000 ? ? ? ? 0.851 ? ? ? ? ? ? ? ? 6.500 ? ? ? ? ? ? ? 1 1 ? ? ? 
+6.040 46.520 ? ? ? ? ? ? 2567 99.900  ? ? ? ? 0.032 ? ? ? ? ? ? ? ? 6.100 ? ? ? ? ? ? ? 2 1 ? ? ? 
+# 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.B_iso_max                                67.070 
+_refine.B_iso_mean                               22.5415 
+_refine.B_iso_min                                12.200 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.details                                  ? 
+_refine.diff_density_max                         ? 
+_refine.diff_density_max_esd                     ? 
+_refine.diff_density_min                         ? 
+_refine.diff_density_min_esd                     ? 
+_refine.diff_density_rms                         ? 
+_refine.diff_density_rms_esd                     ? 
+_refine.entry_id                                 7L39 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.ls_abs_structure_details                 ? 
+_refine.ls_abs_structure_Flack                   ? 
+_refine.ls_abs_structure_Flack_esd               ? 
+_refine.ls_abs_structure_Rogers                  ? 
+_refine.ls_abs_structure_Rogers_esd              ? 
+_refine.ls_d_res_high                            1.3500 
+_refine.ls_d_res_low                             46.5170 
+_refine.ls_extinction_coef                       ? 
+_refine.ls_extinction_coef_esd                   ? 
+_refine.ls_extinction_expression                 ? 
+_refine.ls_extinction_method                     ? 
+_refine.ls_goodness_of_fit_all                   ? 
+_refine.ls_goodness_of_fit_all_esd               ? 
+_refine.ls_goodness_of_fit_obs                   ? 
+_refine.ls_goodness_of_fit_obs_esd               ? 
+_refine.ls_hydrogen_treatment                    ? 
+_refine.ls_matrix_type                           ? 
+_refine.ls_number_constraints                    ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_reflns_all                     ? 
+_refine.ls_number_reflns_obs                     46683 
+_refine.ls_number_reflns_R_free                  2376 
+_refine.ls_number_reflns_R_work                  44307 
+_refine.ls_number_restraints                     ? 
+_refine.ls_percent_reflns_obs                    99.2000 
+_refine.ls_percent_reflns_R_free                 5.0900 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_obs                          0.1507 
+_refine.ls_R_factor_R_free                       0.1670 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_R_factor_R_work                       0.1498 
+_refine.ls_R_Fsqd_factor_obs                     ? 
+_refine.ls_R_I_factor_obs                        ? 
+_refine.ls_redundancy_reflns_all                 ? 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.ls_restrained_S_all                      ? 
+_refine.ls_restrained_S_obs                      ? 
+_refine.ls_shift_over_esd_max                    ? 
+_refine.ls_shift_over_esd_mean                   ? 
+_refine.ls_structure_factor_coef                 ? 
+_refine.ls_weighting_details                     ? 
+_refine.ls_weighting_scheme                      ? 
+_refine.ls_wR_factor_all                         ? 
+_refine.ls_wR_factor_obs                         ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.occupancy_max                            ? 
+_refine.occupancy_min                            ? 
+_refine.solvent_model_details                    'FLAT BULK SOLVENT MODEL' 
+_refine.solvent_model_param_bsol                 ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.pdbx_R_complete                          ? 
+_refine.ls_R_factor_gt                           ? 
+_refine.ls_goodness_of_fit_gt                    ? 
+_refine.ls_goodness_of_fit_ref                   ? 
+_refine.ls_shift_over_su_max                     ? 
+_refine.ls_shift_over_su_max_lt                  ? 
+_refine.ls_shift_over_su_mean                    ? 
+_refine.ls_shift_over_su_mean_lt                 ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          1.330 
+_refine.pdbx_ls_sigma_Fsqd                       ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_ls_cross_valid_method               THROUGHOUT 
+_refine.pdbx_method_to_determine_struct          'MOLECULAR REPLACEMENT' 
+_refine.pdbx_starting_model                      4w51 
+_refine.pdbx_stereochemistry_target_values       ML 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.pdbx_solvent_vdw_probe_radii             1.1100 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             0.9000 
+_refine.pdbx_real_space_R                        ? 
+_refine.pdbx_density_correlation                 ? 
+_refine.pdbx_pd_number_of_powder_patterns        ? 
+_refine.pdbx_pd_number_of_points                 ? 
+_refine.pdbx_pd_meas_number_of_points            ? 
+_refine.pdbx_pd_proc_ls_prof_R_factor            ? 
+_refine.pdbx_pd_proc_ls_prof_wR_factor           ? 
+_refine.pdbx_pd_Marquardt_correlation_coeff      ? 
+_refine.pdbx_pd_Fsqrd_R_factor                   ? 
+_refine.pdbx_pd_ls_matrix_band_width             ? 
+_refine.pdbx_overall_phase_error                 19.6200 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.pdbx_diffrn_id                           1 
+_refine.overall_SU_B                             ? 
+_refine.overall_SU_ML                            0.1500 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_average_fsc_overall                 ? 
+_refine.pdbx_average_fsc_work                    ? 
+_refine.pdbx_average_fsc_free                    ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         final 
+_refine_hist.details                          ? 
+_refine_hist.d_res_high                       1.3500 
+_refine_hist.d_res_low                        46.5170 
+_refine_hist.number_atoms_solvent             90 
+_refine_hist.number_atoms_total               1406 
+_refine_hist.number_reflns_all                ? 
+_refine_hist.number_reflns_obs                ? 
+_refine_hist.number_reflns_R_free             ? 
+_refine_hist.number_reflns_R_work             ? 
+_refine_hist.R_factor_all                     ? 
+_refine_hist.R_factor_obs                     ? 
+_refine_hist.R_factor_R_free                  ? 
+_refine_hist.R_factor_R_work                  ? 
+_refine_hist.pdbx_number_residues_total       162 
+_refine_hist.pdbx_B_iso_mean_ligand           27.29 
+_refine_hist.pdbx_B_iso_mean_solvent          38.51 
+_refine_hist.pdbx_number_atoms_protein        1289 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         27 
+_refine_hist.pdbx_number_atoms_lipid          ? 
+_refine_hist.pdbx_number_atoms_carb           ? 
+_refine_hist.pdbx_pseudo_atom_details         ? 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+f_bond_d           0.005  ? ? 1534 'X-RAY DIFFRACTION' ? 
+f_angle_d          0.730  ? ? 2085 'X-RAY DIFFRACTION' ? 
+f_dihedral_angle_d 18.462 ? ? 596  'X-RAY DIFFRACTION' ? 
+f_chiral_restr     0.063  ? ? 226  'X-RAY DIFFRACTION' ? 
+f_plane_restr      0.004  ? ? 274  'X-RAY DIFFRACTION' ? 
+# 
+loop_
+_refine_ls_shell.pdbx_refine_id 
+_refine_ls_shell.d_res_high 
+_refine_ls_shell.d_res_low 
+_refine_ls_shell.number_reflns_all 
+_refine_ls_shell.number_reflns_obs 
+_refine_ls_shell.number_reflns_R_free 
+_refine_ls_shell.number_reflns_R_work 
+_refine_ls_shell.percent_reflns_obs 
+_refine_ls_shell.percent_reflns_R_free 
+_refine_ls_shell.R_factor_all 
+_refine_ls_shell.R_factor_obs 
+_refine_ls_shell.R_factor_R_free 
+_refine_ls_shell.R_factor_R_free_error 
+_refine_ls_shell.R_factor_R_work 
+_refine_ls_shell.redundancy_reflns_all 
+_refine_ls_shell.redundancy_reflns_obs 
+_refine_ls_shell.wR_factor_all 
+_refine_ls_shell.wR_factor_obs 
+_refine_ls_shell.wR_factor_R_free 
+_refine_ls_shell.wR_factor_R_work 
+_refine_ls_shell.pdbx_R_complete 
+_refine_ls_shell.pdbx_total_number_of_bins_used 
+_refine_ls_shell.pdbx_phase_error 
+_refine_ls_shell.pdbx_fsc_work 
+_refine_ls_shell.pdbx_fsc_free 
+'X-RAY DIFFRACTION' 1.35   1.3775 . . 111 2542 97.0000  . . . 0.3590 0.0000 0.3310 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.3775 1.4074 . . 120 2523 98.0000  . . . 0.3677 0.0000 0.3123 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.4074 1.4402 . . 149 2561 98.0000  . . . 0.3300 0.0000 0.3054 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.4402 1.4762 . . 140 2537 98.0000  . . . 0.3370 0.0000 0.2723 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.4762 1.5161 . . 152 2567 99.0000  . . . 0.2381 0.0000 0.2189 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.5161 1.5607 . . 137 2585 99.0000  . . . 0.2142 0.0000 0.1838 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.5607 1.6111 . . 132 2568 99.0000  . . . 0.2218 0.0000 0.1707 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.6111 1.6687 . . 147 2559 99.0000  . . . 0.2040 0.0000 0.1561 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.6687 1.7355 . . 135 2619 100.0000 . . . 0.1665 0.0000 0.1342 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.7355 1.8145 . . 162 2584 100.0000 . . . 0.1497 0.0000 0.1256 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.8145 1.9101 . . 135 2611 100.0000 . . . 0.1755 0.0000 0.1160 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 1.9101 2.0298 . . 124 2651 100.0000 . . . 0.1344 0.0000 0.1093 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 2.0298 2.1865 . . 130 2639 100.0000 . . . 0.1320 0.0000 0.1035 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 2.1865 2.4066 . . 156 2624 100.0000 . . . 0.1283 0.0000 0.1138 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 2.4066 2.7548 . . 147 2641 100.0000 . . . 0.1668 0.0000 0.1340 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 2.7548 3.4706 . . 163 2655 100.0000 . . . 0.1432 0.0000 0.1397 . . . . . . . . . . . 
+'X-RAY DIFFRACTION' 3.4706 46.517 . . 136 2841 100.0000 . . . 0.1573 0.0000 0.1634 . . . . . . . . . . . 
+# 
+_struct.entry_id                     7L39 
+_struct.title                        'T4 Lysozyme L99A - toluene - RT' 
+_struct.pdbx_model_details           ? 
+_struct.pdbx_formula_weight          ? 
+_struct.pdbx_formula_weight_method   ? 
+_struct.pdbx_model_type_details      ? 
+_struct.pdbx_CASP_flag               N 
+# 
+_struct_keywords.entry_id        7L39 
+_struct_keywords.text            'RT, toluene, L99A, HYDROLASE' 
+_struct_keywords.pdbx_keywords   HYDROLASE 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+D N N 4 ? 
+E N N 5 ? 
+F N N 6 ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 AA1 ASN A 2   ? GLY A 12  ? ASN A 2   GLY A 12  1 ? 11 
+HELX_P HELX_P2 AA2 SER A 38  ? GLY A 51  ? SER A 38  GLY A 51  1 ? 14 
+HELX_P HELX_P3 AA3 THR A 59  ? ASN A 81  ? THR A 59  ASN A 81  1 ? 23 
+HELX_P HELX_P4 AA4 LEU A 84  ? LEU A 91  ? LEU A 84  LEU A 91  1 ? 8  
+HELX_P HELX_P5 AA5 ASP A 92  ? ALA A 112 ? ASP A 92  ALA A 112 1 ? 21 
+HELX_P HELX_P6 AA6 PHE A 114 ? GLN A 123 ? PHE A 114 GLN A 123 1 ? 10 
+HELX_P HELX_P7 AA7 ARG A 125 ? LYS A 135 ? ARG A 125 LYS A 135 1 ? 11 
+HELX_P HELX_P8 AA8 SER A 136 ? THR A 142 ? SER A 136 THR A 142 1 ? 7  
+HELX_P HELX_P9 AA9 THR A 142 ? GLY A 156 ? THR A 142 GLY A 156 1 ? 15 
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+_struct_sheet.id               AA1 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   3 
+_struct_sheet.details          ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+AA1 1 2 ? anti-parallel 
+AA1 2 3 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+AA1 1 ARG A 14 ? LYS A 19 ? ARG A 14 LYS A 19 
+AA1 2 TYR A 25 ? GLY A 28 ? TYR A 25 GLY A 28 
+AA1 3 HIS A 31 ? THR A 34 ? HIS A 31 THR A 34 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+AA1 1 2 N TYR A 18 ? N TYR A 18 O THR A 26 ? O THR A 26 
+AA1 2 3 N TYR A 25 ? N TYR A 25 O LEU A 33 ? O LEU A 33 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+AC1 Software A TRS 201 ? 4 'binding site for residue TRS A 201' 
+AC2 Software A CL  202 ? 4 'binding site for residue CL A 202'  
+AC3 Software A MBN 203 ? 5 'binding site for residue MBN A 203' 
+AC4 Software A BME 204 ? 6 'binding site for residue BME A 204' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1  AC1 4 GLU A 11  ? GLU A 11  . ? 1_555 ? 
+2  AC1 4 GLY A 30  ? GLY A 30  . ? 1_555 ? 
+3  AC1 4 GLN A 105 ? GLN A 105 . ? 1_555 ? 
+4  AC1 4 HOH F .   ? HOH A 314 . ? 1_555 ? 
+5  AC2 4 LYS A 124 ? LYS A 124 . ? 4_565 ? 
+6  AC2 4 THR A 142 ? THR A 142 . ? 1_555 ? 
+7  AC2 4 ASN A 144 ? ASN A 144 . ? 1_555 ? 
+8  AC2 4 ARG A 145 ? ARG A 145 . ? 1_555 ? 
+9  AC3 5 LEU A 84  ? LEU A 84  . ? 1_555 ? 
+10 AC3 5 ALA A 99  ? ALA A 99  . ? 1_555 ? 
+11 AC3 5 VAL A 111 ? VAL A 111 . ? 1_555 ? 
+12 AC3 5 LEU A 118 ? LEU A 118 . ? 1_555 ? 
+13 AC3 5 PHE A 153 ? PHE A 153 . ? 1_555 ? 
+14 AC4 6 ASN A 68  ? ASN A 68  . ? 1_555 ? 
+15 AC4 6 ASP A 72  ? ASP A 72  . ? 1_555 ? 
+16 AC4 6 TYR A 88  ? TYR A 88  . ? 5_555 ? 
+17 AC4 6 ARG A 96  ? ARG A 96  . ? 5_555 ? 
+18 AC4 6 ILE A 100 ? ILE A 100 . ? 5_555 ? 
+19 AC4 6 HOH F .   ? HOH A 320 . ? 1_555 ? 
+# 
+_atom_sites.entry_id                    7L39 
+_atom_sites.Cartn_transf_matrix[1][1]   ? 
+_atom_sites.Cartn_transf_matrix[1][2]   ? 
+_atom_sites.Cartn_transf_matrix[1][3]   ? 
+_atom_sites.Cartn_transf_matrix[2][1]   ? 
+_atom_sites.Cartn_transf_matrix[2][2]   ? 
+_atom_sites.Cartn_transf_matrix[2][3]   ? 
+_atom_sites.Cartn_transf_matrix[3][1]   ? 
+_atom_sites.Cartn_transf_matrix[3][2]   ? 
+_atom_sites.Cartn_transf_matrix[3][3]   ? 
+_atom_sites.Cartn_transf_vector[1]      ? 
+_atom_sites.Cartn_transf_vector[2]      ? 
+_atom_sites.Cartn_transf_vector[3]      ? 
+_atom_sites.fract_transf_matrix[1][1]   0.016389 
+_atom_sites.fract_transf_matrix[1][2]   0.009462 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.018924 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.010199 
+_atom_sites.fract_transf_vector[1]      0.000000 
+_atom_sites.fract_transf_vector[2]      0.000000 
+_atom_sites.fract_transf_vector[3]      0.000000 
+_atom_sites.solution_primary            ? 
+_atom_sites.solution_secondary          ? 
+_atom_sites.solution_hydrogens          ? 
+_atom_sites.special_details             ? 
+# 
+loop_
+_atom_type.symbol 
+C  
+CL 
+N  
+O  
+S  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N  N   . MET A 1 1   ? -17.130 -3.128 9.281   1.00 33.00 ? 1   MET A N   1 
+ATOM   2    C  CA  . MET A 1 1   ? -17.735 -1.805 9.378   1.00 28.68 ? 1   MET A CA  1 
+ATOM   3    C  C   . MET A 1 1   ? -19.145 -1.883 9.938   1.00 24.17 ? 1   MET A C   1 
+ATOM   4    O  O   . MET A 1 1   ? -19.877 -2.841 9.721   1.00 27.28 ? 1   MET A O   1 
+ATOM   5    C  CB  . MET A 1 1   ? -17.780 -1.115 8.014   1.00 32.25 ? 1   MET A CB  1 
+ATOM   6    C  CG  . MET A 1 1   ? -16.442 -0.658 7.465   1.00 37.58 ? 1   MET A CG  1 
+ATOM   7    S  SD  . MET A 1 1   ? -15.981 0.973  8.075   1.00 44.11 ? 1   MET A SD  1 
+ATOM   8    C  CE  . MET A 1 1   ? -17.482 1.893  7.767   1.00 42.56 ? 1   MET A CE  1 
+ATOM   9    N  N   . ASN A 1 2   ? -19.519 -0.844 10.663  1.00 19.11 ? 2   ASN A N   1 
+ATOM   10   C  CA  . ASN A 1 2   ? -20.869 -0.698 11.183  1.00 16.82 ? 2   ASN A CA  1 
+ATOM   11   C  C   . ASN A 1 2   ? -21.185 0.793  11.190  1.00 14.74 ? 2   ASN A C   1 
+ATOM   12   O  O   . ASN A 1 2   ? -20.328 1.626  10.866  1.00 15.80 ? 2   ASN A O   1 
+ATOM   13   C  CB  . ASN A 1 2   ? -20.977 -1.328 12.577  1.00 17.68 ? 2   ASN A CB  1 
+ATOM   14   C  CG  . ASN A 1 2   ? -19.994 -0.718 13.565  1.00 18.57 ? 2   ASN A CG  1 
+ATOM   15   O  OD1 . ASN A 1 2   ? -20.013 0.493  13.802  1.00 19.19 ? 2   ASN A OD1 1 
+ATOM   16   N  ND2 . ASN A 1 2   ? -19.135 -1.550 14.148  1.00 21.45 ? 2   ASN A ND2 1 
+ATOM   17   N  N   . ILE A 1 3   ? -22.411 1.131  11.604  1.00 15.01 ? 3   ILE A N   1 
+ATOM   18   C  CA  . ILE A 1 3   ? -22.863 2.521  11.537  1.00 14.24 ? 3   ILE A CA  1 
+ATOM   19   C  C   . ILE A 1 3   ? -21.995 3.441  12.394  1.00 14.34 ? 3   ILE A C   1 
+ATOM   20   O  O   . ILE A 1 3   ? -21.749 4.598  12.023  1.00 14.93 ? 3   ILE A O   1 
+ATOM   21   C  CB  . ILE A 1 3   ? -24.365 2.623  11.887  1.00 15.22 ? 3   ILE A CB  1 
+ATOM   22   C  CG1 . ILE A 1 3   ? -24.855 4.071  11.748  1.00 15.32 ? 3   ILE A CG1 1 
+ATOM   23   C  CG2 . ILE A 1 3   ? -24.641 2.063  13.279  1.00 16.97 ? 3   ILE A CG2 1 
+ATOM   24   C  CD1 . ILE A 1 3   ? -24.681 4.672  10.337  1.00 16.25 ? 3   ILE A CD1 1 
+ATOM   25   N  N   . PHE A 1 4   ? -21.505 2.948  13.538  1.00 14.92 ? 4   PHE A N   1 
+ATOM   26   C  CA  . PHE A 1 4   ? -20.697 3.801  14.413  1.00 14.90 ? 4   PHE A CA  1 
+ATOM   27   C  C   . PHE A 1 4   ? -19.365 4.148  13.771  1.00 15.27 ? 4   PHE A C   1 
+ATOM   28   O  O   . PHE A 1 4   ? -18.933 5.306  13.817  1.00 16.88 ? 4   PHE A O   1 
+ATOM   29   C  CB  . PHE A 1 4   ? -20.506 3.159  15.794  1.00 15.56 ? 4   PHE A CB  1 
+ATOM   30   C  CG  . PHE A 1 4   ? -21.788 3.014  16.554  1.00 16.33 ? 4   PHE A CG  1 
+ATOM   31   C  CD1 . PHE A 1 4   ? -22.306 4.073  17.295  1.00 19.30 ? 4   PHE A CD1 1 
+ATOM   32   C  CD2 . PHE A 1 4   ? -22.501 1.828  16.501  1.00 18.15 ? 4   PHE A CD2 1 
+ATOM   33   C  CE1 . PHE A 1 4   ? -23.500 3.936  17.975  1.00 20.98 ? 4   PHE A CE1 1 
+ATOM   34   C  CE2 . PHE A 1 4   ? -23.691 1.692  17.181  1.00 20.04 ? 4   PHE A CE2 1 
+ATOM   35   C  CZ  . PHE A 1 4   ? -24.190 2.739  17.915  1.00 21.26 ? 4   PHE A CZ  1 
+ATOM   36   N  N   A GLU A 1 5   ? -18.709 3.164  13.156  0.54 16.20 ? 5   GLU A N   1 
+ATOM   37   N  N   B GLU A 1 5   ? -18.697 3.165  13.167  0.46 16.72 ? 5   GLU A N   1 
+ATOM   38   C  CA  A GLU A 1 5   ? -17.440 3.423  12.482  0.54 17.18 ? 5   GLU A CA  1 
+ATOM   39   C  CA  B GLU A 1 5   ? -17.437 3.456  12.491  0.46 17.84 ? 5   GLU A CA  1 
+ATOM   40   C  C   A GLU A 1 5   ? -17.635 4.319  11.265  0.54 16.10 ? 5   GLU A C   1 
+ATOM   41   C  C   B GLU A 1 5   ? -17.656 4.358  11.285  0.46 16.32 ? 5   GLU A C   1 
+ATOM   42   O  O   A GLU A 1 5   ? -16.794 5.178  10.978  0.54 16.74 ? 5   GLU A O   1 
+ATOM   43   O  O   B GLU A 1 5   ? -16.853 5.263  11.026  0.46 17.08 ? 5   GLU A O   1 
+ATOM   44   C  CB  A GLU A 1 5   ? -16.789 2.098  12.074  0.54 19.02 ? 5   GLU A CB  1 
+ATOM   45   C  CB  B GLU A 1 5   ? -16.745 2.159  12.067  0.46 20.62 ? 5   GLU A CB  1 
+ATOM   46   C  CG  A GLU A 1 5   ? -16.466 1.198  13.262  0.54 24.18 ? 5   GLU A CG  1 
+ATOM   47   C  CG  B GLU A 1 5   ? -16.290 1.296  13.232  0.46 25.46 ? 5   GLU A CG  1 
+ATOM   48   C  CD  A GLU A 1 5   ? -15.862 -0.140 12.867  0.54 30.35 ? 5   GLU A CD  1 
+ATOM   49   C  CD  B GLU A 1 5   ? -15.429 2.056  14.227  0.46 30.79 ? 5   GLU A CD  1 
+ATOM   50   O  OE1 A GLU A 1 5   ? -15.893 -0.489 11.671  0.54 32.84 ? 5   GLU A OE1 1 
+ATOM   51   O  OE1 B GLU A 1 5   ? -14.564 2.850  13.796  0.46 33.73 ? 5   GLU A OE1 1 
+ATOM   52   O  OE2 A GLU A 1 5   ? -15.355 -0.847 13.763  0.54 33.32 ? 5   GLU A OE2 1 
+ATOM   53   O  OE2 B GLU A 1 5   ? -15.625 1.865  15.445  0.46 32.45 ? 5   GLU A OE2 1 
+ATOM   54   N  N   . MET A 1 6   ? -18.737 4.125  10.536  1.00 14.86 ? 6   MET A N   1 
+ATOM   55   C  CA  . MET A 1 6   ? -19.022 4.939  9.360   1.00 14.18 ? 6   MET A CA  1 
+ATOM   56   C  C   . MET A 1 6   ? -19.190 6.406  9.744   1.00 13.42 ? 6   MET A C   1 
+ATOM   57   O  O   . MET A 1 6   ? -18.571 7.297  9.147   1.00 14.31 ? 6   MET A O   1 
+ATOM   58   C  CB  . MET A 1 6   ? -20.295 4.403  8.703   1.00 14.53 ? 6   MET A CB  1 
+ATOM   59   C  CG  . MET A 1 6   ? -20.697 5.110  7.415   1.00 14.78 ? 6   MET A CG  1 
+ATOM   60   S  SD  . MET A 1 6   ? -22.434 4.776  7.064   1.00 15.34 ? 6   MET A SD  1 
+ATOM   61   C  CE  . MET A 1 6   ? -22.523 4.911  5.284   1.00 17.99 ? 6   MET A CE  1 
+ATOM   62   N  N   . LEU A 1 7   ? -20.012 6.677  10.763  1.00 14.14 ? 7   LEU A N   1 
+ATOM   63   C  CA  . LEU A 1 7   ? -20.240 8.066  11.146  1.00 14.37 ? 7   LEU A CA  1 
+ATOM   64   C  C   . LEU A 1 7   ? -19.024 8.672  11.829  1.00 15.78 ? 7   LEU A C   1 
+ATOM   65   O  O   . LEU A 1 7   ? -18.801 9.878  11.717  1.00 16.61 ? 7   LEU A O   1 
+ATOM   66   C  CB  . LEU A 1 7   ? -21.483 8.197  12.022  1.00 14.36 ? 7   LEU A CB  1 
+ATOM   67   C  CG  . LEU A 1 7   ? -22.805 8.202  11.253  1.00 14.20 ? 7   LEU A CG  1 
+ATOM   68   C  CD1 . LEU A 1 7   ? -24.008 7.987  12.185  1.00 16.51 ? 7   LEU A CD1 1 
+ATOM   69   C  CD2 . LEU A 1 7   ? -22.948 9.511  10.500  1.00 17.05 ? 7   LEU A CD2 1 
+ATOM   70   N  N   . ARG A 1 8   ? -18.228 7.868  12.540  1.00 15.49 ? 8   ARG A N   1 
+ATOM   71   C  CA  . ARG A 1 8   ? -17.010 8.416  13.130  1.00 17.13 ? 8   ARG A CA  1 
+ATOM   72   C  C   . ARG A 1 8   ? -16.046 8.880  12.045  1.00 17.85 ? 8   ARG A C   1 
+ATOM   73   O  O   . ARG A 1 8   ? -15.378 9.910  12.192  1.00 19.59 ? 8   ARG A O   1 
+ATOM   74   C  CB  . ARG A 1 8   ? -16.357 7.381  14.045  1.00 20.70 ? 8   ARG A CB  1 
+ATOM   75   C  CG  . ARG A 1 8   ? -14.980 7.754  14.546  1.00 28.04 ? 8   ARG A CG  1 
+ATOM   76   C  CD  . ARG A 1 8   ? -15.002 9.009  15.390  1.00 36.10 ? 8   ARG A CD  1 
+ATOM   77   N  NE  . ARG A 1 8   ? -13.696 9.230  16.006  1.00 42.88 ? 8   ARG A NE  1 
+ATOM   78   C  CZ  . ARG A 1 8   ? -12.667 9.808  15.393  1.00 47.58 ? 8   ARG A CZ  1 
+ATOM   79   N  NH1 . ARG A 1 8   ? -12.788 10.234 14.143  1.00 48.92 ? 8   ARG A NH1 1 
+ATOM   80   N  NH2 . ARG A 1 8   ? -11.515 9.959  16.033  1.00 49.77 ? 8   ARG A NH2 1 
+ATOM   81   N  N   . ILE A 1 9   ? -15.980 8.147  10.933  1.00 17.00 ? 9   ILE A N   1 
+ATOM   82   C  CA  . ILE A 1 9   ? -15.160 8.582  9.802   1.00 17.77 ? 9   ILE A CA  1 
+ATOM   83   C  C   . ILE A 1 9   ? -15.705 9.874  9.198   1.00 17.34 ? 9   ILE A C   1 
+ATOM   84   O  O   . ILE A 1 9   ? -14.948 10.811 8.918   1.00 20.24 ? 9   ILE A O   1 
+ATOM   85   C  CB  . ILE A 1 9   ? -15.072 7.455  8.760   1.00 18.73 ? 9   ILE A CB  1 
+ATOM   86   C  CG1 . ILE A 1 9   ? -14.191 6.320  9.281   1.00 20.89 ? 9   ILE A CG1 1 
+ATOM   87   C  CG2 . ILE A 1 9   ? -14.554 7.994  7.425   1.00 21.15 ? 9   ILE A CG2 1 
+ATOM   88   C  CD1 . ILE A 1 9   ? -14.385 5.013  8.534   1.00 22.37 ? 9   ILE A CD1 1 
+ATOM   89   N  N   . ASP A 1 10  ? -17.025 9.952  9.000   1.00 16.04 ? 10  ASP A N   1 
+ATOM   90   C  CA  . ASP A 1 10  ? -17.611 11.118 8.337   1.00 15.03 ? 10  ASP A CA  1 
+ATOM   91   C  C   . ASP A 1 10  ? -17.589 12.369 9.210   1.00 15.83 ? 10  ASP A C   1 
+ATOM   92   O  O   . ASP A 1 10  ? -17.486 13.480 8.680   1.00 19.02 ? 10  ASP A O   1 
+ATOM   93   C  CB  . ASP A 1 10  ? -19.045 10.816 7.894   1.00 15.63 ? 10  ASP A CB  1 
+ATOM   94   C  CG  . ASP A 1 10  ? -19.096 9.920  6.664   1.00 16.36 ? 10  ASP A CG  1 
+ATOM   95   O  OD1 . ASP A 1 10  ? -18.137 9.972  5.871   1.00 18.11 ? 10  ASP A OD1 1 
+ATOM   96   O  OD2 . ASP A 1 10  ? -20.079 9.170  6.482   1.00 16.95 ? 10  ASP A OD2 1 
+ATOM   97   N  N   . GLU A 1 11  ? -17.705 12.219 10.532  1.00 16.57 ? 11  GLU A N   1 
+ATOM   98   C  CA  . GLU A 1 11  ? -17.874 13.370 11.414  1.00 16.28 ? 11  GLU A CA  1 
+ATOM   99   C  C   . GLU A 1 11  ? -16.606 13.765 12.151  1.00 18.25 ? 11  GLU A C   1 
+ATOM   100  O  O   . GLU A 1 11  ? -16.484 14.928 12.547  1.00 21.62 ? 11  GLU A O   1 
+ATOM   101  C  CB  . GLU A 1 11  ? -18.971 13.098 12.458  1.00 16.20 ? 11  GLU A CB  1 
+ATOM   102  C  CG  . GLU A 1 11  ? -20.329 12.815 11.853  1.00 16.26 ? 11  GLU A CG  1 
+ATOM   103  C  CD  . GLU A 1 11  ? -20.999 14.052 11.294  1.00 16.86 ? 11  GLU A CD  1 
+ATOM   104  O  OE1 . GLU A 1 11  ? -20.587 15.191 11.631  1.00 19.06 ? 11  GLU A OE1 1 
+ATOM   105  O  OE2 . GLU A 1 11  ? -21.961 13.876 10.525  1.00 18.15 ? 11  GLU A OE2 1 
+ATOM   106  N  N   . GLY A 1 12  ? -15.667 12.839 12.342  1.00 18.24 ? 12  GLY A N   1 
+ATOM   107  C  CA  . GLY A 1 12  ? -14.501 13.144 13.152  1.00 18.47 ? 12  GLY A CA  1 
+ATOM   108  C  C   . GLY A 1 12  ? -14.863 13.242 14.628  1.00 19.33 ? 12  GLY A C   1 
+ATOM   109  O  O   . GLY A 1 12  ? -15.979 12.952 15.055  1.00 21.27 ? 12  GLY A O   1 
+ATOM   110  N  N   . LEU A 1 13  ? -13.880 13.675 15.411  1.00 20.48 ? 13  LEU A N   1 
+ATOM   111  C  CA  . LEU A 1 13  ? -14.047 13.822 16.852  1.00 20.53 ? 13  LEU A CA  1 
+ATOM   112  C  C   . LEU A 1 13  ? -13.337 15.090 17.295  1.00 22.13 ? 13  LEU A C   1 
+ATOM   113  O  O   . LEU A 1 13  ? -12.141 15.253 17.038  1.00 25.78 ? 13  LEU A O   1 
+ATOM   114  C  CB  . LEU A 1 13  ? -13.462 12.615 17.594  1.00 23.71 ? 13  LEU A CB  1 
+ATOM   115  C  CG  . LEU A 1 13  ? -13.360 12.739 19.118  1.00 28.24 ? 13  LEU A CG  1 
+ATOM   116  C  CD1 . LEU A 1 13  ? -14.736 12.782 19.759  1.00 29.91 ? 13  LEU A CD1 1 
+ATOM   117  C  CD2 . LEU A 1 13  ? -12.530 11.607 19.705  1.00 31.67 ? 13  LEU A CD2 1 
+ATOM   118  N  N   . ARG A 1 14  ? -14.072 15.983 17.953  1.00 20.82 ? 14  ARG A N   1 
+ATOM   119  C  CA  A ARG A 1 14  ? -13.500 17.190 18.540  0.54 21.59 ? 14  ARG A CA  1 
+ATOM   120  C  CA  B ARG A 1 14  ? -13.492 17.181 18.544  0.46 21.79 ? 14  ARG A CA  1 
+ATOM   121  C  C   . ARG A 1 14  ? -14.085 17.365 19.933  1.00 20.96 ? 14  ARG A C   1 
+ATOM   122  O  O   . ARG A 1 14  ? -15.297 17.242 20.114  1.00 22.86 ? 14  ARG A O   1 
+ATOM   123  C  CB  A ARG A 1 14  ? -13.791 18.424 17.673  0.54 25.19 ? 14  ARG A CB  1 
+ATOM   124  C  CB  B ARG A 1 14  ? -13.730 18.407 17.651  0.46 25.10 ? 14  ARG A CB  1 
+ATOM   125  C  CG  A ARG A 1 14  ? -13.193 18.340 16.268  0.54 28.84 ? 14  ARG A CG  1 
+ATOM   126  C  CG  B ARG A 1 14  ? -12.715 18.509 16.502  0.46 28.28 ? 14  ARG A CG  1 
+ATOM   127  C  CD  A ARG A 1 14  ? -13.384 19.626 15.458  0.54 32.55 ? 14  ARG A CD  1 
+ATOM   128  C  CD  B ARG A 1 14  ? -13.192 19.371 15.329  0.46 31.45 ? 14  ARG A CD  1 
+ATOM   129  N  NE  A ARG A 1 14  ? -12.526 20.713 15.927  0.54 34.06 ? 14  ARG A NE  1 
+ATOM   130  N  NE  B ARG A 1 14  ? -14.025 18.621 14.391  0.46 32.82 ? 14  ARG A NE  1 
+ATOM   131  C  CZ  A ARG A 1 14  ? -12.322 21.847 15.259  0.54 35.11 ? 14  ARG A CZ  1 
+ATOM   132  C  CZ  B ARG A 1 14  ? -14.370 19.054 13.182  0.46 32.65 ? 14  ARG A CZ  1 
+ATOM   133  N  NH1 A ARG A 1 14  ? -12.911 22.049 14.087  0.54 34.82 ? 14  ARG A NH1 1 
+ATOM   134  N  NH1 B ARG A 1 14  ? -13.949 20.237 12.748  0.46 33.07 ? 14  ARG A NH1 1 
+ATOM   135  N  NH2 A ARG A 1 14  ? -11.526 22.780 15.764  0.54 34.86 ? 14  ARG A NH2 1 
+ATOM   136  N  NH2 B ARG A 1 14  ? -15.131 18.300 12.402  0.46 32.21 ? 14  ARG A NH2 1 
+ATOM   137  N  N   . LEU A 1 15  ? -13.228 17.639 20.917  1.00 19.63 ? 15  LEU A N   1 
+ATOM   138  C  CA  . LEU A 1 15  ? -13.661 17.693 22.311  1.00 19.52 ? 15  LEU A CA  1 
+ATOM   139  C  C   . LEU A 1 15  ? -13.981 19.097 22.797  1.00 18.80 ? 15  LEU A C   1 
+ATOM   140  O  O   . LEU A 1 15  ? -14.329 19.266 23.968  1.00 22.16 ? 15  LEU A O   1 
+ATOM   141  C  CB  . LEU A 1 15  ? -12.609 17.045 23.218  1.00 22.10 ? 15  LEU A CB  1 
+ATOM   142  C  CG  . LEU A 1 15  ? -12.309 15.578 22.902  1.00 26.20 ? 15  LEU A CG  1 
+ATOM   143  C  CD1 . LEU A 1 15  ? -11.240 15.024 23.831  1.00 29.56 ? 15  LEU A CD1 1 
+ATOM   144  C  CD2 . LEU A 1 15  ? -13.571 14.733 22.968  1.00 26.43 ? 15  LEU A CD2 1 
+ATOM   145  N  N   . LYS A 1 16  ? -13.871 20.096 21.935  1.00 20.32 ? 16  LYS A N   1 
+ATOM   146  C  CA  . LYS A 1 16  ? -14.212 21.476 22.236  1.00 21.41 ? 16  LYS A CA  1 
+ATOM   147  C  C   . LYS A 1 16  ? -15.245 21.936 21.216  1.00 18.49 ? 16  LYS A C   1 
+ATOM   148  O  O   . LYS A 1 16  ? -15.278 21.436 20.087  1.00 21.42 ? 16  LYS A O   1 
+ATOM   149  C  CB  . LYS A 1 16  ? -12.946 22.352 22.144  1.00 26.92 ? 16  LYS A CB  1 
+ATOM   150  C  CG  . LYS A 1 16  ? -13.135 23.816 22.501  1.00 34.00 ? 16  LYS A CG  1 
+ATOM   151  C  CD  . LYS A 1 16  ? -11.790 24.547 22.605  0.70 37.10 ? 16  LYS A CD  1 
+ATOM   152  C  CE  . LYS A 1 16  ? -11.041 24.541 21.275  0.82 40.92 ? 16  LYS A CE  1 
+ATOM   153  N  NZ  . LYS A 1 16  ? -9.782  25.343 21.325  0.56 42.45 ? 16  LYS A NZ  1 
+ATOM   154  N  N   . ILE A 1 17  ? -16.104 22.880 21.615  1.00 18.35 ? 17  ILE A N   1 
+ATOM   155  C  CA  . ILE A 1 17  ? -17.135 23.377 20.706  1.00 18.28 ? 17  ILE A CA  1 
+ATOM   156  C  C   . ILE A 1 17  ? -16.499 23.863 19.412  1.00 19.08 ? 17  ILE A C   1 
+ATOM   157  O  O   . ILE A 1 17  ? -15.501 24.596 19.426  1.00 21.10 ? 17  ILE A O   1 
+ATOM   158  C  CB  . ILE A 1 17  ? -17.967 24.484 21.372  1.00 19.38 ? 17  ILE A CB  1 
+ATOM   159  C  CG1 . ILE A 1 17  ? -18.757 23.928 22.560  1.00 21.09 ? 17  ILE A CG1 1 
+ATOM   160  C  CG2 . ILE A 1 17  ? -18.900 25.128 20.341  1.00 20.81 ? 17  ILE A CG2 1 
+ATOM   161  C  CD1 . ILE A 1 17  ? -19.517 24.993 23.369  1.00 22.44 ? 17  ILE A CD1 1 
+ATOM   162  N  N   . TYR A 1 18  ? -17.078 23.446 18.284  1.00 18.77 ? 18  TYR A N   1 
+ATOM   163  C  CA  . TYR A 1 18  ? -16.622 23.846 16.959  1.00 17.98 ? 18  TYR A CA  1 
+ATOM   164  C  C   . TYR A 1 18  ? -17.838 24.198 16.115  1.00 17.57 ? 18  TYR A C   1 
+ATOM   165  O  O   . TYR A 1 18  ? -18.980 24.027 16.542  1.00 20.00 ? 18  TYR A O   1 
+ATOM   166  C  CB  . TYR A 1 18  ? -15.770 22.756 16.293  1.00 20.43 ? 18  TYR A CB  1 
+ATOM   167  C  CG  . TYR A 1 18  ? -16.483 21.454 15.961  1.00 19.10 ? 18  TYR A CG  1 
+ATOM   168  C  CD1 . TYR A 1 18  ? -16.644 20.459 16.922  1.00 18.05 ? 18  TYR A CD1 1 
+ATOM   169  C  CD2 . TYR A 1 18  ? -16.957 21.202 14.674  1.00 21.59 ? 18  TYR A CD2 1 
+ATOM   170  C  CE1 . TYR A 1 18  ? -17.273 19.254 16.616  1.00 19.49 ? 18  TYR A CE1 1 
+ATOM   171  C  CE2 . TYR A 1 18  ? -17.587 19.997 14.362  1.00 21.21 ? 18  TYR A CE2 1 
+ATOM   172  C  CZ  . TYR A 1 18  ? -17.736 19.031 15.343  1.00 21.72 ? 18  TYR A CZ  1 
+ATOM   173  O  OH  . TYR A 1 18  ? -18.355 17.831 15.044  1.00 24.08 ? 18  TYR A OH  1 
+ATOM   174  N  N   . LYS A 1 19  ? -17.600 24.715 14.915  1.00 19.84 ? 19  LYS A N   1 
+ATOM   175  C  CA  . LYS A 1 19  ? -18.689 25.002 13.989  1.00 19.72 ? 19  LYS A CA  1 
+ATOM   176  C  C   . LYS A 1 19  ? -18.701 23.969 12.872  1.00 19.15 ? 19  LYS A C   1 
+ATOM   177  O  O   . LYS A 1 19  ? -17.650 23.632 12.313  1.00 21.88 ? 19  LYS A O   1 
+ATOM   178  C  CB  . LYS A 1 19  ? -18.555 26.396 13.375  1.00 21.28 ? 19  LYS A CB  1 
+ATOM   179  C  CG  . LYS A 1 19  ? -18.821 27.535 14.335  1.00 24.42 ? 19  LYS A CG  1 
+ATOM   180  C  CD  . LYS A 1 19  ? -18.666 28.847 13.590  1.00 28.14 ? 19  LYS A CD  1 
+ATOM   181  C  CE  . LYS A 1 19  ? -18.891 30.042 14.477  1.00 31.80 ? 19  LYS A CE  1 
+ATOM   182  N  NZ  . LYS A 1 19  ? -18.674 31.293 13.684  1.00 33.10 ? 19  LYS A NZ  1 
+ATOM   183  N  N   . ASP A 1 20  ? -19.895 23.484 12.538  1.00 17.96 ? 20  ASP A N   1 
+ATOM   184  C  CA  . ASP A 1 20  ? -20.042 22.538 11.437  1.00 17.56 ? 20  ASP A CA  1 
+ATOM   185  C  C   . ASP A 1 20  ? -19.946 23.270 10.098  1.00 18.86 ? 20  ASP A C   1 
+ATOM   186  O  O   . ASP A 1 20  ? -19.675 24.472 10.037  1.00 20.17 ? 20  ASP A O   1 
+ATOM   187  C  CB  . ASP A 1 20  ? -21.296 21.680 11.606  1.00 17.84 ? 20  ASP A CB  1 
+ATOM   188  C  CG  . ASP A 1 20  ? -22.594 22.416 11.279  1.00 18.21 ? 20  ASP A CG  1 
+ATOM   189  O  OD1 . ASP A 1 20  ? -22.574 23.601 10.888  1.00 17.47 ? 20  ASP A OD1 1 
+ATOM   190  O  OD2 . ASP A 1 20  ? -23.664 21.779 11.419  1.00 20.87 ? 20  ASP A OD2 1 
+ATOM   191  N  N   . THR A 1 21  ? -20.192 22.550 9.000   1.00 18.85 ? 21  THR A N   1 
+ATOM   192  C  CA  A THR A 1 21  ? -20.031 23.125 7.665   0.62 19.74 ? 21  THR A CA  1 
+ATOM   193  C  CA  B THR A 1 21  ? -19.989 23.173 7.698   0.38 19.84 ? 21  THR A CA  1 
+ATOM   194  C  C   . THR A 1 21  ? -21.006 24.271 7.404   1.00 19.66 ? 21  THR A C   1 
+ATOM   195  O  O   . THR A 1 21  ? -20.749 25.111 6.531   1.00 20.39 ? 21  THR A O   1 
+ATOM   196  C  CB  A THR A 1 21  ? -20.219 22.037 6.598   0.62 22.48 ? 21  THR A CB  1 
+ATOM   197  C  CB  B THR A 1 21  ? -19.943 22.133 6.577   0.38 22.58 ? 21  THR A CB  1 
+ATOM   198  O  OG1 A THR A 1 21  ? -21.568 21.559 6.634   0.62 25.52 ? 21  THR A OG1 1 
+ATOM   199  O  OG1 B THR A 1 21  ? -19.540 22.774 5.362   0.38 23.90 ? 21  THR A OG1 1 
+ATOM   200  C  CG2 A THR A 1 21  ? -19.272 20.859 6.829   0.62 21.16 ? 21  THR A CG2 1 
+ATOM   201  C  CG2 B THR A 1 21  ? -21.303 21.492 6.379   0.38 23.10 ? 21  THR A CG2 1 
+ATOM   202  N  N   . GLU A 1 22  ? -22.134 24.304 8.117   1.00 19.10 ? 22  GLU A N   1 
+ATOM   203  C  CA  . GLU A 1 22  ? -23.114 25.371 7.960   1.00 19.10 ? 22  GLU A CA  1 
+ATOM   204  C  C   . GLU A 1 22  ? -22.913 26.509 8.949   1.00 20.38 ? 22  GLU A C   1 
+ATOM   205  O  O   . GLU A 1 22  ? -23.652 27.497 8.887   1.00 24.15 ? 22  GLU A O   1 
+ATOM   206  C  CB  . GLU A 1 22  ? -24.544 24.831 8.103   1.00 22.12 ? 22  GLU A CB  1 
+ATOM   207  C  CG  . GLU A 1 22  ? -24.903 23.691 7.149   1.00 25.56 ? 22  GLU A CG  1 
+ATOM   208  C  CD  . GLU A 1 22  ? -25.165 24.144 5.722   1.00 32.14 ? 22  GLU A CD  1 
+ATOM   209  O  OE1 . GLU A 1 22  ? -25.466 25.336 5.508   1.00 34.36 ? 22  GLU A OE1 1 
+ATOM   210  O  OE2 . GLU A 1 22  ? -25.076 23.298 4.807   1.00 35.56 ? 22  GLU A OE2 1 
+ATOM   211  N  N   . GLY A 1 23  ? -21.945 26.397 9.853   1.00 19.95 ? 23  GLY A N   1 
+ATOM   212  C  CA  . GLY A 1 23  ? -21.690 27.428 10.838  1.00 20.66 ? 23  GLY A CA  1 
+ATOM   213  C  C   . GLY A 1 23  ? -22.335 27.221 12.191  1.00 20.01 ? 23  GLY A C   1 
+ATOM   214  O  O   . GLY A 1 23  ? -22.296 28.139 13.019  1.00 23.54 ? 23  GLY A O   1 
+ATOM   215  N  N   . TYR A 1 24  ? -22.916 26.049 12.453  1.00 17.96 ? 24  TYR A N   1 
+ATOM   216  C  CA  . TYR A 1 24  ? -23.644 25.814 13.696  1.00 18.15 ? 24  TYR A CA  1 
+ATOM   217  C  C   . TYR A 1 24  ? -22.739 25.198 14.752  1.00 16.94 ? 24  TYR A C   1 
+ATOM   218  O  O   . TYR A 1 24  ? -21.902 24.341 14.447  1.00 17.43 ? 24  TYR A O   1 
+ATOM   219  C  CB  . TYR A 1 24  ? -24.802 24.857 13.439  1.00 19.96 ? 24  TYR A CB  1 
+ATOM   220  C  CG  . TYR A 1 24  ? -25.839 25.405 12.496  1.00 24.85 ? 24  TYR A CG  1 
+ATOM   221  C  CD1 . TYR A 1 24  ? -26.282 26.716 12.612  1.00 27.87 ? 24  TYR A CD1 1 
+ATOM   222  C  CD2 . TYR A 1 24  ? -26.365 24.619 11.482  1.00 27.59 ? 24  TYR A CD2 1 
+ATOM   223  C  CE1 . TYR A 1 24  ? -27.236 27.227 11.754  1.00 31.79 ? 24  TYR A CE1 1 
+ATOM   224  C  CE2 . TYR A 1 24  ? -27.317 25.123 10.615  1.00 30.00 ? 24  TYR A CE2 1 
+ATOM   225  C  CZ  . TYR A 1 24  ? -27.746 26.431 10.753  1.00 32.64 ? 24  TYR A CZ  1 
+ATOM   226  O  OH  . TYR A 1 24  ? -28.697 26.939 9.895   1.00 37.41 ? 24  TYR A OH  1 
+ATOM   227  N  N   . TYR A 1 25  ? -22.944 25.610 16.005  1.00 16.97 ? 25  TYR A N   1 
+ATOM   228  C  CA  . TYR A 1 25  ? -22.139 25.091 17.107  1.00 16.04 ? 25  TYR A CA  1 
+ATOM   229  C  C   . TYR A 1 25  ? -22.400 23.608 17.342  1.00 14.79 ? 25  TYR A C   1 
+ATOM   230  O  O   . TYR A 1 25  ? -23.550 23.175 17.496  1.00 16.70 ? 25  TYR A O   1 
+ATOM   231  C  CB  . TYR A 1 25  ? -22.397 25.884 18.390  1.00 17.96 ? 25  TYR A CB  1 
+ATOM   232  C  CG  . TYR A 1 25  ? -21.876 27.297 18.330  1.00 20.75 ? 25  TYR A CG  1 
+ATOM   233  C  CD1 . TYR A 1 25  ? -20.530 27.552 18.102  1.00 22.67 ? 25  TYR A CD1 1 
+ATOM   234  C  CD2 . TYR A 1 25  ? -22.729 28.379 18.498  1.00 23.31 ? 25  TYR A CD2 1 
+ATOM   235  C  CE1 . TYR A 1 25  ? -20.045 28.852 18.045  1.00 26.22 ? 25  TYR A CE1 1 
+ATOM   236  C  CE2 . TYR A 1 25  ? -22.258 29.677 18.441  1.00 27.16 ? 25  TYR A CE2 1 
+ATOM   237  C  CZ  . TYR A 1 25  ? -20.916 29.909 18.218  1.00 27.94 ? 25  TYR A CZ  1 
+ATOM   238  O  OH  . TYR A 1 25  ? -20.454 31.205 18.164  1.00 33.18 ? 25  TYR A OH  1 
+ATOM   239  N  N   . THR A 1 26  ? -21.312 22.848 17.441  1.00 14.55 ? 26  THR A N   1 
+ATOM   240  C  CA  . THR A 1 26  ? -21.320 21.394 17.435  1.00 14.45 ? 26  THR A CA  1 
+ATOM   241  C  C   . THR A 1 26  ? -20.219 20.942 18.386  1.00 14.89 ? 26  THR A C   1 
+ATOM   242  O  O   . THR A 1 26  ? -19.307 21.708 18.706  1.00 17.16 ? 26  THR A O   1 
+ATOM   243  C  CB  . THR A 1 26  ? -21.018 20.935 15.991  1.00 15.81 ? 26  THR A CB  1 
+ATOM   244  O  OG1 . THR A 1 26  ? -21.948 21.557 15.096  1.00 17.94 ? 26  THR A OG1 1 
+ATOM   245  C  CG2 . THR A 1 26  ? -21.132 19.429 15.826  1.00 16.22 ? 26  THR A CG2 1 
+ATOM   246  N  N   . ILE A 1 27  ? -20.302 19.695 18.862  1.00 14.48 ? 27  ILE A N   1 
+ATOM   247  C  CA  . ILE A 1 27  ? -19.232 19.141 19.684  1.00 14.97 ? 27  ILE A CA  1 
+ATOM   248  C  C   . ILE A 1 27  ? -19.177 17.631 19.489  1.00 14.28 ? 27  ILE A C   1 
+ATOM   249  O  O   . ILE A 1 27  ? -20.132 17.006 19.020  1.00 15.13 ? 27  ILE A O   1 
+ATOM   250  C  CB  . ILE A 1 27  ? -19.396 19.508 21.177  1.00 17.64 ? 27  ILE A CB  1 
+ATOM   251  C  CG1 . ILE A 1 27  ? -18.059 19.331 21.931  1.00 20.17 ? 27  ILE A CG1 1 
+ATOM   252  C  CG2 . ILE A 1 27  ? -20.515 18.675 21.782  1.00 19.76 ? 27  ILE A CG2 1 
+ATOM   253  C  CD1 . ILE A 1 27  ? -17.932 20.137 23.216  1.00 20.74 ? 27  ILE A CD1 1 
+ATOM   254  N  N   . GLY A 1 28  ? -18.043 17.041 19.859  1.00 15.07 ? 28  GLY A N   1 
+ATOM   255  C  CA  . GLY A 1 28  ? -17.953 15.588 19.873  1.00 16.13 ? 28  GLY A CA  1 
+ATOM   256  C  C   . GLY A 1 28  ? -17.912 15.008 18.471  1.00 15.61 ? 28  GLY A C   1 
+ATOM   257  O  O   . GLY A 1 28  ? -17.185 15.488 17.591  1.00 16.60 ? 28  GLY A O   1 
+ATOM   258  N  N   . ILE A 1 29  ? -18.695 13.956 18.265  1.00 14.98 ? 29  ILE A N   1 
+ATOM   259  C  CA  . ILE A 1 29  ? -18.804 13.313 16.959  1.00 14.29 ? 29  ILE A CA  1 
+ATOM   260  C  C   . ILE A 1 29  ? -20.042 13.876 16.266  1.00 14.38 ? 29  ILE A C   1 
+ATOM   261  O  O   . ILE A 1 29  ? -21.079 13.213 16.155  1.00 15.78 ? 29  ILE A O   1 
+ATOM   262  C  CB  . ILE A 1 29  ? -18.818 11.776 17.095  1.00 15.53 ? 29  ILE A CB  1 
+ATOM   263  C  CG1 . ILE A 1 29  ? -17.597 11.340 17.908  1.00 17.58 ? 29  ILE A CG1 1 
+ATOM   264  C  CG2 . ILE A 1 29  ? -18.805 11.104 15.726  1.00 16.26 ? 29  ILE A CG2 1 
+ATOM   265  C  CD1 . ILE A 1 29  ? -17.686 9.940  18.466  1.00 20.85 ? 29  ILE A CD1 1 
+ATOM   266  N  N   . GLY A 1 30  ? -19.950 15.130 15.835  1.00 14.82 ? 30  GLY A N   1 
+ATOM   267  C  CA  . GLY A 1 30  ? -21.031 15.757 15.096  1.00 14.93 ? 30  GLY A CA  1 
+ATOM   268  C  C   . GLY A 1 30  ? -22.304 16.036 15.868  1.00 14.58 ? 30  GLY A C   1 
+ATOM   269  O  O   . GLY A 1 30  ? -23.379 16.068 15.267  1.00 16.58 ? 30  GLY A O   1 
+ATOM   270  N  N   . HIS A 1 31  ? -22.227 16.253 17.181  1.00 14.00 ? 31  HIS A N   1 
+ATOM   271  C  CA  . HIS A 1 31  ? -23.438 16.536 17.948  1.00 13.95 ? 31  HIS A CA  1 
+ATOM   272  C  C   . HIS A 1 31  ? -23.810 18.014 17.829  1.00 13.63 ? 31  HIS A C   1 
+ATOM   273  O  O   . HIS A 1 31  ? -23.130 18.874 18.397  1.00 14.79 ? 31  HIS A O   1 
+ATOM   274  C  CB  . HIS A 1 31  ? -23.243 16.169 19.415  1.00 14.68 ? 31  HIS A CB  1 
+ATOM   275  C  CG  . HIS A 1 31  ? -24.459 16.433 20.239  1.00 14.90 ? 31  HIS A CG  1 
+ATOM   276  N  ND1 . HIS A 1 31  ? -25.501 15.538 20.327  1.00 15.77 ? 31  HIS A ND1 1 
+ATOM   277  C  CD2 . HIS A 1 31  ? -24.820 17.509 20.980  1.00 16.70 ? 31  HIS A CD2 1 
+ATOM   278  C  CE1 . HIS A 1 31  ? -26.450 16.045 21.093  1.00 18.74 ? 31  HIS A CE1 1 
+ATOM   279  N  NE2 . HIS A 1 31  ? -26.061 17.239 21.506  1.00 18.86 ? 31  HIS A NE2 1 
+ATOM   280  N  N   . LEU A 1 32  ? -24.920 18.312 17.144  1.00 14.86 ? 32  LEU A N   1 
+ATOM   281  C  CA  . LEU A 1 32  ? -25.393 19.689 17.032  1.00 15.92 ? 32  LEU A CA  1 
+ATOM   282  C  C   . LEU A 1 32  ? -25.855 20.201 18.395  1.00 14.97 ? 32  LEU A C   1 
+ATOM   283  O  O   . LEU A 1 32  ? -26.660 19.553 19.072  1.00 17.79 ? 32  LEU A O   1 
+ATOM   284  C  CB  . LEU A 1 32  ? -26.555 19.762 16.033  1.00 17.99 ? 32  LEU A CB  1 
+ATOM   285  C  CG  . LEU A 1 32  ? -27.234 21.130 15.899  1.00 20.49 ? 32  LEU A CG  1 
+ATOM   286  C  CD1 . LEU A 1 32  ? -26.293 22.179 15.315  1.00 22.74 ? 32  LEU A CD1 1 
+ATOM   287  C  CD2 . LEU A 1 32  ? -28.503 21.020 15.063  1.00 25.09 ? 32  LEU A CD2 1 
+ATOM   288  N  N   . LEU A 1 33  ? -25.348 21.367 18.799  1.00 14.58 ? 33  LEU A N   1 
+ATOM   289  C  CA  . LEU A 1 33  ? -25.770 21.963 20.064  1.00 15.88 ? 33  LEU A CA  1 
+ATOM   290  C  C   . LEU A 1 33  ? -26.913 22.953 19.881  1.00 17.45 ? 33  LEU A C   1 
+ATOM   291  O  O   . LEU A 1 33  ? -27.898 22.910 20.621  1.00 20.48 ? 33  LEU A O   1 
+ATOM   292  C  CB  . LEU A 1 33  ? -24.588 22.647 20.757  1.00 15.86 ? 33  LEU A CB  1 
+ATOM   293  C  CG  . LEU A 1 33  ? -23.534 21.699 21.330  1.00 17.16 ? 33  LEU A CG  1 
+ATOM   294  C  CD1 . LEU A 1 33  ? -22.229 22.455 21.642  1.00 18.70 ? 33  LEU A CD1 1 
+ATOM   295  C  CD2 . LEU A 1 33  ? -24.068 20.955 22.569  1.00 18.18 ? 33  LEU A CD2 1 
+ATOM   296  N  N   . THR A 1 34  ? -26.789 23.862 18.920  1.00 18.24 ? 34  THR A N   1 
+ATOM   297  C  CA  . THR A 1 34  ? -27.824 24.861 18.689  1.00 20.54 ? 34  THR A CA  1 
+ATOM   298  C  C   . THR A 1 34  ? -27.557 25.510 17.343  1.00 22.12 ? 34  THR A C   1 
+ATOM   299  O  O   . THR A 1 34  ? -26.421 25.532 16.863  1.00 22.92 ? 34  THR A O   1 
+ATOM   300  C  CB  . THR A 1 34  ? -27.854 25.928 19.791  1.00 23.89 ? 34  THR A CB  1 
+ATOM   301  O  OG1 . THR A 1 34  ? -28.885 26.880 19.505  1.00 25.63 ? 34  THR A OG1 1 
+ATOM   302  C  CG2 . THR A 1 34  ? -26.508 26.656 19.887  1.00 25.24 ? 34  THR A CG2 1 
+ATOM   303  N  N   . LYS A 1 35  ? -28.620 26.034 16.741  1.00 23.81 ? 35  LYS A N   1 
+ATOM   304  C  CA  . LYS A 1 35  ? -28.496 26.856 15.549  1.00 26.07 ? 35  LYS A CA  1 
+ATOM   305  C  C   . LYS A 1 35  ? -28.410 28.338 15.878  1.00 26.72 ? 35  LYS A C   1 
+ATOM   306  O  O   . LYS A 1 35  ? -28.255 29.156 14.965  1.00 29.69 ? 35  LYS A O   1 
+ATOM   307  C  CB  . LYS A 1 35  ? -29.652 26.579 14.585  1.00 28.96 ? 35  LYS A CB  1 
+ATOM   308  C  CG  . LYS A 1 35  ? -29.623 25.172 14.011  1.00 30.54 ? 35  LYS A CG  1 
+ATOM   309  C  CD  . LYS A 1 35  ? -30.714 24.956 12.971  1.00 33.73 ? 35  LYS A CD  1 
+ATOM   310  C  CE  . LYS A 1 35  ? -30.665 23.539 12.435  1.00 35.77 ? 35  LYS A CE  1 
+ATOM   311  N  NZ  . LYS A 1 35  ? -31.734 23.295 11.432  0.71 36.76 ? 35  LYS A NZ  1 
+ATOM   312  N  N   . SER A 1 36  ? -28.498 28.697 17.155  1.00 27.32 ? 36  SER A N   1 
+ATOM   313  C  CA  . SER A 1 36  ? -28.362 30.086 17.552  1.00 29.33 ? 36  SER A CA  1 
+ATOM   314  C  C   . SER A 1 36  ? -26.916 30.548 17.366  1.00 29.70 ? 36  SER A C   1 
+ATOM   315  O  O   . SER A 1 36  ? -25.977 29.775 17.567  1.00 28.12 ? 36  SER A O   1 
+ATOM   316  C  CB  . SER A 1 36  ? -28.741 30.233 19.022  1.00 31.18 ? 36  SER A CB  1 
+ATOM   317  O  OG  . SER A 1 36  ? -28.272 31.461 19.543  1.00 34.82 ? 36  SER A OG  1 
+ATOM   318  N  N   . PRO A 1 37  ? -26.709 31.814 16.987  1.00 31.52 ? 37  PRO A N   1 
+ATOM   319  C  CA  . PRO A 1 37  ? -25.337 32.330 16.850  1.00 31.90 ? 37  PRO A CA  1 
+ATOM   320  C  C   . PRO A 1 37  ? -24.631 32.574 18.171  1.00 32.09 ? 37  PRO A C   1 
+ATOM   321  O  O   . PRO A 1 37  ? -23.464 32.982 18.159  1.00 34.08 ? 37  PRO A O   1 
+ATOM   322  C  CB  . PRO A 1 37  ? -25.531 33.660 16.098  1.00 33.27 ? 37  PRO A CB  1 
+ATOM   323  C  CG  . PRO A 1 37  ? -26.939 33.640 15.601  1.00 35.88 ? 37  PRO A CG  1 
+ATOM   324  C  CD  . PRO A 1 37  ? -27.713 32.789 16.545  1.00 33.96 ? 37  PRO A CD  1 
+ATOM   325  N  N   . SER A 1 38  ? -25.287 32.333 19.303  1.00 29.55 ? 38  SER A N   1 
+ATOM   326  C  CA  . SER A 1 38  ? -24.752 32.697 20.608  1.00 29.17 ? 38  SER A CA  1 
+ATOM   327  C  C   . SER A 1 38  ? -23.914 31.552 21.160  1.00 26.61 ? 38  SER A C   1 
+ATOM   328  O  O   . SER A 1 38  ? -24.432 30.457 21.402  1.00 26.12 ? 38  SER A O   1 
+ATOM   329  C  CB  . SER A 1 38  ? -25.894 33.000 21.572  1.00 29.97 ? 38  SER A CB  1 
+ATOM   330  O  OG  . SER A 1 38  ? -25.405 33.059 22.894  1.00 31.29 ? 38  SER A OG  1 
+ATOM   331  N  N   . LEU A 1 39  ? -22.622 31.808 21.372  1.00 26.65 ? 39  LEU A N   1 
+ATOM   332  C  CA  . LEU A 1 39  ? -21.783 30.796 22.007  1.00 27.47 ? 39  LEU A CA  1 
+ATOM   333  C  C   . LEU A 1 39  ? -22.272 30.474 23.414  1.00 26.88 ? 39  LEU A C   1 
+ATOM   334  O  O   . LEU A 1 39  ? -22.177 29.323 23.856  1.00 25.65 ? 39  LEU A O   1 
+ATOM   335  C  CB  . LEU A 1 39  ? -20.323 31.252 22.031  1.00 28.94 ? 39  LEU A CB  1 
+ATOM   336  C  CG  . LEU A 1 39  ? -19.315 30.263 22.623  1.00 28.85 ? 39  LEU A CG  1 
+ATOM   337  C  CD1 . LEU A 1 39  ? -19.351 28.951 21.869  1.00 29.90 ? 39  LEU A CD1 1 
+ATOM   338  C  CD2 . LEU A 1 39  ? -17.915 30.853 22.607  1.00 31.12 ? 39  LEU A CD2 1 
+ATOM   339  N  N   . ASN A 1 40  ? -22.815 31.466 24.123  1.00 27.41 ? 40  ASN A N   1 
+ATOM   340  C  CA  . ASN A 1 40  ? -23.348 31.196 25.455  1.00 27.39 ? 40  ASN A CA  1 
+ATOM   341  C  C   . ASN A 1 40  ? -24.531 30.233 25.401  1.00 25.07 ? 40  ASN A C   1 
+ATOM   342  O  O   . ASN A 1 40  ? -24.669 29.361 26.266  1.00 25.71 ? 40  ASN A O   1 
+ATOM   343  C  CB  . ASN A 1 40  ? -23.708 32.501 26.167  1.00 32.47 ? 40  ASN A CB  1 
+ATOM   344  C  CG  . ASN A 1 40  ? -22.484 33.224 26.692  1.00 39.48 ? 40  ASN A CG  1 
+ATOM   345  O  OD1 . ASN A 1 40  ? -21.430 32.615 26.882  1.00 42.07 ? 40  ASN A OD1 1 
+ATOM   346  N  ND2 . ASN A 1 40  ? -22.615 34.523 26.931  1.00 42.78 ? 40  ASN A ND2 1 
+ATOM   347  N  N   . ALA A 1 41  ? -25.390 30.368 24.386  1.00 24.21 ? 41  ALA A N   1 
+ATOM   348  C  CA  . ALA A 1 41  ? -26.498 29.430 24.241  1.00 22.20 ? 41  ALA A CA  1 
+ATOM   349  C  C   . ALA A 1 41  ? -25.983 28.021 23.979  1.00 21.22 ? 41  ALA A C   1 
+ATOM   350  O  O   . ALA A 1 41  ? -26.529 27.043 24.504  1.00 20.79 ? 41  ALA A O   1 
+ATOM   351  C  CB  . ALA A 1 41  ? -27.444 29.884 23.127  1.00 24.63 ? 41  ALA A CB  1 
+ATOM   352  N  N   . ALA A 1 42  ? -24.918 27.902 23.181  1.00 20.17 ? 42  ALA A N   1 
+ATOM   353  C  CA  . ALA A 1 42  ? -24.331 26.595 22.903  1.00 19.55 ? 42  ALA A CA  1 
+ATOM   354  C  C   . ALA A 1 42  ? -23.720 25.992 24.160  1.00 17.90 ? 42  ALA A C   1 
+ATOM   355  O  O   . ALA A 1 42  ? -23.860 24.789 24.412  1.00 18.28 ? 42  ALA A O   1 
+ATOM   356  C  CB  . ALA A 1 42  ? -23.273 26.720 21.808  1.00 19.93 ? 42  ALA A CB  1 
+ATOM   357  N  N   . LYS A 1 43  ? -23.042 26.814 24.964  1.00 19.03 ? 43  LYS A N   1 
+ATOM   358  C  CA  . LYS A 1 43  ? -22.445 26.308 26.196  1.00 18.97 ? 43  LYS A CA  1 
+ATOM   359  C  C   . LYS A 1 43  ? -23.513 25.813 27.166  1.00 19.62 ? 43  LYS A C   1 
+ATOM   360  O  O   . LYS A 1 43  ? -23.311 24.808 27.853  1.00 19.92 ? 43  LYS A O   1 
+ATOM   361  C  CB  . LYS A 1 43  ? -21.582 27.385 26.843  1.00 20.96 ? 43  LYS A CB  1 
+ATOM   362  C  CG  . LYS A 1 43  ? -20.248 27.587 26.152  1.00 24.13 ? 43  LYS A CG  1 
+ATOM   363  C  CD  . LYS A 1 43  ? -19.444 28.686 26.818  1.00 27.69 ? 43  LYS A CD  1 
+ATOM   364  C  CE  . LYS A 1 43  ? -18.017 28.682 26.310  1.00 31.89 ? 43  LYS A CE  1 
+ATOM   365  N  NZ  . LYS A 1 43  ? -17.213 29.711 27.003  1.00 35.46 ? 43  LYS A NZ  1 
+ATOM   366  N  N   A SER A 1 44  ? -24.639 26.525 27.238  0.51 19.43 ? 44  SER A N   1 
+ATOM   367  N  N   B SER A 1 44  ? -24.657 26.498 27.221  0.15 19.23 ? 44  SER A N   1 
+ATOM   368  N  N   C SER A 1 44  ? -24.648 26.511 27.236  0.34 19.44 ? 44  SER A N   1 
+ATOM   369  C  CA  A SER A 1 44  ? -25.746 26.089 28.083  0.51 21.08 ? 44  SER A CA  1 
+ATOM   370  C  CA  B SER A 1 44  ? -25.728 26.056 28.113  0.15 19.06 ? 44  SER A CA  1 
+ATOM   371  C  CA  C SER A 1 44  ? -25.728 26.057 28.107  0.34 20.05 ? 44  SER A CA  1 
+ATOM   372  C  C   A SER A 1 44  ? -26.308 24.756 27.604  0.51 19.84 ? 44  SER A C   1 
+ATOM   373  C  C   B SER A 1 44  ? -26.375 24.769 27.611  0.15 18.62 ? 44  SER A C   1 
+ATOM   374  C  C   C SER A 1 44  ? -26.329 24.749 27.608  0.34 19.07 ? 44  SER A C   1 
+ATOM   375  O  O   A SER A 1 44  ? -26.563 23.855 28.412  0.51 20.72 ? 44  SER A O   1 
+ATOM   376  O  O   B SER A 1 44  ? -26.767 23.914 28.415  0.15 18.56 ? 44  SER A O   1 
+ATOM   377  O  O   C SER A 1 44  ? -26.644 23.859 28.409  0.34 19.41 ? 44  SER A O   1 
+ATOM   378  C  CB  A SER A 1 44  ? -26.831 27.168 28.090  0.51 23.32 ? 44  SER A CB  1 
+ATOM   379  C  CB  B SER A 1 44  ? -26.768 27.163 28.300  0.15 19.12 ? 44  SER A CB  1 
+ATOM   380  C  CB  C SER A 1 44  ? -26.803 27.138 28.233  0.34 21.16 ? 44  SER A CB  1 
+ATOM   381  O  OG  A SER A 1 44  ? -27.920 26.807 28.914  0.51 24.57 ? 44  SER A OG  1 
+ATOM   382  O  OG  B SER A 1 44  ? -27.457 27.444 27.094  0.15 18.29 ? 44  SER A OG  1 
+ATOM   383  O  OG  C SER A 1 44  ? -26.317 28.248 28.964  0.34 20.51 ? 44  SER A OG  1 
+ATOM   384  N  N   . GLU A 1 45  ? -26.500 24.612 26.290  1.00 18.27 ? 45  GLU A N   1 
+ATOM   385  C  CA  . GLU A 1 45  ? -26.999 23.348 25.750  1.00 16.36 ? 45  GLU A CA  1 
+ATOM   386  C  C   . GLU A 1 45  ? -26.046 22.202 26.064  1.00 16.31 ? 45  GLU A C   1 
+ATOM   387  O  O   . GLU A 1 45  ? -26.486 21.085 26.371  1.00 17.25 ? 45  GLU A O   1 
+ATOM   388  C  CB  . GLU A 1 45  ? -27.199 23.448 24.238  1.00 17.06 ? 45  GLU A CB  1 
+ATOM   389  C  CG  . GLU A 1 45  ? -28.397 24.290 23.832  1.00 17.83 ? 45  GLU A CG  1 
+ATOM   390  C  CD  . GLU A 1 45  ? -29.701 23.734 24.382  1.00 19.77 ? 45  GLU A CD  1 
+ATOM   391  O  OE1 . GLU A 1 45  ? -30.009 22.540 24.156  1.00 20.30 ? 45  GLU A OE1 1 
+ATOM   392  O  OE2 . GLU A 1 45  ? -30.417 24.489 25.067  1.00 22.45 ? 45  GLU A OE2 1 
+ATOM   393  N  N   . LEU A 1 46  ? -24.738 22.467 25.996  1.00 16.11 ? 46  LEU A N   1 
+ATOM   394  C  CA  . LEU A 1 46  ? -23.742 21.450 26.315  1.00 16.74 ? 46  LEU A CA  1 
+ATOM   395  C  C   . LEU A 1 46  ? -23.851 21.004 27.769  1.00 16.23 ? 46  LEU A C   1 
+ATOM   396  O  O   . LEU A 1 46  ? -23.886 19.803 28.059  1.00 16.84 ? 46  LEU A O   1 
+ATOM   397  C  CB  . LEU A 1 46  ? -22.340 21.984 26.020  1.00 16.68 ? 46  LEU A CB  1 
+ATOM   398  C  CG  . LEU A 1 46  ? -21.231 20.968 26.298  1.00 16.30 ? 46  LEU A CG  1 
+ATOM   399  C  CD1 . LEU A 1 46  ? -21.413 19.696 25.456  1.00 17.50 ? 46  LEU A CD1 1 
+ATOM   400  C  CD2 . LEU A 1 46  ? -19.868 21.607 26.084  1.00 18.36 ? 46  LEU A CD2 1 
+ATOM   401  N  N   . ASP A 1 47  ? -23.907 21.962 28.696  1.00 16.97 ? 47  ASP A N   1 
+ATOM   402  C  CA  . ASP A 1 47  ? -24.010 21.609 30.111  1.00 17.03 ? 47  ASP A CA  1 
+ATOM   403  C  C   . ASP A 1 47  ? -25.263 20.784 30.388  1.00 16.78 ? 47  ASP A C   1 
+ATOM   404  O  O   . ASP A 1 47  ? -25.224 19.823 31.170  1.00 17.19 ? 47  ASP A O   1 
+ATOM   405  C  CB  . ASP A 1 47  ? -24.001 22.880 30.963  1.00 19.83 ? 47  ASP A CB  1 
+ATOM   406  C  CG  . ASP A 1 47  ? -22.632 23.551 31.005  1.00 22.12 ? 47  ASP A CG  1 
+ATOM   407  O  OD1 . ASP A 1 47  ? -21.657 22.992 30.454  1.00 21.66 ? 47  ASP A OD1 1 
+ATOM   408  O  OD2 . ASP A 1 47  ? -22.532 24.643 31.598  1.00 24.44 ? 47  ASP A OD2 1 
+ATOM   409  N  N   . LYS A 1 48  ? -26.386 21.158 29.766  1.00 16.77 ? 48  LYS A N   1 
+ATOM   410  C  CA  . LYS A 1 48  ? -27.638 20.413 29.909  1.00 16.46 ? 48  LYS A CA  1 
+ATOM   411  C  C   . LYS A 1 48  ? -27.501 18.990 29.372  1.00 15.97 ? 48  LYS A C   1 
+ATOM   412  O  O   . LYS A 1 48  ? -28.011 18.030 29.969  1.00 16.32 ? 48  LYS A O   1 
+ATOM   413  C  CB  . LYS A 1 48  ? -28.738 21.174 29.157  1.00 17.65 ? 48  LYS A CB  1 
+ATOM   414  C  CG  . LYS A 1 48  ? -30.110 20.519 29.133  1.00 18.98 ? 48  LYS A CG  1 
+ATOM   415  C  CD  . LYS A 1 48  ? -31.212 21.506 28.720  1.00 19.16 ? 48  LYS A CD  1 
+ATOM   416  C  CE  . LYS A 1 48  ? -30.991 22.157 27.366  1.00 19.19 ? 48  LYS A CE  1 
+ATOM   417  N  NZ  . LYS A 1 48  ? -31.349 21.268 26.230  1.00 18.31 ? 48  LYS A NZ  1 
+ATOM   418  N  N   . ALA A 1 49  ? -26.800 18.832 28.251  1.00 15.68 ? 49  ALA A N   1 
+ATOM   419  C  CA  . ALA A 1 49  ? -26.671 17.515 27.632  1.00 15.90 ? 49  ALA A CA  1 
+ATOM   420  C  C   . ALA A 1 49  ? -25.764 16.594 28.446  1.00 16.28 ? 49  ALA A C   1 
+ATOM   421  O  O   . ALA A 1 49  ? -26.004 15.381 28.512  1.00 17.13 ? 49  ALA A O   1 
+ATOM   422  C  CB  . ALA A 1 49  ? -26.137 17.662 26.201  1.00 18.51 ? 49  ALA A CB  1 
+ATOM   423  N  N   . ILE A 1 50  ? -24.716 17.145 29.055  1.00 17.30 ? 50  ILE A N   1 
+ATOM   424  C  CA  . ILE A 1 50  ? -23.721 16.333 29.748  1.00 17.13 ? 50  ILE A CA  1 
+ATOM   425  C  C   . ILE A 1 50  ? -24.063 16.159 31.228  1.00 19.01 ? 50  ILE A C   1 
+ATOM   426  O  O   . ILE A 1 50  ? -23.718 15.135 31.830  1.00 21.02 ? 50  ILE A O   1 
+ATOM   427  C  CB  . ILE A 1 50  ? -22.328 16.968 29.560  1.00 18.24 ? 50  ILE A CB  1 
+ATOM   428  C  CG1 . ILE A 1 50  ? -22.004 17.114 28.072  1.00 20.16 ? 50  ILE A CG1 1 
+ATOM   429  C  CG2 . ILE A 1 50  ? -21.243 16.164 30.272  1.00 21.03 ? 50  ILE A CG2 1 
+ATOM   430  C  CD1 . ILE A 1 50  ? -21.938 15.795 27.338  1.00 23.47 ? 50  ILE A CD1 1 
+ATOM   431  N  N   . GLY A 1 51  ? -24.741 17.132 31.824  1.00 19.26 ? 51  GLY A N   1 
+ATOM   432  C  CA  . GLY A 1 51  ? -25.061 17.073 33.240  1.00 20.75 ? 51  GLY A CA  1 
+ATOM   433  C  C   . GLY A 1 51  ? -24.010 17.644 34.165  1.00 22.20 ? 51  GLY A C   1 
+ATOM   434  O  O   . GLY A 1 51  ? -23.998 17.303 35.356  1.00 24.90 ? 51  GLY A O   1 
+ATOM   435  N  N   . ARG A 1 52  ? -23.120 18.493 33.664  1.00 21.81 ? 52  ARG A N   1 
+ATOM   436  C  CA  . ARG A 1 52  ? -22.142 19.167 34.510  1.00 22.42 ? 52  ARG A CA  1 
+ATOM   437  C  C   . ARG A 1 52  ? -21.731 20.461 33.820  1.00 21.44 ? 52  ARG A C   1 
+ATOM   438  O  O   . ARG A 1 52  ? -22.070 20.702 32.658  1.00 22.27 ? 52  ARG A O   1 
+ATOM   439  C  CB  . ARG A 1 52  ? -20.921 18.276 34.793  1.00 24.14 ? 52  ARG A CB  1 
+ATOM   440  C  CG  . ARG A 1 52  ? -20.049 18.028 33.570  1.00 23.93 ? 52  ARG A CG  1 
+ATOM   441  C  CD  . ARG A 1 52  ? -18.880 17.082 33.846  1.00 23.84 ? 52  ARG A CD  1 
+ATOM   442  N  NE  . ARG A 1 52  ? -18.122 16.864 32.619  1.00 23.12 ? 52  ARG A NE  1 
+ATOM   443  C  CZ  . ARG A 1 52  ? -17.186 17.688 32.161  1.00 23.18 ? 52  ARG A CZ  1 
+ATOM   444  N  NH1 . ARG A 1 52  ? -16.877 18.789 32.841  1.00 24.52 ? 52  ARG A NH1 1 
+ATOM   445  N  NH2 . ARG A 1 52  ? -16.567 17.414 31.015  1.00 24.48 ? 52  ARG A NH2 1 
+ATOM   446  N  N   . ASN A 1 53  ? -20.996 21.293 34.554  1.00 22.26 ? 53  ASN A N   1 
+ATOM   447  C  CA  A ASN A 1 53  ? -20.488 22.555 34.024  0.48 23.77 ? 53  ASN A CA  1 
+ATOM   448  C  CA  B ASN A 1 53  ? -20.482 22.560 34.041  0.52 23.32 ? 53  ASN A CA  1 
+ATOM   449  C  C   . ASN A 1 53  ? -19.223 22.254 33.235  1.00 23.48 ? 53  ASN A C   1 
+ATOM   450  O  O   . ASN A 1 53  ? -18.154 22.035 33.807  1.00 25.01 ? 53  ASN A O   1 
+ATOM   451  C  CB  A ASN A 1 53  ? -20.219 23.540 35.156  0.48 27.44 ? 53  ASN A CB  1 
+ATOM   452  C  CB  B ASN A 1 53  ? -20.171 23.481 35.217  0.52 26.50 ? 53  ASN A CB  1 
+ATOM   453  C  CG  A ASN A 1 53  ? -21.490 24.127 35.724  0.48 31.26 ? 53  ASN A CG  1 
+ATOM   454  C  CG  B ASN A 1 53  ? -20.007 24.930 34.809  0.52 29.58 ? 53  ASN A CG  1 
+ATOM   455  O  OD1 A ASN A 1 53  ? -22.467 24.335 35.003  0.48 33.29 ? 53  ASN A OD1 1 
+ATOM   456  O  OD1 B ASN A 1 53  ? -19.469 25.237 33.747  0.52 30.72 ? 53  ASN A OD1 1 
+ATOM   457  N  ND2 A ASN A 1 53  ? -21.489 24.393 37.021  0.48 33.18 ? 53  ASN A ND2 1 
+ATOM   458  N  ND2 B ASN A 1 53  ? -20.465 25.833 35.666  0.52 32.04 ? 53  ASN A ND2 1 
+ATOM   459  N  N   . CYS A 1 54  ? -19.353 22.235 31.900  1.00 21.70 ? 54  CYS A N   1 
+ATOM   460  C  CA  . CYS A 1 54  ? -18.276 21.820 31.006  1.00 21.29 ? 54  CYS A CA  1 
+ATOM   461  C  C   . CYS A 1 54  ? -17.384 22.955 30.537  1.00 22.87 ? 54  CYS A C   1 
+ATOM   462  O  O   . CYS A 1 54  ? -16.248 22.691 30.124  1.00 23.39 ? 54  CYS A O   1 
+ATOM   463  C  CB  . CYS A 1 54  ? -18.850 21.173 29.737  1.00 20.26 ? 54  CYS A CB  1 
+ATOM   464  S  SG  . CYS A 1 54  ? -19.766 19.680 30.076  1.00 22.71 ? 54  CYS A SG  1 
+ATOM   465  N  N   . ASN A 1 55  ? -17.882 24.189 30.530  1.00 23.71 ? 55  ASN A N   1 
+ATOM   466  C  CA  . ASN A 1 55  ? -17.157 25.315 29.951  1.00 26.15 ? 55  ASN A CA  1 
+ATOM   467  C  C   . ASN A 1 55  ? -16.661 25.004 28.538  1.00 24.76 ? 55  ASN A C   1 
+ATOM   468  O  O   . ASN A 1 55  ? -15.538 25.349 28.155  1.00 26.68 ? 55  ASN A O   1 
+ATOM   469  C  CB  . ASN A 1 55  ? -16.015 25.770 30.858  1.00 30.03 ? 55  ASN A CB  1 
+ATOM   470  C  CG  . ASN A 1 55  ? -15.519 27.155 30.507  1.00 35.05 ? 55  ASN A CG  1 
+ATOM   471  O  OD1 . ASN A 1 55  ? -16.273 27.981 29.985  1.00 37.42 ? 55  ASN A OD1 1 
+ATOM   472  N  ND2 . ASN A 1 55  ? -14.243 27.410 30.767  1.00 37.46 ? 55  ASN A ND2 1 
+ATOM   473  N  N   . GLY A 1 56  ? -17.497 24.324 27.759  1.00 21.63 ? 56  GLY A N   1 
+ATOM   474  C  CA  . GLY A 1 56  ? -17.225 24.118 26.348  1.00 20.78 ? 56  GLY A CA  1 
+ATOM   475  C  C   . GLY A 1 56  ? -16.326 22.953 25.988  1.00 20.19 ? 56  GLY A C   1 
+ATOM   476  O  O   . GLY A 1 56  ? -16.000 22.793 24.804  1.00 22.42 ? 56  GLY A O   1 
+ATOM   477  N  N   . VAL A 1 57  ? -15.932 22.118 26.949  1.00 20.41 ? 57  VAL A N   1 
+ATOM   478  C  CA  A VAL A 1 57  ? -15.001 21.016 26.722  0.76 20.67 ? 57  VAL A CA  1 
+ATOM   479  C  CA  B VAL A 1 57  ? -15.029 21.006 26.683  0.24 20.07 ? 57  VAL A CA  1 
+ATOM   480  C  C   . VAL A 1 57  ? -15.566 19.748 27.352  1.00 19.00 ? 57  VAL A C   1 
+ATOM   481  O  O   . VAL A 1 57  ? -16.088 19.788 28.472  1.00 21.20 ? 57  VAL A O   1 
+ATOM   482  C  CB  A VAL A 1 57  ? -13.626 21.351 27.338  0.76 23.45 ? 57  VAL A CB  1 
+ATOM   483  C  CB  B VAL A 1 57  ? -13.574 21.312 27.109  0.24 20.68 ? 57  VAL A CB  1 
+ATOM   484  C  CG1 A VAL A 1 57  ? -12.685 20.169 27.222  0.76 25.67 ? 57  VAL A CG1 1 
+ATOM   485  C  CG1 B VAL A 1 57  ? -13.457 21.432 28.619  0.24 21.14 ? 57  VAL A CG1 1 
+ATOM   486  C  CG2 A VAL A 1 57  ? -13.040 22.583 26.676  0.76 24.54 ? 57  VAL A CG2 1 
+ATOM   487  C  CG2 B VAL A 1 57  ? -12.622 20.252 26.569  0.24 21.31 ? 57  VAL A CG2 1 
+ATOM   488  N  N   . ILE A 1 58  ? -15.453 18.618 26.647  1.00 17.57 ? 58  ILE A N   1 
+ATOM   489  C  CA  . ILE A 1 58  ? -15.914 17.329 27.151  1.00 18.21 ? 58  ILE A CA  1 
+ATOM   490  C  C   . ILE A 1 58  ? -14.791 16.302 27.052  1.00 20.32 ? 58  ILE A C   1 
+ATOM   491  O  O   . ILE A 1 58  ? -13.761 16.529 26.415  1.00 21.77 ? 58  ILE A O   1 
+ATOM   492  C  CB  . ILE A 1 58  ? -17.176 16.824 26.423  1.00 18.54 ? 58  ILE A CB  1 
+ATOM   493  C  CG1 . ILE A 1 58  ? -16.891 16.617 24.935  1.00 19.31 ? 58  ILE A CG1 1 
+ATOM   494  C  CG2 . ILE A 1 58  ? -18.349 17.783 26.645  1.00 19.47 ? 58  ILE A CG2 1 
+ATOM   495  C  CD1 . ILE A 1 58  ? -18.067 15.990 24.209  1.00 20.54 ? 58  ILE A CD1 1 
+ATOM   496  N  N   . THR A 1 59  ? -15.007 15.156 27.696  1.00 19.84 ? 59  THR A N   1 
+ATOM   497  C  CA  . THR A 1 59  ? -14.074 14.044 27.615  1.00 21.36 ? 59  THR A CA  1 
+ATOM   498  C  C   . THR A 1 59  ? -14.434 13.137 26.442  1.00 21.59 ? 59  THR A C   1 
+ATOM   499  O  O   . THR A 1 59  ? -15.522 13.220 25.867  1.00 20.13 ? 59  THR A O   1 
+ATOM   500  C  CB  . THR A 1 59  ? -14.090 13.227 28.911  1.00 22.70 ? 59  THR A CB  1 
+ATOM   501  O  OG1 . THR A 1 59  ? -15.331 12.512 29.006  1.00 22.71 ? 59  THR A OG1 1 
+ATOM   502  C  CG2 . THR A 1 59  ? -13.923 14.126 30.144  1.00 25.60 ? 59  THR A CG2 1 
+ATOM   503  N  N   . LYS A 1 60  ? -13.492 12.258 26.087  1.00 22.23 ? 60  LYS A N   1 
+ATOM   504  C  CA  . LYS A 1 60  ? -13.752 11.286 25.031  1.00 23.26 ? 60  LYS A CA  1 
+ATOM   505  C  C   . LYS A 1 60  ? -14.918 10.374 25.401  1.00 21.99 ? 60  LYS A C   1 
+ATOM   506  O  O   . LYS A 1 60  ? -15.779 10.085 24.562  1.00 21.56 ? 60  LYS A O   1 
+ATOM   507  C  CB  . LYS A 1 60  ? -12.491 10.478 24.724  1.00 27.52 ? 60  LYS A CB  1 
+ATOM   508  C  CG  . LYS A 1 60  ? -12.680 9.494  23.576  1.00 32.83 ? 60  LYS A CG  1 
+ATOM   509  C  CD  . LYS A 1 60  ? -11.351 8.936  23.099  1.00 38.86 ? 60  LYS A CD  1 
+ATOM   510  C  CE  . LYS A 1 60  ? -11.550 7.717  22.212  1.00 45.53 ? 60  LYS A CE  1 
+ATOM   511  N  NZ  . LYS A 1 60  ? -12.017 6.538  22.998  1.00 49.41 ? 60  LYS A NZ  1 
+ATOM   512  N  N   . ASP A 1 61  ? -14.974 9.929  26.663  1.00 22.78 ? 61  ASP A N   1 
+ATOM   513  C  CA  A ASP A 1 61  ? -16.080 9.081  27.101  0.90 23.77 ? 61  ASP A CA  1 
+ATOM   514  C  CA  B ASP A 1 61  ? -16.078 9.080  27.099  0.10 22.31 ? 61  ASP A CA  1 
+ATOM   515  C  C   . ASP A 1 61  ? -17.418 9.795  26.953  1.00 20.86 ? 61  ASP A C   1 
+ATOM   516  O  O   . ASP A 1 61  ? -18.411 9.188  26.533  1.00 20.73 ? 61  ASP A O   1 
+ATOM   517  C  CB  A ASP A 1 61  ? -15.885 8.660  28.560  0.90 27.44 ? 61  ASP A CB  1 
+ATOM   518  C  CB  B ASP A 1 61  ? -15.841 8.631  28.543  0.10 22.87 ? 61  ASP A CB  1 
+ATOM   519  C  CG  A ASP A 1 61  ? -14.842 7.572  28.731  0.90 33.75 ? 61  ASP A CG  1 
+ATOM   520  C  CG  B ASP A 1 61  ? -16.843 7.593  29.007  0.10 24.15 ? 61  ASP A CG  1 
+ATOM   521  O  OD1 A ASP A 1 61  ? -14.394 6.979  27.727  0.90 35.55 ? 61  ASP A OD1 1 
+ATOM   522  O  OD1 B ASP A 1 61  ? -18.012 7.954  29.257  0.10 24.98 ? 61  ASP A OD1 1 
+ATOM   523  O  OD2 A ASP A 1 61  ? -14.474 7.308  29.889  0.90 37.92 ? 61  ASP A OD2 1 
+ATOM   524  O  OD2 B ASP A 1 61  ? -16.460 6.409  29.117  0.10 24.66 ? 61  ASP A OD2 1 
+ATOM   525  N  N   . GLU A 1 62  ? -17.467 11.083 27.304  1.00 19.49 ? 62  GLU A N   1 
+ATOM   526  C  CA  . GLU A 1 62  ? -18.706 11.839 27.140  1.00 16.96 ? 62  GLU A CA  1 
+ATOM   527  C  C   . GLU A 1 62  ? -19.081 11.965 25.668  1.00 15.95 ? 62  GLU A C   1 
+ATOM   528  O  O   . GLU A 1 62  ? -20.256 11.824 25.305  1.00 17.53 ? 62  GLU A O   1 
+ATOM   529  C  CB  . GLU A 1 62  ? -18.568 13.216 27.791  1.00 18.39 ? 62  GLU A CB  1 
+ATOM   530  C  CG  . GLU A 1 62  ? -18.611 13.130 29.302  1.00 19.77 ? 62  GLU A CG  1 
+ATOM   531  C  CD  . GLU A 1 62  ? -18.129 14.381 30.015  1.00 20.83 ? 62  GLU A CD  1 
+ATOM   532  O  OE1 . GLU A 1 62  ? -17.480 15.248 29.394  1.00 21.02 ? 62  GLU A OE1 1 
+ATOM   533  O  OE2 . GLU A 1 62  ? -18.399 14.488 31.228  1.00 22.49 ? 62  GLU A OE2 1 
+ATOM   534  N  N   . ALA A 1 63  ? -18.095 12.219 24.801  1.00 17.03 ? 63  ALA A N   1 
+ATOM   535  C  CA  . ALA A 1 63  ? -18.378 12.303 23.369  1.00 17.42 ? 63  ALA A CA  1 
+ATOM   536  C  C   . ALA A 1 63  ? -18.963 10.994 22.843  1.00 17.32 ? 63  ALA A C   1 
+ATOM   537  O  O   . ALA A 1 63  ? -19.906 11.007 22.040  1.00 16.66 ? 63  ALA A O   1 
+ATOM   538  C  CB  . ALA A 1 63  ? -17.102 12.678 22.609  1.00 18.66 ? 63  ALA A CB  1 
+ATOM   539  N  N   A GLU A 1 64  ? -18.426 9.857  23.293  0.66 17.02 ? 64  GLU A N   1 
+ATOM   540  N  N   B GLU A 1 64  ? -18.412 9.856  23.283  0.34 18.73 ? 64  GLU A N   1 
+ATOM   541  C  CA  A GLU A 1 64  ? -18.908 8.569  22.798  0.66 17.33 ? 64  GLU A CA  1 
+ATOM   542  C  CA  B GLU A 1 64  ? -18.899 8.560  22.812  0.34 20.02 ? 64  GLU A CA  1 
+ATOM   543  C  C   A GLU A 1 64  ? -20.306 8.242  23.311  0.66 17.34 ? 64  GLU A C   1 
+ATOM   544  C  C   B GLU A 1 64  ? -20.322 8.294  23.288  0.34 18.38 ? 64  GLU A C   1 
+ATOM   545  O  O   A GLU A 1 64  ? -21.101 7.630  22.586  0.66 16.97 ? 64  GLU A O   1 
+ATOM   546  O  O   B GLU A 1 64  ? -21.145 7.764  22.532  0.34 17.43 ? 64  GLU A O   1 
+ATOM   547  C  CB  A GLU A 1 64  ? -17.904 7.467  23.137  0.66 21.16 ? 64  GLU A CB  1 
+ATOM   548  C  CB  B GLU A 1 64  ? -17.967 7.437  23.277  0.34 24.46 ? 64  GLU A CB  1 
+ATOM   549  C  CG  A GLU A 1 64  ? -16.644 7.558  22.291  0.66 24.28 ? 64  GLU A CG  1 
+ATOM   550  C  CG  B GLU A 1 64  ? -16.493 7.642  22.946  0.34 29.30 ? 64  GLU A CG  1 
+ATOM   551  C  CD  A GLU A 1 64  ? -15.531 6.650  22.777  0.66 33.07 ? 64  GLU A CD  1 
+ATOM   552  C  CD  B GLU A 1 64  ? -16.047 6.938  21.682  0.34 33.90 ? 64  GLU A CD  1 
+ATOM   553  O  OE1 A GLU A 1 64  ? -15.647 6.099  23.890  0.66 36.17 ? 64  GLU A OE1 1 
+ATOM   554  O  OE1 B GLU A 1 64  ? -16.851 6.828  20.734  0.34 34.82 ? 64  GLU A OE1 1 
+ATOM   555  O  OE2 A GLU A 1 64  ? -14.534 6.486  22.045  0.66 38.30 ? 64  GLU A OE2 1 
+ATOM   556  O  OE2 B GLU A 1 64  ? -14.882 6.490  21.639  0.34 36.80 ? 64  GLU A OE2 1 
+ATOM   557  N  N   . LYS A 1 65  ? -20.633 8.649  24.538  1.00 17.84 ? 65  LYS A N   1 
+ATOM   558  C  CA  . LYS A 1 65  ? -21.989 8.436  25.030  1.00 18.52 ? 65  LYS A CA  1 
+ATOM   559  C  C   . LYS A 1 65  ? -22.994 9.306  24.278  1.00 17.68 ? 65  LYS A C   1 
+ATOM   560  O  O   . LYS A 1 65  ? -24.077 8.834  23.912  1.00 17.33 ? 65  LYS A O   1 
+ATOM   561  C  CB  . LYS A 1 65  ? -22.067 8.675  26.532  1.00 20.97 ? 65  LYS A CB  1 
+ATOM   562  C  CG  . LYS A 1 65  ? -23.432 8.321  27.092  1.00 27.46 ? 65  LYS A CG  1 
+ATOM   563  C  CD  . LYS A 1 65  ? -23.427 8.248  28.613  1.00 29.95 ? 65  LYS A CD  1 
+ATOM   564  C  CE  . LYS A 1 65  ? -24.798 7.847  29.162  1.00 32.93 ? 65  LYS A CE  1 
+ATOM   565  N  NZ  . LYS A 1 65  ? -24.822 7.837  30.642  1.00 33.91 ? 65  LYS A NZ  1 
+ATOM   566  N  N   A LEU A 1 66  ? -22.665 10.583 24.043  0.60 16.12 ? 66  LEU A N   1 
+ATOM   567  N  N   B LEU A 1 66  ? -22.643 10.570 24.028  0.40 16.98 ? 66  LEU A N   1 
+ATOM   568  C  CA  A LEU A 1 66  ? -23.543 11.422 23.230  0.60 15.48 ? 66  LEU A CA  1 
+ATOM   569  C  CA  B LEU A 1 66  ? -23.503 11.445 23.239  0.40 17.17 ? 66  LEU A CA  1 
+ATOM   570  C  C   A LEU A 1 66  ? -23.754 10.802 21.857  0.60 15.07 ? 66  LEU A C   1 
+ATOM   571  C  C   B LEU A 1 66  ? -23.726 10.872 21.845  0.40 16.11 ? 66  LEU A C   1 
+ATOM   572  O  O   A LEU A 1 66  ? -24.877 10.786 21.336  0.60 15.56 ? 66  LEU A O   1 
+ATOM   573  O  O   B LEU A 1 66  ? -24.835 10.943 21.301  0.40 16.48 ? 66  LEU A O   1 
+ATOM   574  C  CB  A LEU A 1 66  ? -22.936 12.813 23.043  0.60 17.69 ? 66  LEU A CB  1 
+ATOM   575  C  CB  B LEU A 1 66  ? -22.841 12.819 23.139  0.40 19.51 ? 66  LEU A CB  1 
+ATOM   576  C  CG  A LEU A 1 66  ? -23.001 13.845 24.161  0.60 19.34 ? 66  LEU A CG  1 
+ATOM   577  C  CG  B LEU A 1 66  ? -23.707 14.066 23.026  0.40 20.87 ? 66  LEU A CG  1 
+ATOM   578  C  CD1 A LEU A 1 66  ? -22.218 15.077 23.751  0.60 20.82 ? 66  LEU A CD1 1 
+ATOM   579  C  CD1 B LEU A 1 66  ? -24.658 14.160 24.203  0.40 23.82 ? 66  LEU A CD1 1 
+ATOM   580  C  CD2 A LEU A 1 66  ? -24.442 14.214 24.456  0.60 22.53 ? 66  LEU A CD2 1 
+ATOM   581  C  CD2 B LEU A 1 66  ? -22.808 15.293 22.965  0.40 19.56 ? 66  LEU A CD2 1 
+ATOM   582  N  N   . PHE A 1 67  ? -22.677 10.291 21.257  1.00 15.19 ? 67  PHE A N   1 
+ATOM   583  C  CA  . PHE A 1 67  ? -22.768 9.707  19.928  1.00 15.14 ? 67  PHE A CA  1 
+ATOM   584  C  C   . PHE A 1 67  ? -23.706 8.505  19.923  1.00 15.34 ? 67  PHE A C   1 
+ATOM   585  O  O   . PHE A 1 67  ? -24.548 8.377  19.028  1.00 15.83 ? 67  PHE A O   1 
+ATOM   586  C  CB  . PHE A 1 67  ? -21.345 9.333  19.509  1.00 15.84 ? 67  PHE A CB  1 
+ATOM   587  C  CG  . PHE A 1 67  ? -21.219 8.733  18.131  1.00 15.43 ? 67  PHE A CG  1 
+ATOM   588  C  CD1 . PHE A 1 67  ? -21.860 9.284  17.028  1.00 16.88 ? 67  PHE A CD1 1 
+ATOM   589  C  CD2 . PHE A 1 67  ? -20.392 7.646  17.945  1.00 17.01 ? 67  PHE A CD2 1 
+ATOM   590  C  CE1 . PHE A 1 67  ? -21.693 8.731  15.759  1.00 17.51 ? 67  PHE A CE1 1 
+ATOM   591  C  CE2 . PHE A 1 67  ? -20.215 7.095  16.685  1.00 17.81 ? 67  PHE A CE2 1 
+ATOM   592  C  CZ  . PHE A 1 67  ? -20.878 7.629  15.595  1.00 16.87 ? 67  PHE A CZ  1 
+ATOM   593  N  N   . ASN A 1 68  ? -23.590 7.619  20.925  1.00 15.65 ? 68  ASN A N   1 
+ATOM   594  C  CA  A ASN A 1 68  ? -24.513 6.491  21.038  0.44 16.76 ? 68  ASN A CA  1 
+ATOM   595  C  CA  B ASN A 1 68  ? -24.513 6.492  21.027  0.56 14.82 ? 68  ASN A CA  1 
+ATOM   596  C  C   . ASN A 1 68  ? -25.958 6.972  21.117  1.00 15.52 ? 68  ASN A C   1 
+ATOM   597  O  O   . ASN A 1 68  ? -26.849 6.424  20.455  1.00 16.30 ? 68  ASN A O   1 
+ATOM   598  C  CB  A ASN A 1 68  ? -24.170 5.643  22.267  0.44 21.57 ? 68  ASN A CB  1 
+ATOM   599  C  CB  B ASN A 1 68  ? -24.147 5.638  22.242  0.56 17.80 ? 68  ASN A CB  1 
+ATOM   600  C  CG  A ASN A 1 68  ? -23.039 4.662  22.016  0.44 25.84 ? 68  ASN A CG  1 
+ATOM   601  C  CG  B ASN A 1 68  ? -24.642 4.209  22.137  0.56 20.21 ? 68  ASN A CG  1 
+ATOM   602  O  OD1 A ASN A 1 68  ? -23.058 3.912  21.046  0.44 29.72 ? 68  ASN A OD1 1 
+ATOM   603  O  OD1 B ASN A 1 68  ? -23.952 3.279  22.551  0.56 22.31 ? 68  ASN A OD1 1 
+ATOM   604  N  ND2 A ASN A 1 68  ? -22.055 4.649  22.910  0.44 27.50 ? 68  ASN A ND2 1 
+ATOM   605  N  ND2 B ASN A 1 68  ? -25.839 4.024  21.596  0.56 20.33 ? 68  ASN A ND2 1 
+ATOM   606  N  N   . GLN A 1 69  ? -26.215 7.996  21.940  1.00 14.07 ? 69  GLN A N   1 
+ATOM   607  C  CA  . GLN A 1 69  ? -27.571 8.529  22.040  1.00 14.48 ? 69  GLN A CA  1 
+ATOM   608  C  C   . GLN A 1 69  ? -28.047 9.077  20.704  1.00 14.61 ? 69  GLN A C   1 
+ATOM   609  O  O   . GLN A 1 69  ? -29.211 8.901  20.340  1.00 15.48 ? 69  GLN A O   1 
+ATOM   610  C  CB  . GLN A 1 69  ? -27.636 9.614  23.109  1.00 15.34 ? 69  GLN A CB  1 
+ATOM   611  C  CG  . GLN A 1 69  ? -27.406 9.065  24.501  1.00 16.40 ? 69  GLN A CG  1 
+ATOM   612  C  CD  . GLN A 1 69  ? -27.334 10.145 25.547  1.00 16.73 ? 69  GLN A CD  1 
+ATOM   613  O  OE1 . GLN A 1 69  ? -27.277 11.352 25.236  1.00 20.52 ? 69  GLN A OE1 1 
+ATOM   614  N  NE2 . GLN A 1 69  ? -27.316 9.733  26.792  1.00 18.60 ? 69  GLN A NE2 1 
+ATOM   615  N  N   . ASP A 1 70  ? -27.162 9.763  19.976  1.00 14.51 ? 70  ASP A N   1 
+ATOM   616  C  CA  . ASP A 1 70  ? -27.553 10.389 18.714  1.00 14.03 ? 70  ASP A CA  1 
+ATOM   617  C  C   . ASP A 1 70  ? -27.856 9.353  17.635  1.00 14.68 ? 70  ASP A C   1 
+ATOM   618  O  O   . ASP A 1 70  ? -28.813 9.515  16.868  1.00 16.04 ? 70  ASP A O   1 
+ATOM   619  C  CB  . ASP A 1 70  ? -26.459 11.343 18.231  1.00 14.09 ? 70  ASP A CB  1 
+ATOM   620  C  CG  . ASP A 1 70  ? -26.380 12.623 19.050  1.00 16.95 ? 70  ASP A CG  1 
+ATOM   621  O  OD1 . ASP A 1 70  ? -27.339 12.962 19.781  1.00 17.45 ? 70  ASP A OD1 1 
+ATOM   622  O  OD2 . ASP A 1 70  ? -25.347 13.308 18.932  1.00 17.60 ? 70  ASP A OD2 1 
+ATOM   623  N  N   . VAL A 1 71  ? -27.054 8.289  17.556  1.00 13.57 ? 71  VAL A N   1 
+ATOM   624  C  CA  . VAL A 1 71  ? -27.347 7.220  16.604  1.00 14.65 ? 71  VAL A CA  1 
+ATOM   625  C  C   . VAL A 1 71  ? -28.668 6.548  16.952  1.00 14.84 ? 71  VAL A C   1 
+ATOM   626  O  O   . VAL A 1 71  ? -29.502 6.291  16.074  1.00 16.20 ? 71  VAL A O   1 
+ATOM   627  C  CB  . VAL A 1 71  ? -26.184 6.214  16.548  1.00 15.61 ? 71  VAL A CB  1 
+ATOM   628  C  CG1 . VAL A 1 71  ? -26.573 4.997  15.711  1.00 18.12 ? 71  VAL A CG1 1 
+ATOM   629  C  CG2 . VAL A 1 71  ? -24.938 6.884  15.995  1.00 17.97 ? 71  VAL A CG2 1 
+ATOM   630  N  N   A ASP A 1 72  ? -28.876 6.259  18.243  0.45 15.67 ? 72  ASP A N   1 
+ATOM   631  N  N   B ASP A 1 72  ? -28.888 6.263  18.239  0.55 14.08 ? 72  ASP A N   1 
+ATOM   632  C  CA  A ASP A 1 72  ? -30.131 5.668  18.697  0.45 18.06 ? 72  ASP A CA  1 
+ATOM   633  C  CA  B ASP A 1 72  ? -30.151 5.655  18.640  0.55 15.42 ? 72  ASP A CA  1 
+ATOM   634  C  C   A ASP A 1 72  ? -31.316 6.537  18.300  0.45 17.05 ? 72  ASP A C   1 
+ATOM   635  C  C   B ASP A 1 72  ? -31.326 6.543  18.268  0.55 15.95 ? 72  ASP A C   1 
+ATOM   636  O  O   A ASP A 1 72  ? -32.331 6.031  17.810  0.45 17.34 ? 72  ASP A O   1 
+ATOM   637  O  O   B ASP A 1 72  ? -32.340 6.058  17.757  0.55 16.58 ? 72  ASP A O   1 
+ATOM   638  C  CB  A ASP A 1 72  ? -30.071 5.478  20.219  0.45 20.93 ? 72  ASP A CB  1 
+ATOM   639  C  CB  B ASP A 1 72  ? -30.137 5.364  20.138  0.55 15.79 ? 72  ASP A CB  1 
+ATOM   640  C  CG  A ASP A 1 72  ? -31.249 4.685  20.776  0.45 24.93 ? 72  ASP A CG  1 
+ATOM   641  C  CG  B ASP A 1 72  ? -29.219 4.225  20.488  0.55 18.42 ? 72  ASP A CG  1 
+ATOM   642  O  OD1 A ASP A 1 72  ? -32.409 5.109  20.609  0.45 26.64 ? 72  ASP A OD1 1 
+ATOM   643  O  OD1 B ASP A 1 72  ? -28.780 3.522  19.553  0.55 20.34 ? 72  ASP A OD1 1 
+ATOM   644  O  OD2 A ASP A 1 72  ? -31.007 3.639  21.410  0.45 26.68 ? 72  ASP A OD2 1 
+ATOM   645  O  OD2 B ASP A 1 72  ? -28.937 4.036  21.689  0.55 19.99 ? 72  ASP A OD2 1 
+ATOM   646  N  N   . ALA A 1 73  ? -31.194 7.855  18.481  1.00 15.68 ? 73  ALA A N   1 
+ATOM   647  C  CA  . ALA A 1 73  ? -32.285 8.765  18.137  1.00 17.43 ? 73  ALA A CA  1 
+ATOM   648  C  C   . ALA A 1 73  ? -32.561 8.770  16.635  1.00 16.88 ? 73  ALA A C   1 
+ATOM   649  O  O   . ALA A 1 73  ? -33.720 8.871  16.207  1.00 18.53 ? 73  ALA A O   1 
+ATOM   650  C  CB  . ALA A 1 73  ? -31.962 10.176 18.623  1.00 18.41 ? 73  ALA A CB  1 
+ATOM   651  N  N   . ALA A 1 74  ? -31.509 8.684  15.818  1.00 16.00 ? 74  ALA A N   1 
+ATOM   652  C  CA  . ALA A 1 74  ? -31.715 8.642  14.372  1.00 15.90 ? 74  ALA A CA  1 
+ATOM   653  C  C   . ALA A 1 74  ? -32.479 7.388  13.971  1.00 16.05 ? 74  ALA A C   1 
+ATOM   654  O  O   . ALA A 1 74  ? -33.407 7.449  13.154  1.00 18.14 ? 74  ALA A O   1 
+ATOM   655  C  CB  . ALA A 1 74  ? -30.377 8.717  13.636  1.00 18.07 ? 74  ALA A CB  1 
+ATOM   656  N  N   . VAL A 1 75  ? -32.097 6.239  14.532  1.00 15.55 ? 75  VAL A N   1 
+ATOM   657  C  CA  . VAL A 1 75  ? -32.786 4.992  14.222  1.00 16.55 ? 75  VAL A CA  1 
+ATOM   658  C  C   . VAL A 1 75  ? -34.244 5.061  14.658  1.00 17.96 ? 75  VAL A C   1 
+ATOM   659  O  O   . VAL A 1 75  ? -35.149 4.684  13.906  1.00 18.51 ? 75  VAL A O   1 
+ATOM   660  C  CB  . VAL A 1 75  ? -32.060 3.795  14.856  1.00 16.38 ? 75  VAL A CB  1 
+ATOM   661  C  CG1 . VAL A 1 75  ? -32.892 2.529  14.666  1.00 20.08 ? 75  VAL A CG1 1 
+ATOM   662  C  CG2 . VAL A 1 75  ? -30.685 3.623  14.239  1.00 18.19 ? 75  VAL A CG2 1 
+ATOM   663  N  N   A ARG A 1 76  ? -34.487 5.539  15.883  0.52 17.97 ? 76  ARG A N   1 
+ATOM   664  N  N   B ARG A 1 76  ? -34.493 5.551  15.876  0.48 18.43 ? 76  ARG A N   1 
+ATOM   665  C  CA  A ARG A 1 76  ? -35.859 5.647  16.369  0.52 20.63 ? 76  ARG A CA  1 
+ATOM   666  C  CA  B ARG A 1 76  ? -35.871 5.616  16.355  0.48 20.77 ? 76  ARG A CA  1 
+ATOM   667  C  C   A ARG A 1 76  ? -36.685 6.571  15.487  0.52 21.67 ? 76  ARG A C   1 
+ATOM   668  C  C   B ARG A 1 76  ? -36.705 6.606  15.547  0.48 21.90 ? 76  ARG A C   1 
+ATOM   669  O  O   A ARG A 1 76  ? -37.863 6.300  15.222  0.52 22.24 ? 76  ARG A O   1 
+ATOM   670  O  O   B ARG A 1 76  ? -37.915 6.403  15.388  0.48 22.28 ? 76  ARG A O   1 
+ATOM   671  C  CB  A ARG A 1 76  ? -35.873 6.148  17.813  0.52 24.83 ? 76  ARG A CB  1 
+ATOM   672  C  CB  B ARG A 1 76  ? -35.912 5.932  17.853  0.48 24.26 ? 76  ARG A CB  1 
+ATOM   673  C  CG  A ARG A 1 76  ? -35.412 5.124  18.813  0.52 28.81 ? 76  ARG A CG  1 
+ATOM   674  C  CG  B ARG A 1 76  ? -35.255 4.870  18.725  0.48 28.27 ? 76  ARG A CG  1 
+ATOM   675  C  CD  A ARG A 1 76  ? -35.735 5.561  20.230  0.52 32.95 ? 76  ARG A CD  1 
+ATOM   676  C  CD  B ARG A 1 76  ? -35.918 3.496  18.588  0.48 31.19 ? 76  ARG A CD  1 
+ATOM   677  N  NE  A ARG A 1 76  ? -35.233 4.601  21.205  0.52 35.82 ? 76  ARG A NE  1 
+ATOM   678  N  NE  B ARG A 1 76  ? -37.227 3.415  19.238  0.48 32.38 ? 76  ARG A NE  1 
+ATOM   679  C  CZ  A ARG A 1 76  ? -35.962 3.632  21.752  0.52 39.04 ? 76  ARG A CZ  1 
+ATOM   680  C  CZ  B ARG A 1 76  ? -37.425 3.013  20.493  0.48 33.51 ? 76  ARG A CZ  1 
+ATOM   681  N  NH1 A ARG A 1 76  ? -37.241 3.486  21.429  0.52 40.03 ? 76  ARG A NH1 1 
+ATOM   682  N  NH1 B ARG A 1 76  ? -38.656 2.965  20.990  0.48 32.84 ? 76  ARG A NH1 1 
+ATOM   683  N  NH2 A ARG A 1 76  ? -35.408 2.808  22.626  0.52 39.40 ? 76  ARG A NH2 1 
+ATOM   684  N  NH2 B ARG A 1 76  ? -36.399 2.657  21.255  0.48 34.29 ? 76  ARG A NH2 1 
+ATOM   685  N  N   . GLY A 1 77  ? -36.085 7.670  15.031  1.00 21.17 ? 77  GLY A N   1 
+ATOM   686  C  CA  . GLY A 1 77  ? -36.810 8.585  14.165  1.00 21.30 ? 77  GLY A CA  1 
+ATOM   687  C  C   . GLY A 1 77  ? -37.235 7.933  12.864  1.00 20.83 ? 77  GLY A C   1 
+ATOM   688  O  O   . GLY A 1 77  ? -38.350 8.148  12.387  1.00 24.79 ? 77  GLY A O   1 
+ATOM   689  N  N   . ILE A 1 78  ? -36.356 7.116  12.281  1.00 15.79 ? 78  ILE A N   1 
+ATOM   690  C  CA  . ILE A 1 78  ? -36.721 6.364  11.084  1.00 15.54 ? 78  ILE A CA  1 
+ATOM   691  C  C   . ILE A 1 78  ? -37.887 5.428  11.380  1.00 16.92 ? 78  ILE A C   1 
+ATOM   692  O  O   . ILE A 1 78  ? -38.879 5.383  10.639  1.00 17.65 ? 78  ILE A O   1 
+ATOM   693  C  CB  . ILE A 1 78  ? -35.500 5.595  10.547  1.00 15.96 ? 78  ILE A CB  1 
+ATOM   694  C  CG1 . ILE A 1 78  ? -34.487 6.572  9.946   1.00 16.83 ? 78  ILE A CG1 1 
+ATOM   695  C  CG2 . ILE A 1 78  ? -35.930 4.549  9.514   1.00 18.55 ? 78  ILE A CG2 1 
+ATOM   696  C  CD1 . ILE A 1 78  ? -33.140 5.964  9.724   1.00 19.52 ? 78  ILE A CD1 1 
+ATOM   697  N  N   . LEU A 1 79  ? -37.787 4.671  12.477  1.00 16.53 ? 79  LEU A N   1 
+ATOM   698  C  CA  . LEU A 1 79  ? -38.782 3.644  12.753  1.00 18.63 ? 79  LEU A CA  1 
+ATOM   699  C  C   . LEU A 1 79  ? -40.142 4.229  13.105  1.00 22.05 ? 79  LEU A C   1 
+ATOM   700  O  O   . LEU A 1 79  ? -41.155 3.542  12.939  1.00 24.36 ? 79  LEU A O   1 
+ATOM   701  C  CB  . LEU A 1 79  ? -38.303 2.728  13.882  1.00 20.99 ? 79  LEU A CB  1 
+ATOM   702  C  CG  . LEU A 1 79  ? -37.029 1.927  13.597  1.00 23.88 ? 79  LEU A CG  1 
+ATOM   703  C  CD1 . LEU A 1 79  ? -36.617 1.141  14.826  1.00 25.83 ? 79  LEU A CD1 1 
+ATOM   704  C  CD2 . LEU A 1 79  ? -37.214 1.003  12.402  1.00 26.83 ? 79  LEU A CD2 1 
+ATOM   705  N  N   . ARG A 1 80  ? -40.188 5.465  13.599  1.00 21.30 ? 80  ARG A N   1 
+ATOM   706  C  CA  . ARG A 1 80  ? -41.449 6.116  13.942  1.00 25.28 ? 80  ARG A CA  1 
+ATOM   707  C  C   . ARG A 1 80  ? -42.099 6.813  12.756  1.00 25.54 ? 80  ARG A C   1 
+ATOM   708  O  O   . ARG A 1 80  ? -43.263 7.218  12.853  1.00 28.95 ? 80  ARG A O   1 
+ATOM   709  C  CB  . ARG A 1 80  ? -41.224 7.172  15.031  1.00 32.97 ? 80  ARG A CB  1 
+ATOM   710  C  CG  . ARG A 1 80  ? -41.060 6.635  16.434  1.00 42.58 ? 80  ARG A CG  1 
+ATOM   711  C  CD  . ARG A 1 80  ? -41.294 7.749  17.455  1.00 50.68 ? 80  ARG A CD  1 
+ATOM   712  N  NE  . ARG A 1 80  ? -40.103 8.042  18.248  1.00 58.41 ? 80  ARG A NE  1 
+ATOM   713  C  CZ  . ARG A 1 80  ? -39.200 8.968  17.935  1.00 63.92 ? 80  ARG A CZ  1 
+ATOM   714  N  NH1 . ARG A 1 80  ? -38.148 9.161  18.722  1.00 65.54 ? 80  ARG A NH1 1 
+ATOM   715  N  NH2 . ARG A 1 80  ? -39.347 9.702  16.839  1.00 66.12 ? 80  ARG A NH2 1 
+ATOM   716  N  N   . ASN A 1 81  ? -41.379 6.981  11.656  1.00 23.56 ? 81  ASN A N   1 
+ATOM   717  C  CA  . ASN A 1 81  ? -41.834 7.811  10.551  1.00 22.16 ? 81  ASN A CA  1 
+ATOM   718  C  C   . ASN A 1 81  ? -42.490 6.925  9.497   1.00 23.11 ? 81  ASN A C   1 
+ATOM   719  O  O   . ASN A 1 81  ? -41.845 6.033  8.942   1.00 24.10 ? 81  ASN A O   1 
+ATOM   720  C  CB  . ASN A 1 81  ? -40.637 8.563  9.971   1.00 23.25 ? 81  ASN A CB  1 
+ATOM   721  C  CG  . ASN A 1 81  ? -41.035 9.588  8.929   1.00 25.26 ? 81  ASN A CG  1 
+ATOM   722  O  OD1 . ASN A 1 81  ? -41.561 9.240  7.871   1.00 27.10 ? 81  ASN A OD1 1 
+ATOM   723  N  ND2 . ASN A 1 81  ? -40.756 10.859 9.209   1.00 26.21 ? 81  ASN A ND2 1 
+ATOM   724  N  N   . ALA A 1 82  ? -43.774 7.174  9.224   1.00 25.77 ? 82  ALA A N   1 
+ATOM   725  C  CA  . ALA A 1 82  ? -44.521 6.311  8.314   1.00 28.10 ? 82  ALA A CA  1 
+ATOM   726  C  C   . ALA A 1 82  ? -43.991 6.348  6.884   1.00 28.17 ? 82  ALA A C   1 
+ATOM   727  O  O   . ALA A 1 82  ? -44.233 5.401  6.122   1.00 30.26 ? 82  ALA A O   1 
+ATOM   728  C  CB  . ALA A 1 82  ? -46.004 6.688  8.338   1.00 29.75 ? 82  ALA A CB  1 
+ATOM   729  N  N   . LYS A 1 83  ? -43.285 7.413  6.498   1.00 28.86 ? 83  LYS A N   1 
+ATOM   730  C  CA  . LYS A 1 83  ? -42.717 7.498  5.155   1.00 30.87 ? 83  LYS A CA  1 
+ATOM   731  C  C   . LYS A 1 83  ? -41.363 6.809  5.057   1.00 27.09 ? 83  LYS A C   1 
+ATOM   732  O  O   . LYS A 1 83  ? -41.027 6.255  4.005   1.00 31.13 ? 83  LYS A O   1 
+ATOM   733  C  CB  . LYS A 1 83  ? -42.533 8.961  4.747   1.00 36.31 ? 83  LYS A CB  1 
+ATOM   734  C  CG  . LYS A 1 83  ? -43.770 9.649  4.214   1.00 42.01 ? 83  LYS A CG  1 
+ATOM   735  C  CD  . LYS A 1 83  ? -43.373 10.903 3.443   1.00 46.57 ? 83  LYS A CD  1 
+ATOM   736  C  CE  . LYS A 1 83  ? -42.351 10.580 2.352   1.00 49.35 ? 83  LYS A CE  1 
+ATOM   737  N  NZ  . LYS A 1 83  ? -41.980 11.773 1.536   1.00 50.30 ? 83  LYS A NZ  1 
+ATOM   738  N  N   . LEU A 1 84  ? -40.568 6.849  6.122   1.00 21.17 ? 84  LEU A N   1 
+ATOM   739  C  CA  . LEU A 1 84  ? -39.215 6.305  6.095   1.00 17.50 ? 84  LEU A CA  1 
+ATOM   740  C  C   . LEU A 1 84  ? -39.166 4.827  6.450   1.00 17.03 ? 84  LEU A C   1 
+ATOM   741  O  O   . LEU A 1 84  ? -38.391 4.075  5.847   1.00 18.62 ? 84  LEU A O   1 
+ATOM   742  C  CB  . LEU A 1 84  ? -38.307 7.089  7.048   1.00 17.18 ? 84  LEU A CB  1 
+ATOM   743  C  CG  . LEU A 1 84  ? -38.180 8.595  6.773   1.00 20.24 ? 84  LEU A CG  1 
+ATOM   744  C  CD1 . LEU A 1 84  ? -37.264 9.254  7.799   1.00 21.80 ? 84  LEU A CD1 1 
+ATOM   745  C  CD2 . LEU A 1 84  ? -37.680 8.858  5.353   1.00 22.51 ? 84  LEU A CD2 1 
+ATOM   746  N  N   . LYS A 1 85  ? -39.968 4.396  7.421   1.00 17.14 ? 85  LYS A N   1 
+ATOM   747  C  CA  . LYS A 1 85  ? -39.884 3.010  7.888   1.00 17.44 ? 85  LYS A CA  1 
+ATOM   748  C  C   . LYS A 1 85  ? -40.040 1.978  6.784   1.00 18.09 ? 85  LYS A C   1 
+ATOM   749  O  O   . LYS A 1 85  ? -39.219 1.043  6.729   1.00 17.88 ? 85  LYS A O   1 
+ATOM   750  C  CB  . LYS A 1 85  ? -40.848 2.765  9.051   1.00 20.27 ? 85  LYS A CB  1 
+ATOM   751  C  CG  . LYS A 1 85  ? -40.730 1.362  9.602   1.00 23.46 ? 85  LYS A CG  1 
+ATOM   752  C  CD  . LYS A 1 85  ? -41.694 1.134  10.739  1.00 27.95 ? 85  LYS A CD  1 
+ATOM   753  C  CE  . LYS A 1 85  ? -41.395 -0.176 11.436  1.00 31.05 ? 85  LYS A CE  1 
+ATOM   754  N  NZ  . LYS A 1 85  ? -41.556 -1.343 10.528  1.00 33.38 ? 85  LYS A NZ  1 
+ATOM   755  N  N   . PRO A 1 86  ? -41.030 2.057  5.888   1.00 18.75 ? 86  PRO A N   1 
+ATOM   756  C  CA  . PRO A 1 86  ? -41.147 1.015  4.856   1.00 19.36 ? 86  PRO A CA  1 
+ATOM   757  C  C   . PRO A 1 86  ? -39.938 0.944  3.945   1.00 17.76 ? 86  PRO A C   1 
+ATOM   758  O  O   . PRO A 1 86  ? -39.552 -0.151 3.512   1.00 20.20 ? 86  PRO A O   1 
+ATOM   759  C  CB  . PRO A 1 86  ? -42.414 1.406  4.082   1.00 22.89 ? 86  PRO A CB  1 
+ATOM   760  C  CG  . PRO A 1 86  ? -43.162 2.307  4.988   1.00 24.69 ? 86  PRO A CG  1 
+ATOM   761  C  CD  . PRO A 1 86  ? -42.150 3.018  5.826   1.00 21.23 ? 86  PRO A CD  1 
+ATOM   762  N  N   . VAL A 1 87  ? -39.318 2.087  3.641   1.00 16.87 ? 87  VAL A N   1 
+ATOM   763  C  CA  . VAL A 1 87  ? -38.121 2.061  2.808   1.00 17.23 ? 87  VAL A CA  1 
+ATOM   764  C  C   . VAL A 1 87  ? -36.966 1.427  3.572   1.00 15.23 ? 87  VAL A C   1 
+ATOM   765  O  O   . VAL A 1 87  ? -36.247 0.566  3.054   1.00 16.56 ? 87  VAL A O   1 
+ATOM   766  C  CB  . VAL A 1 87  ? -37.772 3.476  2.310   1.00 18.48 ? 87  VAL A CB  1 
+ATOM   767  C  CG1 . VAL A 1 87  ? -36.575 3.416  1.368   1.00 21.06 ? 87  VAL A CG1 1 
+ATOM   768  C  CG2 . VAL A 1 87  ? -38.977 4.118  1.626   1.00 21.47 ? 87  VAL A CG2 1 
+ATOM   769  N  N   . TYR A 1 88  ? -36.777 1.847  4.822   1.00 15.43 ? 88  TYR A N   1 
+ATOM   770  C  CA  . TYR A 1 88  ? -35.718 1.293  5.661   1.00 14.51 ? 88  TYR A CA  1 
+ATOM   771  C  C   . TYR A 1 88  ? -35.834 -0.225 5.778   1.00 14.91 ? 88  TYR A C   1 
+ATOM   772  O  O   . TYR A 1 88  ? -34.841 -0.950 5.619   1.00 16.16 ? 88  TYR A O   1 
+ATOM   773  C  CB  . TYR A 1 88  ? -35.790 1.947  7.039   1.00 15.48 ? 88  TYR A CB  1 
+ATOM   774  C  CG  . TYR A 1 88  ? -34.692 1.566  7.991   1.00 15.05 ? 88  TYR A CG  1 
+ATOM   775  C  CD1 . TYR A 1 88  ? -33.443 2.175  7.910   1.00 17.05 ? 88  TYR A CD1 1 
+ATOM   776  C  CD2 . TYR A 1 88  ? -34.908 0.640  8.992   1.00 17.38 ? 88  TYR A CD2 1 
+ATOM   777  C  CE1 . TYR A 1 88  ? -32.435 1.857  8.797   1.00 19.45 ? 88  TYR A CE1 1 
+ATOM   778  C  CE2 . TYR A 1 88  ? -33.906 0.316  9.892   1.00 18.93 ? 88  TYR A CE2 1 
+ATOM   779  C  CZ  . TYR A 1 88  ? -32.667 0.924  9.787   1.00 19.56 ? 88  TYR A CZ  1 
+ATOM   780  O  OH  . TYR A 1 88  ? -31.667 0.593  10.675  1.00 24.11 ? 88  TYR A OH  1 
+ATOM   781  N  N   . ASP A 1 89  ? -37.050 -0.727 6.020   1.00 15.72 ? 89  ASP A N   1 
+ATOM   782  C  CA  . ASP A 1 89  ? -37.245 -2.163 6.204   1.00 17.89 ? 89  ASP A CA  1 
+ATOM   783  C  C   . ASP A 1 89  ? -37.000 -2.950 4.926   1.00 18.47 ? 89  ASP A C   1 
+ATOM   784  O  O   . ASP A 1 89  ? -36.776 -4.162 4.997   1.00 22.01 ? 89  ASP A O   1 
+ATOM   785  C  CB  . ASP A 1 89  ? -38.656 -2.448 6.708   1.00 20.52 ? 89  ASP A CB  1 
+ATOM   786  C  CG  . ASP A 1 89  ? -38.825 -2.150 8.184   1.00 24.64 ? 89  ASP A CG  1 
+ATOM   787  O  OD1 . ASP A 1 89  ? -37.813 -1.891 8.877   1.00 26.65 ? 89  ASP A OD1 1 
+ATOM   788  O  OD2 . ASP A 1 89  ? -39.980 -2.183 8.647   1.00 28.86 ? 89  ASP A OD2 1 
+ATOM   789  N  N   . SER A 1 90  ? -37.042 -2.294 3.765   1.00 15.44 ? 90  SER A N   1 
+ATOM   790  C  CA  . SER A 1 90  ? -36.791 -2.974 2.499   1.00 15.94 ? 90  SER A CA  1 
+ATOM   791  C  C   . SER A 1 90  ? -35.306 -3.121 2.194   1.00 15.03 ? 90  SER A C   1 
+ATOM   792  O  O   . SER A 1 90  ? -34.957 -3.898 1.302   1.00 16.71 ? 90  SER A O   1 
+ATOM   793  C  CB  . SER A 1 90  ? -37.472 -2.216 1.346   1.00 17.42 ? 90  SER A CB  1 
+ATOM   794  O  OG  . SER A 1 90  ? -36.752 -1.049 0.979   1.00 17.58 ? 90  SER A OG  1 
+ATOM   795  N  N   . LEU A 1 91  ? -34.439 -2.392 2.896   1.00 15.82 ? 91  LEU A N   1 
+ATOM   796  C  CA  . LEU A 1 91  ? -33.013 -2.353 2.594   1.00 14.07 ? 91  LEU A CA  1 
+ATOM   797  C  C   . LEU A 1 91  ? -32.248 -3.443 3.336   1.00 15.09 ? 91  LEU A C   1 
+ATOM   798  O  O   . LEU A 1 91  ? -32.623 -3.857 4.436   1.00 17.11 ? 91  LEU A O   1 
+ATOM   799  C  CB  . LEU A 1 91  ? -32.425 -1.006 3.006   1.00 15.14 ? 91  LEU A CB  1 
+ATOM   800  C  CG  . LEU A 1 91  ? -32.982 0.222  2.283   1.00 17.03 ? 91  LEU A CG  1 
+ATOM   801  C  CD1 . LEU A 1 91  ? -32.433 1.502  2.913   1.00 18.38 ? 91  LEU A CD1 1 
+ATOM   802  C  CD2 . LEU A 1 91  ? -32.637 0.162  0.807   1.00 19.88 ? 91  LEU A CD2 1 
+ATOM   803  N  N   . ASP A 1 92  ? -31.147 -3.879 2.728   1.00 14.90 ? 92  ASP A N   1 
+ATOM   804  C  CA  . ASP A 1 92  ? -30.175 -4.737 3.392   1.00 13.98 ? 92  ASP A CA  1 
+ATOM   805  C  C   . ASP A 1 92  ? -29.384 -3.941 4.441   1.00 14.49 ? 92  ASP A C   1 
+ATOM   806  O  O   . ASP A 1 92  ? -29.473 -2.716 4.531   1.00 16.00 ? 92  ASP A O   1 
+ATOM   807  C  CB  . ASP A 1 92  ? -29.204 -5.292 2.360   1.00 16.32 ? 92  ASP A CB  1 
+ATOM   808  C  CG  . ASP A 1 92  ? -28.515 -4.196 1.598   1.00 17.82 ? 92  ASP A CG  1 
+ATOM   809  O  OD1 . ASP A 1 92  ? -29.096 -3.701 0.606   1.00 18.34 ? 92  ASP A OD1 1 
+ATOM   810  O  OD2 . ASP A 1 92  ? -27.421 -3.781 2.036   1.00 19.22 ? 92  ASP A OD2 1 
+ATOM   811  N  N   . ALA A 1 93  ? -28.570 -4.658 5.225   1.00 17.26 ? 93  ALA A N   1 
+ATOM   812  C  CA  . ALA A 1 93  ? -27.946 -4.055 6.405   1.00 17.78 ? 93  ALA A CA  1 
+ATOM   813  C  C   . ALA A 1 93  ? -26.962 -2.951 6.032   1.00 17.72 ? 93  ALA A C   1 
+ATOM   814  O  O   . ALA A 1 93  ? -26.851 -1.947 6.747   1.00 18.78 ? 93  ALA A O   1 
+ATOM   815  C  CB  . ALA A 1 93  ? -27.272 -5.124 7.269   1.00 20.78 ? 93  ALA A CB  1 
+ATOM   816  N  N   . VAL A 1 94  ? -26.223 -3.118 4.934   1.00 16.66 ? 94  VAL A N   1 
+ATOM   817  C  CA  . VAL A 1 94  ? -25.253 -2.091 4.563   1.00 15.45 ? 94  VAL A CA  1 
+ATOM   818  C  C   . VAL A 1 94  ? -25.970 -0.827 4.125   1.00 14.20 ? 94  VAL A C   1 
+ATOM   819  O  O   . VAL A 1 94  ? -25.623 0.286  4.541   1.00 15.14 ? 94  VAL A O   1 
+ATOM   820  C  CB  . VAL A 1 94  ? -24.291 -2.606 3.479   1.00 17.27 ? 94  VAL A CB  1 
+ATOM   821  C  CG1 . VAL A 1 94  ? -23.330 -1.495 3.058   1.00 18.69 ? 94  VAL A CG1 1 
+ATOM   822  C  CG2 . VAL A 1 94  ? -23.535 -3.821 3.984   1.00 19.66 ? 94  VAL A CG2 1 
+ATOM   823  N  N   . ARG A 1 95  ? -26.989 -0.975 3.280   1.00 14.44 ? 95  ARG A N   1 
+ATOM   824  C  CA  . ARG A 1 95  ? -27.729 0.201  2.835   1.00 13.66 ? 95  ARG A CA  1 
+ATOM   825  C  C   . ARG A 1 95  ? -28.497 0.864  3.974   1.00 13.98 ? 95  ARG A C   1 
+ATOM   826  O  O   . ARG A 1 95  ? -28.688 2.084  3.956   1.00 14.26 ? 95  ARG A O   1 
+ATOM   827  C  CB  . ARG A 1 95  ? -28.626 -0.156 1.649   1.00 13.97 ? 95  ARG A CB  1 
+ATOM   828  C  CG  . ARG A 1 95  ? -27.826 -0.525 0.417   1.00 13.97 ? 95  ARG A CG  1 
+ATOM   829  C  CD  . ARG A 1 95  ? -28.735 -0.766 -0.782  1.00 15.68 ? 95  ARG A CD  1 
+ATOM   830  N  NE  . ARG A 1 95  ? -28.029 -0.927 -2.052  1.00 15.46 ? 95  ARG A NE  1 
+ATOM   831  C  CZ  . ARG A 1 95  ? -27.647 -2.092 -2.571  1.00 15.01 ? 95  ARG A CZ  1 
+ATOM   832  N  NH1 . ARG A 1 95  ? -27.871 -3.227 -1.918  1.00 16.60 ? 95  ARG A NH1 1 
+ATOM   833  N  NH2 . ARG A 1 95  ? -27.033 -2.122 -3.753  1.00 17.07 ? 95  ARG A NH2 1 
+ATOM   834  N  N   A ARG A 1 96  ? -28.940 0.090  4.974   0.59 13.21 ? 96  ARG A N   1 
+ATOM   835  N  N   B ARG A 1 96  ? -28.937 0.091  4.974   0.41 13.63 ? 96  ARG A N   1 
+ATOM   836  C  CA  A ARG A 1 96  ? -29.559 0.707  6.146   0.59 13.05 ? 96  ARG A CA  1 
+ATOM   837  C  CA  B ARG A 1 96  ? -29.560 0.714  6.139   0.41 13.29 ? 96  ARG A CA  1 
+ATOM   838  C  C   A ARG A 1 96  ? -28.604 1.681  6.830   0.59 13.32 ? 96  ARG A C   1 
+ATOM   839  C  C   B ARG A 1 96  ? -28.605 1.672  6.843   0.41 13.23 ? 96  ARG A C   1 
+ATOM   840  O  O   A ARG A 1 96  ? -29.034 2.711  7.361   0.59 15.16 ? 96  ARG A O   1 
+ATOM   841  O  O   B ARG A 1 96  ? -29.044 2.683  7.402   0.41 14.40 ? 96  ARG A O   1 
+ATOM   842  C  CB  A ARG A 1 96  ? -30.036 -0.362 7.130   0.59 13.80 ? 96  ARG A CB  1 
+ATOM   843  C  CB  B ARG A 1 96  ? -30.060 -0.349 7.116   0.41 13.85 ? 96  ARG A CB  1 
+ATOM   844  C  CG  A ARG A 1 96  ? -31.372 -0.974 6.766   0.59 15.16 ? 96  ARG A CG  1 
+ATOM   845  C  CG  B ARG A 1 96  ? -31.220 -1.164 6.591   0.41 14.55 ? 96  ARG A CG  1 
+ATOM   846  C  CD  A ARG A 1 96  ? -31.790 -2.067 7.745   0.59 17.53 ? 96  ARG A CD  1 
+ATOM   847  C  CD  B ARG A 1 96  ? -31.915 -1.917 7.706   0.41 15.79 ? 96  ARG A CD  1 
+ATOM   848  N  NE  A ARG A 1 96  ? -32.964 -2.777 7.245   0.59 19.29 ? 96  ARG A NE  1 
+ATOM   849  N  NE  B ARG A 1 96  ? -31.052 -2.880 8.383   0.41 15.55 ? 96  ARG A NE  1 
+ATOM   850  C  CZ  A ARG A 1 96  ? -33.482 -3.872 7.786   0.59 20.37 ? 96  ARG A CZ  1 
+ATOM   851  C  CZ  B ARG A 1 96  ? -31.044 -4.185 8.126   0.41 16.94 ? 96  ARG A CZ  1 
+ATOM   852  N  NH1 A ARG A 1 96  ? -32.936 -4.405 8.874   0.59 23.92 ? 96  ARG A NH1 1 
+ATOM   853  N  NH1 B ARG A 1 96  ? -31.837 -4.676 7.179   0.41 17.81 ? 96  ARG A NH1 1 
+ATOM   854  N  NH2 A ARG A 1 96  ? -34.551 -4.436 7.233   0.59 22.14 ? 96  ARG A NH2 1 
+ATOM   855  N  NH2 B ARG A 1 96  ? -30.237 -4.998 8.808   0.41 17.16 ? 96  ARG A NH2 1 
+ATOM   856  N  N   . CYS A 1 97  ? -27.305 1.369  6.836   1.00 13.32 ? 97  CYS A N   1 
+ATOM   857  C  CA  . CYS A 1 97  ? -26.333 2.290  7.423   1.00 13.47 ? 97  CYS A CA  1 
+ATOM   858  C  C   . CYS A 1 97  ? -26.296 3.606  6.670   1.00 13.82 ? 97  CYS A C   1 
+ATOM   859  O  O   . CYS A 1 97  ? -26.187 4.679  7.283   1.00 14.83 ? 97  CYS A O   1 
+ATOM   860  C  CB  . CYS A 1 97  ? -24.939 1.670  7.425   1.00 15.10 ? 97  CYS A CB  1 
+ATOM   861  S  SG  . CYS A 1 97  ? -24.792 0.342  8.630   1.00 17.81 ? 97  CYS A SG  1 
+ATOM   862  N  N   . ALA A 1 98  ? -26.360 3.543  5.337   1.00 13.27 ? 98  ALA A N   1 
+ATOM   863  C  CA  . ALA A 1 98  ? -26.403 4.770  4.550   1.00 12.28 ? 98  ALA A CA  1 
+ATOM   864  C  C   . ALA A 1 98  ? -27.633 5.599  4.893   1.00 12.20 ? 98  ALA A C   1 
+ATOM   865  O  O   . ALA A 1 98  ? -27.564 6.835  4.942   1.00 14.14 ? 98  ALA A O   1 
+ATOM   866  C  CB  . ALA A 1 98  ? -26.371 4.447  3.053   1.00 13.90 ? 98  ALA A CB  1 
+ATOM   867  N  N   . ALA A 1 99  ? -28.771 4.936  5.134   1.00 12.95 ? 99  ALA A N   1 
+ATOM   868  C  CA  . ALA A 1 99  ? -29.987 5.650  5.516   1.00 12.44 ? 99  ALA A CA  1 
+ATOM   869  C  C   . ALA A 1 99  ? -29.822 6.358  6.856   1.00 12.63 ? 99  ALA A C   1 
+ATOM   870  O  O   . ALA A 1 99  ? -30.208 7.526  7.003   1.00 14.27 ? 99  ALA A O   1 
+ATOM   871  C  CB  . ALA A 1 99  ? -31.167 4.673  5.564   1.00 14.83 ? 99  ALA A CB  1 
+ATOM   872  N  N   . ILE A 1 100 ? -29.293 5.653  7.863   1.00 13.08 ? 100 ILE A N   1 
+ATOM   873  C  CA  . ILE A 1 100 ? -29.064 6.284  9.167   1.00 13.04 ? 100 ILE A CA  1 
+ATOM   874  C  C   . ILE A 1 100 ? -28.124 7.475  9.031   1.00 12.28 ? 100 ILE A C   1 
+ATOM   875  O  O   . ILE A 1 100 ? -28.312 8.517  9.675   1.00 14.59 ? 100 ILE A O   1 
+ATOM   876  C  CB  . ILE A 1 100 ? -28.509 5.256  10.169  1.00 13.53 ? 100 ILE A CB  1 
+ATOM   877  C  CG1 . ILE A 1 100 ? -29.512 4.121  10.372  1.00 14.60 ? 100 ILE A CG1 1 
+ATOM   878  C  CG2 . ILE A 1 100 ? -28.139 5.936  11.491  1.00 14.50 ? 100 ILE A CG2 1 
+ATOM   879  C  CD1 . ILE A 1 100 ? -28.911 2.923  11.058  1.00 15.82 ? 100 ILE A CD1 1 
+ATOM   880  N  N   . ASN A 1 101 ? -27.087 7.328  8.206   1.00 13.03 ? 101 ASN A N   1 
+ATOM   881  C  CA  . ASN A 1 101 ? -26.119 8.401  8.005   1.00 12.44 ? 101 ASN A CA  1 
+ATOM   882  C  C   . ASN A 1 101 ? -26.812 9.677  7.529   1.00 13.58 ? 101 ASN A C   1 
+ATOM   883  O  O   . ASN A 1 101 ? -26.568 10.766 8.069   1.00 14.00 ? 101 ASN A O   1 
+ATOM   884  C  CB  . ASN A 1 101 ? -25.048 7.906  7.014   1.00 13.92 ? 101 ASN A CB  1 
+ATOM   885  C  CG  . ASN A 1 101 ? -23.829 8.799  6.952   1.00 14.73 ? 101 ASN A CG  1 
+ATOM   886  O  OD1 . ASN A 1 101 ? -23.937 10.001 6.744   1.00 15.45 ? 101 ASN A OD1 1 
+ATOM   887  N  ND2 . ASN A 1 101 ? -22.655 8.203  7.101   1.00 14.56 ? 101 ASN A ND2 1 
+ATOM   888  N  N   . MET A 1 102 ? -27.704 9.558  6.536   1.00 13.44 ? 102 MET A N   1 
+ATOM   889  C  CA  . MET A 1 102 ? -28.415 10.735 6.035   1.00 12.79 ? 102 MET A CA  1 
+ATOM   890  C  C   . MET A 1 102 ? -29.285 11.368 7.114   1.00 13.11 ? 102 MET A C   1 
+ATOM   891  O  O   . MET A 1 102 ? -29.335 12.600 7.231   1.00 14.95 ? 102 MET A O   1 
+ATOM   892  C  CB  . MET A 1 102 ? -29.290 10.363 4.841   1.00 14.70 ? 102 MET A CB  1 
+ATOM   893  C  CG  . MET A 1 102 ? -28.508 10.059 3.593   1.00 16.50 ? 102 MET A CG  1 
+ATOM   894  S  SD  . MET A 1 102 ? -29.561 9.820  2.144   1.00 18.87 ? 102 MET A SD  1 
+ATOM   895  C  CE  . MET A 1 102 ? -30.086 11.499 1.793   1.00 21.78 ? 102 MET A CE  1 
+ATOM   896  N  N   . VAL A 1 103 ? -30.015 10.549 7.882   1.00 13.19 ? 103 VAL A N   1 
+ATOM   897  C  CA  . VAL A 1 103 ? -30.871 11.096 8.937   1.00 13.51 ? 103 VAL A CA  1 
+ATOM   898  C  C   . VAL A 1 103 ? -30.029 11.759 10.014  1.00 14.23 ? 103 VAL A C   1 
+ATOM   899  O  O   . VAL A 1 103 ? -30.400 12.811 10.553  1.00 16.35 ? 103 VAL A O   1 
+ATOM   900  C  CB  . VAL A 1 103 ? -31.817 10.016 9.500   1.00 15.86 ? 103 VAL A CB  1 
+ATOM   901  C  CG1 . VAL A 1 103 ? -32.582 10.536 10.738  1.00 18.46 ? 103 VAL A CG1 1 
+ATOM   902  C  CG2 . VAL A 1 103 ? -32.787 9.576  8.418   1.00 17.89 ? 103 VAL A CG2 1 
+ATOM   903  N  N   . PHE A 1 104 ? -28.877 11.165 10.341  1.00 13.49 ? 104 PHE A N   1 
+ATOM   904  C  CA  . PHE A 1 104 ? -27.972 11.775 11.313  1.00 14.58 ? 104 PHE A CA  1 
+ATOM   905  C  C   . PHE A 1 104 ? -27.535 13.159 10.853  1.00 14.57 ? 104 PHE A C   1 
+ATOM   906  O  O   . PHE A 1 104 ? -27.515 14.114 11.642  1.00 16.49 ? 104 PHE A O   1 
+ATOM   907  C  CB  . PHE A 1 104 ? -26.770 10.847 11.515  1.00 14.93 ? 104 PHE A CB  1 
+ATOM   908  C  CG  . PHE A 1 104 ? -25.847 11.241 12.638  1.00 14.15 ? 104 PHE A CG  1 
+ATOM   909  C  CD1 . PHE A 1 104 ? -24.850 12.185 12.439  1.00 15.55 ? 104 PHE A CD1 1 
+ATOM   910  C  CD2 . PHE A 1 104 ? -25.929 10.608 13.874  1.00 15.68 ? 104 PHE A CD2 1 
+ATOM   911  C  CE1 . PHE A 1 104 ? -23.981 12.527 13.467  1.00 16.95 ? 104 PHE A CE1 1 
+ATOM   912  C  CE2 . PHE A 1 104 ? -25.060 10.938 14.908  1.00 16.77 ? 104 PHE A CE2 1 
+ATOM   913  C  CZ  . PHE A 1 104 ? -24.085 11.899 14.702  1.00 18.20 ? 104 PHE A CZ  1 
+ATOM   914  N  N   . GLN A 1 105 ? -27.248 13.305 9.565   1.00 14.20 ? 105 GLN A N   1 
+ATOM   915  C  CA  . GLN A 1 105 ? -26.730 14.574 9.075   1.00 14.38 ? 105 GLN A CA  1 
+ATOM   916  C  C   . GLN A 1 105 ? -27.822 15.624 8.890   1.00 15.25 ? 105 GLN A C   1 
+ATOM   917  O  O   . GLN A 1 105 ? -27.609 16.799 9.206   1.00 17.92 ? 105 GLN A O   1 
+ATOM   918  C  CB  . GLN A 1 105 ? -25.998 14.369 7.742   1.00 14.86 ? 105 GLN A CB  1 
+ATOM   919  C  CG  . GLN A 1 105 ? -25.312 15.646 7.242   1.00 16.25 ? 105 GLN A CG  1 
+ATOM   920  C  CD  . GLN A 1 105 ? -24.650 15.498 5.871   1.00 16.09 ? 105 GLN A CD  1 
+ATOM   921  O  OE1 . GLN A 1 105 ? -24.683 14.436 5.255   1.00 17.20 ? 105 GLN A OE1 1 
+ATOM   922  N  NE2 . GLN A 1 105 ? -24.056 16.584 5.389   1.00 19.76 ? 105 GLN A NE2 1 
+ATOM   923  N  N   . MET A 1 106 ? -28.984 15.241 8.361   1.00 15.97 ? 106 MET A N   1 
+ATOM   924  C  CA  A MET A 1 106 ? -29.997 16.190 7.911   0.58 16.44 ? 106 MET A CA  1 
+ATOM   925  C  CA  B MET A 1 106 ? -29.962 16.248 7.980   0.42 17.43 ? 106 MET A CA  1 
+ATOM   926  C  C   . MET A 1 106 ? -31.300 16.148 8.693   1.00 18.70 ? 106 MET A C   1 
+ATOM   927  O  O   . MET A 1 106 ? -32.150 17.029 8.500   1.00 21.31 ? 106 MET A O   1 
+ATOM   928  C  CB  A MET A 1 106 ? -30.297 15.958 6.424   0.58 19.25 ? 106 MET A CB  1 
+ATOM   929  C  CB  B MET A 1 106 ? -30.147 16.294 6.457   0.42 20.53 ? 106 MET A CB  1 
+ATOM   930  C  CG  A MET A 1 106 ? -29.181 16.430 5.512   0.58 21.74 ? 106 MET A CG  1 
+ATOM   931  C  CG  B MET A 1 106 ? -30.739 15.054 5.858   0.42 21.01 ? 106 MET A CG  1 
+ATOM   932  S  SD  A MET A 1 106 ? -29.483 16.066 3.782   0.58 23.08 ? 106 MET A SD  1 
+ATOM   933  S  SD  B MET A 1 106 ? -30.760 15.140 4.060   0.42 22.29 ? 106 MET A SD  1 
+ATOM   934  C  CE  A MET A 1 106 ? -29.255 14.295 3.789   0.58 23.91 ? 106 MET A CE  1 
+ATOM   935  C  CE  B MET A 1 106 ? -29.051 14.790 3.672   0.42 20.85 ? 106 MET A CE  1 
+ATOM   936  N  N   A GLY A 1 107 ? -31.500 15.147 9.548   0.74 18.22 ? 107 GLY A N   1 
+ATOM   937  N  N   B GLY A 1 107 ? -31.511 15.138 9.527   0.26 18.90 ? 107 GLY A N   1 
+ATOM   938  C  CA  A GLY A 1 107 ? -32.741 15.001 10.277  0.74 18.84 ? 107 GLY A CA  1 
+ATOM   939  C  CA  B GLY A 1 107 ? -32.733 15.039 10.295  0.26 19.59 ? 107 GLY A CA  1 
+ATOM   940  C  C   A GLY A 1 107 ? -33.875 14.490 9.410   0.74 21.04 ? 107 GLY A C   1 
+ATOM   941  C  C   B GLY A 1 107 ? -33.792 14.199 9.603   0.26 20.60 ? 107 GLY A C   1 
+ATOM   942  O  O   A GLY A 1 107 ? -33.780 14.399 8.184   0.74 21.82 ? 107 GLY A O   1 
+ATOM   943  O  O   B GLY A 1 107 ? -33.785 14.002 8.389   0.26 21.13 ? 107 GLY A O   1 
+ATOM   944  N  N   A GLU A 1 108 ? -34.983 14.149 10.081  0.65 23.26 ? 108 GLU A N   1 
+ATOM   945  N  N   B GLU A 1 108 ? -34.726 13.700 10.417  0.35 21.96 ? 108 GLU A N   1 
+ATOM   946  C  CA  A GLU A 1 108 ? -36.172 13.695 9.365   0.65 26.13 ? 108 GLU A CA  1 
+ATOM   947  C  CA  B GLU A 1 108 ? -35.788 12.840 9.906   0.35 23.89 ? 108 GLU A CA  1 
+ATOM   948  C  C   A GLU A 1 108 ? -36.679 14.760 8.402   0.65 28.23 ? 108 GLU A C   1 
+ATOM   949  C  C   B GLU A 1 108 ? -36.650 13.576 8.889   0.35 23.57 ? 108 GLU A C   1 
+ATOM   950  O  O   A GLU A 1 108 ? -37.142 14.445 7.298   0.65 30.03 ? 108 GLU A O   1 
+ATOM   951  O  O   B GLU A 1 108 ? -36.972 13.038 7.823   0.35 22.16 ? 108 GLU A O   1 
+ATOM   952  C  CB  A GLU A 1 108 ? -37.278 13.345 10.355  0.65 30.00 ? 108 GLU A CB  1 
+ATOM   953  C  CB  B GLU A 1 108 ? -36.642 12.343 11.072  0.35 26.44 ? 108 GLU A CB  1 
+ATOM   954  C  CG  A GLU A 1 108 ? -36.971 12.196 11.282  0.65 32.43 ? 108 GLU A CG  1 
+ATOM   955  C  CG  B GLU A 1 108 ? -37.850 11.524 10.665  0.35 29.24 ? 108 GLU A CG  1 
+ATOM   956  C  CD  A GLU A 1 108 ? -38.119 11.920 12.230  0.65 33.71 ? 108 GLU A CD  1 
+ATOM   957  C  CD  B GLU A 1 108 ? -38.942 11.537 11.719  0.35 31.27 ? 108 GLU A CD  1 
+ATOM   958  O  OE1 A GLU A 1 108 ? -39.222 11.593 11.746  0.65 34.08 ? 108 GLU A OE1 1 
+ATOM   959  O  OE1 B GLU A 1 108 ? -40.126 11.670 11.348  0.35 32.07 ? 108 GLU A OE1 1 
+ATOM   960  O  OE2 A GLU A 1 108 ? -37.927 12.061 13.456  0.65 34.74 ? 108 GLU A OE2 1 
+ATOM   961  O  OE2 B GLU A 1 108 ? -38.617 11.426 12.920  0.35 32.54 ? 108 GLU A OE2 1 
+ATOM   962  N  N   A THR A 1 109 ? -36.606 16.029 8.806   0.65 29.31 ? 109 THR A N   1 
+ATOM   963  N  N   B THR A 1 109 ? -37.039 14.813 9.204   0.35 24.94 ? 109 THR A N   1 
+ATOM   964  C  CA  A THR A 1 109 ? -37.111 17.103 7.958   0.65 31.48 ? 109 THR A CA  1 
+ATOM   965  C  CA  B THR A 1 109 ? -37.883 15.574 8.288   0.35 27.30 ? 109 THR A CA  1 
+ATOM   966  C  C   A THR A 1 109 ? -36.220 17.336 6.743   0.65 29.78 ? 109 THR A C   1 
+ATOM   967  C  C   B THR A 1 109 ? -37.150 15.904 6.995   0.35 27.10 ? 109 THR A C   1 
+ATOM   968  O  O   A THR A 1 109 ? -36.723 17.666 5.663   0.65 30.93 ? 109 THR A O   1 
+ATOM   969  O  O   B THR A 1 109 ? -37.767 15.931 5.923   0.35 27.82 ? 109 THR A O   1 
+ATOM   970  C  CB  A THR A 1 109 ? -37.262 18.379 8.780   0.65 34.76 ? 109 THR A CB  1 
+ATOM   971  C  CB  B THR A 1 109 ? -38.383 16.847 8.973   0.35 29.10 ? 109 THR A CB  1 
+ATOM   972  O  OG1 A THR A 1 109 ? -35.973 18.801 9.243   0.65 37.88 ? 109 THR A OG1 1 
+ATOM   973  O  OG1 B THR A 1 109 ? -38.973 16.509 10.234  0.35 31.06 ? 109 THR A OG1 1 
+ATOM   974  C  CG2 A THR A 1 109 ? -38.158 18.119 9.982   0.65 34.59 ? 109 THR A CG2 1 
+ATOM   975  C  CG2 B THR A 1 109 ? -39.423 17.550 8.109   0.35 30.42 ? 109 THR A CG2 1 
+ATOM   976  N  N   A GLY A 1 110 ? -34.905 17.177 6.892   0.67 27.53 ? 110 GLY A N   1 
+ATOM   977  N  N   B GLY A 1 110 ? -35.840 16.143 7.071   0.33 26.02 ? 110 GLY A N   1 
+ATOM   978  C  CA  A GLY A 1 110 ? -34.026 17.333 5.744   0.67 27.43 ? 110 GLY A CA  1 
+ATOM   979  C  CA  B GLY A 1 110 ? -35.084 16.447 5.866   0.33 24.95 ? 110 GLY A CA  1 
+ATOM   980  C  C   A GLY A 1 110 ? -34.223 16.241 4.710   0.67 27.73 ? 110 GLY A C   1 
+ATOM   981  C  C   B GLY A 1 110 ? -35.035 15.278 4.900   0.33 23.99 ? 110 GLY A C   1 
+ATOM   982  O  O   A GLY A 1 110 ? -34.110 16.486 3.507   0.67 30.11 ? 110 GLY A O   1 
+ATOM   983  O  O   B GLY A 1 110 ? -35.300 15.434 3.704   0.33 24.43 ? 110 GLY A O   1 
+ATOM   984  N  N   A VAL A 1 111 ? -34.527 15.022 5.163   0.21 26.26 ? 111 VAL A N   1 
+ATOM   985  N  N   B VAL A 1 111 ? -34.696 14.089 5.408   0.34 22.45 ? 111 VAL A N   1 
+ATOM   986  N  N   C VAL A 1 111 ? -34.593 15.067 5.223   0.45 21.44 ? 111 VAL A N   1 
+ATOM   987  C  CA  A VAL A 1 111 ? -34.776 13.907 4.254   0.21 25.16 ? 111 VAL A CA  1 
+ATOM   988  C  CA  B VAL A 1 111 ? -34.614 12.909 4.550   0.34 21.59 ? 111 VAL A CA  1 
+ATOM   989  C  CA  C VAL A 1 111 ? -34.692 13.974 4.261   0.45 21.42 ? 111 VAL A CA  1 
+ATOM   990  C  C   A VAL A 1 111 ? -36.135 14.008 3.571   0.21 24.58 ? 111 VAL A C   1 
+ATOM   991  C  C   B VAL A 1 111 ? -35.985 12.533 4.007   0.34 21.84 ? 111 VAL A C   1 
+ATOM   992  C  C   C VAL A 1 111 ? -36.066 13.959 3.600   0.45 22.21 ? 111 VAL A C   1 
+ATOM   993  O  O   A VAL A 1 111 ? -36.379 13.307 2.581   0.21 24.47 ? 111 VAL A O   1 
+ATOM   994  O  O   B VAL A 1 111 ? -36.100 12.050 2.873   0.34 21.44 ? 111 VAL A O   1 
+ATOM   995  O  O   C VAL A 1 111 ? -36.271 13.293 2.586   0.45 22.15 ? 111 VAL A O   1 
+ATOM   996  C  CB  A VAL A 1 111 ? -34.511 12.586 5.015   0.21 25.73 ? 111 VAL A CB  1 
+ATOM   997  C  CB  B VAL A 1 111 ? -33.948 11.734 5.292   0.34 21.12 ? 111 VAL A CB  1 
+ATOM   998  C  CB  C VAL A 1 111 ? -34.365 12.615 4.913   0.45 22.62 ? 111 VAL A CB  1 
+ATOM   999  C  CG1 A VAL A 1 111 ? -34.793 11.358 4.153   0.21 26.46 ? 111 VAL A CG1 1 
+ATOM   1000 C  CG1 B VAL A 1 111 ? -33.872 10.510 4.393   0.34 20.52 ? 111 VAL A CG1 1 
+ATOM   1001 C  CG1 C VAL A 1 111 ? -32.947 12.617 5.467   0.45 23.38 ? 111 VAL A CG1 1 
+ATOM   1002 C  CG2 A VAL A 1 111 ? -33.071 12.551 5.510   0.21 26.06 ? 111 VAL A CG2 1 
+ATOM   1003 C  CG2 B VAL A 1 111 ? -32.566 12.121 5.761   0.34 21.28 ? 111 VAL A CG2 1 
+ATOM   1004 C  CG2 C VAL A 1 111 ? -35.379 12.287 5.998   0.45 23.68 ? 111 VAL A CG2 1 
+ATOM   1005 N  N   A ALA A 1 112 ? -37.012 14.897 4.050   0.60 24.25 ? 112 ALA A N   1 
+ATOM   1006 N  N   B ALA A 1 112 ? -37.042 12.750 4.794   0.40 23.88 ? 112 ALA A N   1 
+ATOM   1007 C  CA  A ALA A 1 112 ? -38.357 15.003 3.491   0.60 24.83 ? 112 ALA A CA  1 
+ATOM   1008 C  CA  B ALA A 1 112 ? -38.389 12.405 4.355   0.40 25.13 ? 112 ALA A CA  1 
+ATOM   1009 C  C   A ALA A 1 112 ? -38.340 15.319 2.001   0.60 24.98 ? 112 ALA A C   1 
+ATOM   1010 C  C   B ALA A 1 112 ? -38.825 13.214 3.142   0.40 25.29 ? 112 ALA A C   1 
+ATOM   1011 O  O   A ALA A 1 112 ? -39.225 14.869 1.265   0.60 26.40 ? 112 ALA A O   1 
+ATOM   1012 O  O   B ALA A 1 112 ? -39.719 12.776 2.406   0.40 27.37 ? 112 ALA A O   1 
+ATOM   1013 C  CB  A ALA A 1 112 ? -39.163 16.060 4.249   0.60 25.59 ? 112 ALA A CB  1 
+ATOM   1014 C  CB  B ALA A 1 112 ? -39.380 12.582 5.510   0.40 25.43 ? 112 ALA A CB  1 
+ATOM   1015 N  N   A GLY A 1 113 ? -37.357 16.087 1.537   0.65 24.95 ? 113 GLY A N   1 
+ATOM   1016 N  N   B GLY A 1 113 ? -38.214 14.379 2.913   0.35 24.36 ? 113 GLY A N   1 
+ATOM   1017 C  CA  A GLY A 1 113 ? -37.298 16.427 0.128   0.65 23.81 ? 113 GLY A CA  1 
+ATOM   1018 C  CA  B GLY A 1 113 ? -38.512 15.165 1.730   0.35 24.72 ? 113 GLY A CA  1 
+ATOM   1019 C  C   A GLY A 1 113 ? -36.845 15.307 -0.788  0.65 21.92 ? 113 GLY A C   1 
+ATOM   1020 C  C   B GLY A 1 113 ? -37.899 14.623 0.455   0.35 25.02 ? 113 GLY A C   1 
+ATOM   1021 O  O   A GLY A 1 113 ? -36.847 15.487 -2.009  0.65 23.60 ? 113 GLY A O   1 
+ATOM   1022 O  O   B GLY A 1 113 ? -38.304 15.038 -0.636  0.35 27.19 ? 113 GLY A O   1 
+ATOM   1023 N  N   A PHE A 1 114 ? -36.462 14.155 -0.237  0.65 20.73 ? 114 PHE A N   1 
+ATOM   1024 N  N   B PHE A 1 114 ? -36.934 13.707 0.566   0.35 24.11 ? 114 PHE A N   1 
+ATOM   1025 C  CA  A PHE A 1 114 ? -35.903 13.050 -1.010  0.65 17.89 ? 114 PHE A CA  1 
+ATOM   1026 C  CA  B PHE A 1 114 ? -36.313 13.080 -0.599  0.35 23.71 ? 114 PHE A CA  1 
+ATOM   1027 C  C   A PHE A 1 114 ? -36.951 12.007 -1.400  0.65 17.66 ? 114 PHE A C   1 
+ATOM   1028 C  C   B PHE A 1 114 ? -37.252 12.043 -1.204  0.35 23.07 ? 114 PHE A C   1 
+ATOM   1029 O  O   A PHE A 1 114 ? -36.603 10.852 -1.656  0.65 17.02 ? 114 PHE A O   1 
+ATOM   1030 O  O   B PHE A 1 114 ? -36.846 10.905 -1.459  0.35 23.17 ? 114 PHE A O   1 
+ATOM   1031 C  CB  A PHE A 1 114 ? -34.730 12.408 -0.265  0.65 18.86 ? 114 PHE A CB  1 
+ATOM   1032 C  CB  B PHE A 1 114 ? -34.985 12.424 -0.206  0.35 24.31 ? 114 PHE A CB  1 
+ATOM   1033 C  CG  A PHE A 1 114 ? -33.488 13.267 -0.232  0.65 17.84 ? 114 PHE A CG  1 
+ATOM   1034 C  CG  B PHE A 1 114 ? -33.809 13.371 -0.185  0.35 24.40 ? 114 PHE A CG  1 
+ATOM   1035 C  CD1 A PHE A 1 114 ? -33.277 14.187 0.785   0.65 21.35 ? 114 PHE A CD1 1 
+ATOM   1036 C  CD1 B PHE A 1 114 ? -33.776 14.452 0.684   0.35 25.47 ? 114 PHE A CD1 1 
+ATOM   1037 C  CD2 A PHE A 1 114 ? -32.535 13.153 -1.225  0.65 17.37 ? 114 PHE A CD2 1 
+ATOM   1038 C  CD2 B PHE A 1 114 ? -32.728 13.165 -1.027  0.35 24.35 ? 114 PHE A CD2 1 
+ATOM   1039 C  CE1 A PHE A 1 114 ? -32.131 14.974 0.808   0.65 20.82 ? 114 PHE A CE1 1 
+ATOM   1040 C  CE1 B PHE A 1 114 ? -32.688 15.314 0.704   0.35 25.69 ? 114 PHE A CE1 1 
+ATOM   1041 C  CE2 A PHE A 1 114 ? -31.389 13.936 -1.209  0.65 17.18 ? 114 PHE A CE2 1 
+ATOM   1042 C  CE2 B PHE A 1 114 ? -31.640 14.022 -1.013  0.35 24.78 ? 114 PHE A CE2 1 
+ATOM   1043 C  CZ  A PHE A 1 114 ? -31.187 14.847 -0.191  0.65 18.54 ? 114 PHE A CZ  1 
+ATOM   1044 C  CZ  B PHE A 1 114 ? -31.618 15.096 -0.145  0.35 25.42 ? 114 PHE A CZ  1 
+ATOM   1045 N  N   A THR A 1 115 ? -38.221 12.409 -1.483  0.54 18.46 ? 115 THR A N   1 
+ATOM   1046 N  N   B THR A 1 115 ? -38.501 12.445 -1.454  0.46 23.21 ? 115 THR A N   1 
+ATOM   1047 C  CA  A THR A 1 115 ? -39.316 11.477 -1.750  0.54 20.22 ? 115 THR A CA  1 
+ATOM   1048 C  CA  B THR A 1 115 ? -39.555 11.513 -1.847  0.46 22.85 ? 115 THR A CA  1 
+ATOM   1049 C  C   A THR A 1 115 ? -39.073 10.633 -3.000  0.54 20.36 ? 115 THR A C   1 
+ATOM   1050 C  C   B THR A 1 115 ? -39.149 10.644 -3.031  0.46 21.64 ? 115 THR A C   1 
+ATOM   1051 O  O   A THR A 1 115 ? -39.296 9.416  -2.993  0.54 21.42 ? 115 THR A O   1 
+ATOM   1052 O  O   B THR A 1 115 ? -39.303 9.417  -2.999  0.46 22.03 ? 115 THR A O   1 
+ATOM   1053 C  CB  A THR A 1 115 ? -40.623 12.258 -1.878  0.54 23.44 ? 115 THR A CB  1 
+ATOM   1054 C  CB  B THR A 1 115 ? -40.824 12.301 -2.183  0.46 24.56 ? 115 THR A CB  1 
+ATOM   1055 O  OG1 A THR A 1 115 ? -40.734 13.174 -0.786  0.54 25.46 ? 115 THR A OG1 1 
+ATOM   1056 O  OG1 B THR A 1 115 ? -41.389 12.836 -0.982  0.46 26.02 ? 115 THR A OG1 1 
+ATOM   1057 C  CG2 A THR A 1 115 ? -41.811 11.312 -1.864  0.54 23.57 ? 115 THR A CG2 1 
+ATOM   1058 C  CG2 B THR A 1 115 ? -41.843 11.409 -2.874  0.46 23.06 ? 115 THR A CG2 1 
+ATOM   1059 N  N   . ASN A 1 116 ? -38.635 11.264 -4.095  1.00 20.51 ? 116 ASN A N   1 
+ATOM   1060 C  CA  . ASN A 1 116 ? -38.389 10.509 -5.323  1.00 19.64 ? 116 ASN A CA  1 
+ATOM   1061 C  C   . ASN A 1 116 ? -37.239 9.520  -5.160  1.00 19.14 ? 116 ASN A C   1 
+ATOM   1062 O  O   . ASN A 1 116 ? -37.315 8.386  -5.652  1.00 20.64 ? 116 ASN A O   1 
+ATOM   1063 C  CB  . ASN A 1 116 ? -38.162 11.455 -6.505  1.00 21.63 ? 116 ASN A CB  1 
+ATOM   1064 C  CG  . ASN A 1 116 ? -39.381 12.304 -6.804  1.00 23.60 ? 116 ASN A CG  1 
+ATOM   1065 O  OD1 . ASN A 1 116 ? -40.515 11.866 -6.607  1.00 27.68 ? 116 ASN A OD1 1 
+ATOM   1066 N  ND2 . ASN A 1 116 ? -39.157 13.530 -7.276  1.00 22.63 ? 116 ASN A ND2 1 
+ATOM   1067 N  N   . SER A 1 117 ? -36.179 9.917  -4.451  1.00 18.09 ? 117 SER A N   1 
+ATOM   1068 C  CA  . SER A 1 117 ? -35.077 8.994  -4.187  1.00 17.55 ? 117 SER A CA  1 
+ATOM   1069 C  C   . SER A 1 117 ? -35.547 7.809  -3.357  1.00 16.91 ? 117 SER A C   1 
+ATOM   1070 O  O   . SER A 1 117 ? -35.113 6.672  -3.586  1.00 17.96 ? 117 SER A O   1 
+ATOM   1071 C  CB  . SER A 1 117 ? -33.966 9.701  -3.406  1.00 19.44 ? 117 SER A CB  1 
+ATOM   1072 O  OG  . SER A 1 117 ? -33.616 10.947 -3.956  1.00 24.39 ? 117 SER A OG  1 
+ATOM   1073 N  N   . LEU A 1 118 ? -36.397 8.068  -2.354  1.00 17.62 ? 118 LEU A N   1 
+ATOM   1074 C  CA  . LEU A 1 118 ? -36.872 7.002  -1.472  1.00 17.94 ? 118 LEU A CA  1 
+ATOM   1075 C  C   . LEU A 1 118 ? -37.646 5.954  -2.249  1.00 18.07 ? 118 LEU A C   1 
+ATOM   1076 O  O   . LEU A 1 118 ? -37.503 4.751  -1.998  1.00 18.89 ? 118 LEU A O   1 
+ATOM   1077 C  CB  . LEU A 1 118 ? -37.770 7.585  -0.376  1.00 21.66 ? 118 LEU A CB  1 
+ATOM   1078 C  CG  . LEU A 1 118 ? -37.122 8.485  0.667   1.00 25.13 ? 118 LEU A CG  1 
+ATOM   1079 C  CD1 . LEU A 1 118 ? -38.176 9.158  1.542   1.00 28.17 ? 118 LEU A CD1 1 
+ATOM   1080 C  CD2 . LEU A 1 118 ? -36.191 7.665  1.510   1.00 24.49 ? 118 LEU A CD2 1 
+ATOM   1081 N  N   . ARG A 1 119 ? -38.475 6.396  -3.193  1.00 19.21 ? 119 ARG A N   1 
+ATOM   1082 C  CA  . ARG A 1 119 ? -39.236 5.461  -4.011  1.00 21.23 ? 119 ARG A CA  1 
+ATOM   1083 C  C   . ARG A 1 119 ? -38.307 4.597  -4.852  1.00 20.05 ? 119 ARG A C   1 
+ATOM   1084 O  O   . ARG A 1 119 ? -38.503 3.380  -4.954  1.00 19.88 ? 119 ARG A O   1 
+ATOM   1085 C  CB  . ARG A 1 119 ? -40.204 6.249  -4.896  1.00 27.15 ? 119 ARG A CB  1 
+ATOM   1086 C  CG  . ARG A 1 119 ? -41.105 5.411  -5.776  1.00 38.88 ? 119 ARG A CG  1 
+ATOM   1087 C  CD  . ARG A 1 119 ? -42.207 6.276  -6.386  1.00 49.03 ? 119 ARG A CD  1 
+ATOM   1088 N  NE  . ARG A 1 119 ? -43.101 6.834  -5.368  1.00 58.05 ? 119 ARG A NE  1 
+ATOM   1089 C  CZ  . ARG A 1 119 ? -43.115 8.110  -4.988  1.00 64.21 ? 119 ARG A CZ  1 
+ATOM   1090 N  NH1 . ARG A 1 119 ? -42.283 8.981  -5.544  1.00 67.07 ? 119 ARG A NH1 1 
+ATOM   1091 N  NH2 . ARG A 1 119 ? -43.967 8.518  -4.055  1.00 65.00 ? 119 ARG A NH2 1 
+ATOM   1092 N  N   . MET A 1 120 ? -37.277 5.206  -5.448  1.00 17.44 ? 120 MET A N   1 
+ATOM   1093 C  CA  A MET A 1 120 ? -36.331 4.433  -6.244  0.82 16.82 ? 120 MET A CA  1 
+ATOM   1094 C  CA  B MET A 1 120 ? -36.308 4.454  -6.242  0.18 18.85 ? 120 MET A CA  1 
+ATOM   1095 C  C   . MET A 1 120 ? -35.561 3.439  -5.386  1.00 17.81 ? 120 MET A C   1 
+ATOM   1096 O  O   . MET A 1 120 ? -35.295 2.314  -5.824  1.00 19.00 ? 120 MET A O   1 
+ATOM   1097 C  CB  A MET A 1 120 ? -35.371 5.364  -6.974  0.82 17.01 ? 120 MET A CB  1 
+ATOM   1098 C  CB  B MET A 1 120 ? -35.303 5.414  -6.878  0.18 21.50 ? 120 MET A CB  1 
+ATOM   1099 C  CG  A MET A 1 120 ? -36.056 6.265  -7.984  0.82 18.92 ? 120 MET A CG  1 
+ATOM   1100 C  CG  B MET A 1 120 ? -35.900 6.523  -7.730  0.18 24.44 ? 120 MET A CG  1 
+ATOM   1101 S  SD  A MET A 1 120 ? -34.868 7.409  -8.695  0.82 22.83 ? 120 MET A SD  1 
+ATOM   1102 S  SD  B MET A 1 120 ? -36.162 6.042  -9.442  0.18 27.06 ? 120 MET A SD  1 
+ATOM   1103 C  CE  A MET A 1 120 ? -35.966 8.617  -9.426  0.82 24.77 ? 120 MET A CE  1 
+ATOM   1104 C  CE  B MET A 1 120 ? -36.275 7.640  -10.243 0.18 26.98 ? 120 MET A CE  1 
+ATOM   1105 N  N   . LEU A 1 121 ? -35.187 3.834  -4.163  1.00 16.62 ? 121 LEU A N   1 
+ATOM   1106 C  CA  . LEU A 1 121 ? -34.502 2.901  -3.274  1.00 15.84 ? 121 LEU A CA  1 
+ATOM   1107 C  C   . LEU A 1 121 ? -35.405 1.732  -2.899  1.00 16.12 ? 121 LEU A C   1 
+ATOM   1108 O  O   . LEU A 1 121 ? -34.954 0.583  -2.855  1.00 17.75 ? 121 LEU A O   1 
+ATOM   1109 C  CB  . LEU A 1 121 ? -34.023 3.626  -2.017  1.00 16.23 ? 121 LEU A CB  1 
+ATOM   1110 C  CG  . LEU A 1 121 ? -32.873 4.619  -2.196  1.00 17.01 ? 121 LEU A CG  1 
+ATOM   1111 C  CD1 . LEU A 1 121 ? -32.636 5.436  -0.938  1.00 19.13 ? 121 LEU A CD1 1 
+ATOM   1112 C  CD2 . LEU A 1 121 ? -31.596 3.895  -2.586  1.00 18.95 ? 121 LEU A CD2 1 
+ATOM   1113 N  N   . GLN A 1 122 ? -36.684 2.005  -2.622  1.00 17.66 ? 122 GLN A N   1 
+ATOM   1114 C  CA  . GLN A 1 122 ? -37.600 0.924  -2.270  1.00 19.35 ? 122 GLN A CA  1 
+ATOM   1115 C  C   . GLN A 1 122 ? -37.765 -0.056 -3.422  1.00 20.02 ? 122 GLN A C   1 
+ATOM   1116 O  O   . GLN A 1 122 ? -37.919 -1.262 -3.196  1.00 22.63 ? 122 GLN A O   1 
+ATOM   1117 C  CB  . GLN A 1 122 ? -38.959 1.491  -1.866  1.00 21.84 ? 122 GLN A CB  1 
+ATOM   1118 C  CG  . GLN A 1 122 ? -39.867 0.468  -1.206  1.00 26.66 ? 122 GLN A CG  1 
+ATOM   1119 C  CD  . GLN A 1 122 ? -41.062 1.108  -0.539  1.00 34.91 ? 122 GLN A CD  1 
+ATOM   1120 O  OE1 . GLN A 1 122 ? -41.347 2.286  -0.756  1.00 38.99 ? 122 GLN A OE1 1 
+ATOM   1121 N  NE2 . GLN A 1 122 ? -41.771 0.336  0.279   1.00 38.26 ? 122 GLN A NE2 1 
+ATOM   1122 N  N   . GLN A 1 123 ? -37.709 0.440  -4.658  1.00 19.12 ? 123 GLN A N   1 
+ATOM   1123 C  CA  . GLN A 1 123 ? -37.804 -0.390 -5.850  1.00 19.72 ? 123 GLN A CA  1 
+ATOM   1124 C  C   . GLN A 1 123 ? -36.472 -1.012 -6.234  1.00 17.96 ? 123 GLN A C   1 
+ATOM   1125 O  O   . GLN A 1 123 ? -36.414 -1.741 -7.234  1.00 19.81 ? 123 GLN A O   1 
+ATOM   1126 C  CB  . GLN A 1 123 ? -38.336 0.451  -7.012  1.00 23.33 ? 123 GLN A CB  1 
+ATOM   1127 C  CG  . GLN A 1 123 ? -39.759 0.936  -6.784  1.00 29.81 ? 123 GLN A CG  1 
+ATOM   1128 C  CD  . GLN A 1 123 ? -40.243 1.903  -7.845  1.00 38.38 ? 123 GLN A CD  1 
+ATOM   1129 O  OE1 . GLN A 1 123 ? -39.461 2.421  -8.637  1.00 42.00 ? 123 GLN A OE1 1 
+ATOM   1130 N  NE2 . GLN A 1 123 ? -41.546 2.151  -7.863  1.00 42.81 ? 123 GLN A NE2 1 
+ATOM   1131 N  N   A LYS A 1 124 ? -35.407 -0.733 -5.480  0.59 16.85 ? 124 LYS A N   1 
+ATOM   1132 N  N   B LYS A 1 124 ? -35.410 -0.728 -5.479  0.41 17.77 ? 124 LYS A N   1 
+ATOM   1133 C  CA  A LYS A 1 124 ? -34.075 -1.299 -5.717  0.59 15.59 ? 124 LYS A CA  1 
+ATOM   1134 C  CA  B LYS A 1 124 ? -34.083 -1.296 -5.719  0.41 17.91 ? 124 LYS A CA  1 
+ATOM   1135 C  C   A LYS A 1 124 ? -33.488 -0.879 -7.062  0.59 16.35 ? 124 LYS A C   1 
+ATOM   1136 C  C   B LYS A 1 124 ? -33.529 -0.900 -7.088  0.41 17.56 ? 124 LYS A C   1 
+ATOM   1137 O  O   A LYS A 1 124 ? -32.732 -1.625 -7.688  0.59 18.86 ? 124 LYS A O   1 
+ATOM   1138 O  O   B LYS A 1 124 ? -32.849 -1.679 -7.758  0.41 19.63 ? 124 LYS A O   1 
+ATOM   1139 C  CB  A LYS A 1 124 ? -34.040 -2.816 -5.499  0.59 16.49 ? 124 LYS A CB  1 
+ATOM   1140 C  CB  B LYS A 1 124 ? -34.056 -2.808 -5.472  0.41 19.64 ? 124 LYS A CB  1 
+ATOM   1141 C  CG  A LYS A 1 124 ? -34.556 -3.203 -4.115  0.59 15.94 ? 124 LYS A CG  1 
+ATOM   1142 C  CG  B LYS A 1 124 ? -34.475 -3.146 -4.040  0.41 20.36 ? 124 LYS A CG  1 
+ATOM   1143 C  CD  A LYS A 1 124 ? -34.082 -4.588 -3.689  0.59 17.72 ? 124 LYS A CD  1 
+ATOM   1144 C  CD  B LYS A 1 124 ? -34.439 -4.636 -3.732  0.41 21.53 ? 124 LYS A CD  1 
+ATOM   1145 C  CE  A LYS A 1 124 ? -34.608 -4.952 -2.319  0.59 18.29 ? 124 LYS A CE  1 
+ATOM   1146 C  CE  B LYS A 1 124 ? -34.467 -4.872 -2.229  0.41 22.34 ? 124 LYS A CE  1 
+ATOM   1147 N  NZ  A LYS A 1 124 ? -34.011 -4.102 -1.268  0.59 18.05 ? 124 LYS A NZ  1 
+ATOM   1148 N  NZ  B LYS A 1 124 ? -35.647 -4.243 -1.573  0.41 23.60 ? 124 LYS A NZ  1 
+ATOM   1149 N  N   . ARG A 1 125 ? -33.810 0.337  -7.495  1.00 16.16 ? 125 ARG A N   1 
+ATOM   1150 C  CA  . ARG A 1 125 ? -33.275 0.896  -8.731  1.00 17.06 ? 125 ARG A CA  1 
+ATOM   1151 C  C   . ARG A 1 125 ? -32.057 1.727  -8.335  1.00 16.49 ? 125 ARG A C   1 
+ATOM   1152 O  O   . ARG A 1 125 ? -32.106 2.954  -8.237  1.00 17.28 ? 125 ARG A O   1 
+ATOM   1153 C  CB  . ARG A 1 125 ? -34.343 1.732  -9.416  1.00 20.33 ? 125 ARG A CB  1 
+ATOM   1154 C  CG  . ARG A 1 125 ? -35.518 0.913  -9.910  1.00 24.73 ? 125 ARG A CG  1 
+ATOM   1155 C  CD  . ARG A 1 125 ? -36.733 1.787  -10.148 1.00 31.17 ? 125 ARG A CD  1 
+ATOM   1156 N  NE  . ARG A 1 125 ? -36.504 2.790  -11.181 1.00 37.98 ? 125 ARG A NE  1 
+ATOM   1157 C  CZ  . ARG A 1 125 ? -37.350 3.778  -11.454 1.00 45.00 ? 125 ARG A CZ  1 
+ATOM   1158 N  NH1 . ARG A 1 125 ? -37.071 4.652  -12.414 1.00 46.97 ? 125 ARG A NH1 1 
+ATOM   1159 N  NH2 . ARG A 1 125 ? -38.472 3.900  -10.754 1.00 48.18 ? 125 ARG A NH2 1 
+ATOM   1160 N  N   . TRP A 1 126 ? -30.945 1.027  -8.087  1.00 15.86 ? 126 TRP A N   1 
+ATOM   1161 C  CA  . TRP A 1 126 ? -29.824 1.634  -7.373  1.00 15.14 ? 126 TRP A CA  1 
+ATOM   1162 C  C   . TRP A 1 126 ? -29.155 2.742  -8.185  1.00 15.28 ? 126 TRP A C   1 
+ATOM   1163 O  O   . TRP A 1 126 ? -28.836 3.808  -7.645  1.00 17.43 ? 126 TRP A O   1 
+ATOM   1164 C  CB  . TRP A 1 126 ? -28.798 0.572  -6.981  1.00 16.54 ? 126 TRP A CB  1 
+ATOM   1165 C  CG  . TRP A 1 126 ? -29.347 -0.621 -6.239  1.00 15.59 ? 126 TRP A CG  1 
+ATOM   1166 C  CD1 . TRP A 1 126 ? -29.206 -1.938 -6.594  1.00 16.42 ? 126 TRP A CD1 1 
+ATOM   1167 C  CD2 . TRP A 1 126 ? -30.098 -0.619 -5.010  1.00 15.96 ? 126 TRP A CD2 1 
+ATOM   1168 N  NE1 . TRP A 1 126 ? -29.817 -2.746 -5.671  1.00 17.05 ? 126 TRP A NE1 1 
+ATOM   1169 C  CE2 . TRP A 1 126 ? -30.373 -1.966 -4.690  1.00 15.96 ? 126 TRP A CE2 1 
+ATOM   1170 C  CE3 . TRP A 1 126 ? -30.570 0.387  -4.159  1.00 17.70 ? 126 TRP A CE3 1 
+ATOM   1171 C  CZ2 . TRP A 1 126 ? -31.099 -2.332 -3.552  1.00 15.75 ? 126 TRP A CZ2 1 
+ATOM   1172 C  CZ3 . TRP A 1 126 ? -31.286 0.022  -3.029  1.00 17.07 ? 126 TRP A CZ3 1 
+ATOM   1173 C  CH2 . TRP A 1 126 ? -31.544 -1.326 -2.733  1.00 16.57 ? 126 TRP A CH2 1 
+ATOM   1174 N  N   . ASP A 1 127 ? -28.894 2.500  -9.476  1.00 16.50 ? 127 ASP A N   1 
+ATOM   1175 C  CA  . ASP A 1 127 ? -28.228 3.521  -10.280 1.00 17.23 ? 127 ASP A CA  1 
+ATOM   1176 C  C   . ASP A 1 127 ? -29.107 4.753  -10.438 1.00 17.15 ? 127 ASP A C   1 
+ATOM   1177 O  O   . ASP A 1 127 ? -28.612 5.885  -10.379 1.00 19.03 ? 127 ASP A O   1 
+ATOM   1178 C  CB  . ASP A 1 127 ? -27.853 2.978  -11.663 1.00 19.27 ? 127 ASP A CB  1 
+ATOM   1179 C  CG  . ASP A 1 127 ? -26.641 2.069  -11.639 1.00 24.20 ? 127 ASP A CG  1 
+ATOM   1180 O  OD1 . ASP A 1 127 ? -26.045 1.875  -10.572 1.00 28.87 ? 127 ASP A OD1 1 
+ATOM   1181 O  OD2 . ASP A 1 127 ? -26.287 1.536  -12.709 1.00 28.16 ? 127 ASP A OD2 1 
+ATOM   1182 N  N   . GLU A 1 128 ? -30.410 4.553  -10.645 1.00 17.60 ? 128 GLU A N   1 
+ATOM   1183 C  CA  . GLU A 1 128 ? -31.313 5.690  -10.788 1.00 18.33 ? 128 GLU A CA  1 
+ATOM   1184 C  C   . GLU A 1 128 ? -31.413 6.468  -9.487  1.00 16.35 ? 128 GLU A C   1 
+ATOM   1185 O  O   . GLU A 1 128 ? -31.420 7.706  -9.497  1.00 17.93 ? 128 GLU A O   1 
+ATOM   1186 C  CB  . GLU A 1 128 ? -32.688 5.209  -11.242 1.00 20.46 ? 128 GLU A CB  1 
+ATOM   1187 C  CG  . GLU A 1 128 ? -32.691 4.737  -12.696 1.00 24.64 ? 128 GLU A CG  1 
+ATOM   1188 C  CD  . GLU A 1 128 ? -33.973 4.033  -13.081 0.76 27.86 ? 128 GLU A CD  1 
+ATOM   1189 O  OE1 . GLU A 1 128 ? -34.794 4.638  -13.801 0.54 29.82 ? 128 GLU A OE1 1 
+ATOM   1190 O  OE2 . GLU A 1 128 ? -34.155 2.876  -12.656 0.77 29.39 ? 128 GLU A OE2 1 
+ATOM   1191 N  N   . ALA A 1 129 ? -31.477 5.760  -8.355  1.00 15.86 ? 129 ALA A N   1 
+ATOM   1192 C  CA  . ALA A 1 129 ? -31.510 6.430  -7.058  1.00 15.87 ? 129 ALA A CA  1 
+ATOM   1193 C  C   . ALA A 1 129 ? -30.244 7.243  -6.835  1.00 15.21 ? 129 ALA A C   1 
+ATOM   1194 O  O   . ALA A 1 129 ? -30.299 8.359  -6.305  1.00 17.00 ? 129 ALA A O   1 
+ATOM   1195 C  CB  . ALA A 1 129 ? -31.703 5.406  -5.935  1.00 17.94 ? 129 ALA A CB  1 
+ATOM   1196 N  N   . ALA A 1 130 ? -29.091 6.701  -7.239  1.00 16.28 ? 130 ALA A N   1 
+ATOM   1197 C  CA  . ALA A 1 130 ? -27.825 7.401  -7.032  1.00 16.62 ? 130 ALA A CA  1 
+ATOM   1198 C  C   . ALA A 1 130 ? -27.793 8.728  -7.775  1.00 17.31 ? 130 ALA A C   1 
+ATOM   1199 O  O   . ALA A 1 130 ? -27.371 9.747  -7.220  1.00 18.65 ? 130 ALA A O   1 
+ATOM   1200 C  CB  . ALA A 1 130 ? -26.660 6.516  -7.471  1.00 17.74 ? 130 ALA A CB  1 
+ATOM   1201 N  N   . VAL A 1 131 ? -28.248 8.738  -9.032  1.00 17.23 ? 131 VAL A N   1 
+ATOM   1202 C  CA  . VAL A 1 131 ? -28.319 9.986  -9.788  1.00 18.50 ? 131 VAL A CA  1 
+ATOM   1203 C  C   . VAL A 1 131 ? -29.300 10.956 -9.142  1.00 17.00 ? 131 VAL A C   1 
+ATOM   1204 O  O   . VAL A 1 131 ? -29.031 12.159 -9.033  1.00 19.15 ? 131 VAL A O   1 
+ATOM   1205 C  CB  . VAL A 1 131 ? -28.681 9.692  -11.256 1.00 22.99 ? 131 VAL A CB  1 
+ATOM   1206 C  CG1 . VAL A 1 131 ? -28.895 10.998 -12.012 1.00 25.50 ? 131 VAL A CG1 1 
+ATOM   1207 C  CG2 . VAL A 1 131 ? -27.585 8.858  -11.905 1.00 25.02 ? 131 VAL A CG2 1 
+ATOM   1208 N  N   . ASN A 1 132 ? -30.455 10.455 -8.696  1.00 16.54 ? 132 ASN A N   1 
+ATOM   1209 C  CA  . ASN A 1 132 ? -31.445 11.355 -8.111  1.00 15.83 ? 132 ASN A CA  1 
+ATOM   1210 C  C   . ASN A 1 132 ? -30.944 11.943 -6.792  1.00 15.19 ? 132 ASN A C   1 
+ATOM   1211 O  O   . ASN A 1 132 ? -31.173 13.125 -6.505  1.00 16.79 ? 132 ASN A O   1 
+ATOM   1212 C  CB  . ASN A 1 132 ? -32.774 10.626 -7.927  1.00 17.17 ? 132 ASN A CB  1 
+ATOM   1213 C  CG  . ASN A 1 132 ? -33.900 11.557 -7.526  1.00 18.09 ? 132 ASN A CG  1 
+ATOM   1214 O  OD1 . ASN A 1 132 ? -34.236 11.666 -6.346  1.00 20.21 ? 132 ASN A OD1 1 
+ATOM   1215 N  ND2 . ASN A 1 132 ? -34.478 12.250 -8.503  1.00 20.25 ? 132 ASN A ND2 1 
+ATOM   1216 N  N   . LEU A 1 133 ? -30.247 11.137 -5.982  1.00 15.00 ? 133 LEU A N   1 
+ATOM   1217 C  CA  . LEU A 1 133 ? -29.705 11.622 -4.711  1.00 14.14 ? 133 LEU A CA  1 
+ATOM   1218 C  C   . LEU A 1 133 ? -28.693 12.739 -4.922  1.00 14.18 ? 133 LEU A C   1 
+ATOM   1219 O  O   . LEU A 1 133 ? -28.590 13.657 -4.093  1.00 16.54 ? 133 LEU A O   1 
+ATOM   1220 C  CB  . LEU A 1 133 ? -29.035 10.465 -3.958  1.00 14.36 ? 133 LEU A CB  1 
+ATOM   1221 C  CG  . LEU A 1 133 ? -29.983 9.484  -3.265  1.00 15.81 ? 133 LEU A CG  1 
+ATOM   1222 C  CD1 . LEU A 1 133 ? -29.253 8.181  -2.924  1.00 17.18 ? 133 LEU A CD1 1 
+ATOM   1223 C  CD2 . LEU A 1 133 ? -30.588 10.108 -2.006  1.00 19.12 ? 133 LEU A CD2 1 
+ATOM   1224 N  N   . ALA A 1 134 ? -27.931 12.676 -6.016  1.00 14.89 ? 134 ALA A N   1 
+ATOM   1225 C  CA  . ALA A 1 134 ? -26.907 13.675 -6.289  1.00 16.00 ? 134 ALA A CA  1 
+ATOM   1226 C  C   . ALA A 1 134 ? -27.477 15.004 -6.772  1.00 16.59 ? 134 ALA A C   1 
+ATOM   1227 O  O   . ALA A 1 134 ? -26.773 16.024 -6.735  1.00 18.52 ? 134 ALA A O   1 
+ATOM   1228 C  CB  . ALA A 1 134 ? -25.884 13.128 -7.292  1.00 18.13 ? 134 ALA A CB  1 
+ATOM   1229 N  N   . LYS A 1 135 ? -28.727 15.020 -7.223  1.00 15.80 ? 135 LYS A N   1 
+ATOM   1230 C  CA  . LYS A 1 135 ? -29.367 16.265 -7.651  1.00 16.22 ? 135 LYS A CA  1 
+ATOM   1231 C  C   . LYS A 1 135 ? -29.979 16.951 -6.426  1.00 15.91 ? 135 LYS A C   1 
+ATOM   1232 O  O   . LYS A 1 135 ? -31.193 17.026 -6.242  1.00 17.83 ? 135 LYS A O   1 
+ATOM   1233 C  CB  . LYS A 1 135 ? -30.394 15.976 -8.736  1.00 20.42 ? 135 LYS A CB  1 
+ATOM   1234 C  CG  . LYS A 1 135 ? -29.769 15.450 -10.018 1.00 25.56 ? 135 LYS A CG  1 
+ATOM   1235 C  CD  . LYS A 1 135 ? -30.821 15.063 -11.044 1.00 31.33 ? 135 LYS A CD  1 
+ATOM   1236 C  CE  . LYS A 1 135 ? -30.175 14.436 -12.274 1.00 35.91 ? 135 LYS A CE  1 
+ATOM   1237 N  NZ  . LYS A 1 135 ? -31.175 13.914 -13.246 0.53 37.15 ? 135 LYS A NZ  1 
+ATOM   1238 N  N   . SER A 1 136 ? -29.098 17.449 -5.561  1.00 15.70 ? 136 SER A N   1 
+ATOM   1239 C  CA  . SER A 1 136 ? -29.549 17.942 -4.264  1.00 14.44 ? 136 SER A CA  1 
+ATOM   1240 C  C   . SER A 1 136 ? -28.589 19.000 -3.746  1.00 14.79 ? 136 SER A C   1 
+ATOM   1241 O  O   . SER A 1 136 ? -27.397 18.997 -4.070  1.00 15.72 ? 136 SER A O   1 
+ATOM   1242 C  CB  . SER A 1 136 ? -29.625 16.800 -3.240  1.00 15.34 ? 136 SER A CB  1 
+ATOM   1243 O  OG  . SER A 1 136 ? -28.344 16.200 -3.086  1.00 14.90 ? 136 SER A OG  1 
+ATOM   1244 N  N   . ARG A 1 137 ? -29.116 19.891 -2.896  1.00 14.90 ? 137 ARG A N   1 
+ATOM   1245 C  CA  . ARG A 1 137 ? -28.242 20.810 -2.173  1.00 15.46 ? 137 ARG A CA  1 
+ATOM   1246 C  C   . ARG A 1 137 ? -27.218 20.035 -1.356  1.00 15.33 ? 137 ARG A C   1 
+ATOM   1247 O  O   . ARG A 1 137 ? -26.048 20.426 -1.282  1.00 16.59 ? 137 ARG A O   1 
+ATOM   1248 C  CB  . ARG A 1 137 ? -29.060 21.728 -1.259  1.00 17.27 ? 137 ARG A CB  1 
+ATOM   1249 C  CG  . ARG A 1 137 ? -28.174 22.737 -0.521  1.00 19.68 ? 137 ARG A CG  1 
+ATOM   1250 C  CD  . ARG A 1 137 ? -28.916 23.585 0.496   1.00 23.83 ? 137 ARG A CD  1 
+ATOM   1251 N  NE  . ARG A 1 137 ? -28.028 24.584 1.093   1.00 25.54 ? 137 ARG A NE  1 
+ATOM   1252 C  CZ  . ARG A 1 137 ? -27.278 24.389 2.178   1.00 27.36 ? 137 ARG A CZ  1 
+ATOM   1253 N  NH1 . ARG A 1 137 ? -27.287 23.219 2.808   1.00 28.30 ? 137 ARG A NH1 1 
+ATOM   1254 N  NH2 . ARG A 1 137 ? -26.509 25.369 2.634   1.00 27.55 ? 137 ARG A NH2 1 
+ATOM   1255 N  N   . TRP A 1 138 ? -27.647 18.920 -0.757  1.00 14.18 ? 138 TRP A N   1 
+ATOM   1256 C  CA  . TRP A 1 138 ? -26.761 18.068 0.037   1.00 14.72 ? 138 TRP A CA  1 
+ATOM   1257 C  C   . TRP A 1 138 ? -25.495 17.708 -0.731  1.00 14.74 ? 138 TRP A C   1 
+ATOM   1258 O  O   . TRP A 1 138 ? -24.376 17.901 -0.238  1.00 15.67 ? 138 TRP A O   1 
+ATOM   1259 C  CB  . TRP A 1 138 ? -27.537 16.807 0.412   1.00 14.90 ? 138 TRP A CB  1 
+ATOM   1260 C  CG  . TRP A 1 138 ? -26.780 15.707 1.073   1.00 14.39 ? 138 TRP A CG  1 
+ATOM   1261 C  CD1 . TRP A 1 138 ? -26.041 15.776 2.227   1.00 15.49 ? 138 TRP A CD1 1 
+ATOM   1262 C  CD2 . TRP A 1 138 ? -26.765 14.333 0.669   1.00 14.48 ? 138 TRP A CD2 1 
+ATOM   1263 N  NE1 . TRP A 1 138 ? -25.551 14.525 2.548   1.00 15.52 ? 138 TRP A NE1 1 
+ATOM   1264 C  CE2 . TRP A 1 138 ? -25.980 13.624 1.607   1.00 14.32 ? 138 TRP A CE2 1 
+ATOM   1265 C  CE3 . TRP A 1 138 ? -27.327 13.637 -0.403  1.00 15.48 ? 138 TRP A CE3 1 
+ATOM   1266 C  CZ2 . TRP A 1 138 ? -25.758 12.245 1.513   1.00 15.04 ? 138 TRP A CZ2 1 
+ATOM   1267 C  CZ3 . TRP A 1 138 ? -27.096 12.273 -0.500  1.00 17.02 ? 138 TRP A CZ3 1 
+ATOM   1268 C  CH2 . TRP A 1 138 ? -26.316 11.592 0.450   1.00 16.61 ? 138 TRP A CH2 1 
+ATOM   1269 N  N   . TYR A 1 139 ? -25.656 17.158 -1.939  1.00 14.89 ? 139 TYR A N   1 
+ATOM   1270 C  CA  . TYR A 1 139 ? -24.500 16.767 -2.740  1.00 15.73 ? 139 TYR A CA  1 
+ATOM   1271 C  C   . TYR A 1 139 ? -23.641 17.977 -3.103  1.00 17.22 ? 139 TYR A C   1 
+ATOM   1272 O  O   . TYR A 1 139 ? -22.408 17.903 -3.088  1.00 19.27 ? 139 TYR A O   1 
+ATOM   1273 C  CB  . TYR A 1 139 ? -24.990 16.064 -4.001  1.00 18.04 ? 139 TYR A CB  1 
+ATOM   1274 C  CG  . TYR A 1 139 ? -23.899 15.549 -4.903  1.00 21.23 ? 139 TYR A CG  1 
+ATOM   1275 C  CD1 . TYR A 1 139 ? -23.356 14.287 -4.712  1.00 23.02 ? 139 TYR A CD1 1 
+ATOM   1276 C  CD2 . TYR A 1 139 ? -23.430 16.312 -5.963  1.00 23.65 ? 139 TYR A CD2 1 
+ATOM   1277 C  CE1 . TYR A 1 139 ? -22.362 13.804 -5.541  1.00 27.76 ? 139 TYR A CE1 1 
+ATOM   1278 C  CE2 . TYR A 1 139 ? -22.440 15.840 -6.801  1.00 27.62 ? 139 TYR A CE2 1 
+ATOM   1279 C  CZ  . TYR A 1 139 ? -21.909 14.586 -6.588  1.00 30.29 ? 139 TYR A CZ  1 
+ATOM   1280 O  OH  . TYR A 1 139 ? -20.923 14.120 -7.428  1.00 37.44 ? 139 TYR A OH  1 
+ATOM   1281 N  N   . ASN A 1 140 ? -24.272 19.108 -3.415  1.00 15.79 ? 140 ASN A N   1 
+ATOM   1282 C  CA  . ASN A 1 140 ? -23.500 20.265 -3.861  1.00 18.22 ? 140 ASN A CA  1 
+ATOM   1283 C  C   . ASN A 1 140 ? -22.744 20.945 -2.722  1.00 18.95 ? 140 ASN A C   1 
+ATOM   1284 O  O   . ASN A 1 140 ? -21.707 21.574 -2.966  1.00 22.53 ? 140 ASN A O   1 
+ATOM   1285 C  CB  . ASN A 1 140 ? -24.405 21.238 -4.616  1.00 20.46 ? 140 ASN A CB  1 
+ATOM   1286 C  CG  . ASN A 1 140 ? -24.739 20.746 -6.016  1.00 23.22 ? 140 ASN A CG  1 
+ATOM   1287 O  OD1 . ASN A 1 140 ? -25.835 20.251 -6.275  1.00 26.29 ? 140 ASN A OD1 1 
+ATOM   1288 N  ND2 . ASN A 1 140 ? -23.787 20.872 -6.925  1.00 25.59 ? 140 ASN A ND2 1 
+ATOM   1289 N  N   . GLN A 1 141 ? -23.214 20.808 -1.480  1.00 16.64 ? 141 GLN A N   1 
+ATOM   1290 C  CA  . GLN A 1 141 ? -22.568 21.480 -0.357  1.00 17.88 ? 141 GLN A CA  1 
+ATOM   1291 C  C   . GLN A 1 141 ? -21.554 20.601 0.366   1.00 17.49 ? 141 GLN A C   1 
+ATOM   1292 O  O   . GLN A 1 141 ? -20.525 21.104 0.845   1.00 19.67 ? 141 GLN A O   1 
+ATOM   1293 C  CB  . GLN A 1 141 ? -23.613 21.999 0.634   1.00 18.78 ? 141 GLN A CB  1 
+ATOM   1294 C  CG  . GLN A 1 141 ? -24.576 23.044 0.052   1.00 23.03 ? 141 GLN A CG  1 
+ATOM   1295 C  CD  . GLN A 1 141 ? -23.868 24.287 -0.463  1.00 24.29 ? 141 GLN A CD  1 
+ATOM   1296 O  OE1 . GLN A 1 141 ? -24.094 24.719 -1.601  1.00 25.96 ? 141 GLN A OE1 1 
+ATOM   1297 N  NE2 . GLN A 1 141 ? -23.007 24.867 0.367   1.00 24.55 ? 141 GLN A NE2 1 
+ATOM   1298 N  N   . THR A 1 142 ? -21.822 19.301 0.486   1.00 15.52 ? 142 THR A N   1 
+ATOM   1299 C  CA  . THR A 1 142 ? -20.880 18.351 1.082   1.00 15.77 ? 142 THR A CA  1 
+ATOM   1300 C  C   . THR A 1 142 ? -20.681 17.197 0.109   1.00 15.48 ? 142 THR A C   1 
+ATOM   1301 O  O   . THR A 1 142 ? -21.168 16.082 0.338   1.00 15.79 ? 142 THR A O   1 
+ATOM   1302 C  CB  . THR A 1 142 ? -21.329 17.853 2.462   1.00 16.65 ? 142 THR A CB  1 
+ATOM   1303 O  OG1 . THR A 1 142 ? -22.648 17.278 2.405   1.00 18.06 ? 142 THR A OG1 1 
+ATOM   1304 C  CG2 . THR A 1 142 ? -21.324 18.991 3.476   1.00 18.86 ? 142 THR A CG2 1 
+ATOM   1305 N  N   . PRO A 1 143 ? -19.965 17.444 -0.996  1.00 15.11 ? 143 PRO A N   1 
+ATOM   1306 C  CA  . PRO A 1 143 ? -19.902 16.427 -2.063  1.00 15.18 ? 143 PRO A CA  1 
+ATOM   1307 C  C   . PRO A 1 143 ? -19.137 15.182 -1.691  1.00 15.82 ? 143 PRO A C   1 
+ATOM   1308 O  O   . PRO A 1 143 ? -19.509 14.098 -2.138  1.00 16.39 ? 143 PRO A O   1 
+ATOM   1309 C  CB  . PRO A 1 143 ? -19.244 17.169 -3.237  1.00 16.34 ? 143 PRO A CB  1 
+ATOM   1310 C  CG  . PRO A 1 143 ? -18.486 18.291 -2.589  1.00 17.39 ? 143 PRO A CG  1 
+ATOM   1311 C  CD  . PRO A 1 143 ? -19.319 18.705 -1.396  1.00 16.02 ? 143 PRO A CD  1 
+ATOM   1312 N  N   . ASN A 1 144 ? -18.064 15.288 -0.909  1.00 14.97 ? 144 ASN A N   1 
+ATOM   1313 C  CA  . ASN A 1 144 ? -17.315 14.072 -0.601  1.00 16.17 ? 144 ASN A CA  1 
+ATOM   1314 C  C   . ASN A 1 144 ? -18.094 13.157 0.338   1.00 15.90 ? 144 ASN A C   1 
+ATOM   1315 O  O   . ASN A 1 144 ? -18.114 11.938 0.143   1.00 16.75 ? 144 ASN A O   1 
+ATOM   1316 C  CB  . ASN A 1 144 ? -15.933 14.415 -0.058  1.00 18.33 ? 144 ASN A CB  1 
+ATOM   1317 C  CG  . ASN A 1 144 ? -14.996 14.882 -1.153  1.00 23.35 ? 144 ASN A CG  1 
+ATOM   1318 O  OD1 . ASN A 1 144 ? -15.092 14.430 -2.294  1.00 28.40 ? 144 ASN A OD1 1 
+ATOM   1319 N  ND2 . ASN A 1 144 ? -14.102 15.797 -0.822  1.00 25.09 ? 144 ASN A ND2 1 
+ATOM   1320 N  N   . ARG A 1 145 ? -18.720 13.733 1.368   1.00 15.38 ? 145 ARG A N   1 
+ATOM   1321 C  CA  . ARG A 1 145 ? -19.611 12.974 2.244   1.00 16.35 ? 145 ARG A CA  1 
+ATOM   1322 C  C   . ARG A 1 145 ? -20.738 12.342 1.442   1.00 14.63 ? 145 ARG A C   1 
+ATOM   1323 O  O   . ARG A 1 145 ? -21.022 11.140 1.571   1.00 14.85 ? 145 ARG A O   1 
+ATOM   1324 C  CB  . ARG A 1 145 ? -20.199 13.933 3.286   1.00 17.68 ? 145 ARG A CB  1 
+ATOM   1325 C  CG  . ARG A 1 145 ? -21.404 13.410 4.110   1.00 21.24 ? 145 ARG A CG  1 
+ATOM   1326 C  CD  . ARG A 1 145 ? -20.926 12.440 5.124   1.00 20.51 ? 145 ARG A CD  1 
+ATOM   1327 N  NE  . ARG A 1 145 ? -21.891 12.102 6.180   1.00 18.76 ? 145 ARG A NE  1 
+ATOM   1328 C  CZ  . ARG A 1 145 ? -22.015 12.751 7.339   1.00 15.98 ? 145 ARG A CZ  1 
+ATOM   1329 N  NH1 . ARG A 1 145 ? -21.284 13.828 7.588   1.00 18.69 ? 145 ARG A NH1 1 
+ATOM   1330 N  NH2 . ARG A 1 145 ? -22.873 12.309 8.256   1.00 14.39 ? 145 ARG A NH2 1 
+ATOM   1331 N  N   . ALA A 1 146 ? -21.395 13.146 0.607   1.00 14.46 ? 146 ALA A N   1 
+ATOM   1332 C  CA  . ALA A 1 146 ? -22.517 12.645 -0.178  1.00 14.31 ? 146 ALA A CA  1 
+ATOM   1333 C  C   . ALA A 1 146 ? -22.080 11.527 -1.113  1.00 14.29 ? 146 ALA A C   1 
+ATOM   1334 O  O   . ALA A 1 146 ? -22.796 10.534 -1.273  1.00 15.36 ? 146 ALA A O   1 
+ATOM   1335 C  CB  . ALA A 1 146 ? -23.175 13.786 -0.961  1.00 15.90 ? 146 ALA A CB  1 
+ATOM   1336 N  N   . LYS A 1 147 ? -20.917 11.677 -1.760  1.00 13.85 ? 147 LYS A N   1 
+ATOM   1337 C  CA  . LYS A 1 147 ? -20.427 10.626 -2.653  1.00 14.54 ? 147 LYS A CA  1 
+ATOM   1338 C  C   . LYS A 1 147 ? -20.227 9.313  -1.909  1.00 14.33 ? 147 LYS A C   1 
+ATOM   1339 O  O   . LYS A 1 147 ? -20.570 8.243  -2.430  1.00 15.87 ? 147 LYS A O   1 
+ATOM   1340 C  CB  . LYS A 1 147 ? -19.130 11.061 -3.339  1.00 18.47 ? 147 LYS A CB  1 
+ATOM   1341 C  CG  . LYS A 1 147 ? -19.332 12.092 -4.431  1.00 23.20 ? 147 LYS A CG  1 
+ATOM   1342 C  CD  . LYS A 1 147 ? -17.991 12.622 -4.923  1.00 27.99 ? 147 LYS A CD  1 
+ATOM   1343 C  CE  . LYS A 1 147 ? -18.169 13.760 -5.923  1.00 32.15 ? 147 LYS A CE  1 
+ATOM   1344 N  NZ  . LYS A 1 147 ? -16.870 14.203 -6.521  1.00 34.42 ? 147 LYS A NZ  1 
+ATOM   1345 N  N   . ARG A 1 148 ? -19.692 9.365  -0.681  1.00 14.73 ? 148 ARG A N   1 
+ATOM   1346 C  CA  . ARG A 1 148 ? -19.504 8.122  0.070   1.00 14.08 ? 148 ARG A CA  1 
+ATOM   1347 C  C   . ARG A 1 148 ? -20.836 7.464  0.397   1.00 14.05 ? 148 ARG A C   1 
+ATOM   1348 O  O   . ARG A 1 148 ? -20.986 6.242  0.261   1.00 15.11 ? 148 ARG A O   1 
+ATOM   1349 C  CB  . ARG A 1 148 ? -18.709 8.361  1.358   1.00 15.41 ? 148 ARG A CB  1 
+ATOM   1350 C  CG  . ARG A 1 148 ? -17.254 8.704  1.123   1.00 16.49 ? 148 ARG A CG  1 
+ATOM   1351 C  CD  . ARG A 1 148 ? -16.458 8.625  2.411   1.00 17.19 ? 148 ARG A CD  1 
+ATOM   1352 N  NE  . ARG A 1 148 ? -16.800 9.680  3.361   1.00 18.09 ? 148 ARG A NE  1 
+ATOM   1353 C  CZ  . ARG A 1 148 ? -16.292 10.910 3.350   1.00 19.66 ? 148 ARG A CZ  1 
+ATOM   1354 N  NH1 . ARG A 1 148 ? -15.427 11.282 2.411   1.00 19.98 ? 148 ARG A NH1 1 
+ATOM   1355 N  NH2 . ARG A 1 148 ? -16.668 11.778 4.280   1.00 20.31 ? 148 ARG A NH2 1 
+ATOM   1356 N  N   . VAL A 1 149 ? -21.810 8.257  0.841   1.00 13.11 ? 149 VAL A N   1 
+ATOM   1357 C  CA  . VAL A 1 149 ? -23.115 7.707  1.201   1.00 13.18 ? 149 VAL A CA  1 
+ATOM   1358 C  C   . VAL A 1 149 ? -23.828 7.175  -0.043  1.00 13.18 ? 149 VAL A C   1 
+ATOM   1359 O  O   . VAL A 1 149 ? -24.379 6.069  -0.041  1.00 14.79 ? 149 VAL A O   1 
+ATOM   1360 C  CB  . VAL A 1 149 ? -23.944 8.767  1.954   1.00 13.91 ? 149 VAL A CB  1 
+ATOM   1361 C  CG1 . VAL A 1 149 ? -25.370 8.271  2.217   1.00 16.00 ? 149 VAL A CG1 1 
+ATOM   1362 C  CG2 . VAL A 1 149 ? -23.252 9.154  3.279   1.00 15.67 ? 149 VAL A CG2 1 
+ATOM   1363 N  N   . ILE A 1 150 ? -23.822 7.957  -1.129  1.00 13.48 ? 150 ILE A N   1 
+ATOM   1364 C  CA  . ILE A 1 150 ? -24.465 7.515  -2.370  1.00 14.19 ? 150 ILE A CA  1 
+ATOM   1365 C  C   . ILE A 1 150 ? -23.827 6.230  -2.897  1.00 14.88 ? 150 ILE A C   1 
+ATOM   1366 O  O   . ILE A 1 150 ? -24.529 5.314  -3.341  1.00 16.37 ? 150 ILE A O   1 
+ATOM   1367 C  CB  . ILE A 1 150 ? -24.456 8.648  -3.412  1.00 15.54 ? 150 ILE A CB  1 
+ATOM   1368 C  CG1 . ILE A 1 150 ? -25.362 9.794  -2.955  1.00 16.45 ? 150 ILE A CG1 1 
+ATOM   1369 C  CG2 . ILE A 1 150 ? -24.890 8.131  -4.791  1.00 18.00 ? 150 ILE A CG2 1 
+ATOM   1370 C  CD1 . ILE A 1 150 ? -25.240 11.040 -3.812  1.00 18.47 ? 150 ILE A CD1 1 
+ATOM   1371 N  N   . THR A 1 151 ? -22.494 6.133  -2.847  1.00 14.70 ? 151 THR A N   1 
+ATOM   1372 C  CA  . THR A 1 151 ? -21.828 4.914  -3.306  1.00 15.21 ? 151 THR A CA  1 
+ATOM   1373 C  C   . THR A 1 151 ? -22.255 3.710  -2.479  1.00 14.78 ? 151 THR A C   1 
+ATOM   1374 O  O   . THR A 1 151 ? -22.399 2.599  -3.006  1.00 16.08 ? 151 THR A O   1 
+ATOM   1375 C  CB  . THR A 1 151 ? -20.315 5.107  -3.243  1.00 18.02 ? 151 THR A CB  1 
+ATOM   1376 O  OG1 . THR A 1 151 ? -19.947 6.126  -4.178  1.00 21.52 ? 151 THR A OG1 1 
+ATOM   1377 C  CG2 . THR A 1 151 ? -19.561 3.809  -3.569  1.00 21.01 ? 151 THR A CG2 1 
+ATOM   1378 N  N   . THR A 1 152 ? -22.471 3.917  -1.179  1.00 14.69 ? 152 THR A N   1 
+ATOM   1379 C  CA  . THR A 1 152 ? -22.956 2.839  -0.326  1.00 14.72 ? 152 THR A CA  1 
+ATOM   1380 C  C   . THR A 1 152 ? -24.363 2.409  -0.735  1.00 15.43 ? 152 THR A C   1 
+ATOM   1381 O  O   . THR A 1 152 ? -24.659 1.210  -0.794  1.00 16.06 ? 152 THR A O   1 
+ATOM   1382 C  CB  . THR A 1 152 ? -22.888 3.293  1.131   1.00 14.66 ? 152 THR A CB  1 
+ATOM   1383 O  OG1 . THR A 1 152 ? -21.564 3.766  1.404   1.00 16.66 ? 152 THR A OG1 1 
+ATOM   1384 C  CG2 . THR A 1 152 ? -23.174 2.141  2.059   1.00 16.12 ? 152 THR A CG2 1 
+ATOM   1385 N  N   . PHE A 1 153 ? -25.249 3.366  -1.032  1.00 15.70 ? 153 PHE A N   1 
+ATOM   1386 C  CA  . PHE A 1 153 ? -26.567 2.994  -1.551  1.00 16.62 ? 153 PHE A CA  1 
+ATOM   1387 C  C   . PHE A 1 153 ? -26.454 2.294  -2.902  1.00 17.43 ? 153 PHE A C   1 
+ATOM   1388 O  O   . PHE A 1 153 ? -27.223 1.373  -3.203  1.00 19.05 ? 153 PHE A O   1 
+ATOM   1389 C  CB  . PHE A 1 153 ? -27.440 4.237  -1.722  1.00 16.22 ? 153 PHE A CB  1 
+ATOM   1390 C  CG  . PHE A 1 153 ? -28.170 4.667  -0.490  1.00 16.30 ? 153 PHE A CG  1 
+ATOM   1391 C  CD1 . PHE A 1 153 ? -28.992 3.786  0.211   1.00 17.59 ? 153 PHE A CD1 1 
+ATOM   1392 C  CD2 . PHE A 1 153 ? -28.076 5.984  -0.055  1.00 17.77 ? 153 PHE A CD2 1 
+ATOM   1393 C  CE1 . PHE A 1 153 ? -29.687 4.216  1.342   1.00 20.07 ? 153 PHE A CE1 1 
+ATOM   1394 C  CE2 . PHE A 1 153 ? -28.769 6.418  1.078   1.00 19.72 ? 153 PHE A CE2 1 
+ATOM   1395 C  CZ  . PHE A 1 153 ? -29.570 5.538  1.772   1.00 19.66 ? 153 PHE A CZ  1 
+ATOM   1396 N  N   . ARG A 1 154 ? -25.540 2.755  -3.758  1.00 15.64 ? 154 ARG A N   1 
+ATOM   1397 C  CA  . ARG A 1 154 ? -25.492 2.213  -5.113  1.00 18.19 ? 154 ARG A CA  1 
+ATOM   1398 C  C   . ARG A 1 154 ? -25.000 0.770  -5.111  1.00 18.96 ? 154 ARG A C   1 
+ATOM   1399 O  O   . ARG A 1 154 ? -25.564 -0.082 -5.809  1.00 20.59 ? 154 ARG A O   1 
+ATOM   1400 C  CB  . ARG A 1 154 ? -24.626 3.096  -6.014  1.00 21.41 ? 154 ARG A CB  1 
+ATOM   1401 C  CG  . ARG A 1 154 ? -24.745 2.718  -7.499  1.00 26.30 ? 154 ARG A CG  1 
+ATOM   1402 C  CD  . ARG A 1 154 ? -23.923 3.633  -8.404  1.00 32.41 ? 154 ARG A CD  1 
+ATOM   1403 N  NE  . ARG A 1 154 ? -22.555 3.827  -7.928  1.00 39.86 ? 154 ARG A NE  1 
+ATOM   1404 C  CZ  . ARG A 1 154 ? -21.525 3.045  -8.239  1.00 46.48 ? 154 ARG A CZ  1 
+ATOM   1405 N  NH1 . ARG A 1 154 ? -21.694 1.997  -9.036  1.00 49.17 ? 154 ARG A NH1 1 
+ATOM   1406 N  NH2 . ARG A 1 154 ? -20.319 3.312  -7.751  1.00 48.06 ? 154 ARG A NH2 1 
+ATOM   1407 N  N   . THR A 1 155 ? -23.971 0.472  -4.313  1.00 18.29 ? 155 THR A N   1 
+ATOM   1408 C  CA  . THR A 1 155 ? -23.290 -0.817 -4.365  1.00 19.97 ? 155 THR A CA  1 
+ATOM   1409 C  C   . THR A 1 155 ? -23.685 -1.789 -3.262  1.00 19.19 ? 155 THR A C   1 
+ATOM   1410 O  O   . THR A 1 155 ? -23.493 -2.997 -3.436  1.00 21.04 ? 155 THR A O   1 
+ATOM   1411 C  CB  . THR A 1 155 ? -21.767 -0.626 -4.305  1.00 21.09 ? 155 THR A CB  1 
+ATOM   1412 O  OG1 . THR A 1 155 ? -21.383 -0.147 -3.006  1.00 20.41 ? 155 THR A OG1 1 
+ATOM   1413 C  CG2 . THR A 1 155 ? -21.291 0.361  -5.374  1.00 23.92 ? 155 THR A CG2 1 
+ATOM   1414 N  N   . GLY A 1 156 ? -24.198 -1.306 -2.132  1.00 18.26 ? 156 GLY A N   1 
+ATOM   1415 C  CA  . GLY A 1 156 ? -24.424 -2.184 -1.003  1.00 17.34 ? 156 GLY A CA  1 
+ATOM   1416 C  C   . GLY A 1 156 ? -23.156 -2.730 -0.391  1.00 17.73 ? 156 GLY A C   1 
+ATOM   1417 O  O   . GLY A 1 156 ? -23.195 -3.774 0.272   1.00 19.93 ? 156 GLY A O   1 
+ATOM   1418 N  N   . THR A 1 157 ? -22.028 -2.062 -0.610  1.00 17.94 ? 157 THR A N   1 
+ATOM   1419 C  CA  . THR A 1 157 ? -20.746 -2.446 -0.044  1.00 19.09 ? 157 THR A CA  1 
+ATOM   1420 C  C   . THR A 1 157 ? -20.179 -1.271 0.732   1.00 17.36 ? 157 THR A C   1 
+ATOM   1421 O  O   . THR A 1 157 ? -20.658 -0.140 0.621   1.00 19.03 ? 157 THR A O   1 
+ATOM   1422 C  CB  . THR A 1 157 ? -19.730 -2.818 -1.137  1.00 22.27 ? 157 THR A CB  1 
+ATOM   1423 O  OG1 . THR A 1 157 ? -19.288 -1.622 -1.792  1.00 23.69 ? 157 THR A OG1 1 
+ATOM   1424 C  CG2 . THR A 1 157 ? -20.333 -3.759 -2.161  1.00 24.90 ? 157 THR A CG2 1 
+ATOM   1425 N  N   . TRP A 1 158 ? -19.119 -1.551 1.493   1.00 18.02 ? 158 TRP A N   1 
+ATOM   1426 C  CA  . TRP A 1 158 ? -18.368 -0.553 2.240   1.00 19.84 ? 158 TRP A CA  1 
+ATOM   1427 C  C   . TRP A 1 158 ? -17.207 0.040  1.450   1.00 21.06 ? 158 TRP A C   1 
+ATOM   1428 O  O   . TRP A 1 158 ? -16.345 0.691  2.043   1.00 21.61 ? 158 TRP A O   1 
+ATOM   1429 C  CB  . TRP A 1 158 ? -17.814 -1.171 3.532   1.00 21.40 ? 158 TRP A CB  1 
+ATOM   1430 C  CG  . TRP A 1 158 ? -18.868 -1.483 4.525   1.00 21.49 ? 158 TRP A CG  1 
+ATOM   1431 C  CD1 . TRP A 1 158 ? -19.274 -2.720 4.936   1.00 22.86 ? 158 TRP A CD1 1 
+ATOM   1432 C  CD2 . TRP A 1 158 ? -19.681 -0.536 5.229   1.00 20.48 ? 158 TRP A CD2 1 
+ATOM   1433 N  NE1 . TRP A 1 158 ? -20.281 -2.601 5.871   1.00 22.85 ? 158 TRP A NE1 1 
+ATOM   1434 C  CE2 . TRP A 1 158 ? -20.553 -1.269 6.061   1.00 22.13 ? 158 TRP A CE2 1 
+ATOM   1435 C  CE3 . TRP A 1 158 ? -19.754 0.861  5.240   1.00 21.82 ? 158 TRP A CE3 1 
+ATOM   1436 C  CZ2 . TRP A 1 158 ? -21.475 -0.651 6.902   1.00 23.93 ? 158 TRP A CZ2 1 
+ATOM   1437 C  CZ3 . TRP A 1 158 ? -20.681 1.474  6.077   1.00 22.79 ? 158 TRP A CZ3 1 
+ATOM   1438 C  CH2 . TRP A 1 158 ? -21.523 0.719  6.895   1.00 24.27 ? 158 TRP A CH2 1 
+ATOM   1439 N  N   . ASP A 1 159 ? -17.163 -0.166 0.134   1.00 21.63 ? 159 ASP A N   1 
+ATOM   1440 C  CA  . ASP A 1 159 ? -15.963 0.176  -0.623  1.00 23.65 ? 159 ASP A CA  1 
+ATOM   1441 C  C   . ASP A 1 159 ? -15.598 1.653  -0.520  1.00 22.26 ? 159 ASP A C   1 
+ATOM   1442 O  O   . ASP A 1 159 ? -14.412 1.993  -0.570  1.00 24.37 ? 159 ASP A O   1 
+ATOM   1443 C  CB  . ASP A 1 159 ? -16.123 -0.241 -2.083  1.00 28.37 ? 159 ASP A CB  1 
+ATOM   1444 C  CG  . ASP A 1 159 ? -16.028 -1.745 -2.273  1.00 34.11 ? 159 ASP A CG  1 
+ATOM   1445 O  OD1 . ASP A 1 159 ? -15.765 -2.459 -1.286  1.00 37.34 ? 159 ASP A OD1 1 
+ATOM   1446 O  OD2 . ASP A 1 159 ? -16.206 -2.215 -3.414  1.00 39.42 ? 159 ASP A OD2 1 
+ATOM   1447 N  N   . ALA A 1 160 ? -16.584 2.548  -0.385  1.00 20.94 ? 160 ALA A N   1 
+ATOM   1448 C  CA  . ALA A 1 160 ? -16.259 3.971  -0.297  1.00 21.61 ? 160 ALA A CA  1 
+ATOM   1449 C  C   . ALA A 1 160 ? -15.515 4.298  0.984   1.00 23.12 ? 160 ALA A C   1 
+ATOM   1450 O  O   . ALA A 1 160 ? -14.781 5.290  1.031   1.00 25.94 ? 160 ALA A O   1 
+ATOM   1451 C  CB  . ALA A 1 160 ? -17.521 4.829  -0.397  1.00 22.39 ? 160 ALA A CB  1 
+ATOM   1452 N  N   . TYR A 1 161 ? -15.690 3.484  2.022   1.00 21.30 ? 161 TYR A N   1 
+ATOM   1453 C  CA  . TYR A 1 161 ? -15.068 3.746  3.313   1.00 22.27 ? 161 TYR A CA  1 
+ATOM   1454 C  C   . TYR A 1 161 ? -13.740 3.028  3.474   1.00 28.40 ? 161 TYR A C   1 
+ATOM   1455 O  O   . TYR A 1 161 ? -12.880 3.500  4.224   1.00 31.09 ? 161 TYR A O   1 
+ATOM   1456 C  CB  . TYR A 1 161 ? -16.049 3.426  4.453   1.00 20.64 ? 161 TYR A CB  1 
+ATOM   1457 C  CG  . TYR A 1 161 ? -17.143 4.465  4.519   1.00 17.83 ? 161 TYR A CG  1 
+ATOM   1458 C  CD1 . TYR A 1 161 ? -18.274 4.368  3.707   1.00 18.05 ? 161 TYR A CD1 1 
+ATOM   1459 C  CD2 . TYR A 1 161 ? -17.022 5.578  5.342   1.00 18.34 ? 161 TYR A CD2 1 
+ATOM   1460 C  CE1 . TYR A 1 161 ? -19.263 5.336  3.736   1.00 16.68 ? 161 TYR A CE1 1 
+ATOM   1461 C  CE2 . TYR A 1 161 ? -18.012 6.554  5.381   1.00 17.21 ? 161 TYR A CE2 1 
+ATOM   1462 C  CZ  . TYR A 1 161 ? -19.124 6.427  4.571   1.00 16.71 ? 161 TYR A CZ  1 
+ATOM   1463 O  OH  . TYR A 1 161 ? -20.113 7.383  4.585   1.00 17.54 ? 161 TYR A OH  1 
+ATOM   1464 N  N   . LYS A 1 162 ? -13.543 1.917  2.773   1.00 32.70 ? 162 LYS A N   1 
+ATOM   1465 C  CA  . LYS A 1 162 ? -12.250 1.254  2.759   1.00 38.92 ? 162 LYS A CA  1 
+ATOM   1466 C  C   . LYS A 1 162 ? -11.239 2.109  2.007   1.00 40.74 ? 162 LYS A C   1 
+ATOM   1467 O  O   . LYS A 1 162 ? -10.074 2.186  2.394   0.87 41.78 ? 162 LYS A O   1 
+ATOM   1468 C  CB  . LYS A 1 162 ? -12.371 -0.114 2.099   1.00 44.22 ? 162 LYS A CB  1 
+ATOM   1469 C  CG  . LYS A 1 162 ? -13.312 -1.057 2.823   1.00 49.93 ? 162 LYS A CG  1 
+ATOM   1470 C  CD  . LYS A 1 162 ? -13.316 -2.427 2.161   1.00 55.06 ? 162 LYS A CD  1 
+ATOM   1471 C  CE  . LYS A 1 162 ? -14.245 -3.385 2.889   1.00 58.31 ? 162 LYS A CE  1 
+ATOM   1472 N  NZ  . LYS A 1 162 ? -13.821 -3.598 4.302   1.00 60.15 ? 162 LYS A NZ  1 
+HETATM 1473 C  C   . TRS B 2 .   ? -24.112 17.480 11.887  1.00 19.77 ? 201 TRS A C   1 
+HETATM 1474 C  C1  . TRS B 2 .   ? -22.717 18.022 11.575  1.00 22.70 ? 201 TRS A C1  1 
+HETATM 1475 C  C2  . TRS B 2 .   ? -24.171 15.965 11.682  1.00 19.11 ? 201 TRS A C2  1 
+HETATM 1476 C  C3  . TRS B 2 .   ? -25.089 18.164 10.930  1.00 23.80 ? 201 TRS A C3  1 
+HETATM 1477 N  N   . TRS B 2 .   ? -24.455 17.768 13.282  1.00 19.75 ? 201 TRS A N   1 
+HETATM 1478 O  O1  . TRS B 2 .   ? -21.766 17.444 12.420  1.00 22.00 ? 201 TRS A O1  1 
+HETATM 1479 O  O2  . TRS B 2 .   ? -23.816 15.636 10.365  1.00 19.81 ? 201 TRS A O2  1 
+HETATM 1480 O  O3  . TRS B 2 .   ? -26.390 17.898 11.360  1.00 28.15 ? 201 TRS A O3  1 
+HETATM 1481 CL CL  . CL  C 3 .   ? -17.760 16.883 1.978   1.00 22.25 ? 202 CL  A CL  1 
+HETATM 1482 C  C   A MBN D 4 .   ? -32.458 7.504  2.461   0.55 29.75 ? 203 MBN A C   1 
+HETATM 1483 C  C   C MBN D 4 .   ? -33.037 9.010  4.569   0.37 24.78 ? 203 MBN A C   1 
+HETATM 1484 C  C1  A MBN D 4 .   ? -33.314 6.820  3.520   0.55 28.97 ? 203 MBN A C1  1 
+HETATM 1485 C  C1  C MBN D 4 .   ? -33.595 7.599  4.419   0.37 24.45 ? 203 MBN A C1  1 
+HETATM 1486 C  C2  A MBN D 4 .   ? -33.947 5.622  3.233   0.55 28.83 ? 203 MBN A C2  1 
+HETATM 1487 C  C2  C MBN D 4 .   ? -33.240 6.826  3.324   0.37 22.84 ? 203 MBN A C2  1 
+HETATM 1488 C  C3  A MBN D 4 .   ? -34.725 5.006  4.198   0.55 28.84 ? 203 MBN A C3  1 
+HETATM 1489 C  C3  C MBN D 4 .   ? -33.747 5.545  3.187   0.37 22.85 ? 203 MBN A C3  1 
+HETATM 1490 C  C4  A MBN D 4 .   ? -34.868 5.586  5.448   0.55 28.89 ? 203 MBN A C4  1 
+HETATM 1491 C  C4  C MBN D 4 .   ? -34.608 5.040  4.147   0.37 22.85 ? 203 MBN A C4  1 
+HETATM 1492 C  C5  A MBN D 4 .   ? -34.230 6.782  5.737   0.55 29.32 ? 203 MBN A C5  1 
+HETATM 1493 C  C5  C MBN D 4 .   ? -34.966 5.812  5.239   0.37 23.17 ? 203 MBN A C5  1 
+HETATM 1494 C  C6  A MBN D 4 .   ? -33.454 7.400  4.771   0.55 28.74 ? 203 MBN A C6  1 
+HETATM 1495 C  C6  C MBN D 4 .   ? -34.457 7.093  5.377   0.37 24.58 ? 203 MBN A C6  1 
+HETATM 1496 C  C1  . BME E 5 .   ? -28.195 0.653  22.593  0.80 40.71 ? 204 BME A C1  1 
+HETATM 1497 C  C2  . BME E 5 .   ? -27.723 0.234  21.212  0.80 42.97 ? 204 BME A C2  1 
+HETATM 1498 O  O1  . BME E 5 .   ? -29.012 1.778  22.438  0.80 40.14 ? 204 BME A O1  1 
+HETATM 1499 S  S2  . BME E 5 .   ? -26.832 1.643  20.534  0.80 47.48 ? 204 BME A S2  1 
+HETATM 1500 O  O   . HOH F 6 .   ? -12.632 25.708 31.339  1.00 45.69 ? 301 HOH A O   1 
+HETATM 1501 O  O   . HOH F 6 .   ? -24.981 20.766 5.074   1.00 47.88 ? 302 HOH A O   1 
+HETATM 1502 O  O   . HOH F 6 .   ? -29.171 21.092 21.980  1.00 33.91 ? 303 HOH A O   1 
+HETATM 1503 O  O   . HOH F 6 .   ? -20.027 12.960 32.567  1.00 36.57 ? 304 HOH A O   1 
+HETATM 1504 O  O   . HOH F 6 .   ? -17.246 0.000  16.342  0.50 34.79 ? 305 HOH A O   1 
+HETATM 1505 O  O   . HOH F 6 .   ? -21.583 6.030  -6.866  1.00 49.04 ? 306 HOH A O   1 
+HETATM 1506 O  O   . HOH F 6 .   ? -14.093 7.238  -0.616  1.00 38.15 ? 307 HOH A O   1 
+HETATM 1507 O  O   . HOH F 6 .   ? -20.625 4.973  25.123  1.00 46.25 ? 308 HOH A O   1 
+HETATM 1508 O  O   . HOH F 6 .   ? -26.559 27.605 31.528  1.00 48.33 ? 309 HOH A O   1 
+HETATM 1509 O  O   . HOH F 6 .   ? -18.227 14.209 6.237   1.00 32.68 ? 310 HOH A O   1 
+HETATM 1510 O  O   . HOH F 6 .   ? -27.091 10.840 29.198  1.00 30.72 ? 311 HOH A O   1 
+HETATM 1511 O  O   . HOH F 6 .   ? -40.832 -2.473 3.264   1.00 32.16 ? 312 HOH A O   1 
+HETATM 1512 O  O   A HOH F 6 .   ? -20.027 25.513 31.863  0.98 35.28 ? 313 HOH A O   1 
+HETATM 1513 O  O   . HOH F 6 .   ? -23.980 20.363 13.688  1.00 21.18 ? 314 HOH A O   1 
+HETATM 1514 O  O   . HOH F 6 .   ? -24.620 25.997 32.586  1.00 46.81 ? 315 HOH A O   1 
+HETATM 1515 O  O   . HOH F 6 .   ? -28.460 7.522  27.789  1.00 26.79 ? 316 HOH A O   1 
+HETATM 1516 O  O   . HOH F 6 .   ? -25.007 27.664 16.057  1.00 27.47 ? 317 HOH A O   1 
+HETATM 1517 O  O   . HOH F 6 .   ? -32.358 1.546  20.402  1.00 37.63 ? 318 HOH A O   1 
+HETATM 1518 O  O   . HOH F 6 .   ? -15.769 11.221 31.325  1.00 43.28 ? 319 HOH A O   1 
+HETATM 1519 O  O   . HOH F 6 .   ? -24.196 1.089  20.985  1.00 20.92 ? 320 HOH A O   1 
+HETATM 1520 O  O   . HOH F 6 .   ? -34.905 -1.545 -1.096  1.00 20.98 ? 321 HOH A O   1 
+HETATM 1521 O  O   . HOH F 6 .   ? -30.192 25.397 28.420  1.00 30.27 ? 322 HOH A O   1 
+HETATM 1522 O  O   . HOH F 6 .   ? -28.505 17.608 18.588  1.00 38.19 ? 323 HOH A O   1 
+HETATM 1523 O  O   . HOH F 6 .   ? -22.721 12.690 18.510  1.00 17.96 ? 324 HOH A O   1 
+HETATM 1524 O  O   . HOH F 6 .   ? -25.493 -5.368 0.928   1.00 26.91 ? 325 HOH A O   1 
+HETATM 1525 O  O   . HOH F 6 .   ? -15.795 15.866 -4.517  1.00 40.22 ? 326 HOH A O   1 
+HETATM 1526 O  O   . HOH F 6 .   ? -35.814 10.247 17.778  1.00 47.66 ? 327 HOH A O   1 
+HETATM 1527 O  O   . HOH F 6 .   ? -19.359 2.261  0.338   1.00 23.51 ? 328 HOH A O   1 
+HETATM 1528 O  O   . HOH F 6 .   ? -27.925 18.801 22.786  1.00 34.43 ? 329 HOH A O   1 
+HETATM 1529 O  O   . HOH F 6 .   ? -25.701 21.544 9.589   1.00 43.37 ? 330 HOH A O   1 
+HETATM 1530 O  O   . HOH F 6 .   ? -21.215 27.301 4.936   1.00 39.47 ? 331 HOH A O   1 
+HETATM 1531 O  O   . HOH F 6 .   ? -18.463 16.852 12.476  1.00 23.38 ? 332 HOH A O   1 
+HETATM 1532 O  O   . HOH F 6 .   ? -30.604 -7.545 7.796   1.00 54.20 ? 333 HOH A O   1 
+HETATM 1533 O  O   . HOH F 6 .   ? -28.067 1.650  -14.827 1.00 55.27 ? 334 HOH A O   1 
+HETATM 1534 O  O   . HOH F 6 .   ? -19.045 23.445 0.921   1.00 23.31 ? 335 HOH A O   1 
+HETATM 1535 O  O   . HOH F 6 .   ? -20.356 24.372 28.425  1.00 22.28 ? 336 HOH A O   1 
+HETATM 1536 O  O   . HOH F 6 .   ? -25.340 11.755 4.928   1.00 18.03 ? 337 HOH A O   1 
+HETATM 1537 O  O   . HOH F 6 .   ? -28.579 19.936 24.947  1.00 32.11 ? 338 HOH A O   1 
+HETATM 1538 O  O   . HOH F 6 .   ? -22.243 -6.234 1.200   1.00 41.13 ? 339 HOH A O   1 
+HETATM 1539 O  O   . HOH F 6 .   ? -31.356 8.467  22.112  1.00 35.57 ? 340 HOH A O   1 
+HETATM 1540 O  O   . HOH F 6 .   ? -38.650 -3.627 -1.810  1.00 31.20 ? 341 HOH A O   1 
+HETATM 1541 O  O   . HOH F 6 .   ? -15.722 16.408 14.919  1.00 34.68 ? 342 HOH A O   1 
+HETATM 1542 O  O   . HOH F 6 .   ? -20.585 13.123 20.252  1.00 16.60 ? 343 HOH A O   1 
+HETATM 1543 O  O   . HOH F 6 .   ? -45.161 9.320  10.501  1.00 44.51 ? 344 HOH A O   1 
+HETATM 1544 O  O   . HOH F 6 .   ? -27.736 12.913 22.620  1.00 31.76 ? 345 HOH A O   1 
+HETATM 1545 O  O   . HOH F 6 .   ? -19.999 21.068 -5.222  1.00 34.21 ? 346 HOH A O   1 
+HETATM 1546 O  O   . HOH F 6 .   ? -14.986 20.369 31.259  1.00 31.84 ? 347 HOH A O   1 
+HETATM 1547 O  O   . HOH F 6 .   ? -27.799 13.870 26.845  1.00 27.36 ? 348 HOH A O   1 
+HETATM 1548 O  O   . HOH F 6 .   ? -17.389 19.891 35.570  1.00 35.98 ? 349 HOH A O   1 
+HETATM 1549 O  O   . HOH F 6 .   ? -32.656 9.191  -11.633 1.00 32.75 ? 350 HOH A O   1 
+HETATM 1550 O  O   . HOH F 6 .   ? -10.427 17.843 20.256  1.00 35.41 ? 351 HOH A O   1 
+HETATM 1551 O  O   . HOH F 6 .   ? -31.625 2.054  -11.539 1.00 26.03 ? 352 HOH A O   1 
+HETATM 1552 O  O   . HOH F 6 .   ? -25.986 18.110 -8.570  1.00 60.27 ? 353 HOH A O   1 
+HETATM 1553 O  O   . HOH F 6 .   ? -30.759 -1.952 -9.793  1.00 27.30 ? 354 HOH A O   1 
+HETATM 1554 O  O   . HOH F 6 .   ? -25.430 -2.200 -7.793  1.00 42.56 ? 355 HOH A O   1 
+HETATM 1555 O  O   . HOH F 6 .   ? -22.525 34.284 23.441  1.00 60.18 ? 356 HOH A O   1 
+HETATM 1556 O  O   . HOH F 6 .   ? -31.371 25.581 17.607  1.00 42.62 ? 357 HOH A O   1 
+HETATM 1557 O  O   . HOH F 6 .   ? -19.933 16.214 6.558   1.00 45.85 ? 358 HOH A O   1 
+HETATM 1558 O  O   . HOH F 6 .   ? -12.616 11.502 10.562  1.00 46.01 ? 359 HOH A O   1 
+HETATM 1559 O  O   . HOH F 6 .   ? -29.574 17.237 32.328  1.00 19.28 ? 360 HOH A O   1 
+HETATM 1560 O  O   . HOH F 6 .   ? -20.304 20.792 37.368  1.00 39.17 ? 361 HOH A O   1 
+HETATM 1561 O  O   . HOH F 6 .   ? -10.796 12.475 27.281  1.00 36.13 ? 362 HOH A O   1 
+HETATM 1562 O  O   . HOH F 6 .   ? -35.795 16.542 11.622  1.00 44.24 ? 363 HOH A O   1 
+HETATM 1563 O  O   . HOH F 6 .   ? -29.261 -0.115 -10.814 1.00 29.96 ? 364 HOH A O   1 
+HETATM 1564 O  O   . HOH F 6 .   ? -29.833 12.065 15.762  1.00 38.17 ? 365 HOH A O   1 
+HETATM 1565 O  O   . HOH F 6 .   ? -14.241 10.028 -0.012  1.00 28.33 ? 366 HOH A O   1 
+HETATM 1566 O  O   . HOH F 6 .   ? -14.898 25.947 14.459  1.00 38.14 ? 367 HOH A O   1 
+HETATM 1567 O  O   . HOH F 6 .   ? -18.966 -4.464 13.409  1.00 36.09 ? 368 HOH A O   1 
+HETATM 1568 O  O   . HOH F 6 .   ? -15.837 14.617 3.684   1.00 47.23 ? 369 HOH A O   1 
+HETATM 1569 O  O   . HOH F 6 .   ? -18.785 6.186  26.769  1.00 42.77 ? 370 HOH A O   1 
+HETATM 1570 O  O   . HOH F 6 .   ? -14.653 24.124 12.462  1.00 48.09 ? 371 HOH A O   1 
+HETATM 1571 O  O   . HOH F 6 .   ? -18.733 10.013 31.381  1.00 62.08 ? 372 HOH A O   1 
+HETATM 1572 O  O   . HOH F 6 .   ? -12.574 10.040 28.551  1.00 42.25 ? 373 HOH A O   1 
+HETATM 1573 O  O   . HOH F 6 .   ? -24.955 19.255 2.871   1.00 34.01 ? 374 HOH A O   1 
+HETATM 1574 O  O   . HOH F 6 .   ? -18.038 -4.428 1.717   1.00 35.97 ? 375 HOH A O   1 
+HETATM 1575 O  O   . HOH F 6 .   ? -11.343 14.334 13.728  1.00 42.40 ? 376 HOH A O   1 
+HETATM 1576 O  O   . HOH F 6 .   ? -23.966 19.141 7.171   1.00 53.52 ? 377 HOH A O   1 
+HETATM 1577 O  O   . HOH F 6 .   ? -33.279 11.724 -11.357 1.00 34.32 ? 378 HOH A O   1 
+HETATM 1578 O  O   . HOH F 6 .   ? -26.513 -1.201 -10.024 1.00 45.08 ? 379 HOH A O   1 
+HETATM 1579 O  O   . HOH F 6 .   ? -31.217 26.343 21.635  1.00 50.81 ? 380 HOH A O   1 
+HETATM 1580 O  O   . HOH F 6 .   ? -12.472 5.110  12.786  1.00 60.86 ? 381 HOH A O   1 
+HETATM 1581 O  O   . HOH F 6 .   ? -15.656 10.809 -1.691  1.00 46.10 ? 382 HOH A O   1 
+HETATM 1582 O  O   . HOH F 6 .   ? -24.736 12.331 28.821  1.00 52.89 ? 383 HOH A O   1 
+HETATM 1583 O  O   . HOH F 6 .   ? -34.508 -3.460 -10.121 1.00 53.76 ? 384 HOH A O   1 
+HETATM 1584 O  O   . HOH F 6 .   ? -25.269 5.724  -11.258 1.00 51.97 ? 385 HOH A O   1 
+HETATM 1585 O  O   . HOH F 6 .   ? -31.670 18.809 2.118   1.00 46.64 ? 386 HOH A O   1 
+HETATM 1586 O  O   B HOH F 6 .   ? -33.572 6.950  21.350  1.00 52.41 ? 387 HOH A O   1 
+HETATM 1587 O  O   . HOH F 6 .   ? -29.428 20.368 -8.430  1.00 37.98 ? 388 HOH A O   1 
+HETATM 1588 O  O   . HOH F 6 .   ? -28.839 5.705  -14.591 1.00 52.30 ? 389 HOH A O   1 
+HETATM 1589 O  O   . HOH F 6 .   ? -18.178 16.881 5.147   1.00 51.44 ? 390 HOH A O   1 
+# 
+loop_
+_atom_site_anisotrop.id 
+_atom_site_anisotrop.type_symbol 
+_atom_site_anisotrop.pdbx_label_atom_id 
+_atom_site_anisotrop.pdbx_label_alt_id 
+_atom_site_anisotrop.pdbx_label_comp_id 
+_atom_site_anisotrop.pdbx_label_asym_id 
+_atom_site_anisotrop.pdbx_label_seq_id 
+_atom_site_anisotrop.pdbx_PDB_ins_code 
+_atom_site_anisotrop.U[1][1] 
+_atom_site_anisotrop.U[2][2] 
+_atom_site_anisotrop.U[3][3] 
+_atom_site_anisotrop.U[1][2] 
+_atom_site_anisotrop.U[1][3] 
+_atom_site_anisotrop.U[2][3] 
+_atom_site_anisotrop.pdbx_auth_seq_id 
+_atom_site_anisotrop.pdbx_auth_comp_id 
+_atom_site_anisotrop.pdbx_auth_asym_id 
+_atom_site_anisotrop.pdbx_auth_atom_id 
+1    N  N   . MET A 1   ? 0.4064 0.4063 0.4412 0.1306  0.0813  -0.0295 1   MET A N   
+2    C  CA  . MET A 1   ? 0.3494 0.3537 0.3867 0.0726  0.0561  -0.0549 1   MET A CA  
+3    C  C   . MET A 1   ? 0.3224 0.2778 0.3180 0.0258  0.0350  -0.0401 1   MET A C   
+4    O  O   . MET A 1   ? 0.3800 0.3101 0.3463 0.0322  0.0769  -0.0404 1   MET A O   
+5    C  CB  . MET A 1   ? 0.3760 0.4239 0.4253 0.0100  0.0200  -0.0780 1   MET A CB  
+6    C  CG  . MET A 1   ? 0.4613 0.4778 0.4888 0.0130  -0.0227 -0.1069 1   MET A CG  
+7    S  SD  . MET A 1   ? 0.5534 0.5629 0.5596 0.0441  -0.0260 -0.0687 1   MET A SD  
+8    C  CE  . MET A 1   ? 0.5073 0.5500 0.5597 0.0069  -0.0037 -0.0715 1   MET A CE  
+9    N  N   . ASN A 2   ? 0.2517 0.2106 0.2638 0.0166  0.0119  -0.0329 2   ASN A N   
+10   C  CA  . ASN A 2   ? 0.2192 0.1898 0.2301 0.0199  0.0416  -0.0025 2   ASN A CA  
+11   C  C   . ASN A 2   ? 0.2152 0.1527 0.1923 -0.0025 0.0356  0.0090  2   ASN A C   
+12   O  O   . ASN A 2   ? 0.2307 0.1787 0.1908 0.0113  0.0196  -0.0083 2   ASN A O   
+13   C  CB  . ASN A 2   ? 0.2630 0.1778 0.2309 0.0093  -0.0082 -0.0154 2   ASN A CB  
+14   C  CG  . ASN A 2   ? 0.2711 0.2002 0.2341 0.0129  -0.0064 0.0158  2   ASN A CG  
+15   O  OD1 . ASN A 2   ? 0.2797 0.2170 0.2323 0.0258  -0.0076 -0.0039 2   ASN A OD1 
+16   N  ND2 . ASN A 2   ? 0.3036 0.2552 0.2563 0.0526  0.0243  0.0611  2   ASN A ND2 
+17   N  N   . ILE A 3   ? 0.2277 0.1817 0.1609 0.0142  0.0124  -0.0071 3   ILE A N   
+18   C  CA  . ILE A 3   ? 0.1974 0.1783 0.1652 -0.0278 -0.0030 -0.0138 3   ILE A CA  
+19   C  C   . ILE A 3   ? 0.2140 0.1799 0.1509 -0.0002 0.0219  0.0126  3   ILE A C   
+20   O  O   . ILE A 3   ? 0.1957 0.2094 0.1622 -0.0111 -0.0013 0.0195  3   ILE A O   
+21   C  CB  . ILE A 3   ? 0.1963 0.2125 0.1696 -0.0138 0.0148  0.0226  3   ILE A CB  
+22   C  CG1 . ILE A 3   ? 0.1885 0.2097 0.1841 0.0130  -0.0067 0.0230  3   ILE A CG1 
+23   C  CG2 . ILE A 3   ? 0.2301 0.2492 0.1654 0.0129  0.0340  0.0164  3   ILE A CG2 
+24   C  CD1 . ILE A 3   ? 0.2367 0.2062 0.1746 0.0290  -0.0314 0.0276  3   ILE A CD1 
+25   N  N   . PHE A 4   ? 0.2326 0.1961 0.1382 0.0123  -0.0100 -0.0069 4   PHE A N   
+26   C  CA  . PHE A 4   ? 0.2214 0.1996 0.1451 -0.0036 -0.0176 0.0047  4   PHE A CA  
+27   C  C   . PHE A 4   ? 0.2157 0.1857 0.1786 -0.0025 -0.0121 0.0011  4   PHE A C   
+28   O  O   . PHE A 4   ? 0.2260 0.2054 0.2101 -0.0080 -0.0132 -0.0088 4   PHE A O   
+29   C  CB  . PHE A 4   ? 0.2022 0.2299 0.1590 0.0083  -0.0135 0.0214  4   PHE A CB  
+30   C  CG  . PHE A 4   ? 0.2190 0.2393 0.1620 -0.0122 -0.0002 0.0030  4   PHE A CG  
+31   C  CD1 . PHE A 4   ? 0.2743 0.2641 0.1950 0.0338  0.0407  -0.0003 4   PHE A CD1 
+32   C  CD2 . PHE A 4   ? 0.2577 0.2476 0.1842 -0.0247 -0.0214 0.0263  4   PHE A CD2 
+33   C  CE1 . PHE A 4   ? 0.2701 0.3129 0.2139 0.0340  0.0280  0.0004  4   PHE A CE1 
+34   C  CE2 . PHE A 4   ? 0.2645 0.2957 0.2013 -0.0010 0.0077  0.0431  4   PHE A CE2 
+35   C  CZ  . PHE A 4   ? 0.2808 0.3281 0.1989 0.0412  0.0208  0.0246  4   PHE A CZ  
+36   N  N   A GLU A 5   ? 0.2289 0.2019 0.1850 0.0295  -0.0046 -0.0165 5   GLU A N   
+37   N  N   B GLU A 5   ? 0.2314 0.2230 0.1807 0.0473  -0.0199 -0.0061 5   GLU A N   
+38   C  CA  A GLU A 5   ? 0.2320 0.2116 0.2090 0.0337  0.0152  0.0056  5   GLU A CA  
+39   C  CA  B GLU A 5   ? 0.2333 0.2472 0.1974 0.0692  -0.0127 0.0105  5   GLU A CA  
+40   C  C   A GLU A 5   ? 0.2099 0.2055 0.1964 0.0125  0.0153  0.0151  5   GLU A C   
+41   C  C   B GLU A 5   ? 0.2128 0.2259 0.1813 0.0378  -0.0068 0.0040  5   GLU A C   
+42   O  O   A GLU A 5   ? 0.2039 0.2133 0.2189 -0.0345 0.0173  0.0177  5   GLU A O   
+43   O  O   B GLU A 5   ? 0.2135 0.2482 0.1874 0.0239  -0.0148 -0.0174 5   GLU A O   
+44   C  CB  A GLU A 5   ? 0.2809 0.1963 0.2456 0.0413  -0.0005 -0.0059 5   GLU A CB  
+45   C  CB  B GLU A 5   ? 0.2755 0.2784 0.2297 0.1106  -0.0312 0.0133  5   GLU A CB  
+46   C  CG  A GLU A 5   ? 0.3699 0.2678 0.2811 0.0532  -0.0092 0.0090  5   GLU A CG  
+47   C  CG  B GLU A 5   ? 0.3503 0.3581 0.2589 0.1278  -0.0372 0.0319  5   GLU A CG  
+48   C  CD  A GLU A 5   ? 0.4676 0.3623 0.3231 0.0871  -0.0089 0.0167  5   GLU A CD  
+49   C  CD  B GLU A 5   ? 0.4134 0.4600 0.2964 0.1378  -0.0410 0.0297  5   GLU A CD  
+50   O  OE1 A GLU A 5   ? 0.5145 0.3895 0.3440 0.1180  -0.0077 -0.0009 5   GLU A OE1 
+51   O  OE1 B GLU A 5   ? 0.4456 0.5206 0.3154 0.1542  -0.0461 0.0270  5   GLU A OE1 
+52   O  OE2 A GLU A 5   ? 0.4978 0.4146 0.3534 0.0787  -0.0124 0.0174  5   GLU A OE2 
+53   O  OE2 B GLU A 5   ? 0.4349 0.4829 0.3153 0.1174  -0.0329 0.0239  5   GLU A OE2 
+54   N  N   . MET A 6   ? 0.1994 0.2007 0.1644 0.0309  -0.0108 -0.0078 6   MET A N   
+55   C  CA  . MET A 6   ? 0.1718 0.2088 0.1583 0.0108  -0.0026 -0.0098 6   MET A CA  
+56   C  C   . MET A 6   ? 0.1734 0.1785 0.1582 -0.0320 0.0130  -0.0098 6   MET A C   
+57   O  O   . MET A 6   ? 0.1891 0.1885 0.1660 -0.0076 0.0245  -0.0031 6   MET A O   
+58   C  CB  . MET A 6   ? 0.1817 0.2219 0.1483 0.0076  -0.0236 0.0028  6   MET A CB  
+59   C  CG  . MET A 6   ? 0.1899 0.2173 0.1544 0.0073  -0.0226 0.0080  6   MET A CG  
+60   S  SD  . MET A 6   ? 0.1944 0.2111 0.1773 -0.0030 -0.0030 -0.0002 6   MET A SD  
+61   C  CE  . MET A 6   ? 0.2288 0.2786 0.1763 0.0131  -0.0203 -0.0203 6   MET A CE  
+62   N  N   . LEU A 7   ? 0.1743 0.2025 0.1605 0.0085  0.0244  -0.0274 7   LEU A N   
+63   C  CA  . LEU A 7   ? 0.1760 0.1900 0.1801 -0.0010 0.0250  -0.0371 7   LEU A CA  
+64   C  C   . LEU A 7   ? 0.1989 0.2143 0.1862 0.0160  0.0150  -0.0238 7   LEU A C   
+65   O  O   . LEU A 7   ? 0.2175 0.1990 0.2147 -0.0082 0.0161  -0.0107 7   LEU A O   
+66   C  CB  . LEU A 7   ? 0.1499 0.2052 0.1905 0.0081  0.0147  -0.0216 7   LEU A CB  
+67   C  CG  . LEU A 7   ? 0.1609 0.1904 0.1882 -0.0011 0.0145  -0.0111 7   LEU A CG  
+68   C  CD1 . LEU A 7   ? 0.1708 0.2465 0.2098 0.0026  0.0485  -0.0036 7   LEU A CD1 
+69   C  CD2 . LEU A 7   ? 0.2359 0.2218 0.1899 0.0109  0.0306  0.0113  7   LEU A CD2 
+70   N  N   . ARG A 8   ? 0.1749 0.2256 0.1881 0.0125  -0.0028 -0.0440 8   ARG A N   
+71   C  CA  . ARG A 8   ? 0.1847 0.2316 0.2346 0.0312  -0.0159 -0.0257 8   ARG A CA  
+72   C  C   . ARG A 8   ? 0.1929 0.2542 0.2310 0.0021  -0.0047 -0.0307 8   ARG A C   
+73   O  O   . ARG A 8   ? 0.2214 0.2752 0.2478 -0.0211 -0.0047 -0.0532 8   ARG A O   
+74   C  CB  . ARG A 8   ? 0.2278 0.2711 0.2875 0.0080  -0.0759 -0.0475 8   ARG A CB  
+75   C  CG  . ARG A 8   ? 0.3055 0.3902 0.3697 0.0458  -0.0753 -0.0706 8   ARG A CG  
+76   C  CD  . ARG A 8   ? 0.3560 0.5398 0.4758 0.0804  -0.0900 -0.1027 8   ARG A CD  
+77   N  NE  . ARG A 8   ? 0.4096 0.6621 0.5576 0.0740  -0.1101 -0.1362 8   ARG A NE  
+78   C  CZ  . ARG A 8   ? 0.4533 0.7491 0.6057 0.1471  -0.1159 -0.1407 8   ARG A CZ  
+79   N  NH1 . ARG A 8   ? 0.4691 0.7795 0.6101 0.1561  -0.1091 -0.1254 8   ARG A NH1 
+80   N  NH2 . ARG A 8   ? 0.4686 0.7922 0.6303 0.1413  -0.1283 -0.1496 8   ARG A NH2 
+81   N  N   . ILE A 9   ? 0.1977 0.2345 0.2137 0.0058  0.0215  -0.0163 9   ILE A N   
+82   C  CA  . ILE A 9   ? 0.2129 0.2370 0.2254 -0.0249 0.0344  -0.0310 9   ILE A CA  
+83   C  C   . ILE A 9   ? 0.2248 0.2106 0.2236 -0.0330 0.0313  -0.0319 9   ILE A C   
+84   O  O   . ILE A 9   ? 0.2489 0.2645 0.2558 -0.0477 0.0224  -0.0258 9   ILE A O   
+85   C  CB  . ILE A 9   ? 0.2285 0.2366 0.2465 0.0005  0.0455  -0.0535 9   ILE A CB  
+86   C  CG1 . ILE A 9   ? 0.2538 0.2541 0.2858 0.0231  0.0293  -0.0717 9   ILE A CG1 
+87   C  CG2 . ILE A 9   ? 0.2373 0.2948 0.2713 -0.0112 0.0589  -0.0423 9   ILE A CG2 
+88   C  CD1 . ILE A 9   ? 0.2770 0.2805 0.2924 0.0197  0.0140  -0.0992 9   ILE A CD1 
+89   N  N   . ASP A 10  ? 0.1988 0.2153 0.1955 -0.0027 0.0257  -0.0365 10  ASP A N   
+90   C  CA  . ASP A 10  ? 0.1955 0.1861 0.1894 -0.0421 0.0101  -0.0228 10  ASP A CA  
+91   C  C   . ASP A 10  ? 0.2442 0.1829 0.1744 -0.0518 0.0145  -0.0181 10  ASP A C   
+92   O  O   . ASP A 10  ? 0.3214 0.2107 0.1907 -0.0395 0.0328  -0.0225 10  ASP A O   
+93   C  CB  . ASP A 10  ? 0.1748 0.2222 0.1971 -0.0355 -0.0142 -0.0494 10  ASP A CB  
+94   C  CG  . ASP A 10  ? 0.1947 0.2235 0.2032 -0.0207 0.0178  -0.0367 10  ASP A CG  
+95   O  OD1 . ASP A 10  ? 0.2098 0.2695 0.2089 -0.0265 0.0103  -0.0703 10  ASP A OD1 
+96   O  OD2 . ASP A 10  ? 0.1948 0.2323 0.2168 -0.0258 0.0129  -0.0229 10  ASP A OD2 
+97   N  N   . GLU A 11  ? 0.2339 0.2284 0.1674 -0.0062 0.0183  -0.0410 11  GLU A N   
+98   C  CA  . GLU A 11  ? 0.2122 0.2267 0.1799 -0.0306 0.0263  -0.0539 11  GLU A CA  
+99   C  C   . GLU A 11  ? 0.2181 0.2514 0.2238 -0.0604 0.0303  -0.0506 11  GLU A C   
+100  O  O   . GLU A 11  ? 0.2888 0.2681 0.2644 -0.0604 0.0161  -0.0562 11  GLU A O   
+101  C  CB  . GLU A 11  ? 0.2043 0.2238 0.1874 -0.0499 0.0117  -0.0258 11  GLU A CB  
+102  C  CG  . GLU A 11  ? 0.2055 0.2095 0.2029 -0.0282 0.0138  -0.0365 11  GLU A CG  
+103  C  CD  . GLU A 11  ? 0.2320 0.1923 0.2163 -0.0497 0.0054  -0.0249 11  GLU A CD  
+104  O  OE1 . GLU A 11  ? 0.2614 0.2092 0.2538 -0.0095 -0.0150 -0.0129 11  GLU A OE1 
+105  O  OE2 . GLU A 11  ? 0.2421 0.2454 0.2022 -0.0087 -0.0179 -0.0472 11  GLU A OE2 
+106  N  N   . GLY A 12  ? 0.1904 0.2891 0.2136 -0.0334 0.0222  -0.0589 12  GLY A N   
+107  C  CA  . GLY A 12  ? 0.1845 0.3146 0.2027 -0.0437 0.0119  -0.0818 12  GLY A CA  
+108  C  C   . GLY A 12  ? 0.1912 0.3161 0.2271 -0.0423 0.0220  -0.0837 12  GLY A C   
+109  O  O   . GLY A 12  ? 0.2144 0.3506 0.2430 -0.0537 0.0202  -0.0767 12  GLY A O   
+110  N  N   . LEU A 13  ? 0.2114 0.3422 0.2246 -0.0179 -0.0028 -0.0911 13  LEU A N   
+111  C  CA  . LEU A 13  ? 0.2278 0.3273 0.2248 -0.0188 -0.0160 -0.0959 13  LEU A CA  
+112  C  C   . LEU A 13  ? 0.2300 0.3614 0.2496 -0.0435 0.0016  -0.1055 13  LEU A C   
+113  O  O   . LEU A 13  ? 0.2608 0.4167 0.3022 -0.0342 0.0033  -0.1345 13  LEU A O   
+114  C  CB  . LEU A 13  ? 0.2638 0.3904 0.2467 0.0245  -0.0185 -0.0344 13  LEU A CB  
+115  C  CG  . LEU A 13  ? 0.3268 0.4661 0.2801 0.0810  -0.0237 -0.0096 13  LEU A CG  
+116  C  CD1 . LEU A 13  ? 0.3587 0.4834 0.2945 0.0375  -0.0164 -0.0256 13  LEU A CD1 
+117  C  CD2 . LEU A 13  ? 0.3696 0.5256 0.3079 0.1108  -0.0160 0.0343  13  LEU A CD2 
+118  N  N   . ARG A 14  ? 0.2234 0.3354 0.2322 -0.0365 -0.0176 -0.0910 14  ARG A N   
+119  C  CA  A ARG A 14  ? 0.2484 0.3320 0.2401 -0.0295 -0.0045 -0.0824 14  ARG A CA  
+120  C  CA  B ARG A 14  ? 0.2367 0.3565 0.2348 -0.0319 -0.0040 -0.0719 14  ARG A CA  
+121  C  C   . ARG A 14  ? 0.2227 0.3503 0.2234 -0.0395 -0.0089 -0.0714 14  ARG A C   
+122  O  O   . ARG A 14  ? 0.2347 0.3980 0.2360 -0.0599 -0.0153 -0.0867 14  ARG A O   
+123  C  CB  A ARG A 14  ? 0.3123 0.3593 0.2855 0.0026  0.0080  -0.0545 14  ARG A CB  
+124  C  CB  B ARG A 14  ? 0.2758 0.4123 0.2655 -0.0044 0.0124  -0.0407 14  ARG A CB  
+125  C  CG  A ARG A 14  ? 0.3749 0.3903 0.3306 0.0203  -0.0062 -0.0564 14  ARG A CG  
+126  C  CG  B ARG A 14  ? 0.3165 0.4662 0.2916 0.0156  0.0100  -0.0424 14  ARG A CG  
+127  C  CD  A ARG A 14  ? 0.4316 0.4286 0.3767 0.0258  -0.0247 -0.0772 14  ARG A CD  
+128  C  CD  B ARG A 14  ? 0.3657 0.5004 0.3289 0.0284  0.0134  -0.0507 14  ARG A CD  
+129  N  NE  A ARG A 14  ? 0.4620 0.4240 0.4080 0.0210  -0.0169 -0.0831 14  ARG A NE  
+130  N  NE  B ARG A 14  ? 0.3864 0.5069 0.3538 0.0178  0.0314  -0.0181 14  ARG A NE  
+131  C  CZ  A ARG A 14  ? 0.4650 0.4557 0.4134 0.0237  0.0018  -0.0907 14  ARG A CZ  
+132  C  CZ  B ARG A 14  ? 0.3815 0.4899 0.3690 -0.0362 0.0535  0.0107  14  ARG A CZ  
+133  N  NH1 A ARG A 14  ? 0.4516 0.4771 0.3942 0.0365  0.0244  -0.1053 14  ARG A NH1 
+134  N  NH1 B ARG A 14  ? 0.3791 0.5041 0.3735 -0.0434 0.0636  0.0423  14  ARG A NH1 
+135  N  NH2 A ARG A 14  ? 0.4721 0.4244 0.4282 -0.0046 -0.0092 -0.0960 14  ARG A NH2 
+136  N  NH2 B ARG A 14  ? 0.3672 0.4742 0.3824 -0.0540 0.0499  -0.0108 14  ARG A NH2 
+137  N  N   . LEU A 15  ? 0.2297 0.3113 0.2046 -0.0398 -0.0177 -0.0618 15  LEU A N   
+138  C  CA  . LEU A 15  ? 0.2113 0.3125 0.2180 -0.0287 -0.0204 -0.0683 15  LEU A CA  
+139  C  C   . LEU A 15  ? 0.2152 0.2837 0.2155 -0.0819 0.0027  -0.0338 15  LEU A C   
+140  O  O   . LEU A 15  ? 0.2871 0.3394 0.2154 -0.0069 -0.0045 -0.0328 15  LEU A O   
+141  C  CB  . LEU A 15  ? 0.2235 0.3588 0.2573 0.0169  -0.0455 -0.0673 15  LEU A CB  
+142  C  CG  . LEU A 15  ? 0.2882 0.4123 0.2949 0.0624  -0.0184 -0.0576 15  LEU A CG  
+143  C  CD1 . LEU A 15  ? 0.3376 0.4587 0.3267 0.1086  -0.0302 -0.0646 15  LEU A CD1 
+144  C  CD2 . LEU A 15  ? 0.3022 0.4084 0.2935 0.0833  0.0223  -0.0540 15  LEU A CD2 
+145  N  N   . LYS A 16  ? 0.2290 0.3209 0.2222 -0.0812 -0.0152 -0.0312 16  LYS A N   
+146  C  CA  . LYS A 16  ? 0.2454 0.3321 0.2359 -0.1106 -0.0313 -0.0755 16  LYS A CA  
+147  C  C   . LYS A 16  ? 0.2263 0.2833 0.1931 -0.0811 -0.0075 -0.0513 16  LYS A C   
+148  O  O   . LYS A 16  ? 0.2805 0.3415 0.1920 0.0026  0.0007  -0.0654 16  LYS A O   
+149  C  CB  . LYS A 16  ? 0.3118 0.3991 0.3120 -0.0951 -0.0602 -0.1062 16  LYS A CB  
+150  C  CG  . LYS A 16  ? 0.3732 0.5401 0.3784 -0.0736 -0.0525 -0.0939 16  LYS A CG  
+151  C  CD  . LYS A 16  ? 0.3835 0.6098 0.4163 -0.1251 -0.0561 -0.0926 16  LYS A CD  
+152  C  CE  . LYS A 16  ? 0.4041 0.6948 0.4560 -0.1051 -0.0531 -0.0827 16  LYS A CE  
+153  N  NZ  . LYS A 16  ? 0.4183 0.7242 0.4702 -0.0742 -0.0523 -0.0800 16  LYS A NZ  
+154  N  N   . ILE A 17  ? 0.2502 0.2649 0.1823 -0.0264 -0.0035 -0.0208 17  ILE A N   
+155  C  CA  . ILE A 17  ? 0.2460 0.2689 0.1797 -0.0637 0.0087  -0.0108 17  ILE A CA  
+156  C  C   . ILE A 17  ? 0.2660 0.2701 0.1887 -0.1062 0.0093  -0.0088 17  ILE A C   
+157  O  O   . ILE A 17  ? 0.2784 0.3076 0.2157 -0.1264 0.0104  -0.0220 17  ILE A O   
+158  C  CB  . ILE A 17  ? 0.2774 0.2728 0.1863 -0.0447 0.0079  -0.0213 17  ILE A CB  
+159  C  CG1 . ILE A 17  ? 0.2804 0.3265 0.1943 -0.0235 0.0457  -0.0320 17  ILE A CG1 
+160  C  CG2 . ILE A 17  ? 0.3085 0.2846 0.1975 0.0010  0.0037  -0.0116 17  ILE A CG2 
+161  C  CD1 . ILE A 17  ? 0.2908 0.3492 0.2126 -0.0154 0.0338  -0.0560 17  ILE A CD1 
+162  N  N   . TYR A 18  ? 0.2907 0.2701 0.1523 -0.0683 0.0132  -0.0128 18  TYR A N   
+163  C  CA  . TYR A 18  ? 0.2580 0.2471 0.1780 -0.0354 0.0063  -0.0313 18  TYR A CA  
+164  C  C   . TYR A 18  ? 0.2066 0.2774 0.1836 -0.0701 -0.0107 -0.0160 18  TYR A C   
+165  O  O   . TYR A 18  ? 0.1834 0.3590 0.2175 -0.0483 0.0158  0.0318  18  TYR A O   
+166  C  CB  . TYR A 18  ? 0.2499 0.3110 0.2155 -0.0441 0.0080  -0.0428 18  TYR A CB  
+167  C  CG  . TYR A 18  ? 0.2449 0.2752 0.2057 -0.0533 0.0067  -0.0320 18  TYR A CG  
+168  C  CD1 . TYR A 18  ? 0.2234 0.2415 0.2211 -0.0561 0.0267  -0.0358 18  TYR A CD1 
+169  C  CD2 . TYR A 18  ? 0.2565 0.3348 0.2290 -0.0280 -0.0041 -0.0649 18  TYR A CD2 
+170  C  CE1 . TYR A 18  ? 0.2162 0.2969 0.2273 -0.0637 0.0160  -0.0713 18  TYR A CE1 
+171  C  CE2 . TYR A 18  ? 0.2300 0.3419 0.2338 -0.0323 0.0093  -0.0541 18  TYR A CE2 
+172  C  CZ  . TYR A 18  ? 0.2292 0.3481 0.2480 -0.0684 -0.0157 -0.0802 18  TYR A CZ  
+173  O  OH  . TYR A 18  ? 0.2424 0.4205 0.2519 -0.0616 0.0016  -0.0819 18  TYR A OH  
+174  N  N   . LYS A 19  ? 0.2548 0.3121 0.1868 -0.0446 0.0047  0.0085  19  LYS A N   
+175  C  CA  . LYS A 19  ? 0.2627 0.2825 0.2042 -0.0448 0.0011  0.0020  19  LYS A CA  
+176  C  C   . LYS A 19  ? 0.2302 0.3146 0.1826 -0.0415 0.0276  0.0077  19  LYS A C   
+177  O  O   . LYS A 19  ? 0.2161 0.4039 0.2113 -0.0231 0.0363  0.0113  19  LYS A O   
+178  C  CB  . LYS A 19  ? 0.3223 0.2443 0.2420 -0.0668 0.0051  0.0239  19  LYS A CB  
+179  C  CG  . LYS A 19  ? 0.3745 0.2567 0.2966 -0.0966 0.0016  0.0007  19  LYS A CG  
+180  C  CD  . LYS A 19  ? 0.4222 0.2969 0.3500 -0.1174 0.0056  -0.0135 19  LYS A CD  
+181  C  CE  . LYS A 19  ? 0.4866 0.3440 0.3774 -0.0843 0.0167  0.0045  19  LYS A CE  
+182  N  NZ  . LYS A 19  ? 0.5199 0.3432 0.3945 -0.0843 0.0332  0.0319  19  LYS A NZ  
+183  N  N   . ASP A 20  ? 0.2419 0.2611 0.1792 -0.0390 0.0099  0.0126  20  ASP A N   
+184  C  CA  . ASP A 20  ? 0.2338 0.2701 0.1634 -0.0199 0.0189  0.0088  20  ASP A CA  
+185  C  C   . ASP A 20  ? 0.2599 0.2801 0.1766 -0.0276 0.0295  0.0127  20  ASP A C   
+186  O  O   . ASP A 20  ? 0.2921 0.2813 0.1931 -0.0566 0.0245  0.0251  20  ASP A O   
+187  C  CB  . ASP A 20  ? 0.2169 0.2761 0.1848 -0.0353 0.0379  0.0287  20  ASP A CB  
+188  C  CG  . ASP A 20  ? 0.2485 0.2497 0.1936 -0.0359 0.0458  0.0304  20  ASP A CG  
+189  O  OD1 . ASP A 20  ? 0.2597 0.2208 0.1833 -0.0357 0.0428  0.0084  20  ASP A OD1 
+190  O  OD2 . ASP A 20  ? 0.2673 0.2749 0.2507 -0.0501 0.0130  0.0379  20  ASP A OD2 
+191  N  N   . THR A 21  ? 0.2450 0.2992 0.1719 -0.0495 0.0311  -0.0097 21  THR A N   
+192  C  CA  A THR A 21  ? 0.2518 0.3104 0.1876 -0.0352 0.0322  0.0108  21  THR A CA  
+193  C  CA  B THR A 21  ? 0.2540 0.3177 0.1822 -0.0226 0.0383  0.0100  21  THR A CA  
+194  C  C   . THR A 21  ? 0.2547 0.2946 0.1978 -0.0283 0.0325  0.0347  21  THR A C   
+195  O  O   . THR A 21  ? 0.2457 0.3128 0.2163 -0.0453 0.0235  0.0470  21  THR A O   
+196  C  CB  A THR A 21  ? 0.3078 0.3267 0.2197 -0.0092 0.0320  -0.0085 21  THR A CB  
+197  C  CB  B THR A 21  ? 0.2944 0.3659 0.1975 0.0135  0.0536  -0.0051 21  THR A CB  
+198  O  OG1 A THR A 21  ? 0.3655 0.3581 0.2459 -0.0108 0.0230  -0.0530 21  THR A OG1 
+199  O  OG1 B THR A 21  ? 0.3246 0.3939 0.1895 0.0419  0.0761  0.0045  21  THR A OG1 
+200  C  CG2 A THR A 21  ? 0.3029 0.2855 0.2155 -0.0105 0.0331  -0.0163 21  THR A CG2 
+201  C  CG2 B THR A 21  ? 0.2996 0.3660 0.2122 -0.0054 0.0498  -0.0452 21  THR A CG2 
+202  N  N   . GLU A 22  ? 0.2554 0.2851 0.1852 -0.0398 0.0375  0.0072  22  GLU A N   
+203  C  CA  . GLU A 22  ? 0.2677 0.2646 0.1932 -0.0526 0.0083  0.0097  22  GLU A CA  
+204  C  C   . GLU A 22  ? 0.3057 0.2505 0.2183 -0.0185 0.0333  0.0122  22  GLU A C   
+205  O  O   . GLU A 22  ? 0.3422 0.2974 0.2779 0.0038  0.0028  -0.0009 22  GLU A O   
+206  C  CB  . GLU A 22  ? 0.2739 0.3387 0.2278 -0.0476 -0.0041 0.0036  22  GLU A CB  
+207  C  CG  . GLU A 22  ? 0.3518 0.3575 0.2618 -0.0334 -0.0106 -0.0130 22  GLU A CG  
+208  C  CD  . GLU A 22  ? 0.4516 0.4592 0.3103 0.0641  -0.0291 -0.0282 22  GLU A CD  
+209  O  OE1 . GLU A 22  ? 0.4940 0.4951 0.3163 0.0997  -0.0543 -0.0122 22  GLU A OE1 
+210  O  OE2 . GLU A 22  ? 0.4988 0.5145 0.3376 0.0741  -0.0384 -0.0220 22  GLU A OE2 
+211  N  N   . GLY A 23  ? 0.3176 0.2360 0.2046 -0.0296 0.0559  0.0285  23  GLY A N   
+212  C  CA  . GLY A 23  ? 0.3504 0.2156 0.2191 -0.0451 0.0406  0.0123  23  GLY A CA  
+213  C  C   . GLY A 23  ? 0.3501 0.2040 0.2064 -0.0517 0.0322  -0.0004 23  GLY A C   
+214  O  O   . GLY A 23  ? 0.3978 0.2459 0.2508 -0.0397 0.0201  -0.0176 23  GLY A O   
+215  N  N   . TYR A 24  ? 0.2897 0.2080 0.1847 -0.0395 0.0285  0.0107  24  TYR A N   
+216  C  CA  . TYR A 24  ? 0.2762 0.2513 0.1620 -0.0287 0.0301  0.0181  24  TYR A CA  
+217  C  C   . TYR A 24  ? 0.2486 0.2240 0.1709 -0.0453 0.0508  0.0080  24  TYR A C   
+218  O  O   . TYR A 24  ? 0.2291 0.2438 0.1894 -0.0262 0.0352  -0.0117 24  TYR A O   
+219  C  CB  . TYR A 24  ? 0.2688 0.2939 0.1959 -0.0551 0.0224  0.0439  24  TYR A CB  
+220  C  CG  . TYR A 24  ? 0.2925 0.4177 0.2339 -0.0259 0.0019  0.0575  24  TYR A CG  
+221  C  CD1 . TYR A 24  ? 0.3517 0.4389 0.2684 0.0234  -0.0318 0.0720  24  TYR A CD1 
+222  C  CD2 . TYR A 24  ? 0.3061 0.4812 0.2612 -0.0168 0.0083  0.0546  24  TYR A CD2 
+223  C  CE1 . TYR A 24  ? 0.3907 0.5215 0.2954 0.0559  -0.0501 0.0742  24  TYR A CE1 
+224  C  CE2 . TYR A 24  ? 0.3432 0.5293 0.2676 0.0067  -0.0189 0.0611  24  TYR A CE2 
+225  C  CZ  . TYR A 24  ? 0.3836 0.5664 0.2901 0.0459  -0.0601 0.0718  24  TYR A CZ  
+226  O  OH  . TYR A 24  ? 0.4487 0.6469 0.3256 0.1175  -0.0805 0.0863  24  TYR A OH  
+227  N  N   . TYR A 25  ? 0.2745 0.2048 0.1654 -0.0108 0.0453  -0.0070 25  TYR A N   
+228  C  CA  . TYR A 25  ? 0.2659 0.1842 0.1593 -0.0435 0.0221  -0.0136 25  TYR A CA  
+229  C  C   . TYR A 25  ? 0.2120 0.1800 0.1700 -0.0436 0.0336  -0.0068 25  TYR A C   
+230  O  O   . TYR A 25  ? 0.2079 0.2293 0.1973 -0.0528 0.0378  0.0034  25  TYR A O   
+231  C  CB  . TYR A 25  ? 0.2974 0.1911 0.1937 -0.0658 0.0532  -0.0338 25  TYR A CB  
+232  C  CG  . TYR A 25  ? 0.3678 0.2037 0.2171 -0.0963 0.0443  -0.0135 25  TYR A CG  
+233  C  CD1 . TYR A 25  ? 0.4105 0.1965 0.2542 -0.1353 0.0022  -0.0202 25  TYR A CD1 
+234  C  CD2 . TYR A 25  ? 0.4198 0.2118 0.2543 -0.0730 0.0526  0.0097  25  TYR A CD2 
+235  C  CE1 . TYR A 25  ? 0.4784 0.2189 0.2989 -0.1275 0.0055  -0.0194 25  TYR A CE1 
+236  C  CE2 . TYR A 25  ? 0.4843 0.2407 0.3071 -0.0709 0.0493  -0.0071 25  TYR A CE2 
+237  C  CZ  . TYR A 25  ? 0.5300 0.2022 0.3295 -0.1212 0.0224  -0.0194 25  TYR A CZ  
+238  O  OH  . TYR A 25  ? 0.6261 0.2587 0.3760 -0.0999 0.0169  -0.0262 25  TYR A OH  
+239  N  N   . THR A 26  ? 0.2084 0.1742 0.1703 -0.0252 0.0245  -0.0061 26  THR A N   
+240  C  CA  . THR A 26  ? 0.2197 0.1833 0.1460 -0.0351 -0.0002 -0.0005 26  THR A CA  
+241  C  C   . THR A 26  ? 0.2177 0.1888 0.1594 -0.0362 -0.0005 -0.0023 26  THR A C   
+242  O  O   . THR A 26  ? 0.2336 0.2318 0.1867 -0.0472 -0.0067 -0.0303 26  THR A O   
+243  C  CB  . THR A 26  ? 0.2568 0.2039 0.1400 -0.0458 -0.0006 -0.0076 26  THR A CB  
+244  O  OG1 . THR A 26  ? 0.2872 0.2560 0.1384 -0.0281 -0.0161 -0.0144 26  THR A OG1 
+245  C  CG2 . THR A 26  ? 0.2861 0.1766 0.1538 -0.0186 -0.0008 -0.0241 26  THR A CG2 
+246  N  N   . ILE A 27  ? 0.2013 0.1987 0.1501 -0.0243 0.0040  -0.0130 27  ILE A N   
+247  C  CA  . ILE A 27  ? 0.2095 0.1994 0.1600 -0.0180 -0.0083 -0.0307 27  ILE A CA  
+248  C  C   . ILE A 27  ? 0.2011 0.1738 0.1677 -0.0296 0.0005  -0.0306 27  ILE A C   
+249  O  O   . ILE A 27  ? 0.1777 0.2116 0.1855 -0.0330 -0.0026 -0.0300 27  ILE A O   
+250  C  CB  . ILE A 27  ? 0.2394 0.2600 0.1708 -0.0117 -0.0121 -0.0543 27  ILE A CB  
+251  C  CG1 . ILE A 27  ? 0.2751 0.3121 0.1791 0.0097  -0.0522 -0.0636 27  ILE A CG1 
+252  C  CG2 . ILE A 27  ? 0.2828 0.2847 0.1831 -0.0011 0.0250  -0.0338 27  ILE A CG2 
+253  C  CD1 . ILE A 27  ? 0.2773 0.3027 0.2080 -0.0430 -0.0379 -0.0224 27  ILE A CD1 
+254  N  N   . GLY A 28  ? 0.2176 0.1941 0.1607 0.0137  0.0025  -0.0446 28  GLY A N   
+255  C  CA  . GLY A 28  ? 0.2328 0.2119 0.1682 0.0007  -0.0016 -0.0656 28  GLY A CA  
+256  C  C   . GLY A 28  ? 0.2067 0.2359 0.1505 -0.0123 -0.0065 -0.0358 28  GLY A C   
+257  O  O   . GLY A 28  ? 0.2197 0.2272 0.1839 -0.0364 0.0227  -0.0422 28  GLY A O   
+258  N  N   . ILE A 29  ? 0.2016 0.2204 0.1472 -0.0128 -0.0136 -0.0481 29  ILE A N   
+259  C  CA  . ILE A 29  ? 0.1883 0.1935 0.1613 -0.0103 -0.0229 -0.0303 29  ILE A CA  
+260  C  C   . ILE A 29  ? 0.1666 0.2180 0.1617 -0.0003 -0.0071 -0.0091 29  ILE A C   
+261  O  O   . ILE A 29  ? 0.2056 0.2164 0.1778 -0.0037 -0.0022 -0.0303 29  ILE A O   
+262  C  CB  . ILE A 29  ? 0.1868 0.2236 0.1796 0.0076  0.0057  -0.0412 29  ILE A CB  
+263  C  CG1 . ILE A 29  ? 0.2115 0.2238 0.2326 0.0271  0.0039  -0.0012 29  ILE A CG1 
+264  C  CG2 . ILE A 29  ? 0.2089 0.2166 0.1922 -0.0152 0.0280  -0.0626 29  ILE A CG2 
+265  C  CD1 . ILE A 29  ? 0.2337 0.2675 0.2909 0.0199  -0.0191 0.0195  29  ILE A CD1 
+266  N  N   . GLY A 30  ? 0.2109 0.2005 0.1518 0.0116  0.0171  -0.0145 30  GLY A N   
+267  C  CA  . GLY A 30  ? 0.1891 0.2175 0.1607 0.0157  0.0278  -0.0111 30  GLY A CA  
+268  C  C   . GLY A 30  ? 0.2187 0.1860 0.1492 -0.0146 0.0164  -0.0153 30  GLY A C   
+269  O  O   . GLY A 30  ? 0.2176 0.2468 0.1658 -0.0337 0.0011  -0.0340 30  GLY A O   
+270  N  N   . HIS A 31  ? 0.2114 0.1761 0.1444 -0.0110 0.0331  -0.0201 31  HIS A N   
+271  C  CA  . HIS A 31  ? 0.2086 0.1929 0.1284 -0.0268 0.0236  -0.0218 31  HIS A CA  
+272  C  C   . HIS A 31  ? 0.1906 0.1731 0.1543 -0.0366 0.0064  -0.0214 31  HIS A C   
+273  O  O   . HIS A 31  ? 0.1999 0.1787 0.1833 -0.0281 -0.0043 -0.0255 31  HIS A O   
+274  C  CB  . HIS A 31  ? 0.2064 0.2158 0.1354 -0.0396 0.0270  -0.0212 31  HIS A CB  
+275  C  CG  . HIS A 31  ? 0.1957 0.2082 0.1621 -0.0483 0.0402  -0.0218 31  HIS A CG  
+276  N  ND1 . HIS A 31  ? 0.2153 0.2076 0.1761 -0.0367 0.0268  -0.0121 31  HIS A ND1 
+277  C  CD2 . HIS A 31  ? 0.2323 0.2138 0.1883 -0.0333 0.0510  -0.0288 31  HIS A CD2 
+278  C  CE1 . HIS A 31  ? 0.2515 0.2423 0.2182 -0.0186 0.0579  -0.0314 31  HIS A CE1 
+279  N  NE2 . HIS A 31  ? 0.2685 0.2304 0.2177 -0.0299 0.0592  -0.0235 31  HIS A NE2 
+280  N  N   . LEU A 32  ? 0.1963 0.1947 0.1737 0.0155  0.0170  -0.0005 32  LEU A N   
+281  C  CA  . LEU A 32  ? 0.2148 0.2084 0.1817 0.0101  -0.0116 -0.0161 32  LEU A CA  
+282  C  C   . LEU A 32  ? 0.2035 0.1778 0.1877 -0.0339 0.0198  -0.0251 32  LEU A C   
+283  O  O   . LEU A 32  ? 0.2445 0.2140 0.2173 -0.0144 0.0391  -0.0018 32  LEU A O   
+284  C  CB  . LEU A 32  ? 0.2183 0.2309 0.2343 0.0037  -0.0339 0.0042  32  LEU A CB  
+285  C  CG  . LEU A 32  ? 0.2604 0.2419 0.2761 -0.0282 -0.0490 0.0139  32  LEU A CG  
+286  C  CD1 . LEU A 32  ? 0.2884 0.2835 0.2922 -0.0187 0.0100  0.0192  32  LEU A CD1 
+287  C  CD2 . LEU A 32  ? 0.2875 0.3408 0.3249 -0.0110 -0.0631 0.0019  32  LEU A CD2 
+288  N  N   . LEU A 33  ? 0.1922 0.1839 0.1779 -0.0171 0.0147  -0.0165 33  LEU A N   
+289  C  CA  . LEU A 33  ? 0.2072 0.2113 0.1850 -0.0128 0.0146  -0.0320 33  LEU A CA  
+290  C  C   . LEU A 33  ? 0.2329 0.2243 0.2058 -0.0069 0.0353  -0.0114 33  LEU A C   
+291  O  O   . LEU A 33  ? 0.2476 0.2792 0.2515 0.0009  0.0592  -0.0254 33  LEU A O   
+292  C  CB  . LEU A 33  ? 0.2408 0.1796 0.1822 -0.0166 0.0099  -0.0271 33  LEU A CB  
+293  C  CG  . LEU A 33  ? 0.2233 0.2271 0.2016 -0.0367 0.0155  0.0033  33  LEU A CG  
+294  C  CD1 . LEU A 33  ? 0.2233 0.2423 0.2450 -0.0301 -0.0036 -0.0015 33  LEU A CD1 
+295  C  CD2 . LEU A 33  ? 0.2705 0.2261 0.1941 -0.0368 0.0066  0.0098  33  LEU A CD2 
+296  N  N   . THR A 34  ? 0.2586 0.2199 0.2146 0.0222  0.0015  -0.0083 34  THR A N   
+297  C  CA  . THR A 34  ? 0.3029 0.2380 0.2396 0.0383  0.0113  -0.0158 34  THR A CA  
+298  C  C   . THR A 34  ? 0.3272 0.2571 0.2562 0.0304  -0.0088 -0.0068 34  THR A C   
+299  O  O   . THR A 34  ? 0.3317 0.2700 0.2692 0.0602  0.0334  0.0222  34  THR A O   
+300  C  CB  . THR A 34  ? 0.3101 0.2954 0.3022 0.0662  0.0234  -0.0278 34  THR A CB  
+301  O  OG1 . THR A 34  ? 0.3336 0.3159 0.3241 0.0899  0.0303  -0.0065 34  THR A OG1 
+302  C  CG2 . THR A 34  ? 0.3264 0.3196 0.3131 0.0729  0.0047  -0.0559 34  THR A CG2 
+303  N  N   . LYS A 35  ? 0.3617 0.2760 0.2670 0.0374  -0.0292 -0.0036 35  LYS A N   
+304  C  CA  . LYS A 35  ? 0.4029 0.2929 0.2947 0.0081  -0.0388 0.0149  35  LYS A CA  
+305  C  C   . LYS A 35  ? 0.4244 0.2727 0.3182 0.0158  -0.0219 0.0274  35  LYS A C   
+306  O  O   . LYS A 35  ? 0.4689 0.3110 0.3482 0.0604  -0.0112 0.0585  35  LYS A O   
+307  C  CB  . LYS A 35  ? 0.4222 0.3657 0.3125 0.0260  -0.0730 -0.0052 35  LYS A CB  
+308  C  CG  . LYS A 35  ? 0.4448 0.4007 0.3148 0.0387  -0.0950 -0.0312 35  LYS A CG  
+309  C  CD  . LYS A 35  ? 0.4886 0.4567 0.3363 0.0510  -0.0939 -0.0554 35  LYS A CD  
+310  C  CE  . LYS A 35  ? 0.5036 0.5040 0.3516 0.0552  -0.0945 -0.0405 35  LYS A CE  
+311  N  NZ  . LYS A 35  ? 0.5101 0.5307 0.3561 0.0723  -0.1109 -0.0454 35  LYS A NZ  
+312  N  N   . SER A 36  ? 0.4220 0.2674 0.3486 0.0270  0.0038  -0.0242 36  SER A N   
+313  C  CA  . SER A 36  ? 0.4567 0.2936 0.3641 0.0157  0.0345  -0.0402 36  SER A CA  
+314  C  C   . SER A 36  ? 0.4701 0.2901 0.3683 0.0231  0.0410  0.0039  36  SER A C   
+315  O  O   . SER A 36  ? 0.4655 0.2458 0.3572 0.0039  0.0430  0.0026  36  SER A O   
+316  C  CB  . SER A 36  ? 0.4679 0.3377 0.3794 -0.0064 0.0574  -0.0849 36  SER A CB  
+317  O  OG  . SER A 36  ? 0.4962 0.4127 0.4140 0.0160  0.0517  -0.0512 36  SER A OG  
+318  N  N   . PRO A 37  ? 0.4949 0.3092 0.3934 0.0224  0.0169  0.0355  37  PRO A N   
+319  C  CA  . PRO A 37  ? 0.5022 0.3096 0.4003 -0.0177 0.0247  0.0781  37  PRO A CA  
+320  C  C   . PRO A 37  ? 0.5108 0.3008 0.4076 -0.0603 0.0397  0.0495  37  PRO A C   
+321  O  O   . PRO A 37  ? 0.5461 0.3175 0.4315 -0.0774 0.0345  0.0351  37  PRO A O   
+322  C  CB  . PRO A 37  ? 0.5038 0.3424 0.4180 0.0040  -0.0088 0.1057  37  PRO A CB  
+323  C  CG  . PRO A 37  ? 0.5067 0.4240 0.4327 0.0176  -0.0088 0.0978  37  PRO A CG  
+324  C  CD  . PRO A 37  ? 0.4989 0.3781 0.4133 0.0119  -0.0054 0.0762  37  PRO A CD  
+325  N  N   . SER A 38  ? 0.4979 0.2578 0.3670 -0.0421 0.0550  0.0516  38  SER A N   
+326  C  CA  . SER A 38  ? 0.4746 0.2806 0.3533 0.0073  0.0649  0.0152  38  SER A CA  
+327  C  C   . SER A 38  ? 0.4327 0.2490 0.3294 -0.0192 0.0640  -0.0003 38  SER A C   
+328  O  O   . SER A 38  ? 0.4459 0.2360 0.3105 -0.0550 0.0552  -0.0037 38  SER A O   
+329  C  CB  . SER A 38  ? 0.4932 0.2905 0.3552 0.0307  0.0922  0.0332  38  SER A CB  
+330  O  OG  . SER A 38  ? 0.5224 0.2897 0.3769 0.0241  0.0960  0.0132  38  SER A OG  
+331  N  N   . LEU A 39  ? 0.4043 0.2661 0.3423 -0.0547 0.0745  0.0073  39  LEU A N   
+332  C  CA  . LEU A 39  ? 0.3972 0.2913 0.3551 -0.0892 0.0689  -0.0125 39  LEU A CA  
+333  C  C   . LEU A 39  ? 0.3980 0.2936 0.3296 -0.0750 0.0668  -0.0305 39  LEU A C   
+334  O  O   . LEU A 39  ? 0.4019 0.2670 0.3058 -0.0691 0.0609  -0.0399 39  LEU A O   
+335  C  CB  . LEU A 39  ? 0.3963 0.3123 0.3911 -0.1151 0.0715  -0.0246 39  LEU A CB  
+336  C  CG  . LEU A 39  ? 0.3880 0.2862 0.4219 -0.1478 0.0715  -0.0326 39  LEU A CG  
+337  C  CD1 . LEU A 39  ? 0.3946 0.3153 0.4264 -0.0994 0.0705  -0.0523 39  LEU A CD1 
+338  C  CD2 . LEU A 39  ? 0.4001 0.3308 0.4516 -0.1239 0.0575  -0.0385 39  LEU A CD2 
+339  N  N   . ASN A 40  ? 0.4207 0.2772 0.3437 -0.0574 0.0571  -0.0377 40  ASN A N   
+340  C  CA  . ASN A 40  ? 0.4319 0.2543 0.3544 -0.0602 0.0691  -0.0499 40  ASN A CA  
+341  C  C   . ASN A 40  ? 0.3877 0.2404 0.3244 -0.0594 0.0570  -0.0332 40  ASN A C   
+342  O  O   . ASN A 40  ? 0.3951 0.2637 0.3181 -0.0305 0.0513  -0.0612 40  ASN A O   
+343  C  CB  . ASN A 40  ? 0.5209 0.2980 0.4149 -0.0619 0.0508  -0.0911 40  ASN A CB  
+344  C  CG  . ASN A 40  ? 0.6180 0.4057 0.4765 0.0230  0.0379  -0.1167 40  ASN A CG  
+345  O  OD1 . ASN A 40  ? 0.6497 0.4518 0.4971 -0.0219 0.0109  -0.1142 40  ASN A OD1 
+346  N  ND2 . ASN A 40  ? 0.6644 0.4510 0.5100 0.0266  0.0449  -0.1050 40  ASN A ND2 
+347  N  N   . ALA A 41  ? 0.3717 0.2421 0.3060 -0.0263 0.0611  -0.0182 41  ALA A N   
+348  C  CA  . ALA A 41  ? 0.3443 0.2107 0.2885 -0.0156 0.0364  -0.0043 41  ALA A CA  
+349  C  C   . ALA A 41  ? 0.3299 0.2114 0.2647 -0.0137 0.0429  -0.0054 41  ALA A C   
+350  O  O   . ALA A 41  ? 0.3363 0.1901 0.2636 -0.0118 0.0542  0.0141  41  ALA A O   
+351  C  CB  . ALA A 41  ? 0.3859 0.2299 0.3199 0.0094  0.0392  0.0051  41  ALA A CB  
+352  N  N   . ALA A 42  ? 0.2982 0.2310 0.2371 -0.0284 0.0473  -0.0219 42  ALA A N   
+353  C  CA  . ALA A 42  ? 0.2975 0.2266 0.2188 -0.0126 0.0315  -0.0142 42  ALA A CA  
+354  C  C   . ALA A 42  ? 0.2800 0.1962 0.2039 -0.0357 0.0230  -0.0330 42  ALA A C   
+355  O  O   . ALA A 42  ? 0.2724 0.2079 0.2144 -0.0257 0.0374  -0.0238 42  ALA A O   
+356  C  CB  . ALA A 42  ? 0.3071 0.2120 0.2380 -0.0202 0.0407  -0.0168 42  ALA A CB  
+357  N  N   . LYS A 43  ? 0.2839 0.2303 0.2090 -0.0519 0.0125  -0.0408 43  LYS A N   
+358  C  CA  . LYS A 43  ? 0.2791 0.2225 0.2189 -0.0618 0.0132  -0.0292 43  LYS A CA  
+359  C  C   . LYS A 43  ? 0.2972 0.2370 0.2114 -0.0283 0.0326  -0.0592 43  LYS A C   
+360  O  O   . LYS A 43  ? 0.3214 0.2408 0.1948 0.0045  0.0235  -0.0329 43  LYS A O   
+361  C  CB  . LYS A 43  ? 0.2639 0.2713 0.2611 -0.0949 0.0152  -0.0671 43  LYS A CB  
+362  C  CG  . LYS A 43  ? 0.3032 0.3043 0.3092 -0.1118 0.0268  -0.0704 43  LYS A CG  
+363  C  CD  . LYS A 43  ? 0.3295 0.3622 0.3607 -0.1523 0.0271  -0.0506 43  LYS A CD  
+364  C  CE  . LYS A 43  ? 0.3887 0.4173 0.4057 -0.1514 0.0021  -0.0544 43  LYS A CE  
+365  N  NZ  . LYS A 43  ? 0.4309 0.4729 0.4437 -0.1170 -0.0322 -0.0758 43  LYS A NZ  
+366  N  N   A SER A 44  ? 0.3043 0.2251 0.2088 -0.0054 0.0530  -0.0766 44  SER A N   
+367  N  N   B SER A 44  ? 0.2908 0.2341 0.2056 -0.0285 0.0415  -0.0670 44  SER A N   
+368  N  N   C SER A 44  ? 0.2968 0.2322 0.2095 -0.0249 0.0514  -0.0734 44  SER A N   
+369  C  CA  A SER A 44  ? 0.3112 0.2710 0.2188 0.0251  0.0605  -0.0677 44  SER A CA  
+370  C  CA  B SER A 44  ? 0.2856 0.2373 0.2014 -0.0203 0.0467  -0.0661 44  SER A CA  
+371  C  CA  C SER A 44  ? 0.2970 0.2489 0.2161 0.0016  0.0616  -0.0662 44  SER A CA  
+372  C  C   A SER A 44  ? 0.2922 0.2595 0.2021 -0.0043 0.0490  -0.0519 44  SER A C   
+373  C  C   B SER A 44  ? 0.2749 0.2382 0.1941 -0.0244 0.0493  -0.0507 44  SER A C   
+374  C  C   C SER A 44  ? 0.2829 0.2408 0.2007 -0.0160 0.0544  -0.0480 44  SER A C   
+375  O  O   A SER A 44  ? 0.2992 0.2787 0.2093 -0.0069 0.0440  -0.0371 44  SER A O   
+376  O  O   B SER A 44  ? 0.2717 0.2376 0.1959 -0.0367 0.0493  -0.0431 44  SER A O   
+377  O  O   C SER A 44  ? 0.2829 0.2494 0.2051 -0.0180 0.0534  -0.0313 44  SER A O   
+378  C  CB  A SER A 44  ? 0.3430 0.3064 0.2367 0.0381  0.0765  -0.0650 44  SER A CB  
+379  C  CB  B SER A 44  ? 0.2899 0.2356 0.2009 -0.0283 0.0471  -0.0804 44  SER A CB  
+380  C  CB  C SER A 44  ? 0.3086 0.2624 0.2329 0.0031  0.0731  -0.0763 44  SER A CB  
+381  O  OG  A SER A 44  ? 0.3813 0.3072 0.2450 0.0530  0.0898  -0.0488 44  SER A OG  
+382  O  OG  B SER A 44  ? 0.2874 0.2123 0.1953 -0.0564 0.0424  -0.0923 44  SER A OG  
+383  O  OG  C SER A 44  ? 0.3076 0.2307 0.2412 -0.0387 0.0790  -0.0868 44  SER A OG  
+384  N  N   . GLU A 45  ? 0.2667 0.2412 0.1862 -0.0163 0.0531  -0.0392 45  GLU A N   
+385  C  CA  . GLU A 45  ? 0.2235 0.2074 0.1909 0.0097  0.0315  -0.0385 45  GLU A CA  
+386  C  C   . GLU A 45  ? 0.2023 0.2264 0.1908 0.0007  0.0262  -0.0123 45  GLU A C   
+387  O  O   . GLU A 45  ? 0.2252 0.2151 0.2153 0.0021  0.0270  0.0006  45  GLU A O   
+388  C  CB  . GLU A 45  ? 0.2007 0.2422 0.2053 0.0233  0.0266  -0.0257 45  GLU A CB  
+389  C  CG  . GLU A 45  ? 0.2026 0.2437 0.2310 0.0177  0.0419  0.0095  45  GLU A CG  
+390  C  CD  . GLU A 45  ? 0.2386 0.2643 0.2483 0.0188  0.0515  0.0012  45  GLU A CD  
+391  O  OE1 . GLU A 45  ? 0.2428 0.2534 0.2751 0.0168  0.0386  0.0168  45  GLU A OE1 
+392  O  OE2 . GLU A 45  ? 0.2711 0.2873 0.2945 0.0228  0.0731  0.0029  45  GLU A OE2 
+393  N  N   . LEU A 46  ? 0.2010 0.2342 0.1769 -0.0253 0.0149  -0.0348 46  LEU A N   
+394  C  CA  . LEU A 46  ? 0.1945 0.2566 0.1849 -0.0362 0.0144  -0.0216 46  LEU A CA  
+395  C  C   . LEU A 46  ? 0.1987 0.2410 0.1768 -0.0472 0.0146  -0.0180 46  LEU A C   
+396  O  O   . LEU A 46  ? 0.2273 0.2273 0.1853 -0.0262 0.0169  -0.0190 46  LEU A O   
+397  C  CB  . LEU A 46  ? 0.2013 0.2268 0.2058 -0.0320 0.0164  -0.0311 46  LEU A CB  
+398  C  CG  . LEU A 46  ? 0.2202 0.1914 0.2076 -0.0397 0.0102  -0.0334 46  LEU A CG  
+399  C  CD1 . LEU A 46  ? 0.2489 0.2009 0.2152 -0.0160 0.0225  -0.0539 46  LEU A CD1 
+400  C  CD2 . LEU A 46  ? 0.2014 0.2754 0.2210 -0.0823 0.0090  -0.0259 46  LEU A CD2 
+401  N  N   . ASP A 47  ? 0.2228 0.2662 0.1555 -0.0093 0.0124  -0.0311 47  ASP A N   
+402  C  CA  . ASP A 47  ? 0.2591 0.2116 0.1763 -0.0458 0.0133  -0.0459 47  ASP A CA  
+403  C  C   . ASP A 47  ? 0.2420 0.1983 0.1972 -0.0431 0.0198  -0.0390 47  ASP A C   
+404  O  O   . ASP A 47  ? 0.2305 0.2250 0.1976 -0.0237 0.0150  -0.0111 47  ASP A O   
+405  C  CB  . ASP A 47  ? 0.2994 0.2468 0.2073 -0.0744 0.0074  -0.0674 47  ASP A CB  
+406  C  CG  . ASP A 47  ? 0.3289 0.2673 0.2444 -0.0737 0.0172  -0.0739 47  ASP A CG  
+407  O  OD1 . ASP A 47  ? 0.3069 0.2858 0.2303 -0.0878 0.0067  -0.0396 47  ASP A OD1 
+408  O  OD2 . ASP A 47  ? 0.3527 0.2894 0.2866 -0.0833 0.0455  -0.0939 47  ASP A OD2 
+409  N  N   . LYS A 48  ? 0.1973 0.2413 0.1984 -0.0381 0.0243  -0.0514 48  LYS A N   
+410  C  CA  . LYS A 48  ? 0.1925 0.2061 0.2269 -0.0091 0.0224  -0.0612 48  LYS A CA  
+411  C  C   . LYS A 48  ? 0.1958 0.1960 0.2149 -0.0194 0.0308  -0.0209 48  LYS A C   
+412  O  O   . LYS A 48  ? 0.2109 0.2128 0.1964 -0.0048 0.0259  -0.0194 48  LYS A O   
+413  C  CB  . LYS A 48  ? 0.1868 0.2271 0.2568 -0.0033 0.0359  -0.0220 48  LYS A CB  
+414  C  CG  . LYS A 48  ? 0.2019 0.2688 0.2505 0.0240  0.0228  -0.0087 48  LYS A CG  
+415  C  CD  . LYS A 48  ? 0.2363 0.2768 0.2149 0.0442  0.0364  0.0139  48  LYS A CD  
+416  C  CE  . LYS A 48  ? 0.2730 0.2409 0.2150 0.0205  0.0269  0.0090  48  LYS A CE  
+417  N  NZ  . LYS A 48  ? 0.2564 0.2355 0.2037 0.0111  0.0202  0.0024  48  LYS A NZ  
+418  N  N   . ALA A 49  ? 0.2090 0.2128 0.1740 -0.0046 0.0200  -0.0396 49  ALA A N   
+419  C  CA  . ALA A 49  ? 0.2221 0.2140 0.1680 -0.0075 0.0194  -0.0324 49  ALA A CA  
+420  C  C   . ALA A 49  ? 0.2149 0.2049 0.1988 -0.0227 0.0119  -0.0087 49  ALA A C   
+421  O  O   . ALA A 49  ? 0.2251 0.2012 0.2245 -0.0156 0.0054  -0.0002 49  ALA A O   
+422  C  CB  . ALA A 49  ? 0.2714 0.2660 0.1661 0.0075  0.0359  -0.0152 49  ALA A CB  
+423  N  N   . ILE A 50  ? 0.2206 0.2418 0.1948 -0.0026 0.0070  -0.0044 50  ILE A N   
+424  C  CA  . ILE A 50  ? 0.2193 0.2278 0.2036 -0.0231 0.0057  0.0106  50  ILE A CA  
+425  C  C   . ILE A 50  ? 0.2293 0.2794 0.2135 -0.0237 0.0056  0.0095  50  ILE A C   
+426  O  O   . ILE A 50  ? 0.2705 0.2892 0.2389 -0.0043 0.0097  0.0337  50  ILE A O   
+427  C  CB  . ILE A 50  ? 0.2091 0.2794 0.2047 -0.0299 -0.0020 0.0126  50  ILE A CB  
+428  C  CG1 . ILE A 50  ? 0.2614 0.2887 0.2160 -0.0115 -0.0094 -0.0382 50  ILE A CG1 
+429  C  CG2 . ILE A 50  ? 0.2436 0.3275 0.2281 0.0419  -0.0207 -0.0078 50  ILE A CG2 
+430  C  CD1 . ILE A 50  ? 0.3169 0.3216 0.2532 0.0242  0.0087  -0.0575 50  ILE A CD1 
+431  N  N   . GLY A 51  ? 0.2326 0.2944 0.2046 -0.0497 0.0249  -0.0265 51  GLY A N   
+432  C  CA  . GLY A 51  ? 0.2773 0.3233 0.1877 -0.0457 0.0333  -0.0189 51  GLY A CA  
+433  C  C   . GLY A 51  ? 0.3089 0.3401 0.1946 -0.0635 0.0355  -0.0023 51  GLY A C   
+434  O  O   . GLY A 51  ? 0.3747 0.3595 0.2118 -0.0436 0.0162  -0.0084 51  GLY A O   
+435  N  N   . ARG A 52  ? 0.3236 0.3084 0.1966 -0.0649 0.0327  -0.0272 52  ARG A N   
+436  C  CA  . ARG A 52  ? 0.3136 0.3305 0.2076 -0.0896 0.0047  -0.0388 52  ARG A CA  
+437  C  C   . ARG A 52  ? 0.3007 0.3070 0.2067 -0.1108 0.0200  -0.0538 52  ARG A C   
+438  O  O   . ARG A 52  ? 0.2954 0.3483 0.2025 -0.0870 -0.0114 -0.0736 52  ARG A O   
+439  C  CB  . ARG A 52  ? 0.3316 0.3735 0.2119 -0.0570 0.0216  -0.0259 52  ARG A CB  
+440  C  CG  . ARG A 52  ? 0.3063 0.4076 0.1952 -0.0425 0.0178  -0.0207 52  ARG A CG  
+441  C  CD  . ARG A 52  ? 0.3161 0.3964 0.1934 -0.0207 0.0004  -0.0365 52  ARG A CD  
+442  N  NE  . ARG A 52  ? 0.3163 0.3528 0.2092 -0.0148 -0.0201 -0.0567 52  ARG A NE  
+443  C  CZ  . ARG A 52  ? 0.3252 0.3370 0.2187 -0.0475 -0.0288 -0.0885 52  ARG A CZ  
+444  N  NH1 . ARG A 52  ? 0.3201 0.3582 0.2532 -0.0239 -0.0416 -0.0925 52  ARG A NH1 
+445  N  NH2 . ARG A 52  ? 0.3306 0.3716 0.2279 -0.0614 0.0024  -0.0687 52  ARG A NH2 
+446  N  N   . ASN A 53  ? 0.3086 0.3004 0.2369 -0.0907 0.0092  -0.0687 53  ASN A N   
+447  C  CA  A ASN A 53  ? 0.3204 0.3404 0.2425 -0.0863 0.0060  -0.0945 53  ASN A CA  
+448  C  CA  B ASN A 53  ? 0.3251 0.3177 0.2435 -0.0791 0.0074  -0.0957 53  ASN A CA  
+449  C  C   . ASN A 53  ? 0.3067 0.3544 0.2309 -0.0990 -0.0027 -0.0790 53  ASN A C   
+450  O  O   . ASN A 53  ? 0.3122 0.4191 0.2190 -0.0402 -0.0201 -0.0629 53  ASN A O   
+451  C  CB  A ASN A 53  ? 0.3523 0.4065 0.2839 -0.0833 0.0100  -0.1075 53  ASN A CB  
+452  C  CB  B ASN A 53  ? 0.3690 0.3496 0.2882 -0.0637 0.0140  -0.1132 53  ASN A CB  
+453  C  CG  A ASN A 53  ? 0.3857 0.4854 0.3165 -0.0656 0.0028  -0.1117 53  ASN A CG  
+454  C  CG  B ASN A 53  ? 0.4179 0.3826 0.3234 -0.0314 0.0097  -0.1239 53  ASN A CG  
+455  O  OD1 A ASN A 53  ? 0.4062 0.5323 0.3262 -0.0454 0.0192  -0.1013 53  ASN A OD1 
+456  O  OD1 B ASN A 53  ? 0.4309 0.4001 0.3364 -0.0271 0.0090  -0.1038 53  ASN A OD1 
+457  N  ND2 A ASN A 53  ? 0.4042 0.5257 0.3309 -0.0348 -0.0030 -0.1075 53  ASN A ND2 
+458  N  ND2 B ASN A 53  ? 0.4554 0.4119 0.3501 0.0167  0.0070  -0.1153 53  ASN A ND2 
+459  N  N   . CYS A 54  ? 0.2939 0.3330 0.1975 -0.0964 -0.0009 -0.0646 54  CYS A N   
+460  C  CA  . CYS A 54  ? 0.2862 0.3187 0.2039 -0.0915 0.0086  -0.0573 54  CYS A CA  
+461  C  C   . CYS A 54  ? 0.2994 0.3423 0.2270 -0.1150 -0.0031 -0.0813 54  CYS A C   
+462  O  O   . CYS A 54  ? 0.2792 0.3735 0.2358 -0.1159 -0.0133 -0.0953 54  CYS A O   
+463  C  CB  . CYS A 54  ? 0.2584 0.2917 0.2198 -0.1207 0.0043  -0.0482 54  CYS A CB  
+464  S  SG  . CYS A 54  ? 0.3006 0.3284 0.2339 -0.0744 -0.0023 -0.0485 54  CYS A SG  
+465  N  N   . ASN A 55  ? 0.3578 0.3132 0.2300 -0.1339 0.0224  -0.0780 55  ASN A N   
+466  C  CA  . ASN A 55  ? 0.4034 0.3216 0.2687 -0.1989 0.0473  -0.0821 55  ASN A CA  
+467  C  C   . ASN A 55  ? 0.3796 0.3100 0.2511 -0.1198 0.0458  -0.0689 55  ASN A C   
+468  O  O   . ASN A 55  ? 0.3970 0.3392 0.2775 -0.1263 0.0285  -0.0622 55  ASN A O   
+469  C  CB  . ASN A 55  ? 0.4745 0.3343 0.3321 -0.2131 0.0414  -0.0923 55  ASN A CB  
+470  C  CG  . ASN A 55  ? 0.5585 0.3845 0.3889 -0.2101 0.0442  -0.1115 55  ASN A CG  
+471  O  OD1 . ASN A 55  ? 0.6154 0.3811 0.4252 -0.1520 0.0475  -0.0650 55  ASN A OD1 
+472  N  ND2 . ASN A 55  ? 0.5655 0.4642 0.3937 -0.2143 0.0444  -0.1419 55  ASN A ND2 
+473  N  N   . GLY A 56  ? 0.3306 0.2707 0.2206 -0.0702 0.0433  -0.0750 56  GLY A N   
+474  C  CA  . GLY A 56  ? 0.3008 0.2829 0.2060 -0.0407 0.0500  -0.0532 56  GLY A CA  
+475  C  C   . GLY A 56  ? 0.2735 0.2795 0.2142 -0.0496 0.0210  -0.0558 56  GLY A C   
+476  O  O   . GLY A 56  ? 0.3021 0.3284 0.2215 -0.0195 0.0206  -0.0293 56  GLY A O   
+477  N  N   . VAL A 57  ? 0.2524 0.2943 0.2289 -0.0417 -0.0081 -0.0551 57  VAL A N   
+478  C  CA  A VAL A 57  ? 0.2311 0.3135 0.2407 -0.0517 -0.0165 -0.0544 57  VAL A CA  
+479  C  CA  B VAL A 57  ? 0.2421 0.2906 0.2298 -0.0478 -0.0178 -0.0603 57  VAL A CA  
+480  C  C   . VAL A 57  ? 0.2379 0.2666 0.2175 -0.0495 -0.0095 -0.0529 57  VAL A C   
+481  O  O   . VAL A 57  ? 0.2919 0.2822 0.2316 -0.0324 0.0183  -0.0333 57  VAL A O   
+482  C  CB  A VAL A 57  ? 0.2360 0.3630 0.2920 -0.0653 0.0086  -0.0136 57  VAL A CB  
+483  C  CB  B VAL A 57  ? 0.2464 0.2907 0.2488 -0.0538 -0.0161 -0.0543 57  VAL A CB  
+484  C  CG1 A VAL A 57  ? 0.2470 0.4196 0.3089 -0.0328 0.0080  0.0146  57  VAL A CG1 
+485  C  CG1 B VAL A 57  ? 0.2488 0.3009 0.2535 -0.0403 -0.0164 -0.0535 57  VAL A CG1 
+486  C  CG2 A VAL A 57  ? 0.2247 0.3976 0.3102 -0.0710 0.0151  -0.0008 57  VAL A CG2 
+487  C  CG2 B VAL A 57  ? 0.2512 0.3098 0.2487 -0.0483 -0.0196 -0.0588 57  VAL A CG2 
+488  N  N   . ILE A 58  ? 0.2304 0.2428 0.1943 -0.0619 -0.0130 -0.0398 58  ILE A N   
+489  C  CA  . ILE A 58  ? 0.2098 0.2846 0.1975 -0.0498 -0.0334 -0.0379 58  ILE A CA  
+490  C  C   . ILE A 58  ? 0.2313 0.3248 0.2159 -0.0369 -0.0422 -0.0359 58  ILE A C   
+491  O  O   . ILE A 58  ? 0.2408 0.3558 0.2306 -0.0203 -0.0100 -0.0226 58  ILE A O   
+492  C  CB  . ILE A 58  ? 0.2215 0.2999 0.1829 -0.0222 -0.0363 -0.0649 58  ILE A CB  
+493  C  CG1 . ILE A 58  ? 0.2437 0.3090 0.1811 -0.0321 -0.0655 -0.0588 58  ILE A CG1 
+494  C  CG2 . ILE A 58  ? 0.2431 0.2972 0.1994 0.0349  0.0005  -0.0338 58  ILE A CG2 
+495  C  CD1 . ILE A 58  ? 0.2983 0.3050 0.1769 0.0139  -0.0815 -0.0467 58  ILE A CD1 
+496  N  N   . THR A 59  ? 0.2265 0.2959 0.2314 -0.0133 -0.0577 -0.0310 59  THR A N   
+497  C  CA  . THR A 59  ? 0.2562 0.3163 0.2389 0.0241  -0.0633 -0.0280 59  THR A CA  
+498  C  C   . THR A 59  ? 0.2428 0.3280 0.2494 0.0425  -0.0529 -0.0305 59  THR A C   
+499  O  O   . THR A 59  ? 0.2520 0.2938 0.2191 0.0196  -0.0268 -0.0412 59  THR A O   
+500  C  CB  . THR A 59  ? 0.2693 0.3652 0.2278 0.0099  -0.0609 -0.0174 59  THR A CB  
+501  O  OG1 . THR A 59  ? 0.2579 0.3667 0.2384 -0.0211 -0.0590 -0.0004 59  THR A OG1 
+502  C  CG2 . THR A 59  ? 0.3180 0.4287 0.2262 0.0460  -0.0733 -0.0472 59  THR A CG2 
+503  N  N   . LYS A 60  ? 0.2465 0.3231 0.2751 0.0550  -0.0079 -0.0442 60  LYS A N   
+504  C  CA  . LYS A 60  ? 0.2351 0.3415 0.3073 0.0516  0.0006  -0.0551 60  LYS A CA  
+505  C  C   . LYS A 60  ? 0.2530 0.3063 0.2761 0.0350  -0.0257 -0.0500 60  LYS A C   
+506  O  O   . LYS A 60  ? 0.2545 0.3137 0.2509 0.0235  -0.0244 -0.0513 60  LYS A O   
+507  C  CB  . LYS A 60  ? 0.2515 0.4134 0.3808 0.0612  -0.0065 -0.1088 60  LYS A CB  
+508  C  CG  . LYS A 60  ? 0.3094 0.4953 0.4427 0.1135  0.0090  -0.1185 60  LYS A CG  
+509  C  CD  . LYS A 60  ? 0.4165 0.5641 0.4961 0.1526  0.0363  -0.1120 60  LYS A CD  
+510  C  CE  . LYS A 60  ? 0.5374 0.6216 0.5710 0.1935  0.0306  -0.0867 60  LYS A CE  
+511  N  NZ  . LYS A 60  ? 0.5957 0.6650 0.6166 0.2064  0.0316  -0.0801 60  LYS A NZ  
+512  N  N   . ASP A 61  ? 0.2692 0.3317 0.2646 0.0375  -0.0252 -0.0239 61  ASP A N   
+513  C  CA  A ASP A 61  ? 0.2974 0.3347 0.2711 0.0420  -0.0481 0.0036  61  ASP A CA  
+514  C  CA  B ASP A 61  ? 0.2762 0.3178 0.2537 0.0434  -0.0419 -0.0209 61  ASP A CA  
+515  C  C   . ASP A 61  ? 0.2724 0.2778 0.2422 0.0248  -0.0548 -0.0316 61  ASP A C   
+516  O  O   . ASP A 61  ? 0.2907 0.2628 0.2339 0.0250  -0.0430 -0.0085 61  ASP A O   
+517  C  CB  A ASP A 61  ? 0.3360 0.4022 0.3045 0.0795  -0.0788 0.0247  61  ASP A CB  
+518  C  CB  B ASP A 61  ? 0.2892 0.3271 0.2526 0.0718  -0.0487 -0.0206 61  ASP A CB  
+519  C  CG  A ASP A 61  ? 0.4125 0.5140 0.3557 0.1210  -0.0576 0.0191  61  ASP A CG  
+520  C  CG  B ASP A 61  ? 0.3048 0.3575 0.2552 0.1038  -0.0486 -0.0167 61  ASP A CG  
+521  O  OD1 A ASP A 61  ? 0.4282 0.5229 0.3995 0.1130  -0.0375 0.0062  61  ASP A OD1 
+522  O  OD1 B ASP A 61  ? 0.3151 0.3759 0.2582 0.1067  -0.0438 -0.0145 61  ASP A OD1 
+523  O  OD2 A ASP A 61  ? 0.4581 0.5882 0.3947 0.1317  -0.0610 0.0357  61  ASP A OD2 
+524  O  OD2 B ASP A 61  ? 0.3093 0.3734 0.2543 0.1230  -0.0426 -0.0125 61  ASP A OD2 
+525  N  N   . GLU A 62  ? 0.2341 0.2944 0.2118 0.0317  -0.0518 -0.0163 62  GLU A N   
+526  C  CA  . GLU A 62  ? 0.2273 0.2497 0.1675 0.0245  -0.0497 -0.0239 62  GLU A CA  
+527  C  C   . GLU A 62  ? 0.1885 0.2524 0.1653 -0.0240 -0.0277 -0.0147 62  GLU A C   
+528  O  O   . GLU A 62  ? 0.2004 0.2710 0.1944 -0.0177 -0.0283 -0.0333 62  GLU A O   
+529  C  CB  . GLU A 62  ? 0.2794 0.2635 0.1558 0.0208  -0.0360 -0.0549 62  GLU A CB  
+530  C  CG  . GLU A 62  ? 0.2852 0.3048 0.1612 -0.0188 -0.0288 -0.0374 62  GLU A CG  
+531  C  CD  . GLU A 62  ? 0.2945 0.3277 0.1694 -0.0053 -0.0374 -0.0152 62  GLU A CD  
+532  O  OE1 . GLU A 62  ? 0.3019 0.3292 0.1674 -0.0348 -0.0068 -0.0366 62  GLU A OE1 
+533  O  OE2 . GLU A 62  ? 0.3357 0.3302 0.1886 0.0046  -0.0227 -0.0332 62  GLU A OE2 
+534  N  N   . ALA A 63  ? 0.2026 0.2796 0.1647 0.0115  -0.0129 -0.0051 63  ALA A N   
+535  C  CA  . ALA A 63  ? 0.2078 0.2687 0.1852 -0.0253 -0.0143 0.0039  63  ALA A CA  
+536  C  C   . ALA A 63  ? 0.2064 0.2601 0.1917 0.0038  -0.0179 -0.0168 63  ALA A C   
+537  O  O   . ALA A 63  ? 0.2258 0.2381 0.1691 0.0139  -0.0086 -0.0103 63  ALA A O   
+538  C  CB  . ALA A 63  ? 0.1965 0.3231 0.1892 -0.0492 -0.0006 0.0103  63  ALA A CB  
+539  N  N   A GLU A 64  ? 0.2109 0.2285 0.2074 0.0199  -0.0109 -0.0134 64  GLU A N   
+540  N  N   B GLU A 64  ? 0.2292 0.2690 0.2133 0.0081  -0.0036 -0.0062 64  GLU A N   
+541  C  CA  A GLU A 64  ? 0.1959 0.2359 0.2268 -0.0006 -0.0120 -0.0165 64  GLU A CA  
+542  C  CA  B GLU A 64  ? 0.2479 0.2782 0.2344 0.0185  0.0052  0.0040  64  GLU A CA  
+543  C  C   A GLU A 64  ? 0.2060 0.2607 0.1921 0.0016  -0.0063 -0.0080 64  GLU A C   
+544  C  C   B GLU A 64  ? 0.2301 0.2648 0.2035 0.0019  0.0055  -0.0011 64  GLU A C   
+545  O  O   A GLU A 64  ? 0.2198 0.2526 0.1725 0.0270  -0.0222 -0.0012 64  GLU A O   
+546  O  O   B GLU A 64  ? 0.2313 0.2302 0.2008 0.0097  -0.0037 -0.0097 64  GLU A O   
+547  C  CB  A GLU A 64  ? 0.2256 0.3058 0.2724 0.0583  -0.0325 -0.0450 64  GLU A CB  
+548  C  CB  B GLU A 64  ? 0.3085 0.3386 0.2820 0.0718  0.0046  0.0102  64  GLU A CB  
+549  C  CG  A GLU A 64  ? 0.2392 0.3543 0.3289 0.0705  -0.0271 -0.0789 64  GLU A CG  
+550  C  CG  B GLU A 64  ? 0.3762 0.4126 0.3245 0.1253  0.0113  0.0105  64  GLU A CG  
+551  C  CD  A GLU A 64  ? 0.3561 0.4918 0.4087 0.1566  -0.0079 -0.0625 64  GLU A CD  
+552  C  CD  B GLU A 64  ? 0.4462 0.4812 0.3606 0.1997  0.0032  0.0071  64  GLU A CD  
+553  O  OE1 A GLU A 64  ? 0.4046 0.5214 0.4483 0.1830  -0.0389 -0.0644 64  GLU A OE1 
+554  O  OE1 B GLU A 64  ? 0.4719 0.4841 0.3671 0.2613  0.0018  0.0057  64  GLU A OE1 
+555  O  OE2 A GLU A 64  ? 0.4466 0.5648 0.4439 0.2033  0.0164  -0.0523 64  GLU A OE2 
+556  O  OE2 B GLU A 64  ? 0.4746 0.5345 0.3890 0.1986  0.0073  0.0046  64  GLU A OE2 
+557  N  N   . LYS A 65  ? 0.2198 0.2779 0.1801 -0.0072 0.0119  -0.0021 65  LYS A N   
+558  C  CA  . LYS A 65  ? 0.2484 0.2987 0.1568 -0.0186 0.0171  -0.0071 65  LYS A CA  
+559  C  C   . LYS A 65  ? 0.2392 0.2726 0.1600 0.0030  -0.0084 -0.0183 65  LYS A C   
+560  O  O   . LYS A 65  ? 0.2349 0.2506 0.1731 -0.0048 -0.0019 -0.0231 65  LYS A O   
+561  C  CB  . LYS A 65  ? 0.3032 0.3443 0.1492 -0.0220 0.0600  0.0074  65  LYS A CB  
+562  C  CG  . LYS A 65  ? 0.4272 0.4276 0.1885 0.0208  0.0869  0.0108  65  LYS A CG  
+563  C  CD  . LYS A 65  ? 0.4825 0.4462 0.2093 0.0424  0.1409  0.0634  65  LYS A CD  
+564  C  CE  . LYS A 65  ? 0.5186 0.4850 0.2476 0.0583  0.1327  0.0221  65  LYS A CE  
+565  N  NZ  . LYS A 65  ? 0.5282 0.5058 0.2543 0.0567  0.1143  -0.0065 65  LYS A NZ  
+566  N  N   A LEU A 66  ? 0.2299 0.2283 0.1544 -0.0106 0.0026  -0.0283 66  LEU A N   
+567  N  N   B LEU A 66  ? 0.2407 0.2392 0.1650 -0.0109 0.0017  -0.0243 66  LEU A N   
+568  C  CA  A LEU A 66  ? 0.2263 0.1856 0.1763 -0.0233 0.0123  -0.0338 66  LEU A CA  
+569  C  CA  B LEU A 66  ? 0.2506 0.2155 0.1864 -0.0198 0.0083  -0.0258 66  LEU A CA  
+570  C  C   A LEU A 66  ? 0.2116 0.1947 0.1662 -0.0119 0.0150  -0.0249 66  LEU A C   
+571  C  C   B LEU A 66  ? 0.2266 0.2155 0.1700 0.0076  0.0128  -0.0281 66  LEU A C   
+572  O  O   A LEU A 66  ? 0.2317 0.1712 0.1885 -0.0111 0.0144  -0.0069 66  LEU A O   
+573  O  O   B LEU A 66  ? 0.2281 0.2149 0.1831 0.0161  0.0079  -0.0274 66  LEU A O   
+574  C  CB  A LEU A 66  ? 0.2427 0.2056 0.2238 -0.0493 0.0244  -0.0550 66  LEU A CB  
+575  C  CB  B LEU A 66  ? 0.2874 0.2236 0.2302 -0.0430 0.0130  -0.0248 66  LEU A CB  
+576  C  CG  A LEU A 66  ? 0.2231 0.2635 0.2483 -0.0464 0.0067  -0.0717 66  LEU A CG  
+577  C  CG  B LEU A 66  ? 0.3101 0.2295 0.2535 -0.0479 0.0076  -0.0099 66  LEU A CG  
+578  C  CD1 A LEU A 66  ? 0.2329 0.2837 0.2747 -0.0192 -0.0090 -0.0491 66  LEU A CD1 
+579  C  CD1 B LEU A 66  ? 0.3279 0.2995 0.2778 -0.0076 0.0348  0.0020  66  LEU A CD1 
+580  C  CD2 A LEU A 66  ? 0.2379 0.3483 0.2698 0.0273  0.0250  -0.0754 66  LEU A CD2 
+581  C  CD2 B LEU A 66  ? 0.3118 0.1762 0.2552 -0.0862 -0.0241 -0.0267 66  LEU A CD2 
+582  N  N   . PHE A 67  ? 0.2236 0.2021 0.1513 0.0046  0.0239  -0.0224 67  PHE A N   
+583  C  CA  . PHE A 67  ? 0.2116 0.2212 0.1425 0.0017  0.0141  -0.0344 67  PHE A CA  
+584  C  C   . PHE A 67  ? 0.2342 0.1989 0.1498 0.0122  -0.0000 -0.0257 67  PHE A C   
+585  O  O   . PHE A 67  ? 0.2179 0.2447 0.1388 -0.0106 -0.0079 -0.0285 67  PHE A O   
+586  C  CB  . PHE A 67  ? 0.2061 0.2594 0.1364 0.0233  0.0211  -0.0457 67  PHE A CB  
+587  C  CG  . PHE A 67  ? 0.2161 0.2221 0.1479 -0.0090 0.0135  -0.0227 67  PHE A CG  
+588  C  CD1 . PHE A 67  ? 0.2502 0.2683 0.1230 0.0094  0.0158  -0.0228 67  PHE A CD1 
+589  C  CD2 . PHE A 67  ? 0.2619 0.2014 0.1828 0.0190  0.0168  -0.0269 67  PHE A CD2 
+590  C  CE1 . PHE A 67  ? 0.2703 0.2393 0.1556 0.0050  -0.0096 -0.0333 67  PHE A CE1 
+591  C  CE2 . PHE A 67  ? 0.3037 0.1916 0.1815 0.0105  0.0218  -0.0365 67  PHE A CE2 
+592  C  CZ  . PHE A 67  ? 0.2910 0.1880 0.1621 -0.0165 0.0169  -0.0203 67  PHE A CZ  
+593  N  N   . ASN A 68  ? 0.2319 0.2046 0.1580 0.0065  0.0164  -0.0125 68  ASN A N   
+594  C  CA  A ASN A 68  ? 0.2514 0.2041 0.1814 -0.0118 -0.0074 -0.0185 68  ASN A CA  
+595  C  CA  B ASN A 68  ? 0.2116 0.1654 0.1861 -0.0624 -0.0103 0.0003  68  ASN A CA  
+596  C  C   . ASN A 68  ? 0.2337 0.1813 0.1746 -0.0221 -0.0033 -0.0175 68  ASN A C   
+597  O  O   . ASN A 68  ? 0.2541 0.1665 0.1987 -0.0080 0.0044  -0.0043 68  ASN A O   
+598  C  CB  A ASN A 68  ? 0.3345 0.2686 0.2164 0.0408  -0.0262 -0.0291 68  ASN A CB  
+599  C  CB  B ASN A 68  ? 0.2695 0.1774 0.2293 -0.0153 -0.0264 0.0347  68  ASN A CB  
+600  C  CG  A ASN A 68  ? 0.3970 0.3347 0.2502 0.0944  -0.0455 -0.0511 68  ASN A CG  
+601  C  CG  B ASN A 68  ? 0.2928 0.2054 0.2696 -0.0064 -0.0387 0.0572  68  ASN A CG  
+602  O  OD1 A ASN A 68  ? 0.4371 0.4125 0.2798 0.1625  -0.0261 -0.0181 68  ASN A OD1 
+603  O  OD1 B ASN A 68  ? 0.3516 0.1810 0.3152 0.0214  -0.0674 0.0367  68  ASN A OD1 
+604  N  ND2 A ASN A 68  ? 0.4268 0.3405 0.2775 0.1233  -0.0471 -0.0606 68  ASN A ND2 
+605  N  ND2 B ASN A 68  ? 0.2776 0.2189 0.2760 -0.0149 -0.0264 0.0696  68  ASN A ND2 
+606  N  N   . GLN A 69  ? 0.2025 0.1822 0.1500 -0.0010 0.0178  -0.0033 69  GLN A N   
+607  C  CA  . GLN A 69  ? 0.2147 0.1962 0.1392 -0.0005 0.0142  -0.0222 69  GLN A CA  
+608  C  C   . GLN A 69  ? 0.2050 0.1996 0.1506 -0.0242 0.0007  -0.0233 69  GLN A C   
+609  O  O   . GLN A 69  ? 0.1980 0.2019 0.1883 -0.0236 -0.0028 -0.0160 69  GLN A O   
+610  C  CB  . GLN A 69  ? 0.2508 0.1869 0.1453 -0.0123 0.0059  -0.0191 69  GLN A CB  
+611  C  CG  . GLN A 69  ? 0.2582 0.2031 0.1618 -0.0311 0.0035  -0.0122 69  GLN A CG  
+612  C  CD  . GLN A 69  ? 0.2894 0.1498 0.1963 -0.0391 0.0254  -0.0107 69  GLN A CD  
+613  O  OE1 . GLN A 69  ? 0.3532 0.1961 0.2302 -0.0306 0.0547  -0.0155 69  GLN A OE1 
+614  N  NE2 . GLN A 69  ? 0.3098 0.2168 0.1803 -0.0058 0.0148  -0.0034 69  GLN A NE2 
+615  N  N   . ASP A 70  ? 0.2137 0.1875 0.1500 -0.0104 0.0143  0.0063  70  ASP A N   
+616  C  CA  . ASP A 70  ? 0.2214 0.1562 0.1556 -0.0168 0.0015  -0.0200 70  ASP A CA  
+617  C  C   . ASP A 70  ? 0.2326 0.1652 0.1601 -0.0049 0.0045  -0.0271 70  ASP A C   
+618  O  O   . ASP A 70  ? 0.2292 0.1936 0.1866 -0.0145 -0.0114 -0.0133 70  ASP A O   
+619  C  CB  . ASP A 70  ? 0.2041 0.1572 0.1743 -0.0397 0.0365  -0.0117 70  ASP A CB  
+620  C  CG  . ASP A 70  ? 0.2151 0.2067 0.2222 -0.0159 0.0353  -0.0150 70  ASP A CG  
+621  O  OD1 . ASP A 70  ? 0.2048 0.2159 0.2423 -0.0525 0.0315  -0.0356 70  ASP A OD1 
+622  O  OD2 . ASP A 70  ? 0.2406 0.1975 0.2308 -0.0167 0.0232  -0.0432 70  ASP A OD2 
+623  N  N   . VAL A 71  ? 0.2066 0.1536 0.1554 -0.0065 0.0199  -0.0358 71  VAL A N   
+624  C  CA  . VAL A 71  ? 0.2126 0.1803 0.1639 -0.0322 0.0151  -0.0197 71  VAL A CA  
+625  C  C   . VAL A 71  ? 0.2116 0.1874 0.1649 -0.0384 0.0072  -0.0007 71  VAL A C   
+626  O  O   . VAL A 71  ? 0.2360 0.1975 0.1819 -0.0181 -0.0095 -0.0190 71  VAL A O   
+627  C  CB  . VAL A 71  ? 0.2213 0.1795 0.1921 -0.0204 0.0082  -0.0358 71  VAL A CB  
+628  C  CG1 . VAL A 71  ? 0.2754 0.2165 0.1964 0.0238  -0.0231 -0.0677 71  VAL A CG1 
+629  C  CG2 . VAL A 71  ? 0.2380 0.2335 0.2113 -0.0268 0.0194  0.0132  71  VAL A CG2 
+630  N  N   A ASP A 72  ? 0.2268 0.1918 0.1768 -0.0221 0.0228  0.0263  72  ASP A N   
+631  N  N   B ASP A 72  ? 0.2188 0.1639 0.1523 -0.0295 0.0295  0.0198  72  ASP A N   
+632  C  CA  A ASP A 72  ? 0.2429 0.2478 0.1955 -0.0189 0.0102  0.0355  72  ASP A CA  
+633  C  CA  B ASP A 72  ? 0.2367 0.2004 0.1486 -0.0299 0.0160  0.0156  72  ASP A CA  
+634  C  C   A ASP A 72  ? 0.2312 0.2286 0.1880 -0.0129 0.0071  -0.0001 72  ASP A C   
+635  C  C   B ASP A 72  ? 0.2253 0.2191 0.1617 -0.0225 0.0101  -0.0118 72  ASP A C   
+636  O  O   A ASP A 72  ? 0.2235 0.2396 0.1958 -0.0278 0.0025  0.0028  72  ASP A O   
+637  O  O   B ASP A 72  ? 0.2117 0.2565 0.1618 -0.0540 0.0017  -0.0069 72  ASP A O   
+638  C  CB  A ASP A 72  ? 0.2636 0.2989 0.2327 -0.0135 0.0096  0.0643  72  ASP A CB  
+639  C  CB  B ASP A 72  ? 0.2556 0.1939 0.1505 -0.0205 0.0288  0.0184  72  ASP A CB  
+640  C  CG  A ASP A 72  ? 0.2981 0.3682 0.2810 -0.0058 0.0010  0.0831  72  ASP A CG  
+641  C  CG  B ASP A 72  ? 0.2882 0.2368 0.1750 -0.0178 0.0356  0.0090  72  ASP A CG  
+642  O  OD1 A ASP A 72  ? 0.2983 0.4194 0.2943 -0.0324 0.0009  0.0784  72  ASP A OD1 
+643  O  OD1 B ASP A 72  ? 0.3260 0.2550 0.1917 -0.0065 0.0236  -0.0101 72  ASP A OD1 
+644  O  OD2 A ASP A 72  ? 0.3275 0.3722 0.3139 -0.0259 0.0151  0.0901  72  ASP A OD2 
+645  O  OD2 B ASP A 72  ? 0.3070 0.2467 0.2057 0.0231  0.0277  0.0122  72  ASP A OD2 
+646  N  N   . ALA A 73  ? 0.2364 0.1809 0.1784 -0.0160 0.0170  -0.0113 73  ALA A N   
+647  C  CA  . ALA A 73  ? 0.2539 0.2150 0.1934 0.0303  -0.0242 -0.0643 73  ALA A CA  
+648  C  C   . ALA A 73  ? 0.2480 0.2038 0.1895 0.0116  -0.0247 -0.0333 73  ALA A C   
+649  O  O   . ALA A 73  ? 0.2450 0.2522 0.2069 0.0120  -0.0169 -0.0297 73  ALA A O   
+650  C  CB  . ALA A 73  ? 0.2591 0.2250 0.2153 0.0324  -0.0034 -0.0664 73  ALA A CB  
+651  N  N   . ALA A 74  ? 0.2474 0.1840 0.1763 0.0008  -0.0045 -0.0084 74  ALA A N   
+652  C  CA  . ALA A 74  ? 0.2460 0.1807 0.1774 -0.0112 -0.0062 -0.0103 74  ALA A CA  
+653  C  C   . ALA A 74  ? 0.2473 0.1794 0.1831 -0.0126 -0.0176 -0.0062 74  ALA A C   
+654  O  O   . ALA A 74  ? 0.2472 0.2305 0.2113 -0.0372 -0.0378 -0.0021 74  ALA A O   
+655  C  CB  . ALA A 74  ? 0.2776 0.2171 0.1920 -0.0090 0.0223  -0.0068 74  ALA A CB  
+656  N  N   . VAL A 75  ? 0.2469 0.1712 0.1726 -0.0251 0.0094  0.0065  75  VAL A N   
+657  C  CA  . VAL A 75  ? 0.2364 0.2064 0.1861 -0.0295 0.0069  -0.0101 75  VAL A CA  
+658  C  C   . VAL A 75  ? 0.2331 0.2546 0.1947 -0.0502 0.0019  -0.0238 75  VAL A C   
+659  O  O   . VAL A 75  ? 0.2506 0.2539 0.1987 -0.0347 -0.0219 -0.0036 75  VAL A O   
+660  C  CB  . VAL A 75  ? 0.2316 0.1738 0.2168 -0.0361 0.0006  -0.0133 75  VAL A CB  
+661  C  CG1 . VAL A 75  ? 0.2967 0.1997 0.2663 -0.0069 -0.0121 0.0038  75  VAL A CG1 
+662  C  CG2 . VAL A 75  ? 0.2162 0.2412 0.2338 0.0066  0.0100  -0.0254 75  VAL A CG2 
+663  N  N   A ARG A 76  ? 0.2228 0.2539 0.2062 -0.0886 0.0291  -0.0135 76  ARG A N   
+664  N  N   B ARG A 76  ? 0.2365 0.2618 0.2020 -0.0607 0.0265  -0.0161 76  ARG A N   
+665  C  CA  A ARG A 76  ? 0.2347 0.3379 0.2113 -0.0720 0.0403  -0.0125 76  ARG A CA  
+666  C  CA  B ARG A 76  ? 0.2513 0.3339 0.2039 -0.0431 0.0294  -0.0257 76  ARG A CA  
+667  C  C   A ARG A 76  ? 0.2288 0.3609 0.2336 -0.0123 0.0135  -0.0536 76  ARG A C   
+668  C  C   B ARG A 76  ? 0.2396 0.3610 0.2314 -0.0041 0.0016  -0.0600 76  ARG A C   
+669  O  O   A ARG A 76  ? 0.2212 0.3708 0.2532 -0.0219 0.0163  -0.0721 76  ARG A O   
+670  O  O   B ARG A 76  ? 0.2276 0.3668 0.2523 -0.0412 -0.0046 -0.0795 76  ARG A O   
+671  C  CB  A ARG A 76  ? 0.3093 0.3948 0.2392 -0.0704 0.0514  -0.0017 76  ARG A CB  
+672  C  CB  B ARG A 76  ? 0.3226 0.3779 0.2214 -0.0287 0.0361  -0.0253 76  ARG A CB  
+673  C  CG  A ARG A 76  ? 0.3984 0.4263 0.2701 -0.0394 0.0662  0.0388  76  ARG A CG  
+674  C  CG  B ARG A 76  ? 0.4102 0.4140 0.2500 -0.0155 0.0449  -0.0049 76  ARG A CG  
+675  C  CD  A ARG A 76  ? 0.4804 0.4902 0.2813 0.0083  0.0737  0.0689  76  ARG A CD  
+676  C  CD  B ARG A 76  ? 0.4799 0.4465 0.2586 0.0237  0.0450  -0.0005 76  ARG A CD  
+677  N  NE  A ARG A 76  ? 0.5413 0.5243 0.2954 0.0405  0.0796  0.1124  76  ARG A NE  
+678  N  NE  B ARG A 76  ? 0.5111 0.4580 0.2613 0.0419  0.0602  0.0218  76  ARG A NE  
+679  C  CZ  A ARG A 76  ? 0.5775 0.5876 0.3181 0.0849  0.0828  0.1200  76  ARG A CZ  
+680  C  CZ  B ARG A 76  ? 0.5341 0.4805 0.2587 0.0618  0.0398  0.0155  76  ARG A CZ  
+681  N  NH1 A ARG A 76  ? 0.5894 0.6029 0.3287 0.0964  0.0811  0.1170  76  ARG A NH1 
+682  N  NH1 B ARG A 76  ? 0.5302 0.4658 0.2519 0.0615  0.0236  0.0206  76  ARG A NH1 
+683  N  NH2 A ARG A 76  ? 0.5819 0.5913 0.3240 0.0979  0.0875  0.1322  76  ARG A NH2 
+684  N  NH2 B ARG A 76  ? 0.5430 0.4894 0.2706 0.0516  0.0459  0.0298  76  ARG A NH2 
+685  N  N   . GLY A 77  ? 0.2313 0.3355 0.2377 0.0076  -0.0133 -0.0691 77  GLY A N   
+686  C  CA  . GLY A 77  ? 0.2304 0.3259 0.2530 0.0344  -0.0505 -0.0871 77  GLY A CA  
+687  C  C   . GLY A 77  ? 0.2486 0.2815 0.2614 0.0487  -0.0450 -0.0732 77  GLY A C   
+688  O  O   . GLY A 77  ? 0.2994 0.3330 0.3093 0.0852  -0.0698 -0.1147 77  GLY A O   
+689  N  N   . ILE A 78  ? 0.2128 0.1693 0.2178 0.0015  -0.0020 -0.0428 78  ILE A N   
+690  C  CA  . ILE A 78  ? 0.1888 0.1967 0.2047 -0.0232 0.0179  -0.0011 78  ILE A CA  
+691  C  C   . ILE A 78  ? 0.1738 0.2514 0.2176 -0.0184 0.0035  0.0053  78  ILE A C   
+692  O  O   . ILE A 78  ? 0.2102 0.2280 0.2323 0.0000  -0.0050 -0.0189 78  ILE A O   
+693  C  CB  . ILE A 78  ? 0.1751 0.2061 0.2254 -0.0315 0.0253  -0.0282 78  ILE A CB  
+694  C  CG1 . ILE A 78  ? 0.1782 0.2175 0.2436 -0.0409 0.0100  0.0073  78  ILE A CG1 
+695  C  CG2 . ILE A 78  ? 0.2400 0.2337 0.2312 0.0022  0.0239  -0.0370 78  ILE A CG2 
+696  C  CD1 . ILE A 78  ? 0.1995 0.2754 0.2669 -0.0058 0.0055  0.0279  78  ILE A CD1 
+697  N  N   . LEU A 79  ? 0.1833 0.2408 0.2040 -0.0400 0.0252  0.0017  79  LEU A N   
+698  C  CA  . LEU A 79  ? 0.1998 0.2630 0.2450 -0.0427 0.0321  0.0156  79  LEU A CA  
+699  C  C   . LEU A 79  ? 0.2050 0.3527 0.2801 -0.0333 0.0330  -0.0057 79  LEU A C   
+700  O  O   . LEU A 79  ? 0.2366 0.3712 0.3176 -0.0668 0.0174  -0.0241 79  LEU A O   
+701  C  CB  . LEU A 79  ? 0.2586 0.2849 0.2539 -0.0308 0.0153  0.0526  79  LEU A CB  
+702  C  CG  . LEU A 79  ? 0.2939 0.3277 0.2857 0.0034  -0.0106 0.0629  79  LEU A CG  
+703  C  CD1 . LEU A 79  ? 0.3187 0.3466 0.3163 0.0171  -0.0140 0.0863  79  LEU A CD1 
+704  C  CD2 . LEU A 79  ? 0.3292 0.3811 0.3090 0.0224  -0.0119 0.0473  79  LEU A CD2 
+705  N  N   . ARG A 80  ? 0.2032 0.3292 0.2770 -0.0091 0.0476  -0.0375 80  ARG A N   
+706  C  CA  . ARG A 80  ? 0.2483 0.3735 0.3389 -0.0456 0.0110  -0.0669 80  ARG A CA  
+707  C  C   . ARG A 80  ? 0.2265 0.4018 0.3421 -0.0002 0.0246  -0.0417 80  ARG A C   
+708  O  O   . ARG A 80  ? 0.2482 0.4940 0.3577 0.0282  0.0510  -0.0098 80  ARG A O   
+709  C  CB  . ARG A 80  ? 0.3656 0.4723 0.4150 -0.0183 0.0208  -0.1049 80  ARG A CB  
+710  C  CG  . ARG A 80  ? 0.5391 0.5599 0.5188 0.0373  0.0074  -0.1311 80  ARG A CG  
+711  C  CD  . ARG A 80  ? 0.6865 0.6386 0.6005 0.0784  0.0004  -0.1603 80  ARG A CD  
+712  N  NE  . ARG A 80  ? 0.8232 0.7041 0.6922 0.1472  -0.0004 -0.1632 80  ARG A NE  
+713  C  CZ  . ARG A 80  ? 0.9138 0.7662 0.7489 0.1962  0.0011  -0.1717 80  ARG A CZ  
+714  N  NH1 . ARG A 80  ? 0.9394 0.7838 0.7672 0.1883  -0.0096 -0.1754 80  ARG A NH1 
+715  N  NH2 . ARG A 80  ? 0.9598 0.7916 0.7610 0.2237  0.0160  -0.1794 80  ARG A NH2 
+716  N  N   . ASN A 81  ? 0.2336 0.3361 0.3254 0.0091  0.0326  -0.0382 81  ASN A N   
+717  C  CA  . ASN A 81  ? 0.2077 0.2993 0.3350 -0.0094 -0.0018 -0.0434 81  ASN A CA  
+718  C  C   . ASN A 81  ? 0.1992 0.3338 0.3451 -0.0056 -0.0321 -0.0719 81  ASN A C   
+719  O  O   . ASN A 81  ? 0.2452 0.3369 0.3336 0.0495  -0.0185 -0.0518 81  ASN A O   
+720  C  CB  . ASN A 81  ? 0.2605 0.2775 0.3454 -0.0129 -0.0146 -0.0077 81  ASN A CB  
+721  C  CG  . ASN A 81  ? 0.3076 0.2954 0.3567 0.0054  -0.0360 -0.0164 81  ASN A CG  
+722  O  OD1 . ASN A 81  ? 0.3466 0.3303 0.3525 0.0273  -0.0710 -0.0269 81  ASN A OD1 
+723  N  ND2 . ASN A 81  ? 0.3297 0.2968 0.3694 -0.0313 -0.0104 -0.0043 81  ASN A ND2 
+724  N  N   . ALA A 82  ? 0.2061 0.3912 0.3818 0.0091  -0.0422 -0.0868 82  ALA A N   
+725  C  CA  . ALA A 82  ? 0.2160 0.4323 0.4195 0.0329  -0.0579 -0.0968 82  ALA A CA  
+726  C  C   . ALA A 82  ? 0.2308 0.4211 0.4185 0.0500  -0.0796 -0.1239 82  ALA A C   
+727  O  O   . ALA A 82  ? 0.2586 0.4374 0.4537 0.0283  -0.0707 -0.1523 82  ALA A O   
+728  C  CB  . ALA A 82  ? 0.2249 0.4620 0.4435 0.0344  -0.0527 -0.1002 82  ALA A CB  
+729  N  N   . LYS A 83  ? 0.2666 0.4289 0.4009 0.0754  -0.0761 -0.0724 83  LYS A N   
+730  C  CA  . LYS A 83  ? 0.3607 0.4239 0.3883 0.1013  -0.0602 -0.0213 83  LYS A CA  
+731  C  C   . LYS A 83  ? 0.3498 0.3487 0.3306 0.0738  -0.0445 -0.0169 83  LYS A C   
+732  O  O   . LYS A 83  ? 0.3928 0.4555 0.3345 0.1175  -0.0616 -0.0183 83  LYS A O   
+733  C  CB  . LYS A 83  ? 0.4599 0.4882 0.4316 0.1458  -0.0683 -0.0026 83  LYS A CB  
+734  C  CG  . LYS A 83  ? 0.5693 0.5549 0.4722 0.1489  -0.0411 0.0218  83  LYS A CG  
+735  C  CD  . LYS A 83  ? 0.6467 0.6248 0.4978 0.1484  -0.0052 0.0424  83  LYS A CD  
+736  C  CE  . LYS A 83  ? 0.6912 0.6678 0.5161 0.1451  0.0186  0.0534  83  LYS A CE  
+737  N  NZ  . LYS A 83  ? 0.7159 0.6728 0.5224 0.1421  0.0257  0.0620  83  LYS A NZ  
+738  N  N   . LEU A 84  ? 0.2894 0.2433 0.2716 0.0341  -0.0525 0.0007  84  LEU A N   
+739  C  CA  . LEU A 84  ? 0.2634 0.1554 0.2461 -0.0058 -0.0176 -0.0102 84  LEU A CA  
+740  C  C   . LEU A 84  ? 0.2517 0.1619 0.2337 -0.0276 0.0014  -0.0112 84  LEU A C   
+741  O  O   . LEU A 84  ? 0.2698 0.2035 0.2341 -0.0085 0.0186  -0.0224 84  LEU A O   
+742  C  CB  . LEU A 84  ? 0.2727 0.1582 0.2221 -0.0234 -0.0053 -0.0157 84  LEU A CB  
+743  C  CG  . LEU A 84  ? 0.3323 0.2041 0.2325 -0.0175 -0.0115 0.0075  84  LEU A CG  
+744  C  CD1 . LEU A 84  ? 0.3356 0.2339 0.2586 -0.0140 -0.0362 -0.0018 84  LEU A CD1 
+745  C  CD2 . LEU A 84  ? 0.3915 0.2259 0.2378 -0.0228 -0.0069 0.0081  84  LEU A CD2 
+746  N  N   . LYS A 85  ? 0.2272 0.1960 0.2280 -0.0358 0.0134  0.0238  85  LYS A N   
+747  C  CA  . LYS A 85  ? 0.2388 0.2007 0.2232 -0.0423 0.0289  0.0012  85  LYS A CA  
+748  C  C   . LYS A 85  ? 0.2291 0.2260 0.2321 -0.0370 0.0182  0.0045  85  LYS A C   
+749  O  O   . LYS A 85  ? 0.2382 0.2239 0.2172 -0.0282 0.0056  -0.0072 85  LYS A O   
+750  C  CB  . LYS A 85  ? 0.2881 0.2213 0.2609 -0.0617 0.0652  -0.0015 85  LYS A CB  
+751  C  CG  . LYS A 85  ? 0.3465 0.2686 0.2760 -0.0434 0.0964  0.0081  85  LYS A CG  
+752  C  CD  . LYS A 85  ? 0.4196 0.3349 0.3073 -0.0397 0.1000  0.0281  85  LYS A CD  
+753  C  CE  . LYS A 85  ? 0.4711 0.3604 0.3481 -0.0361 0.0957  0.0106  85  LYS A CE  
+754  N  NZ  . LYS A 85  ? 0.4876 0.4062 0.3745 -0.0660 0.1136  0.0163  85  LYS A NZ  
+755  N  N   . PRO A 86  ? 0.2139 0.2610 0.2375 -0.0194 -0.0107 -0.0414 86  PRO A N   
+756  C  CA  . PRO A 86  ? 0.2265 0.2635 0.2457 -0.0428 -0.0001 -0.0236 86  PRO A CA  
+757  C  C   . PRO A 86  ? 0.2227 0.2148 0.2375 -0.0558 0.0174  -0.0056 86  PRO A C   
+758  O  O   . PRO A 86  ? 0.2933 0.2071 0.2670 -0.0086 0.0112  -0.0071 86  PRO A O   
+759  C  CB  . PRO A 86  ? 0.2540 0.3521 0.2637 -0.0106 -0.0268 -0.0448 86  PRO A CB  
+760  C  CG  . PRO A 86  ? 0.2855 0.3790 0.2736 0.0372  -0.0360 -0.0641 86  PRO A CG  
+761  C  CD  . PRO A 86  ? 0.2196 0.3278 0.2594 -0.0000 -0.0466 -0.0436 86  PRO A CD  
+762  N  N   . VAL A 87  ? 0.2186 0.1981 0.2242 -0.0339 -0.0086 0.0096  87  VAL A N   
+763  C  CA  . VAL A 87  ? 0.2259 0.2148 0.2140 -0.0443 0.0011  0.0307  87  VAL A CA  
+764  C  C   . VAL A 87  ? 0.2163 0.1777 0.1846 -0.0448 -0.0185 -0.0114 87  VAL A C   
+765  O  O   . VAL A 87  ? 0.2396 0.2093 0.1802 -0.0176 -0.0018 -0.0106 87  VAL A O   
+766  C  CB  . VAL A 87  ? 0.2558 0.2174 0.2290 -0.0360 -0.0073 0.0370  87  VAL A CB  
+767  C  CG1 . VAL A 87  ? 0.2924 0.2744 0.2335 -0.0303 0.0433  0.0625  87  VAL A CG1 
+768  C  CG2 . VAL A 87  ? 0.3002 0.2496 0.2660 -0.0064 -0.0356 0.0508  87  VAL A CG2 
+769  N  N   . TYR A 88  ? 0.2180 0.2064 0.1620 -0.0641 -0.0279 -0.0132 88  TYR A N   
+770  C  CA  . TYR A 88  ? 0.2220 0.1739 0.1554 -0.0675 -0.0266 -0.0171 88  TYR A CA  
+771  C  C   . TYR A 88  ? 0.2134 0.1690 0.1841 -0.0488 0.0069  -0.0135 88  TYR A C   
+772  O  O   . TYR A 88  ? 0.2041 0.2128 0.1972 0.0028  -0.0033 -0.0297 88  TYR A O   
+773  C  CB  . TYR A 88  ? 0.2363 0.2086 0.1434 -0.0213 -0.0275 -0.0345 88  TYR A CB  
+774  C  CG  . TYR A 88  ? 0.2333 0.1671 0.1715 -0.0512 -0.0141 -0.0218 88  TYR A CG  
+775  C  CD1 . TYR A 88  ? 0.2494 0.2047 0.1939 -0.0565 -0.0048 -0.0580 88  TYR A CD1 
+776  C  CD2 . TYR A 88  ? 0.2354 0.2314 0.1934 -0.0100 0.0055  0.0018  88  TYR A CD2 
+777  C  CE1 . TYR A 88  ? 0.2539 0.2615 0.2236 -0.0083 -0.0224 -0.0131 88  TYR A CE1 
+778  C  CE2 . TYR A 88  ? 0.2288 0.2817 0.2086 0.0031  -0.0236 -0.0144 88  TYR A CE2 
+779  C  CZ  . TYR A 88  ? 0.2364 0.2852 0.2215 -0.0057 -0.0447 -0.0150 88  TYR A CZ  
+780  O  OH  . TYR A 88  ? 0.2690 0.3734 0.2738 0.0209  -0.0835 -0.0225 88  TYR A OH  
+781  N  N   . ASP A 89  ? 0.2548 0.1634 0.1792 -0.0435 0.0156  0.0038  89  ASP A N   
+782  C  CA  . ASP A 89  ? 0.2919 0.1729 0.2150 -0.0517 0.0314  0.0011  89  ASP A CA  
+783  C  C   . ASP A 89  ? 0.3039 0.1803 0.2176 -0.0233 0.0261  0.0324  89  ASP A C   
+784  O  O   . ASP A 89  ? 0.4009 0.1996 0.2357 0.0177  0.0143  0.0307  89  ASP A O   
+785  C  CB  . ASP A 89  ? 0.3456 0.2011 0.2331 -0.0588 0.0582  0.0010  89  ASP A CB  
+786  C  CG  . ASP A 89  ? 0.3984 0.2689 0.2687 -0.0868 0.0895  -0.0121 89  ASP A CG  
+787  O  OD1 . ASP A 89  ? 0.4670 0.3044 0.2412 -0.0517 0.0516  -0.0147 89  ASP A OD1 
+788  O  OD2 . ASP A 89  ? 0.4250 0.3517 0.3200 -0.0606 0.1419  -0.0087 89  ASP A OD2 
+789  N  N   . SER A 90  ? 0.2199 0.1757 0.1910 -0.0342 0.0059  0.0050  90  SER A N   
+790  C  CA  . SER A 90  ? 0.2212 0.2027 0.1817 -0.0461 -0.0125 -0.0060 90  SER A CA  
+791  C  C   . SER A 90  ? 0.2149 0.1710 0.1852 -0.0237 0.0093  0.0002  90  SER A C   
+792  O  O   . SER A 90  ? 0.2408 0.1868 0.2073 -0.0097 0.0227  -0.0284 90  SER A O   
+793  C  CB  . SER A 90  ? 0.2705 0.1861 0.2051 -0.0338 -0.0374 -0.0006 90  SER A CB  
+794  O  OG  . SER A 90  ? 0.2612 0.1964 0.2102 -0.0045 -0.0160 0.0082  90  SER A OG  
+795  N  N   . LEU A 91  ? 0.2264 0.1792 0.1955 -0.0279 0.0070  0.0036  91  LEU A N   
+796  C  CA  . LEU A 91  ? 0.2031 0.1410 0.1905 -0.0351 0.0002  0.0111  91  LEU A CA  
+797  C  C   . LEU A 91  ? 0.2094 0.1765 0.1874 -0.0125 0.0080  0.0163  91  LEU A C   
+798  O  O   . LEU A 91  ? 0.2391 0.2291 0.1818 0.0097  0.0229  0.0343  91  LEU A O   
+799  C  CB  . LEU A 91  ? 0.2301 0.1367 0.2086 -0.0075 0.0051  0.0152  91  LEU A CB  
+800  C  CG  . LEU A 91  ? 0.2596 0.1669 0.2206 0.0018  0.0150  0.0232  91  LEU A CG  
+801  C  CD1 . LEU A 91  ? 0.2906 0.1429 0.2648 0.0034  0.0058  -0.0113 91  LEU A CD1 
+802  C  CD2 . LEU A 91  ? 0.2820 0.2602 0.2133 0.0151  0.0384  0.0567  91  LEU A CD2 
+803  N  N   . ASP A 92  ? 0.2143 0.1623 0.1897 -0.0028 -0.0121 0.0122  92  ASP A N   
+804  C  CA  . ASP A 92  ? 0.1915 0.1317 0.2078 -0.0066 -0.0060 0.0023  92  ASP A CA  
+805  C  C   . ASP A 92  ? 0.1983 0.1413 0.2108 -0.0293 -0.0215 0.0164  92  ASP A C   
+806  O  O   . ASP A 92  ? 0.2512 0.1436 0.2133 -0.0165 -0.0263 -0.0036 92  ASP A O   
+807  C  CB  . ASP A 92  ? 0.2352 0.1661 0.2188 0.0034  0.0264  0.0087  92  ASP A CB  
+808  C  CG  . ASP A 92  ? 0.2553 0.1873 0.2346 -0.0022 0.0155  0.0091  92  ASP A CG  
+809  O  OD1 . ASP A 92  ? 0.2959 0.1779 0.2230 -0.0195 0.0192  0.0208  92  ASP A OD1 
+810  O  OD2 . ASP A 92  ? 0.2469 0.2118 0.2715 -0.0329 0.0080  -0.0083 92  ASP A OD2 
+811  N  N   . ALA A 93  ? 0.2526 0.2071 0.1961 -0.0100 -0.0406 0.0225  93  ALA A N   
+812  C  CA  . ALA A 93  ? 0.2533 0.2012 0.2212 -0.0211 -0.0455 0.0319  93  ALA A CA  
+813  C  C   . ALA A 93  ? 0.2475 0.2088 0.2170 -0.0406 -0.0092 0.0193  93  ALA A C   
+814  O  O   . ALA A 93  ? 0.2500 0.2357 0.2280 -0.0634 0.0216  -0.0091 93  ALA A O   
+815  C  CB  . ALA A 93  ? 0.3113 0.2202 0.2580 0.0277  -0.0538 0.0689  93  ALA A CB  
+816  N  N   . VAL A 94  ? 0.2216 0.1956 0.2157 -0.0042 -0.0145 0.0163  94  VAL A N   
+817  C  CA  . VAL A 94  ? 0.1950 0.1834 0.2085 -0.0045 -0.0102 -0.0066 94  VAL A CA  
+818  C  C   . VAL A 94  ? 0.1847 0.1665 0.1881 -0.0254 0.0014  0.0060  94  VAL A C   
+819  O  O   . VAL A 94  ? 0.1947 0.1848 0.1958 -0.0270 -0.0114 -0.0160 94  VAL A O   
+820  C  CB  . VAL A 94  ? 0.2192 0.1883 0.2488 0.0161  0.0068  0.0078  94  VAL A CB  
+821  C  CG1 . VAL A 94  ? 0.2178 0.2263 0.2659 -0.0040 0.0222  -0.0147 94  VAL A CG1 
+822  C  CG2 . VAL A 94  ? 0.2232 0.2304 0.2936 0.0277  -0.0086 0.0224  94  VAL A CG2 
+823  N  N   . ARG A 95  ? 0.2048 0.1764 0.1673 -0.0028 -0.0114 0.0037  95  ARG A N   
+824  C  CA  . ARG A 95  ? 0.2165 0.1539 0.1488 -0.0163 -0.0123 -0.0192 95  ARG A CA  
+825  C  C   . ARG A 95  ? 0.2247 0.1610 0.1456 -0.0293 -0.0063 -0.0027 95  ARG A C   
+826  O  O   . ARG A 95  ? 0.2436 0.1443 0.1538 -0.0035 -0.0033 0.0005  95  ARG A O   
+827  C  CB  . ARG A 95  ? 0.2355 0.1565 0.1387 -0.0202 -0.0020 -0.0362 95  ARG A CB  
+828  C  CG  . ARG A 95  ? 0.2391 0.1654 0.1262 -0.0157 -0.0018 -0.0230 95  ARG A CG  
+829  C  CD  . ARG A 95  ? 0.2754 0.1806 0.1397 0.0038  -0.0215 -0.0424 95  ARG A CD  
+830  N  NE  . ARG A 95  ? 0.2704 0.1534 0.1638 -0.0211 -0.0151 -0.0458 95  ARG A NE  
+831  C  CZ  . ARG A 95  ? 0.2565 0.1584 0.1556 -0.0479 0.0026  -0.0200 95  ARG A CZ  
+832  N  NH1 . ARG A 95  ? 0.2487 0.1743 0.2078 -0.0540 -0.0081 0.0068  95  ARG A NH1 
+833  N  NH2 . ARG A 95  ? 0.2617 0.2552 0.1317 -0.0593 -0.0006 -0.0099 95  ARG A NH2 
+834  N  N   A ARG A 96  ? 0.2009 0.1568 0.1441 -0.0024 0.0085  0.0066  96  ARG A N   
+835  N  N   B ARG A 96  ? 0.2150 0.1614 0.1414 -0.0072 0.0034  -0.0002 96  ARG A N   
+836  C  CA  A ARG A 96  ? 0.2023 0.1435 0.1499 -0.0445 0.0232  0.0073  96  ARG A CA  
+837  C  CA  B ARG A 96  ? 0.2112 0.1505 0.1431 -0.0407 0.0158  -0.0003 96  ARG A CA  
+838  C  C   A ARG A 96  ? 0.1986 0.1556 0.1518 -0.0496 -0.0013 -0.0040 96  ARG A C   
+839  C  C   B ARG A 96  ? 0.2011 0.1542 0.1473 -0.0429 -0.0028 -0.0072 96  ARG A C   
+840  O  O   A ARG A 96  ? 0.2324 0.1738 0.1696 -0.0152 0.0027  -0.0210 96  ARG A O   
+841  O  O   B ARG A 96  ? 0.2274 0.1599 0.1599 -0.0130 0.0018  -0.0188 96  ARG A O   
+842  C  CB  A ARG A 96  ? 0.2037 0.1391 0.1816 -0.0587 0.0187  0.0025  96  ARG A CB  
+843  C  CB  B ARG A 96  ? 0.2136 0.1482 0.1643 -0.0459 0.0126  -0.0018 96  ARG A CB  
+844  C  CG  A ARG A 96  ? 0.2194 0.1473 0.2093 -0.0912 0.0250  0.0049  96  ARG A CG  
+845  C  CG  B ARG A 96  ? 0.2306 0.1401 0.1820 -0.0765 0.0036  -0.0060 96  ARG A CG  
+846  C  CD  A ARG A 96  ? 0.2232 0.1994 0.2433 -0.0969 0.0334  0.0540  96  ARG A CD  
+847  C  CD  B ARG A 96  ? 0.2462 0.1605 0.1933 -0.0427 0.0018  0.0100  96  ARG A CD  
+848  N  NE  A ARG A 96  ? 0.2201 0.2512 0.2616 -0.1074 0.0249  0.0753  96  ARG A NE  
+849  N  NE  B ARG A 96  ? 0.2398 0.1596 0.1915 -0.0371 -0.0071 0.0224  96  ARG A NE  
+850  C  CZ  A ARG A 96  ? 0.2437 0.2435 0.2868 -0.1051 -0.0311 0.0783  96  ARG A CZ  
+851  C  CZ  B ARG A 96  ? 0.2450 0.1982 0.2004 -0.0183 -0.0222 0.0123  96  ARG A CZ  
+852  N  NH1 A ARG A 96  ? 0.2851 0.3246 0.2992 -0.0482 -0.0321 0.1291  96  ARG A NH1 
+853  N  NH1 B ARG A 96  ? 0.2657 0.2035 0.2074 -0.0121 -0.0355 0.0171  96  ARG A NH1 
+854  N  NH2 A ARG A 96  ? 0.2563 0.2758 0.3089 -0.0871 -0.0495 0.0577  96  ARG A NH2 
+855  N  NH2 B ARG A 96  ? 0.2563 0.2019 0.1936 -0.0010 0.0033  0.0465  96  ARG A NH2 
+856  N  N   . CYS A 97  ? 0.1751 0.1808 0.1503 -0.0352 -0.0225 -0.0101 97  CYS A N   
+857  C  CA  . CYS A 97  ? 0.1628 0.1742 0.1747 -0.0155 -0.0267 0.0037  97  CYS A CA  
+858  C  C   . CYS A 97  ? 0.1866 0.1763 0.1620 0.0144  -0.0173 -0.0065 97  CYS A C   
+859  O  O   . CYS A 97  ? 0.2142 0.1667 0.1824 -0.0082 -0.0163 -0.0130 97  CYS A O   
+860  C  CB  . CYS A 97  ? 0.1904 0.1959 0.1876 0.0084  -0.0366 0.0369  97  CYS A CB  
+861  S  SG  . CYS A 97  ? 0.2619 0.2259 0.1888 0.0189  -0.0217 0.0101  97  CYS A SG  
+862  N  N   . ALA A 98  ? 0.1858 0.1781 0.1401 0.0079  -0.0143 0.0097  98  ALA A N   
+863  C  CA  . ALA A 98  ? 0.1530 0.1733 0.1404 -0.0104 -0.0084 0.0159  98  ALA A CA  
+864  C  C   . ALA A 98  ? 0.1507 0.1585 0.1545 -0.0180 0.0051  0.0071  98  ALA A C   
+865  O  O   . ALA A 98  ? 0.1961 0.1604 0.1808 -0.0218 -0.0050 -0.0044 98  ALA A O   
+866  C  CB  . ALA A 98  ? 0.1889 0.1914 0.1477 -0.0246 0.0020  0.0016  98  ALA A CB  
+867  N  N   . ALA A 99  ? 0.1555 0.1785 0.1581 -0.0187 0.0083  -0.0102 99  ALA A N   
+868  C  CA  . ALA A 99  ? 0.1611 0.1508 0.1609 -0.0369 -0.0152 -0.0351 99  ALA A CA  
+869  C  C   . ALA A 99  ? 0.1752 0.1527 0.1519 -0.0175 -0.0204 0.0079  99  ALA A C   
+870  O  O   . ALA A 99  ? 0.1955 0.1602 0.1865 0.0038  -0.0057 0.0048  99  ALA A O   
+871  C  CB  . ALA A 99  ? 0.1876 0.1922 0.1836 -0.0325 -0.0292 -0.0224 99  ALA A CB  
+872  N  N   . ILE A 100 ? 0.1846 0.1763 0.1360 -0.0192 -0.0071 0.0208  100 ILE A N   
+873  C  CA  . ILE A 100 ? 0.2042 0.1528 0.1383 -0.0323 -0.0156 -0.0016 100 ILE A CA  
+874  C  C   . ILE A 100 ? 0.1717 0.1461 0.1486 -0.0438 -0.0048 0.0078  100 ILE A C   
+875  O  O   . ILE A 100 ? 0.2404 0.1370 0.1769 -0.0082 0.0126  -0.0076 100 ILE A O   
+876  C  CB  . ILE A 100 ? 0.2034 0.1635 0.1473 -0.0236 -0.0165 0.0016  100 ILE A CB  
+877  C  CG1 . ILE A 100 ? 0.2201 0.1454 0.1893 -0.0194 0.0154  0.0219  100 ILE A CG1 
+878  C  CG2 . ILE A 100 ? 0.2175 0.1806 0.1529 -0.0170 -0.0127 -0.0166 100 ILE A CG2 
+879  C  CD1 . ILE A 100 ? 0.2589 0.1380 0.2041 0.0100  0.0143  0.0243  100 ILE A CD1 
+880  N  N   . ASN A 101 ? 0.1503 0.1846 0.1600 -0.0413 0.0177  0.0139  101 ASN A N   
+881  C  CA  . ASN A 101 ? 0.1374 0.1667 0.1685 -0.0154 0.0229  -0.0011 101 ASN A CA  
+882  C  C   . ASN A 101 ? 0.1768 0.1812 0.1582 -0.0148 -0.0127 0.0029  101 ASN A C   
+883  O  O   . ASN A 101 ? 0.1889 0.1758 0.1673 -0.0124 -0.0056 -0.0105 101 ASN A O   
+884  C  CB  . ASN A 101 ? 0.1520 0.1919 0.1850 -0.0111 0.0293  -0.0184 101 ASN A CB  
+885  C  CG  . ASN A 101 ? 0.1705 0.2119 0.1771 -0.0105 0.0078  -0.0160 101 ASN A CG  
+886  O  OD1 . ASN A 101 ? 0.1947 0.1762 0.2160 -0.0214 -0.0012 -0.0178 101 ASN A OD1 
+887  N  ND2 . ASN A 101 ? 0.1713 0.2060 0.1757 -0.0252 0.0119  -0.0062 101 ASN A ND2 
+888  N  N   . MET A 102 ? 0.1645 0.1949 0.1511 0.0001  -0.0056 0.0073  102 MET A N   
+889  C  CA  . MET A 102 ? 0.1765 0.1699 0.1397 -0.0061 -0.0197 -0.0195 102 MET A CA  
+890  C  C   . MET A 102 ? 0.1739 0.1767 0.1477 -0.0186 0.0149  -0.0058 102 MET A C   
+891  O  O   . MET A 102 ? 0.2425 0.1505 0.1750 0.0014  -0.0028 0.0107  102 MET A O   
+892  C  CB  . MET A 102 ? 0.2175 0.1962 0.1450 -0.0087 -0.0055 -0.0259 102 MET A CB  
+893  C  CG  . MET A 102 ? 0.2425 0.2292 0.1555 -0.0077 -0.0266 -0.0121 102 MET A CG  
+894  S  SD  . MET A 102 ? 0.2995 0.2488 0.1686 -0.0181 -0.0344 -0.0015 102 MET A SD  
+895  C  CE  . MET A 102 ? 0.3137 0.2891 0.2249 0.0647  -0.0136 -0.0063 102 MET A CE  
+896  N  N   . VAL A 103 ? 0.1603 0.2095 0.1314 -0.0178 0.0133  -0.0028 103 VAL A N   
+897  C  CA  . VAL A 103 ? 0.1679 0.1996 0.1457 -0.0419 0.0242  -0.0001 103 VAL A CA  
+898  C  C   . VAL A 103 ? 0.1856 0.1969 0.1581 -0.0042 0.0040  -0.0100 103 VAL A C   
+899  O  O   . VAL A 103 ? 0.1999 0.2142 0.2070 0.0181  -0.0011 -0.0232 103 VAL A O   
+900  C  CB  . VAL A 103 ? 0.2013 0.2284 0.1729 -0.0189 0.0237  -0.0303 103 VAL A CB  
+901  C  CG1 . VAL A 103 ? 0.2326 0.2729 0.1959 0.0167  0.0381  -0.0092 103 VAL A CG1 
+902  C  CG2 . VAL A 103 ? 0.2254 0.2599 0.1946 -0.0643 -0.0138 -0.0431 103 VAL A CG2 
+903  N  N   . PHE A 104 ? 0.1722 0.1873 0.1529 -0.0104 -0.0188 -0.0025 104 PHE A N   
+904  C  CA  . PHE A 104 ? 0.1941 0.1857 0.1741 0.0002  -0.0268 -0.0167 104 PHE A CA  
+905  C  C   . PHE A 104 ? 0.2099 0.1680 0.1755 -0.0044 -0.0147 -0.0210 104 PHE A C   
+906  O  O   . PHE A 104 ? 0.2403 0.1828 0.2033 0.0106  -0.0083 -0.0378 104 PHE A O   
+907  C  CB  . PHE A 104 ? 0.1837 0.2062 0.1775 0.0179  -0.0382 -0.0130 104 PHE A CB  
+908  C  CG  . PHE A 104 ? 0.1866 0.1712 0.1797 0.0049  -0.0121 -0.0010 104 PHE A CG  
+909  C  CD1 . PHE A 104 ? 0.1871 0.2074 0.1965 -0.0209 -0.0198 -0.0310 104 PHE A CD1 
+910  C  CD2 . PHE A 104 ? 0.2153 0.2089 0.1716 -0.0081 -0.0028 -0.0159 104 PHE A CD2 
+911  C  CE1 . PHE A 104 ? 0.2219 0.2228 0.1995 0.0094  -0.0103 -0.0287 104 PHE A CE1 
+912  C  CE2 . PHE A 104 ? 0.2412 0.2288 0.1670 0.0098  -0.0057 -0.0178 104 PHE A CE2 
+913  C  CZ  . PHE A 104 ? 0.2527 0.2581 0.1809 0.0275  -0.0229 -0.0438 104 PHE A CZ  
+914  N  N   . GLN A 105 ? 0.1814 0.1926 0.1654 -0.0165 0.0031  0.0108  105 GLN A N   
+915  C  CA  . GLN A 105 ? 0.1856 0.1749 0.1860 -0.0299 0.0178  0.0031  105 GLN A CA  
+916  C  C   . GLN A 105 ? 0.2184 0.1608 0.2001 -0.0053 -0.0190 -0.0335 105 GLN A C   
+917  O  O   . GLN A 105 ? 0.2636 0.1909 0.2265 0.0021  -0.0243 -0.0335 105 GLN A O   
+918  C  CB  . GLN A 105 ? 0.2013 0.1853 0.1782 -0.0736 0.0262  0.0055  105 GLN A CB  
+919  C  CG  . GLN A 105 ? 0.2337 0.2030 0.1806 -0.0590 0.0295  0.0048  105 GLN A CG  
+920  C  CD  . GLN A 105 ? 0.2361 0.1994 0.1759 -0.0519 0.0041  0.0006  105 GLN A CD  
+921  O  OE1 . GLN A 105 ? 0.2617 0.2149 0.1768 -0.0262 0.0058  -0.0041 105 GLN A OE1 
+922  N  NE2 . GLN A 105 ? 0.2793 0.2486 0.2230 -0.0278 0.0083  -0.0003 105 GLN A NE2 
+923  N  N   . MET A 106 ? 0.2228 0.1709 0.2131 0.0162  -0.0174 -0.0194 106 MET A N   
+924  C  CA  A MET A 106 ? 0.2241 0.1715 0.2291 0.0053  -0.0071 0.0066  106 MET A CA  
+925  C  CA  B MET A 106 ? 0.2389 0.1968 0.2266 0.0157  -0.0133 0.0015  106 MET A CA  
+926  C  C   . MET A 106 ? 0.2333 0.2392 0.2379 0.0298  -0.0094 -0.0161 106 MET A C   
+927  O  O   . MET A 106 ? 0.2745 0.2605 0.2748 0.0429  0.0003  -0.0088 106 MET A O   
+928  C  CB  A MET A 106 ? 0.2781 0.2060 0.2472 0.0496  0.0234  0.0216  106 MET A CB  
+929  C  CB  B MET A 106 ? 0.2922 0.2513 0.2364 0.0339  0.0007  0.0198  106 MET A CB  
+930  C  CG  A MET A 106 ? 0.3278 0.2409 0.2573 0.0505  0.0533  0.0613  106 MET A CG  
+931  C  CG  B MET A 106 ? 0.3134 0.2516 0.2334 -0.0032 0.0002  0.0376  106 MET A CG  
+932  S  SD  A MET A 106 ? 0.3532 0.2641 0.2594 0.0253  0.0457  0.0519  106 MET A SD  
+933  S  SD  B MET A 106 ? 0.3410 0.2798 0.2263 -0.0190 -0.0092 0.0306  106 MET A SD  
+934  C  CE  A MET A 106 ? 0.3694 0.2612 0.2778 0.0113  0.0572  0.0222  106 MET A CE  
+935  C  CE  B MET A 106 ? 0.3338 0.2257 0.2326 -0.1031 0.0003  0.0336  106 MET A CE  
+936  N  N   A GLY A 107 ? 0.2105 0.2450 0.2368 0.0150  0.0117  -0.0220 107 GLY A N   
+937  N  N   B GLY A 107 ? 0.2596 0.2141 0.2446 0.0403  -0.0090 -0.0159 107 GLY A N   
+938  C  CA  A GLY A 107 ? 0.1921 0.2642 0.2595 -0.0112 0.0249  -0.0347 107 GLY A CA  
+939  C  CA  B GLY A 107 ? 0.2656 0.2186 0.2600 0.0232  -0.0104 -0.0235 107 GLY A CA  
+940  C  C   A GLY A 107 ? 0.2260 0.2980 0.2754 -0.0057 0.0292  -0.0525 107 GLY A C   
+941  C  C   B GLY A 107 ? 0.2908 0.2193 0.2727 0.0305  -0.0132 -0.0285 107 GLY A C   
+942  O  O   A GLY A 107 ? 0.2428 0.3033 0.2831 -0.0082 0.0140  -0.0683 107 GLY A O   
+943  O  O   B GLY A 107 ? 0.3134 0.2162 0.2735 0.0353  -0.0180 -0.0323 107 GLY A O   
+944  N  N   A GLU A 108 ? 0.2217 0.3721 0.2898 -0.0613 0.0329  -0.0132 108 GLU A N   
+945  N  N   B GLU A 108 ? 0.3041 0.2425 0.2878 0.0185  -0.0168 -0.0232 108 GLU A N   
+946  C  CA  A GLU A 108 ? 0.2825 0.4087 0.3017 -0.0670 0.0557  0.0296  108 GLU A CA  
+947  C  CA  B GLU A 108 ? 0.3303 0.2768 0.3004 0.0275  -0.0118 -0.0082 108 GLU A CA  
+948  C  C   A GLU A 108 ? 0.2983 0.4535 0.3208 -0.0230 0.0446  0.0174  108 GLU A C   
+949  C  C   B GLU A 108 ? 0.3198 0.2651 0.3107 0.0153  -0.0032 0.0122  108 GLU A C   
+950  O  O   A GLU A 108 ? 0.3166 0.5000 0.3245 0.0100  0.0270  -0.0182 108 GLU A O   
+951  O  O   B GLU A 108 ? 0.3106 0.2288 0.3026 0.0162  -0.0100 0.0026  108 GLU A O   
+952  C  CB  A GLU A 108 ? 0.3553 0.4692 0.3151 -0.0414 0.0580  0.0611  108 GLU A CB  
+953  C  CB  B GLU A 108 ? 0.3669 0.3306 0.3071 0.0176  -0.0194 -0.0091 108 GLU A CB  
+954  C  CG  A GLU A 108 ? 0.4120 0.5023 0.3180 -0.0417 0.0333  0.0511  108 GLU A CG  
+955  C  CG  B GLU A 108 ? 0.4136 0.3754 0.3221 0.0320  -0.0341 -0.0176 108 GLU A CG  
+956  C  CD  A GLU A 108 ? 0.4596 0.4937 0.3276 -0.0692 0.0084  0.0523  108 GLU A CD  
+957  C  CD  B GLU A 108 ? 0.4479 0.4084 0.3319 0.0566  -0.0528 -0.0220 108 GLU A CD  
+958  O  OE1 A GLU A 108 ? 0.4651 0.4995 0.3303 -0.0702 -0.0130 0.0382  108 GLU A OE1 
+959  O  OE1 B GLU A 108 ? 0.4617 0.4148 0.3420 0.0700  -0.0536 -0.0163 108 GLU A OE1 
+960  O  OE2 A GLU A 108 ? 0.4951 0.5017 0.3231 -0.0668 -0.0001 0.0294  108 GLU A OE2 
+961  O  OE2 B GLU A 108 ? 0.4674 0.4368 0.3323 0.0812  -0.0651 -0.0159 108 GLU A OE2 
+962  N  N   A THR A 109 ? 0.3262 0.4530 0.3343 0.0146  0.0441  0.0344  109 THR A N   
+963  N  N   B THR A 109 ? 0.3331 0.2850 0.3296 0.0243  -0.0017 0.0314  109 THR A N   
+964  C  CA  A THR A 109 ? 0.4000 0.4394 0.3565 0.0721  0.0325  0.0270  109 THR A CA  
+965  C  CA  B THR A 109 ? 0.3684 0.3158 0.3529 0.0723  0.0104  0.0473  109 THR A CA  
+966  C  C   A THR A 109 ? 0.3870 0.4059 0.3388 0.1082  0.0240  -0.0018 109 THR A C   
+967  C  C   B THR A 109 ? 0.3705 0.3154 0.3439 0.0805  -0.0041 0.0483  109 THR A C   
+968  O  O   A THR A 109 ? 0.3891 0.4440 0.3422 0.1071  0.0123  0.0147  109 THR A O   
+969  O  O   B THR A 109 ? 0.3806 0.3303 0.3462 0.1090  -0.0258 0.0537  109 THR A O   
+970  C  CB  A THR A 109 ? 0.4586 0.4674 0.3946 0.0782  0.0210  0.0185  109 THR A CB  
+971  C  CB  B THR A 109 ? 0.3936 0.3348 0.3772 0.0996  0.0268  0.0505  109 THR A CB  
+972  O  OG1 A THR A 109 ? 0.5049 0.5046 0.4297 0.1023  0.0099  0.0099  109 THR A OG1 
+973  O  OG1 B THR A 109 ? 0.4149 0.3708 0.3944 0.1254  0.0342  0.0338  109 THR A OG1 
+974  C  CG2 A THR A 109 ? 0.4697 0.4596 0.3850 0.0887  0.0354  0.0456  109 THR A CG2 
+975  C  CG2 B THR A 109 ? 0.4178 0.3493 0.3885 0.1063  0.0282  0.0559  109 THR A CG2 
+976  N  N   A GLY A 110 ? 0.3554 0.3674 0.3234 0.1200  0.0218  -0.0176 110 GLY A N   
+977  N  N   B GLY A 110 ? 0.3552 0.2983 0.3351 0.0616  0.0075  0.0435  110 GLY A N   
+978  C  CA  A GLY A 110 ? 0.3597 0.3593 0.3232 0.1210  0.0082  0.0212  110 GLY A CA  
+979  C  CA  B GLY A 110 ? 0.3350 0.2850 0.3281 0.0300  0.0056  0.0279  110 GLY A CA  
+980  C  C   A GLY A 110 ? 0.3687 0.3687 0.3161 0.1053  0.0114  0.0399  110 GLY A C   
+981  C  C   B GLY A 110 ? 0.3299 0.2681 0.3136 0.0121  -0.0078 -0.0013 110 GLY A C   
+982  O  O   A GLY A 110 ? 0.4235 0.3998 0.3209 0.1309  0.0320  0.0689  110 GLY A O   
+983  O  O   B GLY A 110 ? 0.3459 0.2640 0.3183 0.0135  -0.0206 -0.0248 110 GLY A O   
+984  N  N   A VAL A 111 ? 0.3344 0.3429 0.3203 0.0710  0.0081  0.0186  111 VAL A N   
+985  N  N   B VAL A 111 ? 0.3058 0.2474 0.2998 0.0044  -0.0086 -0.0135 111 VAL A N   
+986  N  N   C VAL A 111 ? 0.2322 0.3298 0.2528 -0.0513 -0.0154 -0.0118 111 VAL A N   
+987  C  CA  A VAL A 111 ? 0.3033 0.3280 0.3248 0.0461  0.0025  0.0014  111 VAL A CA  
+988  C  CA  B VAL A 111 ? 0.2975 0.2320 0.2909 0.0441  -0.0146 -0.0209 111 VAL A CA  
+989  C  CA  C VAL A 111 ? 0.2251 0.3344 0.2542 -0.0700 -0.0252 -0.0143 111 VAL A CA  
+990  C  C   A VAL A 111 ? 0.2782 0.3335 0.3222 0.0396  0.0077  -0.0212 111 VAL A C   
+991  C  C   B VAL A 111 ? 0.2860 0.2518 0.2920 0.0438  -0.0211 -0.0210 111 VAL A C   
+992  C  C   C VAL A 111 ? 0.2287 0.3803 0.2349 -0.0574 -0.0287 -0.0256 111 VAL A C   
+993  O  O   A VAL A 111 ? 0.2682 0.3388 0.3226 0.0475  0.0085  -0.0122 111 VAL A O   
+994  O  O   B VAL A 111 ? 0.2823 0.2381 0.2943 0.0547  -0.0151 -0.0237 111 VAL A O   
+995  O  O   C VAL A 111 ? 0.2220 0.4043 0.2152 -0.0594 -0.0246 -0.0041 111 VAL A O   
+996  C  CB  A VAL A 111 ? 0.3136 0.3316 0.3326 0.0585  -0.0083 -0.0025 111 VAL A CB  
+997  C  CB  B VAL A 111 ? 0.2992 0.2310 0.2722 0.0753  -0.0253 -0.0141 111 VAL A CB  
+998  C  CB  C VAL A 111 ? 0.2543 0.3223 0.2829 -0.0426 -0.0322 -0.0256 111 VAL A CB  
+999  C  CG1 A VAL A 111 ? 0.3225 0.3452 0.3375 0.0609  -0.0130 -0.0028 111 VAL A CG1 
+1000 C  CG1 B VAL A 111 ? 0.3065 0.2088 0.2642 0.0719  -0.0299 -0.0086 111 VAL A CG1 
+1001 C  CG1 C VAL A 111 ? 0.2652 0.3279 0.2952 -0.0173 -0.0315 -0.0196 111 VAL A CG1 
+1002 C  CG2 A VAL A 111 ? 0.3173 0.3356 0.3371 0.0714  -0.0117 0.0049  111 VAL A CG2 
+1003 C  CG2 B VAL A 111 ? 0.2918 0.2401 0.2768 0.0866  -0.0116 -0.0078 111 VAL A CG2 
+1004 C  CG2 C VAL A 111 ? 0.2791 0.3240 0.2964 -0.0326 -0.0295 -0.0168 111 VAL A CG2 
+1005 N  N   A ALA A 112 ? 0.2634 0.3428 0.3153 0.0327  0.0153  -0.0409 112 ALA A N   
+1006 N  N   B ALA A 112 ? 0.2956 0.3091 0.3026 0.0466  -0.0253 -0.0101 112 ALA A N   
+1007 C  CA  A ALA A 112 ? 0.2770 0.3373 0.3291 0.0260  -0.0006 -0.0325 112 ALA A CA  
+1008 C  CA  B ALA A 112 ? 0.2999 0.3525 0.3025 0.0669  -0.0306 0.0000  112 ALA A CA  
+1009 C  C   A ALA A 112 ? 0.2948 0.3165 0.3380 -0.0002 -0.0036 -0.0425 112 ALA A C   
+1010 C  C   B ALA A 112 ? 0.2936 0.3711 0.2961 0.0569  -0.0597 -0.0044 112 ALA A C   
+1011 O  O   A ALA A 112 ? 0.2895 0.3635 0.3500 -0.0267 -0.0395 -0.0369 112 ALA A O   
+1012 O  O   B ALA A 112 ? 0.3212 0.4110 0.3076 0.0809  -0.0693 0.0032  112 ALA A O   
+1013 C  CB  A ALA A 112 ? 0.2849 0.3436 0.3439 0.0432  -0.0096 -0.0384 112 ALA A CB  
+1014 C  CB  B ALA A 112 ? 0.3124 0.3544 0.2993 0.0940  -0.0212 -0.0025 112 ALA A CB  
+1015 N  N   A GLY A 113 ? 0.3231 0.2936 0.3313 0.0494  0.0173  -0.0410 113 GLY A N   
+1016 N  N   B GLY A 113 ? 0.2867 0.3567 0.2822 0.0610  -0.0748 -0.0050 113 GLY A N   
+1017 C  CA  A GLY A 113 ? 0.3395 0.2388 0.3263 0.0362  0.0367  -0.0079 113 GLY A CA  
+1018 C  CA  B GLY A 113 ? 0.3099 0.3445 0.2848 0.0402  -0.0634 0.0085  113 GLY A CA  
+1019 C  C   A GLY A 113 ? 0.3112 0.2118 0.3099 -0.0039 0.0476  0.0185  113 GLY A C   
+1020 C  C   B GLY A 113 ? 0.3310 0.3358 0.2838 0.0423  -0.0551 0.0148  113 GLY A C   
+1021 O  O   A GLY A 113 ? 0.3342 0.2300 0.3325 0.0035  0.0458  0.0476  113 GLY A O   
+1022 O  O   B GLY A 113 ? 0.3669 0.3792 0.2868 0.0736  -0.0687 0.0127  113 GLY A O   
+1023 N  N   A PHE A 114 ? 0.3045 0.2016 0.2815 0.0069  0.0400  0.0324  114 PHE A N   
+1024 N  N   B PHE A 114 ? 0.3210 0.3098 0.2854 0.0316  -0.0215 0.0117  114 PHE A N   
+1025 C  CA  A PHE A 114 ? 0.2571 0.1793 0.2434 -0.0002 0.0327  0.0181  114 PHE A CA  
+1026 C  CA  B PHE A 114 ? 0.3264 0.2876 0.2869 0.0151  -0.0186 0.0256  114 PHE A CA  
+1027 C  C   A PHE A 114 ? 0.2340 0.1985 0.2384 0.0135  0.0058  0.0371  114 PHE A C   
+1028 C  C   B PHE A 114 ? 0.3069 0.2858 0.2837 0.0248  -0.0124 0.0386  114 PHE A C   
+1029 O  O   A PHE A 114 ? 0.2391 0.1789 0.2285 0.0033  0.0089  0.0280  114 PHE A O   
+1030 O  O   B PHE A 114 ? 0.3046 0.2932 0.2826 0.0279  -0.0024 0.0395  114 PHE A O   
+1031 C  CB  A PHE A 114 ? 0.2689 0.1958 0.2520 -0.0115 0.0369  0.0138  114 PHE A CB  
+1032 C  CB  B PHE A 114 ? 0.3395 0.2895 0.2946 -0.0061 -0.0200 0.0272  114 PHE A CB  
+1033 C  CG  A PHE A 114 ? 0.2366 0.1964 0.2450 -0.0437 0.0264  -0.0281 114 PHE A CG  
+1034 C  CG  B PHE A 114 ? 0.3432 0.2906 0.2933 -0.0217 -0.0336 0.0089  114 PHE A CG  
+1035 C  CD1 A PHE A 114 ? 0.2583 0.2747 0.2784 -0.0193 0.0417  -0.0362 114 PHE A CD1 
+1036 C  CD1 B PHE A 114 ? 0.3606 0.2983 0.3087 -0.0053 -0.0222 0.0148  114 PHE A CD1 
+1037 C  CD2 A PHE A 114 ? 0.1979 0.2117 0.2504 -0.0373 0.0267  -0.0121 114 PHE A CD2 
+1038 C  CD2 B PHE A 114 ? 0.3357 0.2917 0.2978 -0.0307 -0.0374 0.0120  114 PHE A CD2 
+1039 C  CE1 A PHE A 114 ? 0.2281 0.2970 0.2661 0.0107  0.0293  -0.0570 114 PHE A CE1 
+1040 C  CE1 B PHE A 114 ? 0.3660 0.3020 0.3080 0.0049  -0.0202 0.0150  114 PHE A CE1 
+1041 C  CE2 A PHE A 114 ? 0.1855 0.2164 0.2509 -0.0371 0.0085  -0.0410 114 PHE A CE2 
+1042 C  CE2 B PHE A 114 ? 0.3544 0.2875 0.2995 -0.0209 -0.0374 0.0098  114 PHE A CE2 
+1043 C  CZ  A PHE A 114 ? 0.1832 0.2595 0.2617 -0.0225 0.0069  -0.0575 114 PHE A CZ  
+1044 C  CZ  B PHE A 114 ? 0.3649 0.2965 0.3043 -0.0053 -0.0289 0.0182  114 PHE A CZ  
+1045 N  N   A THR A 115 ? 0.1986 0.2305 0.2724 -0.0122 0.0460  0.0320  115 THR A N   
+1046 N  N   B THR A 115 ? 0.2857 0.2974 0.2988 0.0121  0.0110  0.0346  115 THR A N   
+1047 C  CA  A THR A 115 ? 0.1903 0.2809 0.2969 -0.0183 0.0278  0.0272  115 THR A CA  
+1048 C  CA  B THR A 115 ? 0.2572 0.3076 0.3034 0.0003  -0.0055 0.0355  115 THR A CA  
+1049 C  C   A THR A 115 ? 0.2135 0.2759 0.2843 -0.0032 0.0206  0.0674  115 THR A C   
+1050 C  C   B THR A 115 ? 0.2498 0.2823 0.2899 0.0079  -0.0021 0.0645  115 THR A C   
+1051 O  O   A THR A 115 ? 0.2340 0.3047 0.2754 0.0076  0.0252  0.0597  115 THR A O   
+1052 O  O   B THR A 115 ? 0.2635 0.2904 0.2832 -0.0066 -0.0079 0.0479  115 THR A O   
+1053 C  CB  A THR A 115 ? 0.1877 0.3642 0.3387 0.0001  0.0543  -0.0154 115 THR A CB  
+1054 C  CB  B THR A 115 ? 0.2437 0.3647 0.3246 -0.0142 0.0010  0.0048  115 THR A CB  
+1055 O  OG1 A THR A 115 ? 0.1984 0.4035 0.3655 0.0066  0.0603  -0.0330 115 THR A OG1 
+1056 O  OG1 B THR A 115 ? 0.2804 0.3691 0.3393 -0.0100 -0.0113 -0.0342 115 THR A OG1 
+1057 C  CG2 A THR A 115 ? 0.1886 0.3601 0.3468 0.0003  0.0364  -0.0353 115 THR A CG2 
+1058 C  CG2 B THR A 115 ? 0.2097 0.3493 0.3172 -0.0729 0.0022  0.0222  115 THR A CG2 
+1059 N  N   . ASN A 116 ? 0.2207 0.2785 0.2799 0.0227  -0.0056 0.0884  116 ASN A N   
+1060 C  CA  . ASN A 116 ? 0.2347 0.2442 0.2672 0.0096  -0.0227 0.1080  116 ASN A CA  
+1061 C  C   . ASN A 116 ? 0.2441 0.2360 0.2472 0.0134  -0.0235 0.0943  116 ASN A C   
+1062 O  O   . ASN A 116 ? 0.2706 0.2678 0.2457 -0.0183 -0.0269 0.0420  116 ASN A O   
+1063 C  CB  . ASN A 116 ? 0.2338 0.2993 0.2889 0.0254  -0.0375 0.1384  116 ASN A CB  
+1064 C  CG  . ASN A 116 ? 0.2217 0.3391 0.3357 -0.0288 -0.0233 0.1329  116 ASN A CG  
+1065 O  OD1 . ASN A 116 ? 0.2279 0.4368 0.3869 -0.0030 -0.0226 0.1509  116 ASN A OD1 
+1066 N  ND2 . ASN A 116 ? 0.2223 0.3056 0.3318 -0.0097 -0.0068 0.1087  116 ASN A ND2 
+1067 N  N   . SER A 117 ? 0.1974 0.2509 0.2389 -0.0333 -0.0265 0.0813  117 SER A N   
+1068 C  CA  . SER A 117 ? 0.1966 0.2265 0.2437 -0.0242 -0.0296 0.0683  117 SER A CA  
+1069 C  C   . SER A 117 ? 0.2260 0.1847 0.2317 -0.0097 -0.0230 0.0527  117 SER A C   
+1070 O  O   . SER A 117 ? 0.2513 0.2026 0.2287 -0.0149 -0.0471 0.0285  117 SER A O   
+1071 C  CB  . SER A 117 ? 0.2130 0.2436 0.2820 -0.0968 -0.0401 0.0648  117 SER A CB  
+1072 O  OG  . SER A 117 ? 0.3089 0.3066 0.3113 -0.0907 -0.0568 0.0757  117 SER A OG  
+1073 N  N   . LEU A 118 ? 0.2403 0.2211 0.2082 -0.0109 0.0153  0.0486  118 LEU A N   
+1074 C  CA  . LEU A 118 ? 0.2593 0.2013 0.2210 -0.0342 0.0296  0.0168  118 LEU A CA  
+1075 C  C   . LEU A 118 ? 0.2532 0.2073 0.2262 -0.0286 0.0066  0.0137  118 LEU A C   
+1076 O  O   . LEU A 118 ? 0.2853 0.2141 0.2183 0.0033  0.0239  0.0081  118 LEU A O   
+1077 C  CB  . LEU A 118 ? 0.3334 0.2501 0.2396 -0.0088 0.0378  0.0060  118 LEU A CB  
+1078 C  CG  . LEU A 118 ? 0.3782 0.3049 0.2718 0.0101  0.0139  -0.0010 118 LEU A CG  
+1079 C  CD1 . LEU A 118 ? 0.4116 0.3697 0.2890 0.0420  0.0441  -0.0154 118 LEU A CD1 
+1080 C  CD2 . LEU A 118 ? 0.3569 0.2774 0.2960 0.0161  -0.0694 -0.0141 118 LEU A CD2 
+1081 N  N   . ARG A 119 ? 0.2228 0.2588 0.2485 -0.0214 -0.0181 0.0275  119 ARG A N   
+1082 C  CA  . ARG A 119 ? 0.2310 0.2948 0.2811 -0.0079 -0.0336 0.0215  119 ARG A CA  
+1083 C  C   . ARG A 119 ? 0.2187 0.2959 0.2472 -0.0307 -0.0269 0.0193  119 ARG A C   
+1084 O  O   . ARG A 119 ? 0.2498 0.2502 0.2554 -0.0251 -0.0090 0.0099  119 ARG A O   
+1085 C  CB  . ARG A 119 ? 0.2820 0.3639 0.3858 0.0096  -0.0441 0.0549  119 ARG A CB  
+1086 C  CG  . ARG A 119 ? 0.4264 0.5471 0.5038 0.1174  0.0014  0.0748  119 ARG A CG  
+1087 C  CD  . ARG A 119 ? 0.5630 0.6730 0.6268 0.1836  0.0551  0.0892  119 ARG A CD  
+1088 N  NE  . ARG A 119 ? 0.6852 0.7693 0.7511 0.2040  0.1038  0.1020  119 ARG A NE  
+1089 C  CZ  . ARG A 119 ? 0.7792 0.8295 0.8311 0.2593  0.1382  0.1008  119 ARG A CZ  
+1090 N  NH1 . ARG A 119 ? 0.8201 0.8549 0.8734 0.2478  0.1354  0.1065  119 ARG A NH1 
+1091 N  NH2 . ARG A 119 ? 0.8015 0.8321 0.8363 0.2597  0.1591  0.0902  119 ARG A NH2 
+1092 N  N   . MET A 120 ? 0.2092 0.2395 0.2139 -0.0289 -0.0261 0.0312  120 MET A N   
+1093 C  CA  A MET A 120 ? 0.2265 0.2115 0.2011 -0.0332 -0.0205 0.0332  120 MET A CA  
+1094 C  CA  B MET A 120 ? 0.2413 0.2652 0.2097 0.0051  -0.0307 0.0251  120 MET A CA  
+1095 C  C   . MET A 120 ? 0.2510 0.2316 0.1943 -0.0069 -0.0239 0.0264  120 MET A C   
+1096 O  O   . MET A 120 ? 0.2957 0.2365 0.1896 -0.0168 -0.0290 0.0135  120 MET A O   
+1097 C  CB  A MET A 120 ? 0.2371 0.1962 0.2129 -0.0315 -0.0422 0.0312  120 MET A CB  
+1098 C  CB  B MET A 120 ? 0.2635 0.3308 0.2226 0.0396  -0.0469 0.0118  120 MET A CB  
+1099 C  CG  A MET A 120 ? 0.2639 0.2159 0.2393 -0.0369 -0.0480 0.0477  120 MET A CG  
+1100 C  CG  B MET A 120 ? 0.2972 0.3927 0.2385 0.0754  -0.0575 -0.0033 120 MET A CG  
+1101 S  SD  A MET A 120 ? 0.3019 0.2807 0.2847 -0.0054 0.0029  0.0781  120 MET A SD  
+1102 S  SD  B MET A 120 ? 0.3311 0.4452 0.2517 0.1191  -0.0685 -0.0222 120 MET A SD  
+1103 C  CE  A MET A 120 ? 0.3192 0.3085 0.3136 0.0298  -0.0159 0.0607  120 MET A CE  
+1104 C  CE  B MET A 120 ? 0.3288 0.4469 0.2494 0.1088  -0.0670 -0.0233 120 MET A CE  
+1105 N  N   . LEU A 121 ? 0.2256 0.2234 0.1826 -0.0144 -0.0421 0.0064  121 LEU A N   
+1106 C  CA  . LEU A 121 ? 0.2203 0.1957 0.1857 -0.0319 -0.0390 0.0005  121 LEU A CA  
+1107 C  C   . LEU A 121 ? 0.2240 0.1967 0.1919 -0.0429 -0.0209 -0.0006 121 LEU A C   
+1108 O  O   . LEU A 121 ? 0.2767 0.1948 0.2028 -0.0219 -0.0060 0.0002  121 LEU A O   
+1109 C  CB  . LEU A 121 ? 0.2411 0.1867 0.1888 -0.0294 -0.0453 -0.0168 121 LEU A CB  
+1110 C  CG  . LEU A 121 ? 0.2632 0.1720 0.2112 -0.0288 -0.0397 -0.0321 121 LEU A CG  
+1111 C  CD1 . LEU A 121 ? 0.2794 0.2300 0.2175 -0.0041 -0.0369 -0.0619 121 LEU A CD1 
+1112 C  CD2 . LEU A 121 ? 0.2553 0.2302 0.2344 0.0142  -0.0149 -0.0037 121 LEU A CD2 
+1113 N  N   . GLN A 122 ? 0.2120 0.2492 0.2100 -0.0519 0.0154  0.0308  122 GLN A N   
+1114 C  CA  . GLN A 122 ? 0.2343 0.2582 0.2426 -0.0599 0.0292  0.0186  122 GLN A CA  
+1115 C  C   . GLN A 122 ? 0.2757 0.2405 0.2443 -0.0429 0.0027  0.0088  122 GLN A C   
+1116 O  O   . GLN A 122 ? 0.3364 0.2485 0.2750 -0.0682 0.0161  -0.0091 122 GLN A O   
+1117 C  CB  . GLN A 122 ? 0.2433 0.2828 0.3039 -0.0720 0.0334  0.0233  122 GLN A CB  
+1118 C  CG  . GLN A 122 ? 0.2798 0.3603 0.3727 -0.0728 0.0645  0.0120  122 GLN A CG  
+1119 C  CD  . GLN A 122 ? 0.3638 0.5029 0.4596 -0.0151 0.0686  0.0163  122 GLN A CD  
+1120 O  OE1 . GLN A 122 ? 0.3845 0.5790 0.5178 0.0272  0.0706  -0.0014 122 GLN A OE1 
+1121 N  NE2 . GLN A 122 ? 0.4158 0.5767 0.4611 0.0094  0.0603  0.0162  122 GLN A NE2 
+1122 N  N   . GLN A 123 ? 0.2348 0.2665 0.2252 -0.0653 -0.0130 0.0098  123 GLN A N   
+1123 C  CA  . GLN A 123 ? 0.2584 0.2552 0.2358 -0.0364 -0.0267 -0.0008 123 GLN A CA  
+1124 C  C   . GLN A 123 ? 0.2648 0.2016 0.2161 -0.0343 -0.0327 -0.0224 123 GLN A C   
+1125 O  O   . GLN A 123 ? 0.2655 0.2497 0.2376 -0.0223 -0.0457 -0.0420 123 GLN A O   
+1126 C  CB  . GLN A 123 ? 0.2790 0.3410 0.2663 0.0026  -0.0318 0.0060  123 GLN A CB  
+1127 C  CG  . GLN A 123 ? 0.2998 0.5191 0.3137 0.0638  -0.0325 0.0026  123 GLN A CG  
+1128 C  CD  . GLN A 123 ? 0.3747 0.7066 0.3770 0.1155  -0.0096 0.0459  123 GLN A CD  
+1129 O  OE1 . GLN A 123 ? 0.4459 0.7675 0.3823 0.1781  -0.0091 0.0969  123 GLN A OE1 
+1130 N  NE2 . GLN A 123 ? 0.3975 0.8102 0.4190 0.1392  0.0109  0.0624  123 GLN A NE2 
+1131 N  N   A LYS A 124 ? 0.2544 0.1963 0.1894 -0.0409 -0.0202 -0.0030 124 LYS A N   
+1132 N  N   B LYS A 124 ? 0.2585 0.2102 0.2065 -0.0310 -0.0109 0.0088  124 LYS A N   
+1133 C  CA  A LYS A 124 ? 0.2739 0.1505 0.1680 -0.0330 -0.0154 0.0200  124 LYS A CA  
+1134 C  CA  B LYS A 124 ? 0.2737 0.2062 0.2005 -0.0241 0.0023  0.0457  124 LYS A CA  
+1135 C  C   A LYS A 124 ? 0.2867 0.1718 0.1625 -0.0483 -0.0274 -0.0124 124 LYS A C   
+1136 C  C   B LYS A 124 ? 0.2832 0.1986 0.1853 -0.0375 -0.0147 0.0185  124 LYS A C   
+1137 O  O   A LYS A 124 ? 0.3379 0.2129 0.1658 -0.0294 -0.0121 -0.0180 124 LYS A O   
+1138 O  O   B LYS A 124 ? 0.3211 0.2323 0.1923 -0.0152 -0.0059 0.0235  124 LYS A O   
+1139 C  CB  A LYS A 124 ? 0.2816 0.1602 0.1848 -0.0210 0.0023  0.0141  124 LYS A CB  
+1140 C  CB  B LYS A 124 ? 0.2794 0.2402 0.2267 -0.0225 0.0320  0.0705  124 LYS A CB  
+1141 C  CG  A LYS A 124 ? 0.2733 0.1422 0.1901 -0.0327 -0.0097 0.0018  124 LYS A CG  
+1142 C  CG  B LYS A 124 ? 0.2768 0.2542 0.2426 -0.0279 0.0505  0.0923  124 LYS A CG  
+1143 C  CD  A LYS A 124 ? 0.2828 0.1816 0.2088 -0.0128 -0.0138 0.0045  124 LYS A CD  
+1144 C  CD  B LYS A 124 ? 0.2709 0.2849 0.2623 -0.0447 0.0662  0.0978  124 LYS A CD  
+1145 C  CE  A LYS A 124 ? 0.2565 0.2092 0.2294 -0.0748 -0.0074 0.0028  124 LYS A CE  
+1146 C  CE  B LYS A 124 ? 0.2602 0.3045 0.2840 -0.0700 0.0723  0.0858  124 LYS A CE  
+1147 N  NZ  A LYS A 124 ? 0.2866 0.1815 0.2178 -0.0313 0.0000  0.0014  124 LYS A NZ  
+1148 N  NZ  B LYS A 124 ? 0.2830 0.3229 0.2909 -0.0299 0.0778  0.0753  124 LYS A NZ  
+1149 N  N   . ARG A 125 ? 0.2589 0.1896 0.1656 -0.0647 -0.0285 0.0191  125 ARG A N   
+1150 C  CA  . ARG A 125 ? 0.2400 0.2186 0.1898 -0.0788 -0.0282 0.0429  125 ARG A CA  
+1151 C  C   . ARG A 125 ? 0.2510 0.1889 0.1867 -0.0430 -0.0246 0.0024  125 ARG A C   
+1152 O  O   . ARG A 125 ? 0.2892 0.1802 0.1869 -0.0187 -0.0286 -0.0146 125 ARG A O   
+1153 C  CB  . ARG A 125 ? 0.2405 0.3006 0.2314 -0.0795 -0.0606 0.0327  125 ARG A CB  
+1154 C  CG  . ARG A 125 ? 0.2796 0.3883 0.2719 -0.0936 -0.0895 0.0372  125 ARG A CG  
+1155 C  CD  . ARG A 125 ? 0.3532 0.5189 0.3124 -0.0827 -0.1206 0.0708  125 ARG A CD  
+1156 N  NE  . ARG A 125 ? 0.4331 0.6423 0.3675 -0.0475 -0.1377 0.0813  125 ARG A NE  
+1157 C  CZ  . ARG A 125 ? 0.5202 0.7745 0.4152 0.0377  -0.1140 0.1198  125 ARG A CZ  
+1158 N  NH1 . ARG A 125 ? 0.5582 0.7939 0.4326 0.0653  -0.1150 0.1538  125 ARG A NH1 
+1159 N  NH2 . ARG A 125 ? 0.5614 0.8316 0.4375 0.0956  -0.0962 0.1094  125 ARG A NH2 
+1160 N  N   . TRP A 126 ? 0.2344 0.1961 0.1721 -0.0256 -0.0061 -0.0166 126 TRP A N   
+1161 C  CA  . TRP A 126 ? 0.2219 0.1763 0.1770 -0.0428 -0.0108 -0.0073 126 TRP A CA  
+1162 C  C   . TRP A 126 ? 0.2419 0.1831 0.1556 -0.0148 0.0088  0.0012  126 TRP A C   
+1163 O  O   . TRP A 126 ? 0.2872 0.2085 0.1665 -0.0379 -0.0045 -0.0133 126 TRP A O   
+1164 C  CB  . TRP A 126 ? 0.2469 0.1948 0.1866 -0.0018 0.0001  -0.0009 126 TRP A CB  
+1165 C  CG  . TRP A 126 ? 0.2545 0.1724 0.1656 -0.0389 -0.0032 -0.0301 126 TRP A CG  
+1166 C  CD1 . TRP A 126 ? 0.2652 0.1816 0.1771 -0.0280 -0.0093 -0.0333 126 TRP A CD1 
+1167 C  CD2 . TRP A 126 ? 0.2359 0.1842 0.1862 -0.0306 -0.0137 -0.0295 126 TRP A CD2 
+1168 N  NE1 . TRP A 126 ? 0.2640 0.1959 0.1878 -0.0245 -0.0177 -0.0097 126 TRP A NE1 
+1169 C  CE2 . TRP A 126 ? 0.2390 0.1887 0.1787 -0.0355 -0.0169 -0.0159 126 TRP A CE2 
+1170 C  CE3 . TRP A 126 ? 0.2580 0.2313 0.1833 -0.0052 -0.0217 -0.0251 126 TRP A CE3 
+1171 C  CZ2 . TRP A 126 ? 0.2174 0.1919 0.1891 -0.0331 -0.0296 -0.0157 126 TRP A CZ2 
+1172 C  CZ3 . TRP A 126 ? 0.2585 0.1933 0.1967 0.0148  -0.0211 -0.0314 126 TRP A CZ3 
+1173 C  CH2 . TRP A 126 ? 0.2438 0.1880 0.1978 -0.0162 -0.0368 -0.0361 126 TRP A CH2 
+1174 N  N   . ASP A 127 ? 0.2501 0.2274 0.1496 -0.0200 0.0281  0.0090  127 ASP A N   
+1175 C  CA  . ASP A 127 ? 0.2798 0.2160 0.1587 -0.0154 0.0498  0.0018  127 ASP A CA  
+1176 C  C   . ASP A 127 ? 0.2798 0.2080 0.1638 -0.0277 0.0245  -0.0049 127 ASP A C   
+1177 O  O   . ASP A 127 ? 0.3126 0.2144 0.1963 -0.0355 0.0086  -0.0116 127 ASP A O   
+1178 C  CB  . ASP A 127 ? 0.3075 0.2619 0.1627 -0.0110 0.0512  -0.0137 127 ASP A CB  
+1179 C  CG  . ASP A 127 ? 0.3768 0.3040 0.2385 0.0098  0.0632  -0.0438 127 ASP A CG  
+1180 O  OD1 . ASP A 127 ? 0.3973 0.3816 0.3182 0.0290  0.0292  -0.0631 127 ASP A OD1 
+1181 O  OD2 . ASP A 127 ? 0.4198 0.3624 0.2878 0.0287  0.0728  -0.0352 127 ASP A OD2 
+1182 N  N   . GLU A 128 ? 0.2647 0.2430 0.1611 -0.0162 0.0196  -0.0088 128 GLU A N   
+1183 C  CA  . GLU A 128 ? 0.2846 0.2324 0.1793 -0.0458 -0.0315 -0.0193 128 GLU A CA  
+1184 C  C   . GLU A 128 ? 0.2707 0.1784 0.1719 -0.0418 -0.0317 0.0064  128 GLU A C   
+1185 O  O   . GLU A 128 ? 0.2917 0.2065 0.1830 -0.0090 -0.0263 0.0154  128 GLU A O   
+1186 C  CB  . GLU A 128 ? 0.3117 0.2814 0.1842 -0.0786 -0.0531 -0.0298 128 GLU A CB  
+1187 C  CG  . GLU A 128 ? 0.3684 0.3595 0.2082 -0.0783 -0.0785 -0.0445 128 GLU A CG  
+1188 C  CD  . GLU A 128 ? 0.4050 0.4028 0.2507 -0.0843 -0.1067 -0.0094 128 GLU A CD  
+1189 O  OE1 . GLU A 128 ? 0.4086 0.4468 0.2778 -0.0814 -0.1096 0.0226  128 GLU A OE1 
+1190 O  OE2 . GLU A 128 ? 0.4383 0.4046 0.2738 -0.0835 -0.0919 0.0177  128 GLU A OE2 
+1191 N  N   . ALA A 129 ? 0.2455 0.2125 0.1446 -0.0142 -0.0133 0.0072  129 ALA A N   
+1192 C  CA  . ALA A 129 ? 0.2380 0.2195 0.1457 -0.0311 -0.0087 -0.0100 129 ALA A CA  
+1193 C  C   . ALA A 129 ? 0.2436 0.1824 0.1518 -0.0396 -0.0157 -0.0021 129 ALA A C   
+1194 O  O   . ALA A 129 ? 0.2838 0.1831 0.1791 -0.0330 -0.0211 -0.0173 129 ALA A O   
+1195 C  CB  . ALA A 129 ? 0.2683 0.2470 0.1664 -0.0288 -0.0070 -0.0261 129 ALA A CB  
+1196 N  N   . ALA A 130 ? 0.2296 0.2201 0.1688 -0.0321 -0.0162 0.0080  130 ALA A N   
+1197 C  CA  . ALA A 130 ? 0.2365 0.1968 0.1984 -0.0169 -0.0145 -0.0014 130 ALA A CA  
+1198 C  C   . ALA A 130 ? 0.2650 0.1880 0.2049 -0.0214 0.0015  -0.0051 130 ALA A C   
+1199 O  O   . ALA A 130 ? 0.2823 0.1940 0.2325 -0.0276 0.0007  -0.0173 130 ALA A O   
+1200 C  CB  . ALA A 130 ? 0.2434 0.2071 0.2236 0.0002  -0.0161 -0.0133 130 ALA A CB  
+1201 N  N   . VAL A 131 ? 0.2801 0.1981 0.1766 -0.0138 0.0086  0.0167  131 VAL A N   
+1202 C  CA  . VAL A 131 ? 0.3076 0.2110 0.1842 -0.0426 0.0133  0.0131  131 VAL A CA  
+1203 C  C   . VAL A 131 ? 0.2553 0.1908 0.1999 -0.0588 -0.0024 0.0165  131 VAL A C   
+1204 O  O   . VAL A 131 ? 0.2822 0.2138 0.2315 -0.0402 0.0010  0.0236  131 VAL A O   
+1205 C  CB  . VAL A 131 ? 0.3997 0.2725 0.2013 0.0281  0.0253  0.0276  131 VAL A CB  
+1206 C  CG1 . VAL A 131 ? 0.4600 0.2935 0.2153 0.0429  -0.0047 0.0425  131 VAL A CG1 
+1207 C  CG2 . VAL A 131 ? 0.4141 0.3007 0.2359 -0.0178 0.0375  0.0007  131 VAL A CG2 
+1208 N  N   . ASN A 132 ? 0.2341 0.2111 0.1832 -0.0091 0.0026  0.0147  132 ASN A N   
+1209 C  CA  . ASN A 132 ? 0.2057 0.2065 0.1895 -0.0002 -0.0211 -0.0197 132 ASN A CA  
+1210 C  C   . ASN A 132 ? 0.2148 0.1726 0.1898 -0.0158 -0.0202 -0.0031 132 ASN A C   
+1211 O  O   . ASN A 132 ? 0.2373 0.1873 0.2133 0.0028  -0.0369 -0.0067 132 ASN A O   
+1212 C  CB  . ASN A 132 ? 0.2263 0.2313 0.1947 -0.0106 -0.0322 -0.0022 132 ASN A CB  
+1213 C  CG  . ASN A 132 ? 0.2620 0.2197 0.2058 -0.0202 -0.0341 0.0272  132 ASN A CG  
+1214 O  OD1 . ASN A 132 ? 0.3024 0.2525 0.2132 0.0129  -0.0157 0.0383  132 ASN A OD1 
+1215 N  ND2 . ASN A 132 ? 0.2728 0.2626 0.2339 -0.0121 -0.0482 0.0549  132 ASN A ND2 
+1216 N  N   . LEU A 133 ? 0.1998 0.1881 0.1821 -0.0003 -0.0239 0.0033  133 LEU A N   
+1217 C  CA  . LEU A 133 ? 0.2069 0.1511 0.1793 -0.0027 -0.0214 0.0272  133 LEU A CA  
+1218 C  C   . LEU A 133 ? 0.2311 0.1325 0.1752 -0.0026 -0.0272 -0.0008 133 LEU A C   
+1219 O  O   . LEU A 133 ? 0.2677 0.1673 0.1934 -0.0234 -0.0214 -0.0224 133 LEU A O   
+1220 C  CB  . LEU A 133 ? 0.2066 0.1456 0.1933 0.0012  -0.0104 0.0206  133 LEU A CB  
+1221 C  CG  . LEU A 133 ? 0.2238 0.1892 0.1878 -0.0200 0.0166  0.0348  133 LEU A CG  
+1222 C  CD1 . LEU A 133 ? 0.2317 0.1893 0.2319 0.0061  -0.0179 0.0333  133 LEU A CD1 
+1223 C  CD2 . LEU A 133 ? 0.2941 0.2535 0.1790 -0.0307 0.0479  0.0218  133 LEU A CD2 
+1224 N  N   . ALA A 134 ? 0.2008 0.1914 0.1735 -0.0288 -0.0048 0.0174  134 ALA A N   
+1225 C  CA  . ALA A 134 ? 0.2005 0.1970 0.2104 -0.0299 0.0100  0.0143  134 ALA A CA  
+1226 C  C   . ALA A 134 ? 0.2319 0.2046 0.1937 -0.0224 -0.0059 0.0135  134 ALA A C   
+1227 O  O   . ALA A 134 ? 0.2482 0.2288 0.2268 -0.0399 -0.0018 0.0068  134 ALA A O   
+1228 C  CB  . ALA A 134 ? 0.2282 0.2300 0.2307 0.0139  0.0405  -0.0073 134 ALA A CB  
+1229 N  N   . LYS A 135 ? 0.2325 0.2059 0.1618 0.0025  -0.0081 0.0150  135 LYS A N   
+1230 C  CA  . LYS A 135 ? 0.2547 0.1968 0.1648 -0.0145 -0.0479 0.0013  135 LYS A CA  
+1231 C  C   . LYS A 135 ? 0.2652 0.1655 0.1737 -0.0102 -0.0216 0.0150  135 LYS A C   
+1232 O  O   . LYS A 135 ? 0.2505 0.2272 0.1997 -0.0324 -0.0273 -0.0084 135 LYS A O   
+1233 C  CB  . LYS A 135 ? 0.3396 0.2728 0.1634 0.0018  -0.0569 -0.0158 135 LYS A CB  
+1234 C  CG  . LYS A 135 ? 0.4259 0.3632 0.1821 0.0172  -0.0646 -0.0209 135 LYS A CG  
+1235 C  CD  . LYS A 135 ? 0.5051 0.4724 0.2130 0.0532  -0.0678 -0.0540 135 LYS A CD  
+1236 C  CE  . LYS A 135 ? 0.5715 0.5359 0.2571 0.0968  -0.0530 -0.0452 135 LYS A CE  
+1237 N  NZ  . LYS A 135 ? 0.5905 0.5575 0.2637 0.0978  -0.0623 -0.0254 135 LYS A NZ  
+1238 N  N   . SER A 136 ? 0.2632 0.1773 0.1562 -0.0189 -0.0011 -0.0033 136 SER A N   
+1239 C  CA  . SER A 136 ? 0.2355 0.1580 0.1552 -0.0384 -0.0039 -0.0079 136 SER A CA  
+1240 C  C   . SER A 136 ? 0.2399 0.1544 0.1678 -0.0256 0.0115  0.0186  136 SER A C   
+1241 O  O   . SER A 136 ? 0.2117 0.1838 0.2017 -0.0294 0.0309  -0.0026 136 SER A O   
+1242 C  CB  . SER A 136 ? 0.1991 0.1883 0.1956 -0.0056 -0.0033 0.0139  136 SER A CB  
+1243 O  OG  . SER A 136 ? 0.1770 0.1847 0.2045 -0.0193 -0.0182 0.0021  136 SER A OG  
+1244 N  N   . ARG A 137 ? 0.2566 0.1358 0.1735 -0.0117 0.0003  0.0129  137 ARG A N   
+1245 C  CA  . ARG A 137 ? 0.2233 0.1642 0.2000 -0.0089 0.0106  -0.0158 137 ARG A CA  
+1246 C  C   . ARG A 137 ? 0.2130 0.1658 0.2036 -0.0437 0.0048  0.0051  137 ARG A C   
+1247 O  O   . ARG A 137 ? 0.2093 0.1654 0.2558 -0.0464 -0.0126 0.0149  137 ARG A O   
+1248 C  CB  . ARG A 137 ? 0.2447 0.1966 0.2151 -0.0108 0.0225  -0.0339 137 ARG A CB  
+1249 C  CG  . ARG A 137 ? 0.2931 0.2114 0.2431 -0.0221 0.0273  -0.0540 137 ARG A CG  
+1250 C  CD  . ARG A 137 ? 0.3308 0.2857 0.2889 0.0087  0.0069  -0.0709 137 ARG A CD  
+1251 N  NE  . ARG A 137 ? 0.3376 0.3266 0.3063 0.0047  -0.0183 -0.0710 137 ARG A NE  
+1252 C  CZ  . ARG A 137 ? 0.3786 0.3332 0.3276 0.0062  -0.0070 -0.0598 137 ARG A CZ  
+1253 N  NH1 . ARG A 137 ? 0.4141 0.3406 0.3204 0.0186  0.0137  -0.0329 137 ARG A NH1 
+1254 N  NH2 . ARG A 137 ? 0.3836 0.3169 0.3464 0.0017  -0.0181 -0.0912 137 ARG A NH2 
+1255 N  N   . TRP A 138 ? 0.2235 0.1404 0.1749 -0.0283 -0.0065 0.0211  138 TRP A N   
+1256 C  CA  . TRP A 138 ? 0.2013 0.1537 0.2042 -0.0216 -0.0123 0.0342  138 TRP A CA  
+1257 C  C   . TRP A 138 ? 0.2085 0.1441 0.2072 -0.0328 -0.0328 -0.0090 138 TRP A C   
+1258 O  O   . TRP A 138 ? 0.1875 0.1869 0.2211 -0.0225 -0.0321 0.0007  138 TRP A O   
+1259 C  CB  . TRP A 138 ? 0.2091 0.1468 0.2103 -0.0337 -0.0080 0.0422  138 TRP A CB  
+1260 C  CG  . TRP A 138 ? 0.1994 0.1617 0.1856 -0.0249 -0.0071 0.0463  138 TRP A CG  
+1261 C  CD1 . TRP A 138 ? 0.2018 0.1857 0.2011 -0.0046 -0.0224 0.0270  138 TRP A CD1 
+1262 C  CD2 . TRP A 138 ? 0.2001 0.1664 0.1835 -0.0197 0.0016  0.0105  138 TRP A CD2 
+1263 N  NE1 . TRP A 138 ? 0.2192 0.1726 0.1980 -0.0155 -0.0206 -0.0004 138 TRP A NE1 
+1264 C  CE2 . TRP A 138 ? 0.2004 0.1626 0.1812 -0.0169 0.0048  0.0102  138 TRP A CE2 
+1265 C  CE3 . TRP A 138 ? 0.2106 0.1997 0.1778 -0.0020 0.0055  -0.0270 138 TRP A CE3 
+1266 C  CZ2 . TRP A 138 ? 0.2105 0.1882 0.1726 -0.0279 0.0264  0.0142  138 TRP A CZ2 
+1267 C  CZ3 . TRP A 138 ? 0.2280 0.2241 0.1945 0.0095  -0.0318 -0.0448 138 TRP A CZ3 
+1268 C  CH2 . TRP A 138 ? 0.1978 0.2258 0.2074 -0.0379 -0.0236 -0.0084 138 TRP A CH2 
+1269 N  N   . TYR A 139 ? 0.2223 0.1412 0.2021 -0.0167 -0.0103 -0.0195 139 TYR A N   
+1270 C  CA  . TYR A 139 ? 0.2180 0.1467 0.2327 -0.0090 0.0066  -0.0203 139 TYR A CA  
+1271 C  C   . TYR A 139 ? 0.2188 0.1729 0.2626 0.0004  0.0337  0.0034  139 TYR A C   
+1272 O  O   . TYR A 139 ? 0.2142 0.1968 0.3210 0.0003  0.0300  0.0116  139 TYR A O   
+1273 C  CB  . TYR A 139 ? 0.2368 0.2049 0.2440 0.0074  0.0163  -0.0468 139 TYR A CB  
+1274 C  CG  . TYR A 139 ? 0.2770 0.2486 0.2811 0.0020  0.0411  -0.0286 139 TYR A CG  
+1275 C  CD1 . TYR A 139 ? 0.2795 0.2968 0.2983 0.0275  0.0436  -0.0349 139 TYR A CD1 
+1276 C  CD2 . TYR A 139 ? 0.3030 0.2862 0.3095 -0.0148 0.0795  -0.0157 139 TYR A CD2 
+1277 C  CE1 . TYR A 139 ? 0.3574 0.3712 0.3262 0.0847  0.0859  -0.0092 139 TYR A CE1 
+1278 C  CE2 . TYR A 139 ? 0.3572 0.3542 0.3379 0.0392  0.1145  -0.0137 139 TYR A CE2 
+1279 C  CZ  . TYR A 139 ? 0.3757 0.4222 0.3532 0.0707  0.1506  0.0064  139 TYR A CZ  
+1280 O  OH  . TYR A 139 ? 0.4575 0.5558 0.4092 0.1197  0.1681  -0.0210 139 TYR A OH  
+1281 N  N   . ASN A 140 ? 0.2247 0.1473 0.2280 -0.0276 -0.0033 0.0002  140 ASN A N   
+1282 C  CA  . ASN A 140 ? 0.2505 0.1988 0.2429 -0.0513 0.0038  0.0233  140 ASN A CA  
+1283 C  C   . ASN A 140 ? 0.2369 0.2143 0.2689 -0.0956 0.0481  0.0116  140 ASN A C   
+1284 O  O   . ASN A 140 ? 0.3217 0.2538 0.2804 -0.1443 0.0502  -0.0285 140 ASN A O   
+1285 C  CB  . ASN A 140 ? 0.2888 0.2138 0.2749 -0.0386 -0.0033 0.0481  140 ASN A CB  
+1286 C  CG  . ASN A 140 ? 0.2791 0.3158 0.2874 -0.0780 0.0103  0.0662  140 ASN A CG  
+1287 O  OD1 . ASN A 140 ? 0.3431 0.3471 0.3087 -0.0666 0.0570  0.0841  140 ASN A OD1 
+1288 N  ND2 . ASN A 140 ? 0.2789 0.3870 0.3062 -0.0362 0.0206  0.0469  140 ASN A ND2 
+1289 N  N   . GLN A 141 ? 0.2020 0.1658 0.2644 -0.0265 0.0273  0.0010  141 GLN A N   
+1290 C  CA  . GLN A 141 ? 0.2154 0.1969 0.2671 -0.0095 0.0078  -0.0314 141 GLN A CA  
+1291 C  C   . GLN A 141 ? 0.2297 0.1682 0.2666 -0.0384 -0.0117 -0.0537 141 GLN A C   
+1292 O  O   . GLN A 141 ? 0.2234 0.2200 0.3039 -0.0423 -0.0322 -0.0233 141 GLN A O   
+1293 C  CB  . GLN A 141 ? 0.2162 0.2110 0.2862 -0.0109 -0.0036 -0.0040 141 GLN A CB  
+1294 C  CG  . GLN A 141 ? 0.2827 0.2751 0.3172 -0.0261 -0.0241 0.0095  141 GLN A CG  
+1295 C  CD  . GLN A 141 ? 0.3129 0.2836 0.3264 -0.0477 -0.0288 0.0098  141 GLN A CD  
+1296 O  OE1 . GLN A 141 ? 0.3482 0.2962 0.3421 -0.0507 -0.0115 0.0385  141 GLN A OE1 
+1297 N  NE2 . GLN A 141 ? 0.3188 0.2803 0.3335 -0.0596 -0.0112 -0.0341 141 GLN A NE2 
+1298 N  N   . THR A 142 ? 0.2161 0.1502 0.2236 -0.0443 0.0146  -0.0356 142 THR A N   
+1299 C  CA  . THR A 142 ? 0.2218 0.1789 0.1985 -0.0357 0.0257  -0.0032 142 THR A CA  
+1300 C  C   . THR A 142 ? 0.1973 0.1889 0.2021 -0.0686 0.0123  0.0017  142 THR A C   
+1301 O  O   . THR A 142 ? 0.2056 0.1891 0.2051 -0.0601 0.0360  -0.0143 142 THR A O   
+1302 C  CB  . THR A 142 ? 0.2479 0.1965 0.1882 -0.1041 0.0156  -0.0181 142 THR A CB  
+1303 O  OG1 . THR A 142 ? 0.2554 0.2287 0.2022 -0.0689 0.0240  -0.0454 142 THR A OG1 
+1304 C  CG2 . THR A 142 ? 0.3112 0.2163 0.1890 -0.0771 -0.0354 -0.0536 142 THR A CG2 
+1305 N  N   . PRO A 143 ? 0.1995 0.1750 0.1997 -0.0599 0.0202  0.0085  143 PRO A N   
+1306 C  CA  . PRO A 143 ? 0.1975 0.1977 0.1817 -0.0385 0.0097  0.0042  143 PRO A CA  
+1307 C  C   . PRO A 143 ? 0.2086 0.1989 0.1937 -0.0305 0.0244  0.0333  143 PRO A C   
+1308 O  O   . PRO A 143 ? 0.2283 0.1777 0.2167 -0.0548 -0.0007 0.0166  143 PRO A O   
+1309 C  CB  . PRO A 143 ? 0.2343 0.1846 0.2021 -0.0569 0.0409  0.0162  143 PRO A CB  
+1310 C  CG  . PRO A 143 ? 0.2654 0.1915 0.2036 -0.0744 0.0536  0.0058  143 PRO A CG  
+1311 C  CD  . PRO A 143 ? 0.2157 0.1711 0.2219 -0.0709 0.0496  0.0175  143 PRO A CD  
+1312 N  N   . ASN A 144 ? 0.1792 0.1901 0.1996 -0.0211 0.0208  0.0265  144 ASN A N   
+1313 C  CA  . ASN A 144 ? 0.1749 0.2068 0.2327 -0.0585 0.0198  0.0288  144 ASN A CA  
+1314 C  C   . ASN A 144 ? 0.1965 0.2046 0.2031 -0.0595 0.0070  0.0196  144 ASN A C   
+1315 O  O   . ASN A 144 ? 0.2152 0.2073 0.2140 -0.0272 0.0017  0.0100  144 ASN A O   
+1316 C  CB  . ASN A 144 ? 0.1832 0.2427 0.2707 -0.0676 0.0364  0.0273  144 ASN A CB  
+1317 C  CG  . ASN A 144 ? 0.2485 0.3202 0.3185 -0.0555 0.0495  0.0134  144 ASN A CG  
+1318 O  OD1 . ASN A 144 ? 0.2897 0.4251 0.3643 -0.0518 0.1003  0.0233  144 ASN A OD1 
+1319 N  ND2 . ASN A 144 ? 0.3045 0.2909 0.3581 -0.0624 0.0445  0.0141  144 ASN A ND2 
+1320 N  N   . ARG A 145 ? 0.2003 0.2209 0.1631 -0.0470 0.0232  0.0041  145 ARG A N   
+1321 C  CA  . ARG A 145 ? 0.2297 0.2191 0.1724 -0.0791 0.0350  -0.0096 145 ARG A CA  
+1322 C  C   . ARG A 145 ? 0.2225 0.1563 0.1770 -0.0777 0.0122  -0.0038 145 ARG A C   
+1323 O  O   . ARG A 145 ? 0.2249 0.1530 0.1862 -0.0538 0.0060  0.0237  145 ARG A O   
+1324 C  CB  . ARG A 145 ? 0.2677 0.2444 0.1596 -0.0859 0.0780  0.0164  145 ARG A CB  
+1325 C  CG  . ARG A 145 ? 0.3141 0.2917 0.2011 -0.0702 0.0238  0.0236  145 ARG A CG  
+1326 C  CD  . ARG A 145 ? 0.3094 0.2878 0.1819 -0.0551 0.0065  0.0489  145 ARG A CD  
+1327 N  NE  . ARG A 145 ? 0.2755 0.2820 0.1554 -0.0619 0.0360  0.0374  145 ARG A NE  
+1328 C  CZ  . ARG A 145 ? 0.2182 0.2037 0.1852 -0.0874 0.0395  0.0160  145 ARG A CZ  
+1329 N  NH1 . ARG A 145 ? 0.2792 0.2212 0.2096 -0.0586 0.0123  0.0194  145 ARG A NH1 
+1330 N  NH2 . ARG A 145 ? 0.1891 0.1917 0.1658 -0.0444 0.0260  -0.0049 145 ARG A NH2 
+1331 N  N   . ALA A 146 ? 0.1892 0.1951 0.1653 -0.0532 0.0063  0.0043  146 ALA A N   
+1332 C  CA  . ALA A 146 ? 0.1659 0.1812 0.1964 -0.0307 -0.0158 0.0093  146 ALA A CA  
+1333 C  C   . ALA A 146 ? 0.1846 0.1633 0.1949 -0.0269 -0.0004 -0.0047 146 ALA A C   
+1334 O  O   . ALA A 146 ? 0.1991 0.1518 0.2328 -0.0370 -0.0144 -0.0030 146 ALA A O   
+1335 C  CB  . ALA A 146 ? 0.2002 0.1740 0.2300 0.0072  -0.0445 0.0051  146 ALA A CB  
+1336 N  N   . LYS A 147 ? 0.1710 0.1745 0.1810 -0.0188 0.0321  -0.0056 147 LYS A N   
+1337 C  CA  . LYS A 147 ? 0.2043 0.1778 0.1702 -0.0284 0.0443  0.0187  147 LYS A CA  
+1338 C  C   . LYS A 147 ? 0.1995 0.1716 0.1733 -0.0347 0.0198  0.0026  147 LYS A C   
+1339 O  O   . LYS A 147 ? 0.2284 0.1737 0.2010 -0.0311 -0.0087 -0.0108 147 LYS A O   
+1340 C  CB  . LYS A 147 ? 0.2508 0.2442 0.2067 -0.0433 0.0572  0.0427  147 LYS A CB  
+1341 C  CG  . LYS A 147 ? 0.2940 0.3298 0.2575 -0.0781 0.0543  0.0376  147 LYS A CG  
+1342 C  CD  . LYS A 147 ? 0.3389 0.4266 0.2980 -0.1073 0.0747  0.0823  147 LYS A CD  
+1343 C  CE  . LYS A 147 ? 0.3907 0.5123 0.3184 -0.0870 0.0916  0.0987  147 LYS A CE  
+1344 N  NZ  . LYS A 147 ? 0.4239 0.5451 0.3387 -0.1084 0.0845  0.0774  147 LYS A NZ  
+1345 N  N   . ARG A 148 ? 0.1688 0.2250 0.1658 -0.0373 0.0314  0.0019  148 ARG A N   
+1346 C  CA  . ARG A 148 ? 0.1744 0.1948 0.1659 -0.0299 0.0150  0.0115  148 ARG A CA  
+1347 C  C   . ARG A 148 ? 0.1900 0.1612 0.1825 -0.0047 0.0093  -0.0039 148 ARG A C   
+1348 O  O   . ARG A 148 ? 0.1888 0.1821 0.2032 0.0015  0.0165  0.0034  148 ARG A O   
+1349 C  CB  . ARG A 148 ? 0.1593 0.2474 0.1788 -0.0326 0.0059  -0.0293 148 ARG A CB  
+1350 C  CG  . ARG A 148 ? 0.1550 0.2865 0.1850 -0.0298 0.0069  -0.0124 148 ARG A CG  
+1351 C  CD  . ARG A 148 ? 0.1794 0.2814 0.1925 -0.0185 0.0265  -0.0224 148 ARG A CD  
+1352 N  NE  . ARG A 148 ? 0.2097 0.2769 0.2006 -0.0244 0.0082  -0.0114 148 ARG A NE  
+1353 C  CZ  . ARG A 148 ? 0.2147 0.3159 0.2165 -0.0330 0.0101  -0.0007 148 ARG A CZ  
+1354 N  NH1 . ARG A 148 ? 0.2130 0.3067 0.2393 -0.0728 0.0246  0.0297  148 ARG A NH1 
+1355 N  NH2 . ARG A 148 ? 0.2291 0.3170 0.2255 -0.0282 0.0072  -0.0309 148 ARG A NH2 
+1356 N  N   . VAL A 149 ? 0.1661 0.1575 0.1746 -0.0115 0.0207  -0.0033 149 VAL A N   
+1357 C  CA  . VAL A 149 ? 0.1740 0.1513 0.1756 -0.0252 0.0130  -0.0287 149 VAL A CA  
+1358 C  C   . VAL A 149 ? 0.1961 0.1264 0.1782 -0.0221 -0.0167 -0.0156 149 VAL A C   
+1359 O  O   . VAL A 149 ? 0.2100 0.1500 0.2019 -0.0257 -0.0053 -0.0005 149 VAL A O   
+1360 C  CB  . VAL A 149 ? 0.1688 0.1796 0.1802 -0.0110 0.0057  -0.0334 149 VAL A CB  
+1361 C  CG1 . VAL A 149 ? 0.1671 0.2050 0.2356 -0.0198 0.0272  -0.0109 149 VAL A CG1 
+1362 C  CG2 . VAL A 149 ? 0.2221 0.2009 0.1724 -0.0074 -0.0069 -0.0385 149 VAL A CG2 
+1363 N  N   . ILE A 150 ? 0.1887 0.1517 0.1717 -0.0235 -0.0242 0.0085  150 ILE A N   
+1364 C  CA  . ILE A 150 ? 0.2148 0.1523 0.1720 -0.0139 -0.0234 0.0216  150 ILE A CA  
+1365 C  C   . ILE A 150 ? 0.1918 0.1867 0.1867 -0.0473 0.0228  0.0186  150 ILE A C   
+1366 O  O   . ILE A 150 ? 0.2205 0.1981 0.2035 -0.0329 -0.0035 -0.0127 150 ILE A O   
+1367 C  CB  . ILE A 150 ? 0.2482 0.1610 0.1811 -0.0193 -0.0414 0.0171  150 ILE A CB  
+1368 C  CG1 . ILE A 150 ? 0.2412 0.1645 0.2192 -0.0286 -0.0144 0.0365  150 ILE A CG1 
+1369 C  CG2 . ILE A 150 ? 0.2637 0.2362 0.1839 -0.0368 -0.0633 -0.0060 150 ILE A CG2 
+1370 C  CD1 . ILE A 150 ? 0.2962 0.1795 0.2260 -0.0305 -0.0088 0.0388  150 ILE A CD1 
+1371 N  N   . THR A 151 ? 0.1931 0.1813 0.1841 -0.0248 0.0226  -0.0004 151 THR A N   
+1372 C  CA  . THR A 151 ? 0.2028 0.1754 0.1994 -0.0247 0.0190  -0.0151 151 THR A CA  
+1373 C  C   . THR A 151 ? 0.2186 0.1491 0.1937 -0.0262 -0.0088 -0.0174 151 THR A C   
+1374 O  O   . THR A 151 ? 0.2504 0.1564 0.2043 -0.0289 -0.0156 -0.0358 151 THR A O   
+1375 C  CB  . THR A 151 ? 0.2329 0.2068 0.2449 -0.0261 0.0532  -0.0309 151 THR A CB  
+1376 O  OG1 . THR A 151 ? 0.2938 0.2667 0.2572 -0.0484 0.0781  -0.0121 151 THR A OG1 
+1377 C  CG2 . THR A 151 ? 0.2712 0.2481 0.2791 0.0053  0.0414  -0.0741 151 THR A CG2 
+1378 N  N   . THR A 152 ? 0.1954 0.1893 0.1733 -0.0151 0.0042  -0.0039 152 THR A N   
+1379 C  CA  . THR A 152 ? 0.2050 0.1779 0.1763 -0.0347 -0.0156 -0.0038 152 THR A CA  
+1380 C  C   . THR A 152 ? 0.2066 0.1764 0.2031 -0.0192 -0.0330 0.0127  152 THR A C   
+1381 O  O   . THR A 152 ? 0.2209 0.1547 0.2346 -0.0173 -0.0170 0.0116  152 THR A O   
+1382 C  CB  . THR A 152 ? 0.2008 0.1779 0.1783 -0.0638 -0.0354 -0.0075 152 THR A CB  
+1383 O  OG1 . THR A 152 ? 0.2425 0.1923 0.1983 -0.0360 -0.0468 0.0076  152 THR A OG1 
+1384 C  CG2 . THR A 152 ? 0.2439 0.1713 0.1971 -0.0028 -0.0024 0.0237  152 THR A CG2 
+1385 N  N   . PHE A 153 ? 0.1988 0.1897 0.2080 -0.0126 -0.0111 0.0184  153 PHE A N   
+1386 C  CA  . PHE A 153 ? 0.2076 0.2016 0.2222 -0.0135 -0.0274 0.0188  153 PHE A CA  
+1387 C  C   . PHE A 153 ? 0.2281 0.1926 0.2415 -0.0466 -0.0346 0.0233  153 PHE A C   
+1388 O  O   . PHE A 153 ? 0.2502 0.2040 0.2697 -0.0477 -0.0422 -0.0015 153 PHE A O   
+1389 C  CB  . PHE A 153 ? 0.2242 0.1883 0.2038 0.0074  -0.0037 0.0171  153 PHE A CB  
+1390 C  CG  . PHE A 153 ? 0.2298 0.1972 0.1925 -0.0162 -0.0084 0.0429  153 PHE A CG  
+1391 C  CD1 . PHE A 153 ? 0.2531 0.2310 0.1842 -0.0154 -0.0078 0.0418  153 PHE A CD1 
+1392 C  CD2 . PHE A 153 ? 0.2212 0.2314 0.2226 -0.0305 -0.0023 0.0148  153 PHE A CD2 
+1393 C  CE1 . PHE A 153 ? 0.2642 0.2969 0.2014 -0.0020 -0.0213 0.0426  153 PHE A CE1 
+1394 C  CE2 . PHE A 153 ? 0.2526 0.2700 0.2266 0.0182  -0.0070 0.0105  153 PHE A CE2 
+1395 C  CZ  . PHE A 153 ? 0.2337 0.3095 0.2039 -0.0074 -0.0197 0.0342  153 PHE A CZ  
+1396 N  N   . ARG A 154 ? 0.2126 0.1855 0.1963 -0.0230 -0.0244 -0.0119 154 ARG A N   
+1397 C  CA  . ARG A 154 ? 0.2618 0.2162 0.2130 -0.0504 -0.0246 -0.0019 154 ARG A CA  
+1398 C  C   . ARG A 154 ? 0.2836 0.1876 0.2493 -0.0461 -0.0477 -0.0338 154 ARG A C   
+1399 O  O   . ARG A 154 ? 0.3091 0.1966 0.2768 -0.0225 -0.0658 -0.0394 154 ARG A O   
+1400 C  CB  . ARG A 154 ? 0.3113 0.2845 0.2178 -0.0733 -0.0384 -0.0150 154 ARG A CB  
+1401 C  CG  . ARG A 154 ? 0.3754 0.3576 0.2663 -0.0564 -0.0448 -0.0368 154 ARG A CG  
+1402 C  CD  . ARG A 154 ? 0.4604 0.4530 0.3181 -0.0448 -0.0136 -0.0022 154 ARG A CD  
+1403 N  NE  . ARG A 154 ? 0.5674 0.5823 0.3646 0.0448  0.0598  0.0517  154 ARG A NE  
+1404 C  CZ  . ARG A 154 ? 0.6514 0.7088 0.4058 0.1498  0.0780  0.0628  154 ARG A CZ  
+1405 N  NH1 . ARG A 154 ? 0.6878 0.7585 0.4220 0.1869  0.1086  0.0549  154 ARG A NH1 
+1406 N  NH2 . ARG A 154 ? 0.6615 0.7323 0.4322 0.1269  0.0673  0.0786  154 ARG A NH2 
+1407 N  N   . THR A 155 ? 0.2855 0.1898 0.2195 0.0092  -0.0528 -0.0335 155 THR A N   
+1408 C  CA  . THR A 155 ? 0.3119 0.2082 0.2388 0.0318  -0.0252 -0.0289 155 THR A CA  
+1409 C  C   . THR A 155 ? 0.2918 0.1738 0.2635 -0.0109 -0.0262 -0.0412 155 THR A C   
+1410 O  O   . THR A 155 ? 0.3251 0.1926 0.2815 0.0086  -0.0338 -0.0545 155 THR A O   
+1411 C  CB  . THR A 155 ? 0.3152 0.2459 0.2403 0.0173  -0.0095 -0.0217 155 THR A CB  
+1412 O  OG1 . THR A 155 ? 0.3025 0.2280 0.2448 0.0043  -0.0157 -0.0341 155 THR A OG1 
+1413 C  CG2 . THR A 155 ? 0.3525 0.3053 0.2510 0.0255  0.0402  -0.0003 155 THR A CG2 
+1414 N  N   . GLY A 156 ? 0.2564 0.1758 0.2617 -0.0087 -0.0267 -0.0114 156 GLY A N   
+1415 C  CA  . GLY A 156 ? 0.2095 0.1899 0.2595 -0.0032 -0.0079 -0.0011 156 GLY A CA  
+1416 C  C   . GLY A 156 ? 0.2294 0.1931 0.2513 -0.0082 -0.0091 -0.0184 156 GLY A C   
+1417 O  O   . GLY A 156 ? 0.2679 0.2171 0.2721 0.0131  -0.0114 -0.0278 156 GLY A O   
+1418 N  N   . THR A 157 ? 0.2294 0.2187 0.2337 -0.0145 -0.0067 -0.0346 157 THR A N   
+1419 C  CA  . THR A 157 ? 0.2162 0.2603 0.2490 0.0087  -0.0027 -0.0373 157 THR A CA  
+1420 C  C   . THR A 157 ? 0.2041 0.2184 0.2370 -0.0059 -0.0049 -0.0304 157 THR A C   
+1421 O  O   . THR A 157 ? 0.2548 0.2172 0.2509 0.0209  -0.0194 -0.0347 157 THR A O   
+1422 C  CB  . THR A 157 ? 0.2551 0.3262 0.2647 0.0363  0.0045  -0.0729 157 THR A CB  
+1423 O  OG1 . THR A 157 ? 0.2983 0.3543 0.2477 0.0417  0.0097  -0.0445 157 THR A OG1 
+1424 C  CG2 . THR A 157 ? 0.2865 0.3690 0.2906 0.0638  -0.0155 -0.1004 157 THR A CG2 
+1425 N  N   . TRP A 158 ? 0.1913 0.2565 0.2371 -0.0218 -0.0093 -0.0313 158 TRP A N   
+1426 C  CA  . TRP A 158 ? 0.2345 0.2654 0.2538 -0.0011 -0.0409 -0.0271 158 TRP A CA  
+1427 C  C   . TRP A 158 ? 0.2380 0.2823 0.2798 0.0121  -0.0130 -0.0395 158 TRP A C   
+1428 O  O   . TRP A 158 ? 0.2218 0.3114 0.2878 0.0096  -0.0195 -0.0439 158 TRP A O   
+1429 C  CB  . TRP A 158 ? 0.2796 0.2678 0.2657 0.0262  -0.0436 -0.0243 158 TRP A CB  
+1430 C  CG  . TRP A 158 ? 0.3117 0.2505 0.2544 0.0285  -0.0334 -0.0428 158 TRP A CG  
+1431 C  CD1 . TRP A 158 ? 0.3307 0.2694 0.2687 0.0473  -0.0290 -0.0397 158 TRP A CD1 
+1432 C  CD2 . TRP A 158 ? 0.2793 0.2297 0.2691 0.0005  -0.0044 -0.0381 158 TRP A CD2 
+1433 N  NE1 . TRP A 158 ? 0.3356 0.2471 0.2854 0.0111  -0.0238 -0.0330 158 TRP A NE1 
+1434 C  CE2 . TRP A 158 ? 0.2990 0.2649 0.2771 0.0051  -0.0076 -0.0331 158 TRP A CE2 
+1435 C  CE3 . TRP A 158 ? 0.2922 0.2570 0.2798 0.0191  0.0016  -0.0488 158 TRP A CE3 
+1436 C  CZ2 . TRP A 158 ? 0.3165 0.2932 0.2996 0.0637  -0.0117 -0.0405 158 TRP A CZ2 
+1437 C  CZ3 . TRP A 158 ? 0.3020 0.2700 0.2940 0.0364  0.0037  -0.0462 158 TRP A CZ3 
+1438 C  CH2 . TRP A 158 ? 0.3041 0.3165 0.3015 0.0423  -0.0073 -0.0428 158 TRP A CH2 
+1439 N  N   . ASP A 159 ? 0.2388 0.2847 0.2983 -0.0233 0.0365  -0.0558 159 ASP A N   
+1440 C  CA  . ASP A 159 ? 0.2625 0.3038 0.3322 -0.0359 0.0652  -0.0638 159 ASP A CA  
+1441 C  C   . ASP A 159 ? 0.2319 0.2869 0.3272 -0.0180 0.0718  -0.0505 159 ASP A C   
+1442 O  O   . ASP A 159 ? 0.2385 0.3281 0.3592 -0.0029 0.0845  -0.0670 159 ASP A O   
+1443 C  CB  . ASP A 159 ? 0.3649 0.3412 0.3716 -0.0178 0.0452  -0.1174 159 ASP A CB  
+1444 C  CG  . ASP A 159 ? 0.4635 0.4053 0.4272 0.0158  0.0454  -0.1343 159 ASP A CG  
+1445 O  OD1 . ASP A 159 ? 0.5135 0.4306 0.4746 0.0670  0.0491  -0.1010 159 ASP A OD1 
+1446 O  OD2 . ASP A 159 ? 0.5373 0.4932 0.4673 0.0730  0.0456  -0.1727 159 ASP A OD2 
+1447 N  N   . ALA A 160 ? 0.2526 0.2400 0.3031 -0.0062 0.0361  -0.0640 160 ALA A N   
+1448 C  CA  . ALA A 160 ? 0.2441 0.2710 0.3061 -0.0223 0.0036  -0.0542 160 ALA A CA  
+1449 C  C   . ALA A 160 ? 0.2580 0.2720 0.3483 -0.0444 -0.0095 -0.0554 160 ALA A C   
+1450 O  O   . ALA A 160 ? 0.3241 0.2887 0.3729 -0.0539 -0.0326 -0.0549 160 ALA A O   
+1451 C  CB  . ALA A 160 ? 0.2475 0.3097 0.2936 0.0461  -0.0074 -0.0237 160 ALA A CB  
+1452 N  N   . TYR A 161 ? 0.2160 0.2671 0.3263 0.0020  0.0009  -0.0602 161 TYR A N   
+1453 C  CA  . TYR A 161 ? 0.2238 0.2709 0.3514 0.0285  -0.0177 -0.0443 161 TYR A CA  
+1454 C  C   . TYR A 161 ? 0.2826 0.3569 0.4396 0.0908  -0.0411 -0.0905 161 TYR A C   
+1455 O  O   . TYR A 161 ? 0.3053 0.4033 0.4726 0.0803  -0.0834 -0.1197 161 TYR A O   
+1456 C  CB  . TYR A 161 ? 0.2405 0.2550 0.2887 0.0467  -0.0183 -0.0330 161 TYR A CB  
+1457 C  CG  . TYR A 161 ? 0.2192 0.2314 0.2268 0.0099  -0.0288 -0.0212 161 TYR A CG  
+1458 C  CD1 . TYR A 161 ? 0.2095 0.2541 0.2223 -0.0077 -0.0178 -0.0114 161 TYR A CD1 
+1459 C  CD2 . TYR A 161 ? 0.2468 0.2392 0.2109 0.0050  -0.0129 -0.0069 161 TYR A CD2 
+1460 C  CE1 . TYR A 161 ? 0.2088 0.2304 0.1946 -0.0112 0.0016  -0.0370 161 TYR A CE1 
+1461 C  CE2 . TYR A 161 ? 0.2198 0.2303 0.2038 -0.0209 -0.0150 0.0009  161 TYR A CE2 
+1462 C  CZ  . TYR A 161 ? 0.2093 0.2296 0.1959 -0.0201 -0.0021 -0.0064 161 TYR A CZ  
+1463 O  OH  . TYR A 161 ? 0.2150 0.2574 0.1941 -0.0222 0.0045  -0.0167 161 TYR A OH  
+1464 N  N   . LYS A 162 ? 0.3475 0.3939 0.5010 0.1641  0.0080  -0.0687 162 LYS A N   
+1465 C  CA  . LYS A 162 ? 0.4278 0.4799 0.5709 0.2145  0.0403  -0.0518 162 LYS A CA  
+1466 C  C   . LYS A 162 ? 0.4601 0.4838 0.6041 0.2064  0.0694  -0.0566 162 LYS A C   
+1467 O  O   . LYS A 162 ? 0.4417 0.5247 0.6210 0.1750  0.0654  -0.0640 162 LYS A O   
+1468 C  CB  . LYS A 162 ? 0.5479 0.5249 0.6076 0.2407  0.0386  -0.0282 162 LYS A CB  
+1469 C  CG  . LYS A 162 ? 0.6332 0.6224 0.6414 0.2582  0.0353  -0.0107 162 LYS A CG  
+1470 C  CD  . LYS A 162 ? 0.7155 0.7078 0.6687 0.2659  0.0394  0.0232  162 LYS A CD  
+1471 C  CE  . LYS A 162 ? 0.7651 0.7658 0.6847 0.2548  0.0441  0.0410  162 LYS A CE  
+1472 N  NZ  . LYS A 162 ? 0.7903 0.8029 0.6923 0.2490  0.0507  0.0409  162 LYS A NZ  
+1473 C  C   . TRS B .   ? 0.2752 0.2514 0.2246 -0.0476 -0.0027 -0.0417 201 TRS A C   
+1474 C  C1  . TRS B .   ? 0.3032 0.2955 0.2638 -0.0538 -0.0071 -0.0096 201 TRS A C1  
+1475 C  C2  . TRS B .   ? 0.2515 0.2673 0.2071 -0.0166 0.0085  -0.0288 201 TRS A C2  
+1476 C  C3  . TRS B .   ? 0.3141 0.3076 0.2828 0.0135  -0.0148 -0.0527 201 TRS A C3  
+1477 N  N   . TRS B .   ? 0.2859 0.2707 0.1936 -0.0098 0.0246  -0.0665 201 TRS A N   
+1478 O  O1  . TRS B .   ? 0.2724 0.2947 0.2688 -0.0403 -0.0116 -0.0319 201 TRS A O1  
+1479 O  O2  . TRS B .   ? 0.2526 0.3036 0.1966 0.0071  -0.0179 -0.0286 201 TRS A O2  
+1480 O  O3  . TRS B .   ? 0.3652 0.3749 0.3294 0.0848  -0.0244 -0.0455 201 TRS A O3  
+1481 CL CL  . CL  C .   ? 0.2866 0.2870 0.2719 -0.0384 -0.0202 -0.0388 202 CL  A CL  
+1482 C  C   A MBN D .   ? 0.3177 0.4304 0.3821 0.0992  -0.0133 0.0247  203 MBN A C   
+1483 C  C   C MBN D .   ? 0.3310 0.2788 0.3316 -0.0083 -0.0893 0.0268  203 MBN A C   
+1484 C  C1  A MBN D .   ? 0.3102 0.4074 0.3831 0.0771  -0.0374 0.0048  203 MBN A C1  
+1485 C  C1  C MBN D .   ? 0.3220 0.2847 0.3224 -0.0155 -0.0871 0.0354  203 MBN A C1  
+1486 C  C2  A MBN D .   ? 0.3059 0.4057 0.3837 0.0582  -0.0551 -0.0111 203 MBN A C2  
+1487 C  C2  C MBN D .   ? 0.2990 0.2617 0.3073 -0.0509 -0.1048 0.0219  203 MBN A C2  
+1488 C  C3  A MBN D .   ? 0.3114 0.3947 0.3899 0.0510  -0.0490 -0.0100 203 MBN A C3  
+1489 C  C3  C MBN D .   ? 0.2839 0.2796 0.3047 -0.0743 -0.1186 0.0096  203 MBN A C3  
+1490 C  C4  A MBN D .   ? 0.3136 0.3870 0.3973 0.0671  -0.0298 -0.0182 203 MBN A C4  
+1491 C  C4  C MBN D .   ? 0.2892 0.2698 0.3093 -0.0733 -0.1094 0.0174  203 MBN A C4  
+1492 C  C5  A MBN D .   ? 0.3170 0.4003 0.3968 0.0738  -0.0266 -0.0129 203 MBN A C5  
+1493 C  C5  C MBN D .   ? 0.2991 0.2637 0.3177 -0.0550 -0.0966 0.0088  203 MBN A C5  
+1494 C  C6  A MBN D .   ? 0.3096 0.3938 0.3885 0.0708  -0.0337 -0.0078 203 MBN A C6  
+1495 C  C6  C MBN D .   ? 0.3228 0.2873 0.3237 -0.0156 -0.0820 0.0330  203 MBN A C6  
+1496 C  C1  . BME E .   ? 0.5545 0.6597 0.3324 0.1812  0.1122  0.1301  204 BME A C1  
+1497 C  C2  . BME E .   ? 0.5409 0.7172 0.3746 0.1712  0.0957  0.0944  204 BME A C2  
+1498 O  O1  . BME E .   ? 0.5947 0.6192 0.3111 0.1908  0.1033  0.1598  204 BME A O1  
+1499 S  S2  . BME E .   ? 0.5511 0.8240 0.4289 0.2089  0.0568  0.0437  204 BME A S2  
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   MET 1   1   1   MET MET A . n 
+A 1 2   ASN 2   2   2   ASN ASN A . n 
+A 1 3   ILE 3   3   3   ILE ILE A . n 
+A 1 4   PHE 4   4   4   PHE PHE A . n 
+A 1 5   GLU 5   5   5   GLU GLU A . n 
+A 1 6   MET 6   6   6   MET MET A . n 
+A 1 7   LEU 7   7   7   LEU LEU A . n 
+A 1 8   ARG 8   8   8   ARG ARG A . n 
+A 1 9   ILE 9   9   9   ILE ILE A . n 
+A 1 10  ASP 10  10  10  ASP ASP A . n 
+A 1 11  GLU 11  11  11  GLU GLU A . n 
+A 1 12  GLY 12  12  12  GLY GLY A . n 
+A 1 13  LEU 13  13  13  LEU LEU A . n 
+A 1 14  ARG 14  14  14  ARG ARG A . n 
+A 1 15  LEU 15  15  15  LEU LEU A . n 
+A 1 16  LYS 16  16  16  LYS LYS A . n 
+A 1 17  ILE 17  17  17  ILE ILE A . n 
+A 1 18  TYR 18  18  18  TYR TYR A . n 
+A 1 19  LYS 19  19  19  LYS LYS A . n 
+A 1 20  ASP 20  20  20  ASP ASP A . n 
+A 1 21  THR 21  21  21  THR THR A . n 
+A 1 22  GLU 22  22  22  GLU GLU A . n 
+A 1 23  GLY 23  23  23  GLY GLY A . n 
+A 1 24  TYR 24  24  24  TYR TYR A . n 
+A 1 25  TYR 25  25  25  TYR TYR A . n 
+A 1 26  THR 26  26  26  THR THR A . n 
+A 1 27  ILE 27  27  27  ILE ILE A . n 
+A 1 28  GLY 28  28  28  GLY GLY A . n 
+A 1 29  ILE 29  29  29  ILE ILE A . n 
+A 1 30  GLY 30  30  30  GLY GLY A . n 
+A 1 31  HIS 31  31  31  HIS HIS A . n 
+A 1 32  LEU 32  32  32  LEU LEU A . n 
+A 1 33  LEU 33  33  33  LEU LEU A . n 
+A 1 34  THR 34  34  34  THR THR A . n 
+A 1 35  LYS 35  35  35  LYS LYS A . n 
+A 1 36  SER 36  36  36  SER SER A . n 
+A 1 37  PRO 37  37  37  PRO PRO A . n 
+A 1 38  SER 38  38  38  SER SER A . n 
+A 1 39  LEU 39  39  39  LEU LEU A . n 
+A 1 40  ASN 40  40  40  ASN ASN A . n 
+A 1 41  ALA 41  41  41  ALA ALA A . n 
+A 1 42  ALA 42  42  42  ALA ALA A . n 
+A 1 43  LYS 43  43  43  LYS LYS A . n 
+A 1 44  SER 44  44  44  SER SER A . n 
+A 1 45  GLU 45  45  45  GLU GLU A . n 
+A 1 46  LEU 46  46  46  LEU LEU A . n 
+A 1 47  ASP 47  47  47  ASP ASP A . n 
+A 1 48  LYS 48  48  48  LYS LYS A . n 
+A 1 49  ALA 49  49  49  ALA ALA A . n 
+A 1 50  ILE 50  50  50  ILE ILE A . n 
+A 1 51  GLY 51  51  51  GLY GLY A . n 
+A 1 52  ARG 52  52  52  ARG ARG A . n 
+A 1 53  ASN 53  53  53  ASN ASN A . n 
+A 1 54  CYS 54  54  54  CYS CYS A . n 
+A 1 55  ASN 55  55  55  ASN ASN A . n 
+A 1 56  GLY 56  56  56  GLY GLY A . n 
+A 1 57  VAL 57  57  57  VAL VAL A . n 
+A 1 58  ILE 58  58  58  ILE ILE A . n 
+A 1 59  THR 59  59  59  THR THR A . n 
+A 1 60  LYS 60  60  60  LYS LYS A . n 
+A 1 61  ASP 61  61  61  ASP ASP A . n 
+A 1 62  GLU 62  62  62  GLU GLU A . n 
+A 1 63  ALA 63  63  63  ALA ALA A . n 
+A 1 64  GLU 64  64  64  GLU GLU A . n 
+A 1 65  LYS 65  65  65  LYS LYS A . n 
+A 1 66  LEU 66  66  66  LEU LEU A . n 
+A 1 67  PHE 67  67  67  PHE PHE A . n 
+A 1 68  ASN 68  68  68  ASN ASN A . n 
+A 1 69  GLN 69  69  69  GLN GLN A . n 
+A 1 70  ASP 70  70  70  ASP ASP A . n 
+A 1 71  VAL 71  71  71  VAL VAL A . n 
+A 1 72  ASP 72  72  72  ASP ASP A . n 
+A 1 73  ALA 73  73  73  ALA ALA A . n 
+A 1 74  ALA 74  74  74  ALA ALA A . n 
+A 1 75  VAL 75  75  75  VAL VAL A . n 
+A 1 76  ARG 76  76  76  ARG ARG A . n 
+A 1 77  GLY 77  77  77  GLY GLY A . n 
+A 1 78  ILE 78  78  78  ILE ILE A . n 
+A 1 79  LEU 79  79  79  LEU LEU A . n 
+A 1 80  ARG 80  80  80  ARG ARG A . n 
+A 1 81  ASN 81  81  81  ASN ASN A . n 
+A 1 82  ALA 82  82  82  ALA ALA A . n 
+A 1 83  LYS 83  83  83  LYS LYS A . n 
+A 1 84  LEU 84  84  84  LEU LEU A . n 
+A 1 85  LYS 85  85  85  LYS LYS A . n 
+A 1 86  PRO 86  86  86  PRO PRO A . n 
+A 1 87  VAL 87  87  87  VAL VAL A . n 
+A 1 88  TYR 88  88  88  TYR TYR A . n 
+A 1 89  ASP 89  89  89  ASP ASP A . n 
+A 1 90  SER 90  90  90  SER SER A . n 
+A 1 91  LEU 91  91  91  LEU LEU A . n 
+A 1 92  ASP 92  92  92  ASP ASP A . n 
+A 1 93  ALA 93  93  93  ALA ALA A . n 
+A 1 94  VAL 94  94  94  VAL VAL A . n 
+A 1 95  ARG 95  95  95  ARG ARG A . n 
+A 1 96  ARG 96  96  96  ARG ARG A . n 
+A 1 97  CYS 97  97  97  CYS CYS A . n 
+A 1 98  ALA 98  98  98  ALA ALA A . n 
+A 1 99  ALA 99  99  99  ALA ALA A . n 
+A 1 100 ILE 100 100 100 ILE ILE A . n 
+A 1 101 ASN 101 101 101 ASN ASN A . n 
+A 1 102 MET 102 102 102 MET MET A . n 
+A 1 103 VAL 103 103 103 VAL VAL A . n 
+A 1 104 PHE 104 104 104 PHE PHE A . n 
+A 1 105 GLN 105 105 105 GLN GLN A . n 
+A 1 106 MET 106 106 106 MET MET A . n 
+A 1 107 GLY 107 107 107 GLY GLY A . n 
+A 1 108 GLU 108 108 108 GLU GLU A . n 
+A 1 109 THR 109 109 109 THR THR A . n 
+A 1 110 GLY 110 110 110 GLY GLY A . n 
+A 1 111 VAL 111 111 111 VAL VAL A . n 
+A 1 112 ALA 112 112 112 ALA ALA A . n 
+A 1 113 GLY 113 113 113 GLY GLY A . n 
+A 1 114 PHE 114 114 114 PHE PHE A . n 
+A 1 115 THR 115 115 115 THR THR A . n 
+A 1 116 ASN 116 116 116 ASN ASN A . n 
+A 1 117 SER 117 117 117 SER SER A . n 
+A 1 118 LEU 118 118 118 LEU LEU A . n 
+A 1 119 ARG 119 119 119 ARG ARG A . n 
+A 1 120 MET 120 120 120 MET MET A . n 
+A 1 121 LEU 121 121 121 LEU LEU A . n 
+A 1 122 GLN 122 122 122 GLN GLN A . n 
+A 1 123 GLN 123 123 123 GLN GLN A . n 
+A 1 124 LYS 124 124 124 LYS LYS A . n 
+A 1 125 ARG 125 125 125 ARG ARG A . n 
+A 1 126 TRP 126 126 126 TRP TRP A . n 
+A 1 127 ASP 127 127 127 ASP ASP A . n 
+A 1 128 GLU 128 128 128 GLU GLU A . n 
+A 1 129 ALA 129 129 129 ALA ALA A . n 
+A 1 130 ALA 130 130 130 ALA ALA A . n 
+A 1 131 VAL 131 131 131 VAL VAL A . n 
+A 1 132 ASN 132 132 132 ASN ASN A . n 
+A 1 133 LEU 133 133 133 LEU LEU A . n 
+A 1 134 ALA 134 134 134 ALA ALA A . n 
+A 1 135 LYS 135 135 135 LYS LYS A . n 
+A 1 136 SER 136 136 136 SER SER A . n 
+A 1 137 ARG 137 137 137 ARG ARG A . n 
+A 1 138 TRP 138 138 138 TRP TRP A . n 
+A 1 139 TYR 139 139 139 TYR TYR A . n 
+A 1 140 ASN 140 140 140 ASN ASN A . n 
+A 1 141 GLN 141 141 141 GLN GLN A . n 
+A 1 142 THR 142 142 142 THR THR A . n 
+A 1 143 PRO 143 143 143 PRO PRO A . n 
+A 1 144 ASN 144 144 144 ASN ASN A . n 
+A 1 145 ARG 145 145 145 ARG ARG A . n 
+A 1 146 ALA 146 146 146 ALA ALA A . n 
+A 1 147 LYS 147 147 147 LYS LYS A . n 
+A 1 148 ARG 148 148 148 ARG ARG A . n 
+A 1 149 VAL 149 149 149 VAL VAL A . n 
+A 1 150 ILE 150 150 150 ILE ILE A . n 
+A 1 151 THR 151 151 151 THR THR A . n 
+A 1 152 THR 152 152 152 THR THR A . n 
+A 1 153 PHE 153 153 153 PHE PHE A . n 
+A 1 154 ARG 154 154 154 ARG ARG A . n 
+A 1 155 THR 155 155 155 THR THR A . n 
+A 1 156 GLY 156 156 156 GLY GLY A . n 
+A 1 157 THR 157 157 157 THR THR A . n 
+A 1 158 TRP 158 158 158 TRP TRP A . n 
+A 1 159 ASP 159 159 159 ASP ASP A . n 
+A 1 160 ALA 160 160 160 ALA ALA A . n 
+A 1 161 TYR 161 161 161 TYR TYR A . n 
+A 1 162 LYS 162 162 162 LYS LYS A . n 
+A 1 163 ASN 163 163 ?   ?   ?   A . n 
+A 1 164 LEU 164 164 ?   ?   ?   A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 TRS 1  201 1  TRS TRS A . 
+C 3 CL  1  202 1  CL  CL  A . 
+D 4 MBN 1  203 1  MBN MBN A . 
+E 5 BME 1  204 1  BME BME A . 
+F 6 HOH 1  301 45 HOH HOH A . 
+F 6 HOH 2  302 60 HOH HOH A . 
+F 6 HOH 3  303 34 HOH HOH A . 
+F 6 HOH 4  304 38 HOH HOH A . 
+F 6 HOH 5  305 84 HOH HOH A . 
+F 6 HOH 6  306 76 HOH HOH A . 
+F 6 HOH 7  307 39 HOH HOH A . 
+F 6 HOH 8  308 77 HOH HOH A . 
+F 6 HOH 9  309 59 HOH HOH A . 
+F 6 HOH 10 310 78 HOH HOH A . 
+F 6 HOH 11 311 32 HOH HOH A . 
+F 6 HOH 12 312 16 HOH HOH A . 
+F 6 HOH 13 313 83 HOH HOH A . 
+F 6 HOH 14 314 11 HOH HOH A . 
+F 6 HOH 15 315 58 HOH HOH A . 
+F 6 HOH 16 316 20 HOH HOH A . 
+F 6 HOH 17 317 18 HOH HOH A . 
+F 6 HOH 18 318 23 HOH HOH A . 
+F 6 HOH 19 319 43 HOH HOH A . 
+F 6 HOH 20 320 8  HOH HOH A . 
+F 6 HOH 21 321 9  HOH HOH A . 
+F 6 HOH 22 322 35 HOH HOH A . 
+F 6 HOH 23 323 41 HOH HOH A . 
+F 6 HOH 24 324 2  HOH HOH A . 
+F 6 HOH 25 325 27 HOH HOH A . 
+F 6 HOH 26 326 64 HOH HOH A . 
+F 6 HOH 27 327 93 HOH HOH A . 
+F 6 HOH 28 328 6  HOH HOH A . 
+F 6 HOH 29 329 31 HOH HOH A . 
+F 6 HOH 30 330 62 HOH HOH A . 
+F 6 HOH 31 331 24 HOH HOH A . 
+F 6 HOH 32 332 13 HOH HOH A . 
+F 6 HOH 33 333 86 HOH HOH A . 
+F 6 HOH 34 334 82 HOH HOH A . 
+F 6 HOH 35 335 7  HOH HOH A . 
+F 6 HOH 36 336 4  HOH HOH A . 
+F 6 HOH 37 337 5  HOH HOH A . 
+F 6 HOH 38 338 30 HOH HOH A . 
+F 6 HOH 39 339 53 HOH HOH A . 
+F 6 HOH 40 340 36 HOH HOH A . 
+F 6 HOH 41 341 19 HOH HOH A . 
+F 6 HOH 42 342 40 HOH HOH A . 
+F 6 HOH 43 343 3  HOH HOH A . 
+F 6 HOH 44 344 90 HOH HOH A . 
+F 6 HOH 45 345 29 HOH HOH A . 
+F 6 HOH 46 346 26 HOH HOH A . 
+F 6 HOH 47 347 21 HOH HOH A . 
+F 6 HOH 48 348 50 HOH HOH A . 
+F 6 HOH 49 349 51 HOH HOH A . 
+F 6 HOH 50 350 42 HOH HOH A . 
+F 6 HOH 51 351 25 HOH HOH A . 
+F 6 HOH 52 352 14 HOH HOH A . 
+F 6 HOH 53 353 44 HOH HOH A . 
+F 6 HOH 54 354 28 HOH HOH A . 
+F 6 HOH 55 355 74 HOH HOH A . 
+F 6 HOH 56 356 92 HOH HOH A . 
+F 6 HOH 57 357 52 HOH HOH A . 
+F 6 HOH 58 358 79 HOH HOH A . 
+F 6 HOH 59 359 69 HOH HOH A . 
+F 6 HOH 60 360 12 HOH HOH A . 
+F 6 HOH 61 361 57 HOH HOH A . 
+F 6 HOH 62 362 15 HOH HOH A . 
+F 6 HOH 63 363 87 HOH HOH A . 
+F 6 HOH 64 364 17 HOH HOH A . 
+F 6 HOH 65 365 46 HOH HOH A . 
+F 6 HOH 66 366 10 HOH HOH A . 
+F 6 HOH 67 367 37 HOH HOH A . 
+F 6 HOH 68 368 85 HOH HOH A . 
+F 6 HOH 69 369 80 HOH HOH A . 
+F 6 HOH 70 370 55 HOH HOH A . 
+F 6 HOH 71 371 71 HOH HOH A . 
+F 6 HOH 72 372 48 HOH HOH A . 
+F 6 HOH 73 373 33 HOH HOH A . 
+F 6 HOH 74 374 54 HOH HOH A . 
+F 6 HOH 75 375 66 HOH HOH A . 
+F 6 HOH 76 376 68 HOH HOH A . 
+F 6 HOH 77 377 61 HOH HOH A . 
+F 6 HOH 78 378 22 HOH HOH A . 
+F 6 HOH 79 379 75 HOH HOH A . 
+F 6 HOH 80 380 88 HOH HOH A . 
+F 6 HOH 81 381 67 HOH HOH A . 
+F 6 HOH 82 382 81 HOH HOH A . 
+F 6 HOH 83 383 56 HOH HOH A . 
+F 6 HOH 84 384 70 HOH HOH A . 
+F 6 HOH 85 385 73 HOH HOH A . 
+F 6 HOH 86 386 89 HOH HOH A . 
+F 6 HOH 87 387 91 HOH HOH A . 
+F 6 HOH 88 388 47 HOH HOH A . 
+F 6 HOH 89 389 72 HOH HOH A . 
+F 6 HOH 90 390 63 HOH HOH A . 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D,E,F 
+# 
+loop_
+_pdbx_struct_assembly_prop.biol_id 
+_pdbx_struct_assembly_prop.type 
+_pdbx_struct_assembly_prop.value 
+_pdbx_struct_assembly_prop.details 
+1 'ABSA (A^2)' 940  ? 
+1 MORE         -3   ? 
+1 'SSA (A^2)'  8710 ? 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+_pdbx_struct_special_symmetry.id              1 
+_pdbx_struct_special_symmetry.PDB_model_num   1 
+_pdbx_struct_special_symmetry.auth_asym_id    A 
+_pdbx_struct_special_symmetry.auth_comp_id    HOH 
+_pdbx_struct_special_symmetry.auth_seq_id     305 
+_pdbx_struct_special_symmetry.PDB_ins_code    ? 
+_pdbx_struct_special_symmetry.label_asym_id   F 
+_pdbx_struct_special_symmetry.label_comp_id   HOH 
+_pdbx_struct_special_symmetry.label_seq_id    . 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 2021-10-27 
+2 'Structure model' 1 1 2023-10-18 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+_pdbx_audit_revision_details.details             ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Data collection'        
+2 2 'Structure model' 'Refinement description' 
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1 2 'Structure model' chem_comp_atom                
+2 2 'Structure model' chem_comp_bond                
+3 2 'Structure model' pdbx_initial_refinement_model 
+# 
+_pdbx_phasing_MR.entry_id                     7L39 
+_pdbx_phasing_MR.method_rotation              ? 
+_pdbx_phasing_MR.method_translation           ? 
+_pdbx_phasing_MR.model_details                ? 
+_pdbx_phasing_MR.R_factor                     ? 
+_pdbx_phasing_MR.R_rigid_body                 ? 
+_pdbx_phasing_MR.correlation_coeff_Fo_to_Fc   ? 
+_pdbx_phasing_MR.correlation_coeff_Io_to_Ic   ? 
+_pdbx_phasing_MR.d_res_high_rotation          5.130 
+_pdbx_phasing_MR.d_res_low_rotation           46.520 
+_pdbx_phasing_MR.d_res_high_translation       5.130 
+_pdbx_phasing_MR.d_res_low_translation        46.520 
+_pdbx_phasing_MR.packing                      ? 
+_pdbx_phasing_MR.reflns_percent_rotation      ? 
+_pdbx_phasing_MR.reflns_percent_translation   ? 
+_pdbx_phasing_MR.sigma_F_rotation             ? 
+_pdbx_phasing_MR.sigma_F_translation          ? 
+_pdbx_phasing_MR.sigma_I_rotation             ? 
+_pdbx_phasing_MR.sigma_I_translation          ? 
+# 
+_phasing.method   MR 
+# 
+loop_
+_software.citation_id 
+_software.classification 
+_software.compiler_name 
+_software.compiler_version 
+_software.contact_author 
+_software.contact_author_email 
+_software.date 
+_software.description 
+_software.dependencies 
+_software.hardware 
+_software.language 
+_software.location 
+_software.mods 
+_software.name 
+_software.os 
+_software.os_version 
+_software.type 
+_software.version 
+_software.pdbx_ordinal 
+? 'data scaling'    ? ? ? ? ? ? ? ? ? ? ? xia2        ? ? ? .         1 
+? phasing           ? ? ? ? ? ? ? ? ? ? ? PHASER      ? ? ? 2.8.2     2 
+? refinement        ? ? ? ? ? ? ? ? ? ? ? PHENIX      ? ? ? 1.14_3260 3 
+? 'data extraction' ? ? ? ? ? ? ? ? ? ? ? PDB_EXTRACT ? ? ? 3.27      4 
+? 'data reduction'  ? ? ? ? ? ? ? ? ? ? ? xia2        ? ? ? .         5 
+# 
+_pdbx_entry_details.entry_id                 7L39 
+_pdbx_entry_details.has_ligand_of_interest   Y 
+_pdbx_entry_details.compound_details         ? 
+_pdbx_entry_details.source_details           ? 
+_pdbx_entry_details.nonpolymer_details       ? 
+_pdbx_entry_details.sequence_details         ? 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_residues.label_asym_id 
+_pdbx_unobs_or_zero_occ_residues.label_comp_id 
+_pdbx_unobs_or_zero_occ_residues.label_seq_id 
+1 1 Y 1 A ASN 163 ? A ASN 163 
+2 1 Y 1 A LEU 164 ? A LEU 164 
+# 
+loop_
+_chem_comp_atom.comp_id 
+_chem_comp_atom.atom_id 
+_chem_comp_atom.type_symbol 
+_chem_comp_atom.pdbx_aromatic_flag 
+_chem_comp_atom.pdbx_stereo_config 
+_chem_comp_atom.pdbx_ordinal 
+ALA N    N  N N 1   
+ALA CA   C  N S 2   
+ALA C    C  N N 3   
+ALA O    O  N N 4   
+ALA CB   C  N N 5   
+ALA OXT  O  N N 6   
+ALA H    H  N N 7   
+ALA H2   H  N N 8   
+ALA HA   H  N N 9   
+ALA HB1  H  N N 10  
+ALA HB2  H  N N 11  
+ALA HB3  H  N N 12  
+ALA HXT  H  N N 13  
+ARG N    N  N N 14  
+ARG CA   C  N S 15  
+ARG C    C  N N 16  
+ARG O    O  N N 17  
+ARG CB   C  N N 18  
+ARG CG   C  N N 19  
+ARG CD   C  N N 20  
+ARG NE   N  N N 21  
+ARG CZ   C  N N 22  
+ARG NH1  N  N N 23  
+ARG NH2  N  N N 24  
+ARG OXT  O  N N 25  
+ARG H    H  N N 26  
+ARG H2   H  N N 27  
+ARG HA   H  N N 28  
+ARG HB2  H  N N 29  
+ARG HB3  H  N N 30  
+ARG HG2  H  N N 31  
+ARG HG3  H  N N 32  
+ARG HD2  H  N N 33  
+ARG HD3  H  N N 34  
+ARG HE   H  N N 35  
+ARG HH11 H  N N 36  
+ARG HH12 H  N N 37  
+ARG HH21 H  N N 38  
+ARG HH22 H  N N 39  
+ARG HXT  H  N N 40  
+ASN N    N  N N 41  
+ASN CA   C  N S 42  
+ASN C    C  N N 43  
+ASN O    O  N N 44  
+ASN CB   C  N N 45  
+ASN CG   C  N N 46  
+ASN OD1  O  N N 47  
+ASN ND2  N  N N 48  
+ASN OXT  O  N N 49  
+ASN H    H  N N 50  
+ASN H2   H  N N 51  
+ASN HA   H  N N 52  
+ASN HB2  H  N N 53  
+ASN HB3  H  N N 54  
+ASN HD21 H  N N 55  
+ASN HD22 H  N N 56  
+ASN HXT  H  N N 57  
+ASP N    N  N N 58  
+ASP CA   C  N S 59  
+ASP C    C  N N 60  
+ASP O    O  N N 61  
+ASP CB   C  N N 62  
+ASP CG   C  N N 63  
+ASP OD1  O  N N 64  
+ASP OD2  O  N N 65  
+ASP OXT  O  N N 66  
+ASP H    H  N N 67  
+ASP H2   H  N N 68  
+ASP HA   H  N N 69  
+ASP HB2  H  N N 70  
+ASP HB3  H  N N 71  
+ASP HD2  H  N N 72  
+ASP HXT  H  N N 73  
+BME C1   C  N N 74  
+BME C2   C  N N 75  
+BME O1   O  N N 76  
+BME S2   S  N N 77  
+BME H11  H  N N 78  
+BME H12  H  N N 79  
+BME H21  H  N N 80  
+BME H22  H  N N 81  
+BME HO1  H  N N 82  
+BME HS2  H  N N 83  
+CL  CL   CL N N 84  
+CYS N    N  N N 85  
+CYS CA   C  N R 86  
+CYS C    C  N N 87  
+CYS O    O  N N 88  
+CYS CB   C  N N 89  
+CYS SG   S  N N 90  
+CYS OXT  O  N N 91  
+CYS H    H  N N 92  
+CYS H2   H  N N 93  
+CYS HA   H  N N 94  
+CYS HB2  H  N N 95  
+CYS HB3  H  N N 96  
+CYS HG   H  N N 97  
+CYS HXT  H  N N 98  
+GLN N    N  N N 99  
+GLN CA   C  N S 100 
+GLN C    C  N N 101 
+GLN O    O  N N 102 
+GLN CB   C  N N 103 
+GLN CG   C  N N 104 
+GLN CD   C  N N 105 
+GLN OE1  O  N N 106 
+GLN NE2  N  N N 107 
+GLN OXT  O  N N 108 
+GLN H    H  N N 109 
+GLN H2   H  N N 110 
+GLN HA   H  N N 111 
+GLN HB2  H  N N 112 
+GLN HB3  H  N N 113 
+GLN HG2  H  N N 114 
+GLN HG3  H  N N 115 
+GLN HE21 H  N N 116 
+GLN HE22 H  N N 117 
+GLN HXT  H  N N 118 
+GLU N    N  N N 119 
+GLU CA   C  N S 120 
+GLU C    C  N N 121 
+GLU O    O  N N 122 
+GLU CB   C  N N 123 
+GLU CG   C  N N 124 
+GLU CD   C  N N 125 
+GLU OE1  O  N N 126 
+GLU OE2  O  N N 127 
+GLU OXT  O  N N 128 
+GLU H    H  N N 129 
+GLU H2   H  N N 130 
+GLU HA   H  N N 131 
+GLU HB2  H  N N 132 
+GLU HB3  H  N N 133 
+GLU HG2  H  N N 134 
+GLU HG3  H  N N 135 
+GLU HE2  H  N N 136 
+GLU HXT  H  N N 137 
+GLY N    N  N N 138 
+GLY CA   C  N N 139 
+GLY C    C  N N 140 
+GLY O    O  N N 141 
+GLY OXT  O  N N 142 
+GLY H    H  N N 143 
+GLY H2   H  N N 144 
+GLY HA2  H  N N 145 
+GLY HA3  H  N N 146 
+GLY HXT  H  N N 147 
+HIS N    N  N N 148 
+HIS CA   C  N S 149 
+HIS C    C  N N 150 
+HIS O    O  N N 151 
+HIS CB   C  N N 152 
+HIS CG   C  Y N 153 
+HIS ND1  N  Y N 154 
+HIS CD2  C  Y N 155 
+HIS CE1  C  Y N 156 
+HIS NE2  N  Y N 157 
+HIS OXT  O  N N 158 
+HIS H    H  N N 159 
+HIS H2   H  N N 160 
+HIS HA   H  N N 161 
+HIS HB2  H  N N 162 
+HIS HB3  H  N N 163 
+HIS HD1  H  N N 164 
+HIS HD2  H  N N 165 
+HIS HE1  H  N N 166 
+HIS HE2  H  N N 167 
+HIS HXT  H  N N 168 
+HOH O    O  N N 169 
+HOH H1   H  N N 170 
+HOH H2   H  N N 171 
+ILE N    N  N N 172 
+ILE CA   C  N S 173 
+ILE C    C  N N 174 
+ILE O    O  N N 175 
+ILE CB   C  N S 176 
+ILE CG1  C  N N 177 
+ILE CG2  C  N N 178 
+ILE CD1  C  N N 179 
+ILE OXT  O  N N 180 
+ILE H    H  N N 181 
+ILE H2   H  N N 182 
+ILE HA   H  N N 183 
+ILE HB   H  N N 184 
+ILE HG12 H  N N 185 
+ILE HG13 H  N N 186 
+ILE HG21 H  N N 187 
+ILE HG22 H  N N 188 
+ILE HG23 H  N N 189 
+ILE HD11 H  N N 190 
+ILE HD12 H  N N 191 
+ILE HD13 H  N N 192 
+ILE HXT  H  N N 193 
+LEU N    N  N N 194 
+LEU CA   C  N S 195 
+LEU C    C  N N 196 
+LEU O    O  N N 197 
+LEU CB   C  N N 198 
+LEU CG   C  N N 199 
+LEU CD1  C  N N 200 
+LEU CD2  C  N N 201 
+LEU OXT  O  N N 202 
+LEU H    H  N N 203 
+LEU H2   H  N N 204 
+LEU HA   H  N N 205 
+LEU HB2  H  N N 206 
+LEU HB3  H  N N 207 
+LEU HG   H  N N 208 
+LEU HD11 H  N N 209 
+LEU HD12 H  N N 210 
+LEU HD13 H  N N 211 
+LEU HD21 H  N N 212 
+LEU HD22 H  N N 213 
+LEU HD23 H  N N 214 
+LEU HXT  H  N N 215 
+LYS N    N  N N 216 
+LYS CA   C  N S 217 
+LYS C    C  N N 218 
+LYS O    O  N N 219 
+LYS CB   C  N N 220 
+LYS CG   C  N N 221 
+LYS CD   C  N N 222 
+LYS CE   C  N N 223 
+LYS NZ   N  N N 224 
+LYS OXT  O  N N 225 
+LYS H    H  N N 226 
+LYS H2   H  N N 227 
+LYS HA   H  N N 228 
+LYS HB2  H  N N 229 
+LYS HB3  H  N N 230 
+LYS HG2  H  N N 231 
+LYS HG3  H  N N 232 
+LYS HD2  H  N N 233 
+LYS HD3  H  N N 234 
+LYS HE2  H  N N 235 
+LYS HE3  H  N N 236 
+LYS HZ1  H  N N 237 
+LYS HZ2  H  N N 238 
+LYS HZ3  H  N N 239 
+LYS HXT  H  N N 240 
+MBN C    C  N N 241 
+MBN C1   C  Y N 242 
+MBN C2   C  Y N 243 
+MBN C3   C  Y N 244 
+MBN C4   C  Y N 245 
+MBN C5   C  Y N 246 
+MBN C6   C  Y N 247 
+MBN H1   H  N N 248 
+MBN H2A  H  N N 249 
+MBN H3A  H  N N 250 
+MBN H2   H  N N 251 
+MBN H3   H  N N 252 
+MBN H4   H  N N 253 
+MBN H5   H  N N 254 
+MBN H6   H  N N 255 
+MET N    N  N N 256 
+MET CA   C  N S 257 
+MET C    C  N N 258 
+MET O    O  N N 259 
+MET CB   C  N N 260 
+MET CG   C  N N 261 
+MET SD   S  N N 262 
+MET CE   C  N N 263 
+MET OXT  O  N N 264 
+MET H    H  N N 265 
+MET H2   H  N N 266 
+MET HA   H  N N 267 
+MET HB2  H  N N 268 
+MET HB3  H  N N 269 
+MET HG2  H  N N 270 
+MET HG3  H  N N 271 
+MET HE1  H  N N 272 
+MET HE2  H  N N 273 
+MET HE3  H  N N 274 
+MET HXT  H  N N 275 
+PHE N    N  N N 276 
+PHE CA   C  N S 277 
+PHE C    C  N N 278 
+PHE O    O  N N 279 
+PHE CB   C  N N 280 
+PHE CG   C  Y N 281 
+PHE CD1  C  Y N 282 
+PHE CD2  C  Y N 283 
+PHE CE1  C  Y N 284 
+PHE CE2  C  Y N 285 
+PHE CZ   C  Y N 286 
+PHE OXT  O  N N 287 
+PHE H    H  N N 288 
+PHE H2   H  N N 289 
+PHE HA   H  N N 290 
+PHE HB2  H  N N 291 
+PHE HB3  H  N N 292 
+PHE HD1  H  N N 293 
+PHE HD2  H  N N 294 
+PHE HE1  H  N N 295 
+PHE HE2  H  N N 296 
+PHE HZ   H  N N 297 
+PHE HXT  H  N N 298 
+PRO N    N  N N 299 
+PRO CA   C  N S 300 
+PRO C    C  N N 301 
+PRO O    O  N N 302 
+PRO CB   C  N N 303 
+PRO CG   C  N N 304 
+PRO CD   C  N N 305 
+PRO OXT  O  N N 306 
+PRO H    H  N N 307 
+PRO HA   H  N N 308 
+PRO HB2  H  N N 309 
+PRO HB3  H  N N 310 
+PRO HG2  H  N N 311 
+PRO HG3  H  N N 312 
+PRO HD2  H  N N 313 
+PRO HD3  H  N N 314 
+PRO HXT  H  N N 315 
+SER N    N  N N 316 
+SER CA   C  N S 317 
+SER C    C  N N 318 
+SER O    O  N N 319 
+SER CB   C  N N 320 
+SER OG   O  N N 321 
+SER OXT  O  N N 322 
+SER H    H  N N 323 
+SER H2   H  N N 324 
+SER HA   H  N N 325 
+SER HB2  H  N N 326 
+SER HB3  H  N N 327 
+SER HG   H  N N 328 
+SER HXT  H  N N 329 
+THR N    N  N N 330 
+THR CA   C  N S 331 
+THR C    C  N N 332 
+THR O    O  N N 333 
+THR CB   C  N R 334 
+THR OG1  O  N N 335 
+THR CG2  C  N N 336 
+THR OXT  O  N N 337 
+THR H    H  N N 338 
+THR H2   H  N N 339 
+THR HA   H  N N 340 
+THR HB   H  N N 341 
+THR HG1  H  N N 342 
+THR HG21 H  N N 343 
+THR HG22 H  N N 344 
+THR HG23 H  N N 345 
+THR HXT  H  N N 346 
+TRP N    N  N N 347 
+TRP CA   C  N S 348 
+TRP C    C  N N 349 
+TRP O    O  N N 350 
+TRP CB   C  N N 351 
+TRP CG   C  Y N 352 
+TRP CD1  C  Y N 353 
+TRP CD2  C  Y N 354 
+TRP NE1  N  Y N 355 
+TRP CE2  C  Y N 356 
+TRP CE3  C  Y N 357 
+TRP CZ2  C  Y N 358 
+TRP CZ3  C  Y N 359 
+TRP CH2  C  Y N 360 
+TRP OXT  O  N N 361 
+TRP H    H  N N 362 
+TRP H2   H  N N 363 
+TRP HA   H  N N 364 
+TRP HB2  H  N N 365 
+TRP HB3  H  N N 366 
+TRP HD1  H  N N 367 
+TRP HE1  H  N N 368 
+TRP HE3  H  N N 369 
+TRP HZ2  H  N N 370 
+TRP HZ3  H  N N 371 
+TRP HH2  H  N N 372 
+TRP HXT  H  N N 373 
+TRS C    C  N N 374 
+TRS C1   C  N N 375 
+TRS C2   C  N N 376 
+TRS C3   C  N N 377 
+TRS N    N  N N 378 
+TRS O1   O  N N 379 
+TRS O2   O  N N 380 
+TRS O3   O  N N 381 
+TRS H11  H  N N 382 
+TRS H12  H  N N 383 
+TRS H21  H  N N 384 
+TRS H22  H  N N 385 
+TRS H31  H  N N 386 
+TRS H32  H  N N 387 
+TRS HN1  H  N N 388 
+TRS HN2  H  N N 389 
+TRS HN3  H  N N 390 
+TRS HO1  H  N N 391 
+TRS HO2  H  N N 392 
+TRS HO3  H  N N 393 
+TYR N    N  N N 394 
+TYR CA   C  N S 395 
+TYR C    C  N N 396 
+TYR O    O  N N 397 
+TYR CB   C  N N 398 
+TYR CG   C  Y N 399 
+TYR CD1  C  Y N 400 
+TYR CD2  C  Y N 401 
+TYR CE1  C  Y N 402 
+TYR CE2  C  Y N 403 
+TYR CZ   C  Y N 404 
+TYR OH   O  N N 405 
+TYR OXT  O  N N 406 
+TYR H    H  N N 407 
+TYR H2   H  N N 408 
+TYR HA   H  N N 409 
+TYR HB2  H  N N 410 
+TYR HB3  H  N N 411 
+TYR HD1  H  N N 412 
+TYR HD2  H  N N 413 
+TYR HE1  H  N N 414 
+TYR HE2  H  N N 415 
+TYR HH   H  N N 416 
+TYR HXT  H  N N 417 
+VAL N    N  N N 418 
+VAL CA   C  N S 419 
+VAL C    C  N N 420 
+VAL O    O  N N 421 
+VAL CB   C  N N 422 
+VAL CG1  C  N N 423 
+VAL CG2  C  N N 424 
+VAL OXT  O  N N 425 
+VAL H    H  N N 426 
+VAL H2   H  N N 427 
+VAL HA   H  N N 428 
+VAL HB   H  N N 429 
+VAL HG11 H  N N 430 
+VAL HG12 H  N N 431 
+VAL HG13 H  N N 432 
+VAL HG21 H  N N 433 
+VAL HG22 H  N N 434 
+VAL HG23 H  N N 435 
+VAL HXT  H  N N 436 
+# 
+loop_
+_chem_comp_bond.comp_id 
+_chem_comp_bond.atom_id_1 
+_chem_comp_bond.atom_id_2 
+_chem_comp_bond.value_order 
+_chem_comp_bond.pdbx_aromatic_flag 
+_chem_comp_bond.pdbx_stereo_config 
+_chem_comp_bond.pdbx_ordinal 
+ALA N   CA   sing N N 1   
+ALA N   H    sing N N 2   
+ALA N   H2   sing N N 3   
+ALA CA  C    sing N N 4   
+ALA CA  CB   sing N N 5   
+ALA CA  HA   sing N N 6   
+ALA C   O    doub N N 7   
+ALA C   OXT  sing N N 8   
+ALA CB  HB1  sing N N 9   
+ALA CB  HB2  sing N N 10  
+ALA CB  HB3  sing N N 11  
+ALA OXT HXT  sing N N 12  
+ARG N   CA   sing N N 13  
+ARG N   H    sing N N 14  
+ARG N   H2   sing N N 15  
+ARG CA  C    sing N N 16  
+ARG CA  CB   sing N N 17  
+ARG CA  HA   sing N N 18  
+ARG C   O    doub N N 19  
+ARG C   OXT  sing N N 20  
+ARG CB  CG   sing N N 21  
+ARG CB  HB2  sing N N 22  
+ARG CB  HB3  sing N N 23  
+ARG CG  CD   sing N N 24  
+ARG CG  HG2  sing N N 25  
+ARG CG  HG3  sing N N 26  
+ARG CD  NE   sing N N 27  
+ARG CD  HD2  sing N N 28  
+ARG CD  HD3  sing N N 29  
+ARG NE  CZ   sing N N 30  
+ARG NE  HE   sing N N 31  
+ARG CZ  NH1  sing N N 32  
+ARG CZ  NH2  doub N N 33  
+ARG NH1 HH11 sing N N 34  
+ARG NH1 HH12 sing N N 35  
+ARG NH2 HH21 sing N N 36  
+ARG NH2 HH22 sing N N 37  
+ARG OXT HXT  sing N N 38  
+ASN N   CA   sing N N 39  
+ASN N   H    sing N N 40  
+ASN N   H2   sing N N 41  
+ASN CA  C    sing N N 42  
+ASN CA  CB   sing N N 43  
+ASN CA  HA   sing N N 44  
+ASN C   O    doub N N 45  
+ASN C   OXT  sing N N 46  
+ASN CB  CG   sing N N 47  
+ASN CB  HB2  sing N N 48  
+ASN CB  HB3  sing N N 49  
+ASN CG  OD1  doub N N 50  
+ASN CG  ND2  sing N N 51  
+ASN ND2 HD21 sing N N 52  
+ASN ND2 HD22 sing N N 53  
+ASN OXT HXT  sing N N 54  
+ASP N   CA   sing N N 55  
+ASP N   H    sing N N 56  
+ASP N   H2   sing N N 57  
+ASP CA  C    sing N N 58  
+ASP CA  CB   sing N N 59  
+ASP CA  HA   sing N N 60  
+ASP C   O    doub N N 61  
+ASP C   OXT  sing N N 62  
+ASP CB  CG   sing N N 63  
+ASP CB  HB2  sing N N 64  
+ASP CB  HB3  sing N N 65  
+ASP CG  OD1  doub N N 66  
+ASP CG  OD2  sing N N 67  
+ASP OD2 HD2  sing N N 68  
+ASP OXT HXT  sing N N 69  
+BME C1  C2   sing N N 70  
+BME C1  O1   sing N N 71  
+BME C1  H11  sing N N 72  
+BME C1  H12  sing N N 73  
+BME C2  S2   sing N N 74  
+BME C2  H21  sing N N 75  
+BME C2  H22  sing N N 76  
+BME O1  HO1  sing N N 77  
+BME S2  HS2  sing N N 78  
+CYS N   CA   sing N N 79  
+CYS N   H    sing N N 80  
+CYS N   H2   sing N N 81  
+CYS CA  C    sing N N 82  
+CYS CA  CB   sing N N 83  
+CYS CA  HA   sing N N 84  
+CYS C   O    doub N N 85  
+CYS C   OXT  sing N N 86  
+CYS CB  SG   sing N N 87  
+CYS CB  HB2  sing N N 88  
+CYS CB  HB3  sing N N 89  
+CYS SG  HG   sing N N 90  
+CYS OXT HXT  sing N N 91  
+GLN N   CA   sing N N 92  
+GLN N   H    sing N N 93  
+GLN N   H2   sing N N 94  
+GLN CA  C    sing N N 95  
+GLN CA  CB   sing N N 96  
+GLN CA  HA   sing N N 97  
+GLN C   O    doub N N 98  
+GLN C   OXT  sing N N 99  
+GLN CB  CG   sing N N 100 
+GLN CB  HB2  sing N N 101 
+GLN CB  HB3  sing N N 102 
+GLN CG  CD   sing N N 103 
+GLN CG  HG2  sing N N 104 
+GLN CG  HG3  sing N N 105 
+GLN CD  OE1  doub N N 106 
+GLN CD  NE2  sing N N 107 
+GLN NE2 HE21 sing N N 108 
+GLN NE2 HE22 sing N N 109 
+GLN OXT HXT  sing N N 110 
+GLU N   CA   sing N N 111 
+GLU N   H    sing N N 112 
+GLU N   H2   sing N N 113 
+GLU CA  C    sing N N 114 
+GLU CA  CB   sing N N 115 
+GLU CA  HA   sing N N 116 
+GLU C   O    doub N N 117 
+GLU C   OXT  sing N N 118 
+GLU CB  CG   sing N N 119 
+GLU CB  HB2  sing N N 120 
+GLU CB  HB3  sing N N 121 
+GLU CG  CD   sing N N 122 
+GLU CG  HG2  sing N N 123 
+GLU CG  HG3  sing N N 124 
+GLU CD  OE1  doub N N 125 
+GLU CD  OE2  sing N N 126 
+GLU OE2 HE2  sing N N 127 
+GLU OXT HXT  sing N N 128 
+GLY N   CA   sing N N 129 
+GLY N   H    sing N N 130 
+GLY N   H2   sing N N 131 
+GLY CA  C    sing N N 132 
+GLY CA  HA2  sing N N 133 
+GLY CA  HA3  sing N N 134 
+GLY C   O    doub N N 135 
+GLY C   OXT  sing N N 136 
+GLY OXT HXT  sing N N 137 
+HIS N   CA   sing N N 138 
+HIS N   H    sing N N 139 
+HIS N   H2   sing N N 140 
+HIS CA  C    sing N N 141 
+HIS CA  CB   sing N N 142 
+HIS CA  HA   sing N N 143 
+HIS C   O    doub N N 144 
+HIS C   OXT  sing N N 145 
+HIS CB  CG   sing N N 146 
+HIS CB  HB2  sing N N 147 
+HIS CB  HB3  sing N N 148 
+HIS CG  ND1  sing Y N 149 
+HIS CG  CD2  doub Y N 150 
+HIS ND1 CE1  doub Y N 151 
+HIS ND1 HD1  sing N N 152 
+HIS CD2 NE2  sing Y N 153 
+HIS CD2 HD2  sing N N 154 
+HIS CE1 NE2  sing Y N 155 
+HIS CE1 HE1  sing N N 156 
+HIS NE2 HE2  sing N N 157 
+HIS OXT HXT  sing N N 158 
+HOH O   H1   sing N N 159 
+HOH O   H2   sing N N 160 
+ILE N   CA   sing N N 161 
+ILE N   H    sing N N 162 
+ILE N   H2   sing N N 163 
+ILE CA  C    sing N N 164 
+ILE CA  CB   sing N N 165 
+ILE CA  HA   sing N N 166 
+ILE C   O    doub N N 167 
+ILE C   OXT  sing N N 168 
+ILE CB  CG1  sing N N 169 
+ILE CB  CG2  sing N N 170 
+ILE CB  HB   sing N N 171 
+ILE CG1 CD1  sing N N 172 
+ILE CG1 HG12 sing N N 173 
+ILE CG1 HG13 sing N N 174 
+ILE CG2 HG21 sing N N 175 
+ILE CG2 HG22 sing N N 176 
+ILE CG2 HG23 sing N N 177 
+ILE CD1 HD11 sing N N 178 
+ILE CD1 HD12 sing N N 179 
+ILE CD1 HD13 sing N N 180 
+ILE OXT HXT  sing N N 181 
+LEU N   CA   sing N N 182 
+LEU N   H    sing N N 183 
+LEU N   H2   sing N N 184 
+LEU CA  C    sing N N 185 
+LEU CA  CB   sing N N 186 
+LEU CA  HA   sing N N 187 
+LEU C   O    doub N N 188 
+LEU C   OXT  sing N N 189 
+LEU CB  CG   sing N N 190 
+LEU CB  HB2  sing N N 191 
+LEU CB  HB3  sing N N 192 
+LEU CG  CD1  sing N N 193 
+LEU CG  CD2  sing N N 194 
+LEU CG  HG   sing N N 195 
+LEU CD1 HD11 sing N N 196 
+LEU CD1 HD12 sing N N 197 
+LEU CD1 HD13 sing N N 198 
+LEU CD2 HD21 sing N N 199 
+LEU CD2 HD22 sing N N 200 
+LEU CD2 HD23 sing N N 201 
+LEU OXT HXT  sing N N 202 
+LYS N   CA   sing N N 203 
+LYS N   H    sing N N 204 
+LYS N   H2   sing N N 205 
+LYS CA  C    sing N N 206 
+LYS CA  CB   sing N N 207 
+LYS CA  HA   sing N N 208 
+LYS C   O    doub N N 209 
+LYS C   OXT  sing N N 210 
+LYS CB  CG   sing N N 211 
+LYS CB  HB2  sing N N 212 
+LYS CB  HB3  sing N N 213 
+LYS CG  CD   sing N N 214 
+LYS CG  HG2  sing N N 215 
+LYS CG  HG3  sing N N 216 
+LYS CD  CE   sing N N 217 
+LYS CD  HD2  sing N N 218 
+LYS CD  HD3  sing N N 219 
+LYS CE  NZ   sing N N 220 
+LYS CE  HE2  sing N N 221 
+LYS CE  HE3  sing N N 222 
+LYS NZ  HZ1  sing N N 223 
+LYS NZ  HZ2  sing N N 224 
+LYS NZ  HZ3  sing N N 225 
+LYS OXT HXT  sing N N 226 
+MBN C   C1   sing N N 227 
+MBN C   H1   sing N N 228 
+MBN C   H2A  sing N N 229 
+MBN C   H3A  sing N N 230 
+MBN C1  C2   doub Y N 231 
+MBN C1  C6   sing Y N 232 
+MBN C2  C3   sing Y N 233 
+MBN C2  H2   sing N N 234 
+MBN C3  C4   doub Y N 235 
+MBN C3  H3   sing N N 236 
+MBN C4  C5   sing Y N 237 
+MBN C4  H4   sing N N 238 
+MBN C5  C6   doub Y N 239 
+MBN C5  H5   sing N N 240 
+MBN C6  H6   sing N N 241 
+MET N   CA   sing N N 242 
+MET N   H    sing N N 243 
+MET N   H2   sing N N 244 
+MET CA  C    sing N N 245 
+MET CA  CB   sing N N 246 
+MET CA  HA   sing N N 247 
+MET C   O    doub N N 248 
+MET C   OXT  sing N N 249 
+MET CB  CG   sing N N 250 
+MET CB  HB2  sing N N 251 
+MET CB  HB3  sing N N 252 
+MET CG  SD   sing N N 253 
+MET CG  HG2  sing N N 254 
+MET CG  HG3  sing N N 255 
+MET SD  CE   sing N N 256 
+MET CE  HE1  sing N N 257 
+MET CE  HE2  sing N N 258 
+MET CE  HE3  sing N N 259 
+MET OXT HXT  sing N N 260 
+PHE N   CA   sing N N 261 
+PHE N   H    sing N N 262 
+PHE N   H2   sing N N 263 
+PHE CA  C    sing N N 264 
+PHE CA  CB   sing N N 265 
+PHE CA  HA   sing N N 266 
+PHE C   O    doub N N 267 
+PHE C   OXT  sing N N 268 
+PHE CB  CG   sing N N 269 
+PHE CB  HB2  sing N N 270 
+PHE CB  HB3  sing N N 271 
+PHE CG  CD1  doub Y N 272 
+PHE CG  CD2  sing Y N 273 
+PHE CD1 CE1  sing Y N 274 
+PHE CD1 HD1  sing N N 275 
+PHE CD2 CE2  doub Y N 276 
+PHE CD2 HD2  sing N N 277 
+PHE CE1 CZ   doub Y N 278 
+PHE CE1 HE1  sing N N 279 
+PHE CE2 CZ   sing Y N 280 
+PHE CE2 HE2  sing N N 281 
+PHE CZ  HZ   sing N N 282 
+PHE OXT HXT  sing N N 283 
+PRO N   CA   sing N N 284 
+PRO N   CD   sing N N 285 
+PRO N   H    sing N N 286 
+PRO CA  C    sing N N 287 
+PRO CA  CB   sing N N 288 
+PRO CA  HA   sing N N 289 
+PRO C   O    doub N N 290 
+PRO C   OXT  sing N N 291 
+PRO CB  CG   sing N N 292 
+PRO CB  HB2  sing N N 293 
+PRO CB  HB3  sing N N 294 
+PRO CG  CD   sing N N 295 
+PRO CG  HG2  sing N N 296 
+PRO CG  HG3  sing N N 297 
+PRO CD  HD2  sing N N 298 
+PRO CD  HD3  sing N N 299 
+PRO OXT HXT  sing N N 300 
+SER N   CA   sing N N 301 
+SER N   H    sing N N 302 
+SER N   H2   sing N N 303 
+SER CA  C    sing N N 304 
+SER CA  CB   sing N N 305 
+SER CA  HA   sing N N 306 
+SER C   O    doub N N 307 
+SER C   OXT  sing N N 308 
+SER CB  OG   sing N N 309 
+SER CB  HB2  sing N N 310 
+SER CB  HB3  sing N N 311 
+SER OG  HG   sing N N 312 
+SER OXT HXT  sing N N 313 
+THR N   CA   sing N N 314 
+THR N   H    sing N N 315 
+THR N   H2   sing N N 316 
+THR CA  C    sing N N 317 
+THR CA  CB   sing N N 318 
+THR CA  HA   sing N N 319 
+THR C   O    doub N N 320 
+THR C   OXT  sing N N 321 
+THR CB  OG1  sing N N 322 
+THR CB  CG2  sing N N 323 
+THR CB  HB   sing N N 324 
+THR OG1 HG1  sing N N 325 
+THR CG2 HG21 sing N N 326 
+THR CG2 HG22 sing N N 327 
+THR CG2 HG23 sing N N 328 
+THR OXT HXT  sing N N 329 
+TRP N   CA   sing N N 330 
+TRP N   H    sing N N 331 
+TRP N   H2   sing N N 332 
+TRP CA  C    sing N N 333 
+TRP CA  CB   sing N N 334 
+TRP CA  HA   sing N N 335 
+TRP C   O    doub N N 336 
+TRP C   OXT  sing N N 337 
+TRP CB  CG   sing N N 338 
+TRP CB  HB2  sing N N 339 
+TRP CB  HB3  sing N N 340 
+TRP CG  CD1  doub Y N 341 
+TRP CG  CD2  sing Y N 342 
+TRP CD1 NE1  sing Y N 343 
+TRP CD1 HD1  sing N N 344 
+TRP CD2 CE2  doub Y N 345 
+TRP CD2 CE3  sing Y N 346 
+TRP NE1 CE2  sing Y N 347 
+TRP NE1 HE1  sing N N 348 
+TRP CE2 CZ2  sing Y N 349 
+TRP CE3 CZ3  doub Y N 350 
+TRP CE3 HE3  sing N N 351 
+TRP CZ2 CH2  doub Y N 352 
+TRP CZ2 HZ2  sing N N 353 
+TRP CZ3 CH2  sing Y N 354 
+TRP CZ3 HZ3  sing N N 355 
+TRP CH2 HH2  sing N N 356 
+TRP OXT HXT  sing N N 357 
+TRS C   C1   sing N N 358 
+TRS C   C2   sing N N 359 
+TRS C   C3   sing N N 360 
+TRS C   N    sing N N 361 
+TRS C1  O1   sing N N 362 
+TRS C1  H11  sing N N 363 
+TRS C1  H12  sing N N 364 
+TRS C2  O2   sing N N 365 
+TRS C2  H21  sing N N 366 
+TRS C2  H22  sing N N 367 
+TRS C3  O3   sing N N 368 
+TRS C3  H31  sing N N 369 
+TRS C3  H32  sing N N 370 
+TRS N   HN1  sing N N 371 
+TRS N   HN2  sing N N 372 
+TRS N   HN3  sing N N 373 
+TRS O1  HO1  sing N N 374 
+TRS O2  HO2  sing N N 375 
+TRS O3  HO3  sing N N 376 
+TYR N   CA   sing N N 377 
+TYR N   H    sing N N 378 
+TYR N   H2   sing N N 379 
+TYR CA  C    sing N N 380 
+TYR CA  CB   sing N N 381 
+TYR CA  HA   sing N N 382 
+TYR C   O    doub N N 383 
+TYR C   OXT  sing N N 384 
+TYR CB  CG   sing N N 385 
+TYR CB  HB2  sing N N 386 
+TYR CB  HB3  sing N N 387 
+TYR CG  CD1  doub Y N 388 
+TYR CG  CD2  sing Y N 389 
+TYR CD1 CE1  sing Y N 390 
+TYR CD1 HD1  sing N N 391 
+TYR CD2 CE2  doub Y N 392 
+TYR CD2 HD2  sing N N 393 
+TYR CE1 CZ   doub Y N 394 
+TYR CE1 HE1  sing N N 395 
+TYR CE2 CZ   sing Y N 396 
+TYR CE2 HE2  sing N N 397 
+TYR CZ  OH   sing N N 398 
+TYR OH  HH   sing N N 399 
+TYR OXT HXT  sing N N 400 
+VAL N   CA   sing N N 401 
+VAL N   H    sing N N 402 
+VAL N   H2   sing N N 403 
+VAL CA  C    sing N N 404 
+VAL CA  CB   sing N N 405 
+VAL CA  HA   sing N N 406 
+VAL C   O    doub N N 407 
+VAL C   OXT  sing N N 408 
+VAL CB  CG1  sing N N 409 
+VAL CB  CG2  sing N N 410 
+VAL CB  HB   sing N N 411 
+VAL CG1 HG11 sing N N 412 
+VAL CG1 HG12 sing N N 413 
+VAL CG1 HG13 sing N N 414 
+VAL CG2 HG21 sing N N 415 
+VAL CG2 HG22 sing N N 416 
+VAL CG2 HG23 sing N N 417 
+VAL OXT HXT  sing N N 418 
+# 
+_pdbx_entity_instance_feature.ordinal        1 
+_pdbx_entity_instance_feature.comp_id        MBN 
+_pdbx_entity_instance_feature.asym_id        ? 
+_pdbx_entity_instance_feature.seq_num        ? 
+_pdbx_entity_instance_feature.auth_comp_id   MBN 
+_pdbx_entity_instance_feature.auth_asym_id   ? 
+_pdbx_entity_instance_feature.auth_seq_num   ? 
+_pdbx_entity_instance_feature.feature_type   'SUBJECT OF INVESTIGATION' 
+_pdbx_entity_instance_feature.details        ? 
+# 
+loop_
+_pdbx_entity_nonpoly.entity_id 
+_pdbx_entity_nonpoly.name 
+_pdbx_entity_nonpoly.comp_id 
+2 2-AMINO-2-HYDROXYMETHYL-PROPANE-1,3-DIOL TRS 
+3 'CHLORIDE ION'                           CL  
+4 TOLUENE                                  MBN 
+5 BETA-MERCAPTOETHANOL                     BME 
+6 water                                    HOH 
+# 
+_pdbx_initial_refinement_model.id               1 
+_pdbx_initial_refinement_model.entity_id_list   ? 
+_pdbx_initial_refinement_model.type             'experimental model' 
+_pdbx_initial_refinement_model.source_name      PDB 
+_pdbx_initial_refinement_model.accession_code   4W51 
+_pdbx_initial_refinement_model.details          ? 
+# 
+_pdbx_struct_assembly_auth_evidence.id                     1 
+_pdbx_struct_assembly_auth_evidence.assembly_id            1 
+_pdbx_struct_assembly_auth_evidence.experimental_support   'native gel electrophoresis' 
+_pdbx_struct_assembly_auth_evidence.details                ? 
+# 

--- a/openfold3/tests/test_setup_openfold.py
+++ b/openfold3/tests/test_setup_openfold.py
@@ -1,4 +1,13 @@
-from openfold3.setup_openfold import setup_biotite_ccd
+from unittest.mock import patch
+
+import pytest
+
+from openfold3.setup_openfold import (
+    OpenFoldSetupConfig,
+    _require_pytest,
+    run_setup,
+    setup_biotite_ccd,
+)
 
 
 def test_setup_biotite_ccd(tmp_path):
@@ -9,3 +18,60 @@ def test_setup_biotite_ccd(tmp_path):
 
     has_downloaded = setup_biotite_ccd(ccd_path=ccd_path, force_download=False)
     assert not has_downloaded
+
+
+def test_require_pytest_passes_when_installed():
+    """This suite runs under pytest, so the probe must find it."""
+    _require_pytest()
+
+
+def test_require_pytest_exits_with_install_instructions(caplog):
+    with (
+        patch("importlib.util.find_spec", return_value=None),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        _require_pytest()
+    assert exit_info.value.code == 1
+    assert "openfold3[dev]" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("run_integration_tests", "pytest_installed", "expect_exit"),
+    [
+        pytest.param(True, False, True, id="tests-requested-pytest-missing"),
+        pytest.param(True, True, False, id="tests-requested-pytest-present"),
+        pytest.param(False, False, False, id="tests-skipped-pytest-irrelevant"),
+    ],
+)
+def test_pytest_is_checked_before_anything_is_downloaded(
+    tmp_path, run_integration_tests, pytest_installed, expect_exit
+):
+    """A missing test dependency must not surface after a multi-gigabyte download.
+
+    Downloads are stubbed out, so reaching them at all is the failure being guarded
+    against: when pytest is missing and tests were requested, setup has to exit before
+    ``_download_parameters`` is ever called.
+    """
+    config = OpenFoldSetupConfig(
+        openfold_cache=tmp_path / "cache",
+        param_directory=tmp_path / "params",
+        run_integration_tests=run_integration_tests,
+    )
+    find_spec_result = object() if pytest_installed else None
+
+    with (
+        patch("importlib.util.find_spec", return_value=find_spec_result),
+        patch("openfold3.setup_openfold._download_parameters") as download,
+        patch("openfold3.setup_openfold.setup_biotite_ccd") as ccd,
+        patch("openfold3.setup_openfold._run_integration_tests") as integration_tests,
+    ):
+        if expect_exit:
+            with pytest.raises(SystemExit) as exit_info:
+                run_setup(config)
+            assert exit_info.value.code == 1
+        else:
+            run_setup(config)
+
+    assert download.called is not expect_exit
+    assert ccd.called is not expect_exit
+    assert integration_tests.called == (run_integration_tests and not expect_exit)

--- a/openfold3/tests/test_setup_openfold.py
+++ b/openfold3/tests/test_setup_openfold.py
@@ -4,7 +4,8 @@ import pytest
 
 from openfold3.setup_openfold import (
     OpenFoldSetupConfig,
-    _require_pytest,
+    _prompt_for_config,
+    _pytest_is_installed,
     run_setup,
     setup_biotite_ccd,
 )
@@ -20,37 +21,71 @@ def test_setup_biotite_ccd(tmp_path):
     assert not has_downloaded
 
 
-def test_require_pytest_passes_when_installed():
+def test_pytest_probe_finds_pytest_when_installed():
     """This suite runs under pytest, so the probe must find it."""
-    _require_pytest()
+    assert _pytest_is_installed()
 
 
-def test_require_pytest_exits_with_install_instructions(caplog):
+def test_pytest_probe_reports_missing():
+    with patch("importlib.util.find_spec", return_value=None):
+        assert not _pytest_is_installed()
+
+
+def _prompts_seen(
+    *, pytest_installed: bool, answer: str = ""
+) -> tuple[list[str], bool]:
+    """Drive ``_prompt_for_config`` on defaults, returning the prompts and the flag.
+
+    ``answer`` is given only to the integration-test question; every other prompt takes
+    its default via an empty string.
+    """
+    prompts: list[str] = []
+
+    def fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return answer if "integration test" in prompt.lower() else ""
+
     with (
-        patch("importlib.util.find_spec", return_value=None),
-        pytest.raises(SystemExit) as exit_info,
+        patch(
+            "openfold3.setup_openfold._pytest_is_installed",
+            return_value=pytest_installed,
+        ),
+        patch("builtins.input", side_effect=fake_input),
     ):
-        _require_pytest()
-    assert exit_info.value.code == 1
+        config = _prompt_for_config()
+    return prompts, config.run_integration_tests
+
+
+def test_prompt_offers_integration_tests_when_pytest_installed():
+    prompts, run_integration_tests = _prompts_seen(pytest_installed=True, answer="yes")
+    assert any("integration test" in p.lower() for p in prompts)
+    assert run_integration_tests
+
+
+def test_prompt_skips_integration_question_when_pytest_missing(caplog):
+    """Asking is pointless when the answer could not be honoured either way."""
+    prompts, run_integration_tests = _prompts_seen(pytest_installed=False, answer="yes")
+    assert not any("integration test" in p.lower() for p in prompts)
+    assert not run_integration_tests
     assert "openfold3[dev]" in caplog.text
 
 
 @pytest.mark.parametrize(
-    ("run_integration_tests", "pytest_installed", "expect_exit"),
+    ("run_integration_tests", "pytest_installed", "expect_tests_run"),
     [
-        pytest.param(True, False, True, id="tests-requested-pytest-missing"),
-        pytest.param(True, True, False, id="tests-requested-pytest-present"),
+        pytest.param(True, False, False, id="tests-requested-pytest-missing"),
+        pytest.param(True, True, True, id="tests-requested-pytest-present"),
         pytest.param(False, False, False, id="tests-skipped-pytest-irrelevant"),
     ],
 )
-def test_pytest_is_checked_before_anything_is_downloaded(
-    tmp_path, run_integration_tests, pytest_installed, expect_exit
+def test_missing_pytest_warns_without_losing_the_downloads(
+    tmp_path, caplog, run_integration_tests, pytest_installed, expect_tests_run
 ):
-    """A missing test dependency must not surface after a multi-gigabyte download.
+    """A missing test dependency downgrades the request; it never aborts setup.
 
-    Downloads are stubbed out, so reaching them at all is the failure being guarded
-    against: when pytest is missing and tests were requested, setup has to exit before
-    ``_download_parameters`` is ever called.
+    pytest is not needed to *set up* openfold3, and the downloads are the expensive
+    part — exiting over it would force the user to redo the whole run. So the parameters
+    and CCD are fetched regardless, and only the tests themselves are dropped.
     """
     config = OpenFoldSetupConfig(
         openfold_cache=tmp_path / "cache",
@@ -65,13 +100,11 @@ def test_pytest_is_checked_before_anything_is_downloaded(
         patch("openfold3.setup_openfold.setup_biotite_ccd") as ccd,
         patch("openfold3.setup_openfold._run_integration_tests") as integration_tests,
     ):
-        if expect_exit:
-            with pytest.raises(SystemExit) as exit_info:
-                run_setup(config)
-            assert exit_info.value.code == 1
-        else:
-            run_setup(config)
+        run_setup(config)
 
-    assert download.called is not expect_exit
-    assert ccd.called is not expect_exit
-    assert integration_tests.called == (run_integration_tests and not expect_exit)
+    assert download.called
+    assert ccd.called
+    assert integration_tests.called == expect_tests_run
+
+    warned = run_integration_tests and not pytest_installed
+    assert ("openfold3[dev]" in caplog.text) == warned

--- a/openfold3/tests/utils/compare_utils.py
+++ b/openfold3/tests/utils/compare_utils.py
@@ -117,8 +117,54 @@ def skip_unless_triton_installed():
     return pytest.mark.skipif(not triton_is_installed, reason="Requires Triton")
 
 
+#: Accelerator backends the suite knows how to detect. ``cuda`` and ``rocm`` are both
+#: driven through the ``torch.cuda`` API — a ROCm build reports HIP devices through it
+#: too — so they are told apart by ``torch.version.hip``.
+ACCELERATORS = ("cuda", "rocm", "mps")
+
+
+@functools.lru_cache(maxsize=1)
+def current_accelerator() -> str | None:
+    """Return the accelerator torch can use here, or None when this is a CPU-only box."""
+    if torch.cuda.is_available():
+        return "rocm" if torch.version.hip is not None else "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return None
+
+
+def skip_unless_accelerator_available(*required: str):
+    """Skip unless an accelerator is available, optionally restricted to *required*.
+
+    With no arguments any accelerator will do, so a test runs wherever torch has one.
+    Pass one or more names from :data:`ACCELERATORS` to demand a specific backend —
+    ``skip_unless_accelerator_available("cuda", "rocm")`` for tests needing real GPU
+    kernels, which is exactly what :func:`skip_unless_cuda_available` asks for. Names
+    are validated eagerly so a typo fails at import rather than skipping forever.
+    """
+    unknown = sorted(set(required) - set(ACCELERATORS))
+    if unknown:
+        raise ValueError(
+            f"Unknown accelerator(s) {unknown}; expected any of {list(ACCELERATORS)}"
+        )
+
+    wanted = required or ACCELERATORS
+    current = current_accelerator()
+    if current in wanted:
+        return _no_skip(f"Running on {current}")
+    return pytest.mark.skipif(
+        True, reason=f"Requires {' or '.join(wanted)}; found {current or 'cpu'}"
+    )
+
+
 def skip_unless_cuda_available():
-    return pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    """Skip unless a GPU is available.
+
+    ROCm counts: torch reports HIP devices through the ``torch.cuda`` API, so this has
+    always passed on AMD. Use :func:`skip_unless_accelerator_available` directly for
+    tests that can also run on MPS.
+    """
+    return skip_unless_accelerator_available("cuda")
 
 
 def _assert_abs_diff_small_base(compare_func, expected, actual, eps):


### PR DESCRIPTION
**Summary**

Move to a world where we can catch inference regression easy. Still not ideal, very brittle (CA-RMSD only, with a ceil only)

**Changes**

The best way to review is going commit by commit in github, happy to pair. 

The 1st moves are purely mechanical – putting inference_full into a directory, split the tests for inference into templating and regular inference, isolate out some helper classes. 

Towards the end it's just cleanup, stop parsing CIFs over and over, and tighten up the metrics. 

Challenge for the review: I can't find a good way to capture how to measure these regressions, for now we mostly do mean/min/max. There is a lot of noise in some cases from the 5 samples drawn. 

**Related Issues**

- some of our inference examples i couldn't tie to real PDBs (all the MCL1 example are the asymmetric unit, with a ligand that doesn't exist in the PDB and 3x ATP that don't bind to MCL1)
- seeing some low RMSD examples that can't be rescued by templates (MSA-free)

**Testing**

**Other Notes**
