### PR TITLE
fix: save per-run MSA outputs

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -229,12 +229,12 @@ Configures the ColabFold MSA server integration.
 **Pydantic Model**: [`MsaComputationSettings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py#L904)
 
 **All Options**:
-- `msa_file_format` *(Literal["npz", "a3m"])*: Format for saved MSAs (default: `npz`)
+- `msa_file_format` *(Literal["npz", "a3m"])*: Format for reusable per-sequence MSAs under `main/` and `paired/`; `a3m` is portable, inspectable text, while `npz` is the compressed default and is faster to parse (default: `npz`)
 - `server_user_agent` *(str)*: User agent string (default: `openfold`)
 - `server_url` *(Url)*: ColabFold server URL (default: `https://api.colabfold.com`)
 - `save_mappings` *(bool)*: Save sequence ID mappings (default: `true`)
 - `msa_output_directory` *(Path)*: Directory for MSA outputs (default: `temporary directory/of3-of-<user>/colabfold_msas`)
-- `cleanup_msa_dir` *(bool)*: Delete MSAs after processing (default: `true`)
+- `cleanup_msa_dir` *(bool)*: Delete the entire MSA output directory after a successful prediction; when `false`, move or delete the preserved `raw/` directory before another server request (default: `true`)
 
 **Example**:
 ```yaml
@@ -295,4 +295,3 @@ For the complete list of default values, see the Pydantic model classes in:
 - [`openfold3/projects/of3_all_atom/config/dataset_config_components.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/projects/of3_all_atom/config/dataset_config_components.py) - MSA and template settings
 - [`openfold3/core/data/tools/colabfold_msa_server.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py) - MSA server settings
 - [`openfold3/core/data/pipelines/preprocessing/template.py`](http://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/pipelines/preprocessing/template.py) - Template preprocessing settings
-

--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -226,22 +226,27 @@ output_writer_settings:
 
 Configures the ColabFold MSA server integration.
 
-**Pydantic Model**: [`MsaComputationSettings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py#L904)
+**Pydantic Model**: [`MsaComputationSettings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py)
 
 **All Options**:
-- `msa_file_format` *(Literal["npz", "a3m"])*: Format for reusable per-sequence MSAs under `main/` and `paired/`; `a3m` is portable, inspectable text, while `npz` is the compressed default and is faster to parse (default: `npz`)
+- `msa_file_format` *(Literal["npz", "a3m"])*: Format for saved MSAs (default: `npz`)
 - `server_user_agent` *(str)*: User agent string (default: `openfold`)
 - `server_url` *(Url)*: ColabFold server URL (default: `https://api.colabfold.com`)
 - `save_mappings` *(bool)*: Save sequence ID mappings (default: `true`)
-- `msa_output_directory` *(Path)*: Directory for MSA outputs (default: `temporary directory/of3-of-<user>/colabfold_msas`)
-- `cleanup_msa_dir` *(bool)*: Delete the entire MSA output directory after a successful prediction; when `false`, move or delete the preserved `raw/` directory before another server request (default: `true`)
+- `msa_output_directory` *(Path | None)*: Optional exact destination for OpenFold-formatted alignments (default during inference: `<output_dir>/msas/<run-id>`)
+- `save_openfold_outputs` *(bool)*: Save OpenFold-formatted alignments (default: `true`)
+- `save_colabfold_outputs` *(bool)*: Save raw ColabFold server outputs (default: `true`)
+- `colabfold_output_dir` *(Path | None)*: Optional parent directory for raw ColabFold run records (default during inference when `msa_output_directory` is not set: `<output_dir>/msas/raw`)
+- `cleanup_msa_dir` *(bool)*: Delete temporary template preprocessing files after an MSA server run (default: `true`). The temporary MSA workspace is always removed.
+
+When temporary MSA work is needed, each command uses a unique workspace under the OpenFold system temporary directory. This workspace is separate from `msa_output_directory` and is always removed during final cleanup.
 
 **Example**:
 ```yaml
 msa_computation_settings:
   msa_file_format: npz
-  cleanup_msa_dir: false
-  msa_output_directory: /path/to/msas
+  save_openfold_outputs: true
+  save_colabfold_outputs: false
 ```
 
 ---
@@ -295,3 +300,4 @@ For the complete list of default values, see the Pydantic model classes in:
 - [`openfold3/projects/of3_all_atom/config/dataset_config_components.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/projects/of3_all_atom/config/dataset_config_components.py) - MSA and template settings
 - [`openfold3/core/data/tools/colabfold_msa_server.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py) - MSA server settings
 - [`openfold3/core/data/pipelines/preprocessing/template.py`](http://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/pipelines/preprocessing/template.py) - Template preprocessing settings
+

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -406,21 +406,32 @@ All settings for the ColabFold server and outputs can be set under [`msa_computa
 (34-saving-msa-outputs)=
 #### Saving MSA outputs
 
-By default, MSA outputs are written to a temporary directory and are deleted after prediction is complete. 
+By default, MSA outputs are written to a temporary directory. When a run uses
+the ColabFold MSA server, rank zero deletes the entire MSA directory after
+prediction if `cleanup_msa_dir` is `true`.
 
-These settings can be saved by changing the following fields:
+To keep both the processed MSAs and the raw response, use a persistent directory
+and disable cleanup:
 
 ```yaml
 msa_computation_settings:
   msa_output_directory: <custom path>
-  cleanup_msa_dir: False  # If False, msa paths will not be deleted between runs 
-  save_mappings: True 
+  msa_file_format: a3m
+  cleanup_msa_dir: false
+  save_mappings: true
 
 template_preprocessor_settings:
-  output_directory: <custom path> 
+  output_directory: <custom path>
 ```
 
-MSAs per chain are saved using a file / directory name that is the hash of the sequence. Mappings between the chain name, sequence, and representative ids can be saved via the `save_mappings` field. 
+The reusable per-sequence MSAs are stored under `main/` and `paired/` using
+representative IDs. The raw ColabFold files are kept under `raw/`.
+`save_mappings` records how the input chain names and sequences map to those
+representative IDs.
+
+The MSA client will not overwrite an existing `raw/` directory. Move or delete
+it, or choose a new `msa_output_directory`, before starting another server
+request.
 
 ---
 
@@ -433,8 +444,12 @@ msa_computation_settings:
 
 ---
 
-#### Save MSAs in A3M Format
-Choose the file format for saving MSAs retrieved from ColabFold:
+#### Choose the Processed MSA Format
+
+Choose the format for the reusable per-sequence MSAs under `main/` and
+`paired/`. Both formats can be passed to another OpenFold3 run. Use `a3m` for
+portable, inspectable text alignments; `npz` is the compressed default and is
+faster to parse:
 ```yaml
 msa_computation_settings:
   msa_file_format: a3m     # Options: a3m, npz (default: npz)
@@ -495,17 +510,24 @@ Each seed produces `l` (number of diffusion samples) structure predictions, and 
 
 ### 4.2 Processed MSAs (`main/` and `paired/`)
 Only created if `--use-msa-server=True`. <br/>
-Processed MSAs for each unique chain are saved as `.npz` files used to create input features for OpenFold3. 
+Processed MSAs for each unique chain are saved in the selected `npz` or `a3m`
+format and can be reused in another OpenFold3 run.
 If a chain is reused across multiple queries, its MSA is only computed once and named after the first occurrence. This reduces the number of queries to the ColabFold server.
 
 
-For a sequence with two representative chains, the final output directory would have this format:
+For two representative chains, the combined illustration below shows both
+possible layouts. A run writes only the format selected by `msa_file_format`;
+the `npz` files and `a3m` directories do not appear together:
 
 ```bash
 <msa_output_directory>
 ├── main
-│   ├── <hash of sequence A>.npz
-│   └── <hash of sequence B>.npz
+│   ├── <hash of sequence A>.npz                         # npz
+│   ├── <hash of sequence B>.npz
+│   ├── <hash of sequence A>                             # a3m
+│   │   └── colabfold_main.a3m
+│   └── <hash of sequence B>
+│       └── colabfold_main.a3m
 ├── mappings
 │   ├── chain_id_to_rep_id.json
 │   ├── query_name_to_complex_id.json
@@ -514,41 +536,56 @@ For a sequence with two representative chains, the final output directory would 
 │   └── seq_to_rep_id.json
 └── paired
     └── <hash of concatenation of sequences A and B>
-        ├── <hash of sequence A>.npz
-        └── <hash of sequence B>.npz
+        ├── <hash of sequence A>.npz                     # npz
+        ├── <hash of sequence B>.npz
+        ├── <hash of sequence A>                         # a3m
+        │   └── colabfold_paired.a3m
+        └── <hash of sequence B>
+            └── colabfold_paired.a3m
 ```
 
 
 If a query is a heteromeric protein complex (has at least two different protein chains) and `--use-msa-server` is enabled, **paired MSAs** are also generated. 
 If a set of chains with a specific stoichiometry is reused across multiple queries, for example if the same heterodimer is screened against multiple small molecule ligands, its set of paired MSAs is only computed once and named after the first occurrence. This reduces the number of queries to the ColabFold server. 
 
+The paired portion of the same combined illustration is:
+
 ```bash
 <msa_output_directory>
- ├── paired
-    └── <hash of concatenation of sequences A and B> 
-        ├── <hash of sequence A>.npz
-        └── <hash of sequence B>.npz
+└── paired
+    └── <hash of concatenation of sequences A and B>
+        ├── <hash of sequence A>.npz                     # npz
+        ├── <hash of sequence B>.npz
+        ├── <hash of sequence A>                         # a3m
+        │   └── colabfold_paired.a3m
+        └── <hash of sequence B>
+            └── colabfold_paired.a3m
 ```
 
-In summary, we submit a total of 1 + n queries to the ColabFold MSA server per run - one query for the set of all unqiue protein sequences in the inference query json file (unpaired/main MSAs) and n additional queries for the collection of unqiue protein chain combinations for heteromeric complexes (paired MSAs).
+In summary, we submit a total of 1 + n queries to the ColabFold MSA server per run - one query for the set of all unique protein sequences in the inference query json file (unpaired/main MSAs) and n additional queries for the collection of unique protein chain combinations for heteromeric complexes (paired MSAs).
 
 The MSA deduplication behavior is also present for precomputed MSAs. See the {ref}`chain deduplication utility <4-msa-reusing-utility>` section for details.
 
-Note: The raw ColabFold MSA `.a3m` alignment files and scripts are saved to `<msa_output_directory>/raw/`. <br/> 
-This directory is then deleted upon completion of MSA processing by the OpenFold3 workflow to avoid disruption to future inference submissions. <br/>
+The raw ColabFold `.a3m` files and helper scripts are stored in
+`<msa_output_directory>/raw/`. Set `cleanup_msa_dir: false` to keep them after
+prediction. Before submitting another server request to the same output
+directory, move or delete `raw/`.
 
-To manually keep the raw ColabFold outputs, remove this line here [here](https://github.com/aqlaboratory/openfold-3/blob/9d3ff681560cdd65fa92f80f08a4ab5becaebf87/openfold3/core/data/tools/colabfold_msa_server.py#L933). <br/>
+### 4.3 Mapping outputs (`mappings/`)
 
-### 4.3 Mapping outputs (`mapping/`)
-
-If the same `msa_output_directory` is used between runs, the `rep_id_to_seq.json` and `seq_to_rep_id.json` mappings are updated with the new sequences, while the other mappings are overwritten.
+If the same `msa_output_directory` is used between runs, the
+`rep_id_to_seq.json` and `seq_to_rep_id.json` mappings are updated with the new
+sequences, while the other mappings are overwritten. A preserved `raw/`
+directory must first be moved or deleted before a new server request.
 
 ```bash
 <msa_output_directory>
- ├── paired
-    └── <hash of concatenation of sequences A and B> 
-        ├── <hash of sequence A>.npz
-        └── <hash of sequence B>.npz
+└── mappings
+    ├── chain_id_to_rep_id.json
+    ├── query_name_to_complex_id.json
+    ├── README.md
+    ├── rep_id_to_seq.json
+    └── seq_to_rep_id.json
 ```
 
 ### 4.4 Query Metadata 

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -400,38 +400,47 @@ template_preprocessor_settings:
 
 ### 3.4 Customized ColabFold MSA Server Settings Using `runner.yml` 
 
-All settings for the ColabFold server and outputs can be set under [`msa_computation_settings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py#L904)
+All settings for the ColabFold server and outputs can be set under [`msa_computation_settings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py)
 
 
 (34-saving-msa-outputs)=
 #### Saving MSA outputs
 
-By default, MSA outputs are written to a temporary directory. When a run uses
-the ColabFold MSA server, rank zero deletes the entire MSA directory after
-prediction if `cleanup_msa_dir` is `true`.
+OpenFold saves both forms of MSA output by default:
 
-To keep both the processed MSAs and the raw response, use a persistent directory
-and disable cleanup:
+- OpenFold-formatted alignments are saved to `<output_dir>/msas/<run-id>`.
+- Raw ColabFold server outputs are saved to `<output_dir>/msas/raw/<run-id>`.
+
+When temporary MSA work is needed, each run uses a unique workspace. OpenFold removes that workspace when the command finishes normally or exits through a handled error. The saved files are a record of that run. OpenFold does not automatically reuse them as a cache.
+
+You can turn off either output in `runner.yml`:
 
 ```yaml
 msa_computation_settings:
-  msa_output_directory: <custom path>
-  msa_file_format: a3m
-  cleanup_msa_dir: false
-  save_mappings: true
-
-template_preprocessor_settings:
-  output_directory: <custom path>
+  save_openfold_outputs: true
+  save_colabfold_outputs: false
 ```
 
-The reusable per-sequence MSAs are stored under `main/` and `paired/` using
-representative IDs. The raw ColabFold files are kept under `raw/`.
-`save_mappings` records how the input chain names and sequences map to those
-representative IDs.
+For multi-node inference that generates MSAs, keep `save_openfold_outputs` enabled and put the output directory on storage that every node can read. Rank zero broadcasts its alignment paths to the other ranks, and the temporary workspace may be local to the node that created it.
 
-The MSA client will not overwrite an existing `raw/` directory. Move or delete
-it, or choose a new `msa_output_directory`, before starting another server
-request.
+Set `colabfold_output_dir` when raw records need a different parent directory.
+Each run still receives its own child directory there.
+
+OpenFold copies raw files as soon as the ColabFold server query finishes. It saves the formatted alignments after MSA processing completes. Each per-chain file or directory uses the sequence hash as its name. `save_mappings` includes the chain, sequence, and representative ID mappings in the organized OpenFold record.
+
+Set `msa_output_directory` to save the OpenFold-formatted alignments to an exact directory instead of the default per-run directory. OpenFold still uses and removes a separate temporary workspace. If `colabfold_output_dir` is not set, the raw files are saved under `<msa_output_directory>/raw`. Existing exact destinations remain supported, but OpenFold does not automatically read them as a cache.
+
+##### Running the MSA server separately
+
+Use `align-msa-server` when you want to generate alignments before running prediction. Put all queries for the job in one query JSON so OpenFold can deduplicate the server requests across that set.
+
+```bash
+run_openfold align-msa-server \
+    --query-json queries.json \
+    --output-dir output/alignments
+```
+
+The command writes the alignments and `query_msa.json` under `output/alignments`. The paths in that JSON remain valid after the separate temporary workspace is removed. The command always saves the organized alignments because the JSON depends on them. Pass this JSON to `predict` with `--use-msa-server false` to use the saved alignments without querying the server again.
 
 ---
 
@@ -444,12 +453,8 @@ msa_computation_settings:
 
 ---
 
-#### Choose the Processed MSA Format
-
-Choose the format for the reusable per-sequence MSAs under `main/` and
-`paired/`. Both formats can be passed to another OpenFold3 run. Use `a3m` for
-portable, inspectable text alignments; `npz` is the compressed default and is
-faster to parse:
+#### Save MSAs in A3M Format
+Choose the file format for saving MSAs retrieved from ColabFold:
 ```yaml
 msa_computation_settings:
   msa_file_format: a3m     # Options: a3m, npz (default: npz)
@@ -457,7 +462,7 @@ msa_computation_settings:
 
 ## 4. Model Outputs
 
-In the inference pipeline, we generate a dedicated output directory for each query, named by the corresponding query key (e.g., `query_1` or `3hfm`, if the PDB ID is provided). Each such directory will contain prediction results, MSAs, and intermediate files for MSA and template processing:
+The inference pipeline creates a dedicated output directory for each query, named by the corresponding query key (for example, `query_1` or `3hfm` when a PDB ID is provided). Prediction results are stored there. By default, saved MSA records are stored under `<output_dir>/msas`.
 
 (41-prediction-outputs)=
 ### 4.1 Prediction Outputs (`query/seed/`)
@@ -510,24 +515,17 @@ Each seed produces `l` (number of diffusion samples) structure predictions, and 
 
 ### 4.2 Processed MSAs (`main/` and `paired/`)
 Only created if `--use-msa-server=True`. <br/>
-Processed MSAs for each unique chain are saved in the selected `npz` or `a3m`
-format and can be reused in another OpenFold3 run.
+Processed MSAs for each unique chain are saved as `.npz` files used to create input features for OpenFold3. 
 If a chain is reused across multiple queries, its MSA is only computed once and named after the first occurrence. This reduces the number of queries to the ColabFold server.
 
 
-For two representative chains, the combined illustration below shows both
-possible layouts. A run writes only the format selected by `msa_file_format`;
-the `npz` files and `a3m` directories do not appear together:
+For a sequence with two representative chains, the final output directory would have this format:
 
 ```bash
-<msa_output_directory>
+<output_dir>/msas/<run-id>
 ├── main
-│   ├── <hash of sequence A>.npz                         # npz
-│   ├── <hash of sequence B>.npz
-│   ├── <hash of sequence A>                             # a3m
-│   │   └── colabfold_main.a3m
-│   └── <hash of sequence B>
-│       └── colabfold_main.a3m
+│   ├── <hash of sequence A>.npz
+│   └── <hash of sequence B>.npz
 ├── mappings
 │   ├── chain_id_to_rep_id.json
 │   ├── query_name_to_complex_id.json
@@ -536,56 +534,38 @@ the `npz` files and `a3m` directories do not appear together:
 │   └── seq_to_rep_id.json
 └── paired
     └── <hash of concatenation of sequences A and B>
-        ├── <hash of sequence A>.npz                     # npz
-        ├── <hash of sequence B>.npz
-        ├── <hash of sequence A>                         # a3m
-        │   └── colabfold_paired.a3m
-        └── <hash of sequence B>
-            └── colabfold_paired.a3m
+        ├── <hash of sequence A>.npz
+        └── <hash of sequence B>.npz
 ```
 
 
 If a query is a heteromeric protein complex (has at least two different protein chains) and `--use-msa-server` is enabled, **paired MSAs** are also generated. 
 If a set of chains with a specific stoichiometry is reused across multiple queries, for example if the same heterodimer is screened against multiple small molecule ligands, its set of paired MSAs is only computed once and named after the first occurrence. This reduces the number of queries to the ColabFold server. 
 
-The paired portion of the same combined illustration is:
-
 ```bash
-<msa_output_directory>
-└── paired
-    └── <hash of concatenation of sequences A and B>
-        ├── <hash of sequence A>.npz                     # npz
-        ├── <hash of sequence B>.npz
-        ├── <hash of sequence A>                         # a3m
-        │   └── colabfold_paired.a3m
-        └── <hash of sequence B>
-            └── colabfold_paired.a3m
+<output_dir>/msas/<run-id>
+ ├── paired
+    └── <hash of concatenation of sequences A and B> 
+        ├── <hash of sequence A>.npz
+        └── <hash of sequence B>.npz
 ```
 
-In summary, we submit a total of 1 + n queries to the ColabFold MSA server per run - one query for the set of all unique protein sequences in the inference query json file (unpaired/main MSAs) and n additional queries for the collection of unique protein chain combinations for heteromeric complexes (paired MSAs).
+In summary, we submit a total of 1 + n queries to the ColabFold MSA server per run - one query for the set of all unqiue protein sequences in the inference query json file (unpaired/main MSAs) and n additional queries for the collection of unqiue protein chain combinations for heteromeric complexes (paired MSAs).
 
 The MSA deduplication behavior is also present for precomputed MSAs. See the {ref}`chain deduplication utility <4-msa-reusing-utility>` section for details.
 
-The raw ColabFold `.a3m` files and helper scripts are stored in
-`<msa_output_directory>/raw/`. Set `cleanup_msa_dir: false` to keep them after
-prediction. Before submitting another server request to the same output
-directory, move or delete `raw/`.
+Raw ColabFold `.a3m` files and helper scripts are saved under `<colabfold_output_dir>/<run-id>`. During inference, the parent defaults to `<output_dir>/msas/raw` when `msa_output_directory` is not set.
 
 ### 4.3 Mapping outputs (`mappings/`)
 
-If the same `msa_output_directory` is used between runs, the
-`rep_id_to_seq.json` and `seq_to_rep_id.json` mappings are updated with the new
-sequences, while the other mappings are overwritten. A preserved `raw/`
-directory must first be moved or deleted before a new server request.
+The mapping files describe the sequences and representative IDs in the saved MSA record. When the same explicit `msa_output_directory` is reused, the `rep_id_to_seq.json` and `seq_to_rep_id.json` mappings gain the new sequences, while the other mappings are overwritten.
 
 ```bash
-<msa_output_directory>
-└── mappings
-    ├── chain_id_to_rep_id.json
-    ├── query_name_to_complex_id.json
-    ├── README.md
-    ├── rep_id_to_seq.json
-    └── seq_to_rep_id.json
+<output_dir>/msas/<run-id>
+ ├── paired
+    └── <hash of concatenation of sequences A and B> 
+        ├── <hash of sequence A>.npz
+        └── <hash of sequence B>.npz
 ```
 
 ### 4.4 Query Metadata 
@@ -621,13 +601,6 @@ This file representing the full input query in a validated internal format defin
 
   Note: Refer to the {doc}`Template How-To Documentation <template_how_to>` for how to specify these fields if you want to use precomputed template alignments instead of Colabfold alignments for template inputs, or see {ref}`CIF Direct Template Mode <inference-cif-direct-templates>` for using template structures directly without alignments.
 
-Note: If MSA and template files are persisted between runs, the same `inference_query_set.json` file can be used to resubmit the query without needing to rerun the template and MSA pipelines. To do so:
-
-1. Turn off the [MSA cleanup option](34-saving-msa-outputs).
-2. pass in the generated `inference_query_set.json` as the `query.json` and use `--use-msa-server=False` and `--use-templates=True`.
-
-Model seeds should still be set either from the command line or using the `seeds` field under `experiment_settings` in the `runner.yml`.
-
 (442-model-config-json)=
 #### 4.4.2 Model Config (`model_config.json`)
 
@@ -642,7 +615,7 @@ This file records the entire state of the experiment, as defined by the [Inferen
 
 **🔗 Example:**
 
-See the full multimer output for [Deoxy human hemoglobin](https://huggingface.co/OpenFold/OpenFold3/tree/main/examples/output_multimer_with_colabfold_msas), which were generated with `run_multimer.sh`. For this example, the colabfold_msas and colabfold_template directories are stored in the same outbut directory. 
+See the full multimer output for [Deoxy human hemoglobin](https://huggingface.co/OpenFold/OpenFold3/tree/main/examples/output_multimer_with_colabfold_msas), generated with `run_multimer.sh`. This published example predates the per-run MSA directory layout described above, so it keeps the `colabfold_msas` and `colabfold_templates` directories directly in the output directory.
 
 
 When processing multimer inputs (e.g., hemoglobin α + β chains), OpenFold3 automatically:

--- a/examples/colabfold_msa_alignment/msa_server.yml
+++ b/examples/colabfold_msa_alignment/msa_server.yml
@@ -1,13 +1,15 @@
-# This yaml is an example configuration for using the `align_msa_server` cli option in `run_openfold.py`
+# Settings for the `align-msa-server` command in `run_openfold.py`.
+# Put every query for the job in one query JSON so the server requests can be
+# deduplicated across the full set.
 
 # This uses the model defined by core.data.tools.colabfold_msa_server.MsaComputationSettings
 
 # To run with this server yaml:
 #   ```
-#   python run_openfold.py align-msa-server \
-#       --query_json query_example.json \
-#       --output_dir output/msa_server_test \
-#       --msa_computation_settings_yaml examples/msa_server.yml 
+#   run_openfold align-msa-server \
+#       --query-json examples/example_inference_inputs/query_ubiquitin.json \
+#       --output-dir output/msa_server_test \
+#       --msa-computation-settings-yaml examples/colabfold_msa_alignment/msa_server.yml
 #   ```
   
 

--- a/examples/example_runner_yamls/save_msa_output.yml
+++ b/examples/example_runner_yamls/save_msa_output.yml
@@ -1,7 +1,9 @@
 msa_computation_settings:
   msa_output_directory: ./colabfold_msas
-  cleanup_msa_dir: False
-  save_mappings: True 
+  msa_file_format: a3m
+  cleanup_msa_dir: false
+  save_mappings: true
+  # Move or delete raw/ before reusing this directory for another server request.
 
 template_preprocessor_settings:
   output_directory: ./colabfold_templates

--- a/examples/example_runner_yamls/save_msa_output.yml
+++ b/examples/example_runner_yamls/save_msa_output.yml
@@ -1,9 +1,4 @@
 msa_computation_settings:
-  msa_output_directory: ./colabfold_msas
-  msa_file_format: a3m
-  cleanup_msa_dir: false
+  save_openfold_outputs: true
+  save_colabfold_outputs: true
   save_mappings: true
-  # Move or delete raw/ before reusing this directory for another server request.
-
-template_preprocessor_settings:
-  output_directory: ./colabfold_templates

--- a/examples/reference_full_config/full_config.yml
+++ b/examples/reference_full_config/full_config.yml
@@ -125,15 +125,18 @@ output_writer_settings:
   write_latent_outputs: false
   write_full_confidence_scores: true
 
-# MSAComputationSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py#L904
+# MSAComputationSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py
 # Configure MSA server settings for colabfold 
 msa_computation_settings: 
   msa_file_format: npz
   server_user_agent: openfold
   server_url: https://api.colabfold.com/
   save_mappings: true
-  msa_output_directory: <tmp-dir>/of3-of-<user>/colabfold_msas/ 
+  msa_output_directory: null
   cleanup_msa_dir: true
+  save_openfold_outputs: true
+  save_colabfold_outputs: true
+  colabfold_output_dir: null
 
 # TemplatePreprocessorSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/pipelines/preprocessing/template.py#L1459
 # Configure template processing settings, more information in docs/source/template_how_to.md

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1428,13 +1428,10 @@ openfold3/core/data/resources/residues.py:0: error: Type argument "int" of "ndar
 openfold3/core/data/resources/residues.py:0: error: Type argument "str" of "ndarray" must be a subtype of "tuple[int, ...]"  [type-var]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: "append" of "list" does not return a value (it only ever returns None)  [func-returns-value]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: "str" not callable  [operator]
-openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument "output_directory" to "ColabFoldQueryRunner" has incompatible type "Path | None"; expected "Path"  [arg-type]
-openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument "output_directory" to "add_msa_paths_to_iqs" has incompatible type "Path | None"; expected "Path"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 1 to "append" of "list" has incompatible type "None"; expected "str"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 1 to "append" of "list" has incompatible type "str | None"; expected "str"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 1 to "append" of "list" has incompatible type "str"; expected "ChainInput"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 1 to "get_sequence_hash" has incompatible type "str | None"; expected "str"  [arg-type]
-openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 2 to "save_colabfold_mappings" has incompatible type "Path | None"; expected "Path"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 2 to "savez_compressed" has incompatible type "**dict[str, dict[Any, Any]]"; expected "Buffer | _SupportsArray[dtype[Any]] | _NestedSequence[_SupportsArray[dtype[Any]]] | complex | bytes | str | _NestedSequence[complex | bytes | str]"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 2 to "savez_compressed" has incompatible type "**dict[str, dict[Any, Any]]"; expected "bool"  [arg-type]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Argument 3 to "ChainInput" has incompatible type "str | None"; expected "str"  [arg-type]
@@ -1461,12 +1458,7 @@ openfold3/core/data/tools/colabfold_msa_server.py:0: error: Need type annotation
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Need type annotation for "chain_inputs_seen" (hint: "chain_inputs_seen: set[<type>] = ...")  [var-annotated]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Need type annotation for "template_paths_" (hint: "template_paths_: list[<type>] = ...")  [var-annotated]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Need type annotation for "templates" (hint: "templates: dict[<type>, <type>] = ...")  [var-annotated]
-openfold3/core/data/tools/colabfold_msa_server.py:0: error: Unsupported left operand type for / ("None")  [operator]
-openfold3/core/data/tools/colabfold_msa_server.py:0: error: Unsupported left operand type for / ("None")  [operator]
 openfold3/core/data/tools/colabfold_msa_server.py:0: error: Unsupported operand types for + ("str" and "None")  [operator]
-openfold3/core/data/tools/colabfold_msa_server.py:0: note: Left operand is of type "Path | Any"
-openfold3/core/data/tools/colabfold_msa_server.py:0: note: Left operand is of type "Path | None"
-openfold3/core/data/tools/colabfold_msa_server.py:0: note: Left operand is of type "Path | None"
 openfold3/core/data/tools/colabfold_msa_server.py:0: note: Right operand is of type "str | None"
 openfold3/core/data/tools/jackhmmer.py:0: error: Incompatible return value type (got "list[Mapping[str, Any]]", expected "Sequence[Sequence[Mapping[str, Any]]]")  [return-value]
 openfold3/core/data/tools/jackhmmer.py:0: error: Need type annotation for "chunked_outputs"  [var-annotated]

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -1160,6 +1160,11 @@ def preprocess_colabfold_msas(
         InferenceQuerySet:
             The updated inference query set with the MSA file paths added.
 
+    Raises:
+        FileExistsError:
+            If `output_directory/raw` already exists. Move or remove that directory
+            before retrying.
+
     Mapping:
         First, maps each sequence to a representative ID (deduplicate repeated
         sequences). Then maps each set of sequences in a structure to a representative
@@ -1200,19 +1205,21 @@ def preprocess_colabfold_msas(
     output_directory = compute_settings.msa_output_directory
     logger.warning(f"Using output directory: {output_directory} for ColabFold MSAs.")
 
+    raw_dir = output_directory / "raw"
+    try:
+        # Creating `raw/` is the reservation. A second process fails here.
+        raw_dir.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        raise FileExistsError(
+            f"ColabFold raw output directory already exists: {raw_dir}\n"
+            "Move or remove it before starting another MSA-server run with this "
+            "output directory. OpenFold3 will not overwrite or reuse existing raw "
+            "output because it may belong to a different query."
+        ) from None
+
     # Save mappings to file
     if compute_settings.save_mappings:
         save_colabfold_mappings(colabfold_mapper, output_directory)
-
-    # Abort early if a stale raw directory exists — it contains unvalidated
-    # out.tar.gz files that would be silently reused for the wrong query.
-    raw_dir = output_directory / "raw"
-    if raw_dir.exists():
-        raise FileExistsError(
-            f"ColabFold raw directory already exists: {raw_dir}\n"
-            "This is likely left over from a previous failed run. "
-            "Please remove it before starting a new run."
-        )
 
     # Run batch queries for main and paired MSAs
     colabfold_query_runner = ColabFoldQueryRunner(

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import getpass
 import json
 import logging
 import os
 import random
+import secrets
 import shutil
 import tarfile
 import time
 import warnings
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import IntEnum
 from pathlib import Path
 from typing import Literal, NamedTuple
-from uuid import uuid4
 
 import numpy as np
 import pandas as pd
@@ -1104,6 +1107,12 @@ def _default_msa_output_root() -> Path:
     return get_of3_tmpdir()
 
 
+def _default_run_directory_name() -> str:
+    """Return a readable, per-run MSA directory name."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"msa-{getpass.getuser()}-{timestamp}-{secrets.token_hex(4)}"
+
+
 def _workspace_contains_output(workspace: Path, output_directory: Path) -> bool:
     """Return whether workspace cleanup would remove the output directory."""
     workspace = workspace.resolve()
@@ -1126,9 +1135,9 @@ class MsaComputationSettings(BaseModel):
     save_openfold_outputs: bool = True
     save_colabfold_outputs: bool = True
     colabfold_output_dir: Path | None = None
-    _workspace_token: str = PrivateAttr(default_factory=lambda: uuid4().hex)
-    _run_directory_name: str = PrivateAttr(default_factory=lambda: f"msa-{uuid4().hex}")
+    _run_directory_name: str = PrivateAttr(default_factory=_default_run_directory_name)
     _saved_output_root: Path | None = PrivateAttr(default=None)
+    _workspace_created: bool = PrivateAttr(default=False)
 
     @property
     def run_directory_name(self) -> str:
@@ -1204,32 +1213,17 @@ class MsaComputationSettings(BaseModel):
             raise
 
     def create_workspace(self) -> None:
-        """Create and mark the temporary workspace owned by this run."""
+        """Create the temporary workspace and record ownership for cleanup."""
         self.workspace_directory.mkdir(parents=True, exist_ok=False)
-        try:
-            (self.workspace_directory / ".openfold3-msa-workspace").write_text(
-                self._workspace_token
-            )
-        except OSError:
-            shutil.rmtree(self.workspace_directory, ignore_errors=True)
-            raise
+        self._workspace_created = True
 
-    def cleanup_workspace(self) -> bool:
-        """Remove this run's temporary workspace and report whether it was removed."""
-        marker = self.workspace_directory / ".openfold3-msa-workspace"
-        try:
-            if marker.read_bytes() == self._workspace_token.encode():
-                shutil.rmtree(self.workspace_directory, ignore_errors=True)
-                removed = not self.workspace_directory.exists()
-                if not removed:
-                    logger.warning(
-                        f"Could not remove temporary MSA directory: "
-                        f"{self.workspace_directory}"
-                    )
-                return removed
-        except OSError:
-            pass
-        return False
+    def cleanup_workspace(self) -> None:
+        """Remove the temporary workspace created by this settings instance."""
+        if not self._workspace_created:
+            return
+        with suppress(FileNotFoundError):
+            shutil.rmtree(self.workspace_directory)
+        self._workspace_created = False
 
     @classmethod
     def from_config_with_cli_override(

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -991,14 +991,6 @@ class ColabFoldQueryRunner:
                         msas_preparsed[k] = v.to_dict()
                     np.savez_compressed(npz_file, **msas_preparsed)
 
-    def cleanup(self):
-        """Remove raw colabfold MSA directory.
-
-        If the same MSA output directory is used, this directory must be removed
-        to avoid using old MSAs for new inputs.
-        """
-        shutil.rmtree(self.output_directory / "raw", ignore_errors=True)
-
 
 def add_msa_paths_to_iqs(
     inference_query_set: InferenceQuerySet,

--- a/openfold3/core/data/tools/colabfold_msa_server.py
+++ b/openfold3/core/data/tools/colabfold_msa_server.py
@@ -20,15 +20,17 @@ import shutil
 import tarfile
 import time
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum
 from pathlib import Path
 from typing import Literal, NamedTuple
+from uuid import uuid4
 
 import numpy as np
 import pandas as pd
 import requests
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, PrivateAttr
 from pydantic import ConfigDict as PydanticConfigDict
 from pydantic_core import Url
 from tqdm import tqdm
@@ -127,6 +129,7 @@ def query_colabfold_msa_server(
     use_filter: bool = True,
     filter: bool | None = None,
     host_url: str = "https://api.colabfold.com",
+    raw_output_callback: Callable[[Path], None] | None = None,
 ) -> list[str] | tuple[list[str], list[str]]:
     """Submints a single query to the colabfold MSA server.
 
@@ -156,6 +159,8 @@ def query_colabfold_msa_server(
             Legacy option to enable diversity filter. Defaults to None.
         host_url (str, optional):
             host url for MSA server. Defaults to "https://api.colabfold.com".
+        raw_output_callback (Callable[[Path], None] | None, optional):
+            Called with the validated raw output directory before parsing begins.
 
     Returns:
         list[str] | tuple[list[str], list[str]]:
@@ -395,6 +400,8 @@ def query_colabfold_msa_server(
     # Validate the download produced the expected outputs before any downstream
     # code blindly opens them (issue #269).
     _validate_expected_msa_files(a3m_files, tar_gz_file, use_pairing=use_pairing)
+    if raw_output_callback is not None:
+        raw_output_callback(Path(path))
 
     # Process templates
     if use_templates:
@@ -810,6 +817,7 @@ class ColabFoldQueryRunner:
         msa_file_format: str | list[str],
         user_agent: str,
         host_url: Url = "https://api.colabfold.com",
+        colabfold_output_dir: Path | None = None,
     ):
         self.colabfold_mapper = colabfold_mapper
         self.output_directory = output_directory
@@ -817,6 +825,7 @@ class ColabFoldQueryRunner:
             msa_file_format if isinstance(msa_file_format, list) else [msa_file_format]
         )
         self.user_agent = user_agent
+        self.colabfold_output_dir = colabfold_output_dir
         self.output_directory.mkdir(parents=True, exist_ok=True)
         self.host_url = host_url
         for subdir in ["raw", "main", "paired"]:
@@ -826,6 +835,14 @@ class ColabFoldQueryRunner:
                     (self.output_directory / subdir / subsubdir).mkdir(
                         parents=True, exist_ok=True
                     )
+
+    def _save_raw_output(self, source: Path, relative_path: str) -> None:
+        if self.colabfold_output_dir is not None:
+            shutil.copytree(
+                source,
+                self.colabfold_output_dir / relative_path,
+                dirs_exist_ok=True,
+            )
 
     def query_format_main(self):
         """Submits queries and formats the outputs for main MSAs."""
@@ -847,6 +864,7 @@ class ColabFoldQueryRunner:
             use_pairing=False,
             user_agent=self.user_agent,
             host_url=self.host_url,
+            raw_output_callback=lambda path: self._save_raw_output(path, "main"),
         )
 
         main_alignments_path = self.output_directory / "main"
@@ -943,6 +961,9 @@ class ColabFoldQueryRunner:
                 use_pairing=True,
                 user_agent=self.user_agent,
                 host_url=self.host_url,
+                raw_output_callback=lambda path, relative_path=f"paired/{complex_id}": (
+                    self._save_raw_output(path, relative_path)
+                ),
             )
 
             # TODO: process the returned MSAs - save per representative ID
@@ -1076,6 +1097,20 @@ def add_msa_paths_to_iqs(
     return inference_query_set
 
 
+def _default_msa_output_root() -> Path:
+    """Return the default parent directory for temporary MSA workspaces."""
+    from openfold3.core.data.tools.utils import get_of3_tmpdir
+
+    return get_of3_tmpdir()
+
+
+def _workspace_contains_output(workspace: Path, output_directory: Path) -> bool:
+    """Return whether workspace cleanup would remove the output directory."""
+    workspace = workspace.resolve()
+    output_directory = output_directory.resolve()
+    return workspace == output_directory or workspace in output_directory.parents
+
+
 class MsaComputationSettings(BaseModel):
     """Settings to run ColabFold MSA server.
 
@@ -1088,17 +1123,113 @@ class MsaComputationSettings(BaseModel):
     save_mappings: bool = True
     msa_output_directory: Path | None = None
     cleanup_msa_dir: bool = True
+    save_openfold_outputs: bool = True
+    save_colabfold_outputs: bool = True
+    colabfold_output_dir: Path | None = None
+    _workspace_token: str = PrivateAttr(default_factory=lambda: uuid4().hex)
+    _run_directory_name: str = PrivateAttr(default_factory=lambda: f"msa-{uuid4().hex}")
+    _saved_output_root: Path | None = PrivateAttr(default=None)
 
-    @model_validator(mode="after")
-    def create_dir(self) -> "MsaComputationSettings":
-        """Creates the output directory if it does not exist."""
-        if self.msa_output_directory is None:
-            from openfold3.core.data.tools.utils import get_of3_tmpdir
+    @property
+    def run_directory_name(self) -> str:
+        """Return the unique directory name shared by this run's MSA records."""
+        return self._run_directory_name
 
-            self.msa_output_directory = get_of3_tmpdir("colabfold_msas")
-        elif not self.msa_output_directory.exists():
-            self.msa_output_directory.mkdir(parents=True, exist_ok=True)
-        return self
+    @property
+    def workspace_directory(self) -> Path:
+        """Return this run's unique temporary workspace."""
+        return _default_msa_output_root() / self.run_directory_name
+
+    @property
+    def saved_output_directory(self) -> Path | None:
+        """Return this run's persistent MSA record directory, when configured."""
+        if self.msa_output_directory is not None:
+            return self.msa_output_directory
+        if self._saved_output_root is None:
+            return None
+        return self._saved_output_root / self.run_directory_name
+
+    @property
+    def saved_colabfold_output_directory(self) -> Path | None:
+        """Return this run's raw ColabFold record directory, when configured."""
+        if self.colabfold_output_dir is not None:
+            return self.colabfold_output_dir / self.run_directory_name
+        if self.msa_output_directory is not None:
+            return self.msa_output_directory / "raw"
+        if self._saved_output_root is not None:
+            return self._saved_output_root / "raw" / self.run_directory_name
+        return None
+
+    def validate_output_paths(self) -> None:
+        """Ensure final cleanup cannot remove either saved MSA record."""
+        saved_directories = {
+            "OpenFold MSA output directory": (
+                self.saved_output_directory if self.save_openfold_outputs else None
+            ),
+            "ColabFold output directory": (
+                self.saved_colabfold_output_directory
+                if self.save_colabfold_outputs
+                else None
+            ),
+        }
+        for label, output_directory in saved_directories.items():
+            if output_directory is not None and _workspace_contains_output(
+                self.workspace_directory, output_directory
+            ):
+                raise ValueError(
+                    f"{label} '{output_directory}' must not overlap the temporary "
+                    f"MSA workspace '{self.workspace_directory}'."
+                )
+
+        organized = saved_directories["OpenFold MSA output directory"]
+        raw = saved_directories["ColabFold output directory"]
+        if (
+            organized is not None
+            and raw is not None
+            and organized.resolve() == raw.resolve()
+        ):
+            raise ValueError(
+                "The OpenFold and ColabFold output directories must differ when "
+                "both outputs are saved."
+            )
+
+    def set_saved_output_root(self, output_directory: Path) -> None:
+        """Set the parent directory for this run's saved MSA record."""
+        previous_root = self._saved_output_root
+        self._saved_output_root = Path(output_directory)
+        try:
+            self.validate_output_paths()
+        except ValueError:
+            self._saved_output_root = previous_root
+            raise
+
+    def create_workspace(self) -> None:
+        """Create and mark the temporary workspace owned by this run."""
+        self.workspace_directory.mkdir(parents=True, exist_ok=False)
+        try:
+            (self.workspace_directory / ".openfold3-msa-workspace").write_text(
+                self._workspace_token
+            )
+        except OSError:
+            shutil.rmtree(self.workspace_directory, ignore_errors=True)
+            raise
+
+    def cleanup_workspace(self) -> bool:
+        """Remove this run's temporary workspace and report whether it was removed."""
+        marker = self.workspace_directory / ".openfold3-msa-workspace"
+        try:
+            if marker.read_bytes() == self._workspace_token.encode():
+                shutil.rmtree(self.workspace_directory, ignore_errors=True)
+                removed = not self.workspace_directory.exists()
+                if not removed:
+                    logger.warning(
+                        f"Could not remove temporary MSA directory: "
+                        f"{self.workspace_directory}"
+                    )
+                return removed
+        except OSError:
+            pass
+        return False
 
     @classmethod
     def from_config_with_cli_override(
@@ -1116,25 +1247,21 @@ class MsaComputationSettings(BaseModel):
             ValueError: If config specifies a different output directory than CLI
         """
         config_dict = config_utils.load_yaml(config_yaml) if config_yaml else dict()
-
-        if (
-            "msa_output_directory" in config_dict
-            and Path(config_dict["msa_output_directory"]) != cli_output_dir
-        ):
+        configured_output = config_dict.get("msa_output_directory")
+        if configured_output is not None and Path(configured_output) != cli_output_dir:
             raise ValueError(
                 f"Output directory mismatch: CLI argument '{cli_output_dir}' "
-                f"vs settings file '{config_dict['msa_output_directory']}'. "
-                f"Please ensure they match or omit 'msa_output_directory' "
-                "from your settings file."
+                f"vs settings file '{configured_output}'. Please ensure they match "
+                "or omit 'msa_output_directory' from your settings file."
             )
-
         config_dict = config_dict.copy()
-        config_dict["msa_output_directory"] = str(cli_output_dir)
-
-        # Disable cleanup assuming this mode is used for the run_msa_server option.
-        config_dict["cleanup_msa_dir"] = False
-
-        return cls.model_validate(config_dict)
+        config_dict["msa_output_directory"] = cli_output_dir
+        settings = cls.model_validate(config_dict)
+        # The alignment-only command must save organized files because the query JSON
+        # it writes needs paths that survive temporary-workspace cleanup.
+        settings.save_openfold_outputs = True
+        settings.set_saved_output_root(cli_output_dir)
+        return settings
 
 
 def preprocess_colabfold_msas(
@@ -1159,11 +1286,6 @@ def preprocess_colabfold_msas(
     Returns:
         InferenceQuerySet:
             The updated inference query set with the MSA file paths added.
-
-    Raises:
-        FileExistsError:
-            If `output_directory/raw` already exists. Move or remove that directory
-            before retrying.
 
     Mapping:
         First, maps each sequence to a representative ID (deduplicate repeated
@@ -1200,22 +1322,13 @@ def preprocess_colabfold_msas(
         By default, uses the npz file paths if available, otherwise uses the a3m file
         paths.
     """
+    output_directory = compute_settings.workspace_directory
+    logger.warning(f"Using output directory: {output_directory} for ColabFold MSAs.")
+    compute_settings.validate_output_paths()
+    compute_settings.create_workspace()
+
     # Gather MSA data
     colabfold_mapper = collect_colabfold_msa_data(inference_query_set)
-    output_directory = compute_settings.msa_output_directory
-    logger.warning(f"Using output directory: {output_directory} for ColabFold MSAs.")
-
-    raw_dir = output_directory / "raw"
-    try:
-        # Creating `raw/` is the reservation. A second process fails here.
-        raw_dir.mkdir(parents=True, exist_ok=False)
-    except FileExistsError:
-        raise FileExistsError(
-            f"ColabFold raw output directory already exists: {raw_dir}\n"
-            "Move or remove it before starting another MSA-server run with this "
-            "output directory. OpenFold3 will not overwrite or reuse existing raw "
-            "output because it may belong to a different query."
-        ) from None
 
     # Save mappings to file
     if compute_settings.save_mappings:
@@ -1228,15 +1341,50 @@ def preprocess_colabfold_msas(
         msa_file_format=compute_settings.msa_file_format,
         user_agent=compute_settings.server_user_agent,
         host_url=compute_settings.server_url,
+        colabfold_output_dir=(
+            compute_settings.saved_colabfold_output_directory
+            if compute_settings.save_colabfold_outputs
+            and compute_settings.saved_colabfold_output_directory is not None
+            else None
+        ),
     )
     colabfold_query_runner.query_format_main()
     colabfold_query_runner.query_format_paired()
+
+    # Save OpenFold-formatted outputs after processing is complete.
+    msa_path_directory = output_directory
+    if (
+        compute_settings.save_openfold_outputs
+        and compute_settings.saved_output_directory is not None
+    ):
+        saved_output_directory = compute_settings.saved_output_directory
+        explicit_output_directory = compute_settings.msa_output_directory is not None
+        saved_output_directory.mkdir(parents=True, exist_ok=explicit_output_directory)
+        try:
+            directory_names = ["main", "paired", "template"]
+            if not explicit_output_directory:
+                directory_names.append("mappings")
+            for directory_name in directory_names:
+                source = output_directory / directory_name
+                if source.exists():
+                    shutil.copytree(
+                        source,
+                        saved_output_directory / directory_name,
+                        dirs_exist_ok=explicit_output_directory,
+                    )
+            if explicit_output_directory and compute_settings.save_mappings:
+                save_colabfold_mappings(colabfold_mapper, saved_output_directory)
+        except BaseException:
+            if not explicit_output_directory:
+                shutil.rmtree(saved_output_directory, ignore_errors=True)
+            raise
+        msa_path_directory = saved_output_directory
 
     # Add paths to the IQS
     inference_query_set = add_msa_paths_to_iqs(
         inference_query_set=inference_query_set,
         colabfold_mapper=colabfold_mapper,
-        output_directory=output_directory,
+        output_directory=msa_path_directory,
     )
 
     return inference_query_set
@@ -1246,13 +1394,30 @@ def augment_main_msa_with_query_sequence(
     inference_query_set: InferenceQuerySet,
     compute_settings: MsaComputationSettings,
 ) -> InferenceQuerySet:
-    output_directory = compute_settings.msa_output_directory
+    compute_settings.validate_output_paths()
+    saved_output_directory = compute_settings.saved_output_directory
+    if compute_settings.save_openfold_outputs and saved_output_directory is not None:
+        save_to_output = True
+        output_directory = saved_output_directory
+    else:
+        save_to_output = False
+        output_directory = compute_settings.workspace_directory
+    output_ready = False
     for query_name, query in inference_query_set.queries.items():
         for chain in query.chains:
             if (
                 chain.molecule_type == MoleculeType.PROTEIN
                 or chain.molecule_type == MoleculeType.RNA
             ) and chain.main_msa_file_paths is None:
+                if not output_ready:
+                    if save_to_output:
+                        output_directory.mkdir(
+                            parents=True,
+                            exist_ok=compute_settings.msa_output_directory is not None,
+                        )
+                    else:
+                        compute_settings.create_workspace()
+                    output_ready = True
                 dummy_rep_dir = (
                     output_directory / "dummy" / get_sequence_hash(chain.sequence)
                 )

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -806,9 +806,13 @@ class InferenceExperimentRunner(ExperimentRunner):
     def cleanup_msa_workspace(self):
         """Remove the temporary MSA workspace created by this run."""
         msa_settings = self.experiment_config.msa_computation_settings
-        if msa_settings.cleanup_workspace():
-            logger.info(
-                f"Removed temporary MSA directory: {msa_settings.workspace_directory}"
+        try:
+            msa_settings.cleanup_workspace()
+        except OSError:
+            logger.warning(
+                "Could not remove temporary MSA workspace for run %s",
+                msa_settings.run_directory_name,
+                exc_info=True,
             )
 
     def cleanup(self):

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -802,31 +802,27 @@ class InferenceExperimentRunner(ExperimentRunner):
             shutil.rmtree(path)
 
     def cleanup(self):
-        """Cleanup directories from colabfold MSA"""
+        """Clean up temporary inference directories."""
         if self.is_rank_zero and self.log_dir.is_dir() and not os.listdir(self.log_dir):
             print("Removing empty log directory...")
             self.log_dir.rmdir()
 
-        if self.use_msa_server and self.is_rank_zero:
+        if (
+            self.use_msa_server
+            and self.is_rank_zero
+            and self.experiment_config.msa_computation_settings.cleanup_msa_dir
+        ):
             print("Cleaning up MSA directories...")
-
-            # Always remove raw directory
-            # TODO: Change to use ColabFoldQueryRunner.cleanup() when
-            # msa processing is performed in `prepare_data` lightning data hook
-            raw_colabfold_msa_path = (
+            msa_output_dir = (
                 self.experiment_config.msa_computation_settings.msa_output_directory
-                / "raw"
             )
-            self._maybe_remove_dir(raw_colabfold_msa_path)
-            if self.experiment_config.msa_computation_settings.cleanup_msa_dir:
-                msa_output_dir = (
-                    self.experiment_config.msa_computation_settings.msa_output_directory
-                )
-                logger.info(f"Removing MSA output directory: {msa_output_dir}")
-                self._maybe_remove_dir(msa_output_dir)
-                if self.use_templates:
-                    template_dir = self.experiment_config.template_preprocessor_settings.structure_directory.parent  # noqa: E501
-                    self._maybe_remove_dir(template_dir)
+            # Raw and normalized MSAs share this directory, so the flag
+            # governs their lifecycle together.
+            logger.info(f"Removing MSA output directory: {msa_output_dir}")
+            self._maybe_remove_dir(msa_output_dir)
+            if self.use_templates:
+                template_dir = self.experiment_config.template_preprocessor_settings.structure_directory.parent  # noqa: E501
+                self._maybe_remove_dir(template_dir)
 
 
 class WandbHandler:

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -596,6 +596,8 @@ class InferenceExperimentRunner(ExperimentRunner):
             use_msa_server,
             use_templates,
         )
+        msa_settings = experiment_config.msa_computation_settings
+        msa_settings.set_saved_output_root(self.output_dir / "msas")
 
     def set_num_diffusion_samples(self, num_diffusion_samples: int) -> None:
         update_dict = {
@@ -801,28 +803,31 @@ class InferenceExperimentRunner(ExperimentRunner):
         if path.exists():
             shutil.rmtree(path)
 
+    def cleanup_msa_workspace(self):
+        """Remove the temporary MSA workspace created by this run."""
+        msa_settings = self.experiment_config.msa_computation_settings
+        if msa_settings.cleanup_workspace():
+            logger.info(
+                f"Removed temporary MSA directory: {msa_settings.workspace_directory}"
+            )
+
     def cleanup(self):
-        """Clean up temporary inference directories."""
+        """Cleanup directories from colabfold MSA"""
+        self.cleanup_msa_workspace()
+        msa_settings = self.experiment_config.msa_computation_settings
+
         if self.is_rank_zero and self.log_dir.is_dir() and not os.listdir(self.log_dir):
             print("Removing empty log directory...")
             self.log_dir.rmdir()
 
         if (
-            self.use_msa_server
-            and self.is_rank_zero
-            and self.experiment_config.msa_computation_settings.cleanup_msa_dir
+            self.is_rank_zero
+            and self.use_msa_server
+            and msa_settings.cleanup_msa_dir
+            and self.use_templates
         ):
-            print("Cleaning up MSA directories...")
-            msa_output_dir = (
-                self.experiment_config.msa_computation_settings.msa_output_directory
-            )
-            # Raw and normalized MSAs share this directory, so the flag
-            # governs their lifecycle together.
-            logger.info(f"Removing MSA output directory: {msa_output_dir}")
-            self._maybe_remove_dir(msa_output_dir)
-            if self.use_templates:
-                template_dir = self.experiment_config.template_preprocessor_settings.structure_directory.parent  # noqa: E501
-                self._maybe_remove_dir(template_dir)
+            template_dir = self.experiment_config.template_preprocessor_settings.structure_directory.parent  # noqa: E501
+            self._maybe_remove_dir(template_dir)
 
 
 class WandbHandler:

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -24,7 +24,7 @@ from typing import Any, Literal
 from lightning_fabric.plugins.collectives.torch_collective import default_pg_timeout
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic import ConfigDict as PydanticConfigDict
 
 from openfold3.core.data.pipelines.preprocessing.template import (
@@ -384,7 +384,9 @@ class InferenceExperimentConfig(ExperimentConfig):
     data_module_args: DataModuleArgs = DataModuleArgs()
     dataset_config_kwargs: InferenceDatasetConfigKwargs = InferenceDatasetConfigKwargs()
     output_writer_settings: OutputWritingSettings = OutputWritingSettings()
-    msa_computation_settings: MsaComputationSettings = MsaComputationSettings()
+    msa_computation_settings: MsaComputationSettings = Field(
+        default_factory=MsaComputationSettings
+    )
     template_preprocessor_settings: TemplatePreprocessorSettings = (
         TemplatePreprocessorSettings(mode="predict")
     )

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -262,7 +262,14 @@ def align_msa_server(
         with open(output_dir / "query_msa.json", "w") as fp:
             fp.write(query_set.model_dump_json(indent=4))
     finally:
-        msa_settings.cleanup_workspace()
+        try:
+            msa_settings.cleanup_workspace()
+        except OSError:
+            logger.warning(
+                "Could not remove temporary MSA workspace for run %s",
+                msa_settings.run_directory_name,
+                exc_info=True,
+            )
 
 
 if __name__ == "__main__":

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -197,8 +197,12 @@ def predict(
     query_set = InferenceQuerySet.from_json(query_json)
 
     # Run the forward pass
-    expt_runner.setup()
-    expt_runner.run(query_set)
+    try:
+        expt_runner.setup()
+        expt_runner.run(query_set)
+    except BaseException:
+        expt_runner.cleanup_msa_workspace()
+        raise
     expt_runner.cleanup()
 
 
@@ -230,15 +234,11 @@ def align_msa_server(
     output_dir: Path,
     msa_computation_settings_yaml: Path | None = None,
 ):
-    """Run MSA server alignment only with ColabFold MSA server.
-    
-    Example command:
-    python run_openfold.py align-msa-server \
-        --query_json query_example.json \
-        --output_dir output/msa_server_test \
-    
-    More settings can be specified using the `msa_computation_settings_yaml` flag
-    An example yaml file is provided in `examples/msa_server.yml`
+    """Generate ColabFold alignments without running model inference.
+
+    Submit all queries for the job in one JSON file. The command writes a new
+    ``query_msa.json`` whose alignment paths point to files in ``output_dir``.
+    Server settings can be supplied with ``msa_computation_settings_yaml``.
     """
     _torch_gpu_setup()
     from openfold3.core.data.tools.colabfold_msa_server import (
@@ -249,18 +249,20 @@ def align_msa_server(
         InferenceQuerySet,
     )
 
-    query_set = InferenceQuerySet.from_json(query_json)
-
     msa_settings = MsaComputationSettings.from_config_with_cli_override(
         output_dir, msa_computation_settings_yaml
     )
-    query_set = preprocess_colabfold_msas(
-        inference_query_set=query_set,
-        compute_settings=msa_settings,
-    )
+    try:
+        query_set = InferenceQuerySet.from_json(query_json)
+        query_set = preprocess_colabfold_msas(
+            inference_query_set=query_set,
+            compute_settings=msa_settings,
+        )
 
-    with open(output_dir / "query_msa.json", "w") as fp:
-        fp.write(query_set.model_dump_json(indent=4))
+        with open(output_dir / "query_msa.json", "w") as fp:
+            fp.write(query_set.model_dump_json(indent=4))
+    finally:
+        msa_settings.cleanup_workspace()
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -821,8 +821,6 @@ class TestMsaComputationSettings:
         settings.cleanup_workspace()
 
         assert not settings.workspace_directory.exists()
-        settings.cleanup_workspace()
-        assert not settings.workspace_directory.exists()
 
     def test_workspace_cleanup_raises_and_can_retry_after_failed_removal(self):
         settings = MsaComputationSettings()

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -28,6 +28,7 @@ import pytest
 from pydantic_core import Url
 
 from openfold3.core.data.framework.data_module import DataModule, DataModuleConfig
+from openfold3.core.data.io.sequence.msa import parse_a3m as parse_msa_a3m
 from openfold3.core.data.pipelines.preprocessing.template import (
     TemplatePreprocessorSettings,
 )
@@ -44,6 +45,7 @@ from openfold3.core.data.tools.colabfold_msa_server import (
     query_colabfold_msa_server,
     remap_colabfold_template_chain_ids,
 )
+from openfold3.entry_points.validator import InferenceExperimentConfig
 from openfold3.projects.of3_all_atom.config.dataset_config_components import MSASettings
 from openfold3.projects.of3_all_atom.config.dataset_configs import (
     InferenceDatasetSpec,
@@ -58,9 +60,6 @@ _MOCK_FETCH_TARGET = (
 )
 _MOCK_QUERY_TARGET = (
     "openfold3.core.data.tools.colabfold_msa_server.query_colabfold_msa_server"
-)
-_MOCK_SAVE_MAPPINGS_TARGET = (
-    "openfold3.core.data.tools.colabfold_msa_server.save_colabfold_mappings"
 )
 
 # Realistic label->author mappings for test PDB entries.
@@ -249,6 +248,17 @@ class TestColabFoldQueryRunner:
         return result
 
     @staticmethod
+    def _construct_dummy_a3m_with_raw_output(seqs, prefix, **unused_kwargs):
+        prefix.mkdir(parents=True, exist_ok=True)
+        (prefix / "server-output.a3m").write_text("raw output")
+        if prefix.name == "main":
+            (prefix / "pdb70.m8").touch()
+        raw_output_callback = unused_kwargs.get("raw_output_callback")
+        if raw_output_callback is not None:
+            raw_output_callback(prefix)
+        return TestColabFoldQueryRunner._construct_dummy_a3m(seqs)
+
+    @staticmethod
     def _make_dummy_template_file(path: Path):
         raw_main_dir = path / "raw" / "main"
         raw_main_dir.mkdir(parents=True, exist_ok=True)
@@ -324,6 +334,106 @@ class TestColabFoldQueryRunner:
             assert (expected_unpaired_dir / f).exists()
             assert (expected_paired_dir / f).exists()
 
+    @patch(_MOCK_QUERY_TARGET)
+    def test_raw_output_is_saved_before_formatting(
+        self, mock_query, tmp_path, multimer_query_set
+    ):
+        mock_query.side_effect = self._construct_dummy_a3m_with_raw_output
+        settings = MsaComputationSettings(
+            msa_file_format="npz",
+            colabfold_output_dir=tmp_path / "raw-records",
+        )
+        settings.set_saved_output_root(tmp_path / "saved")
+        mapper = collect_colabfold_msa_data(multimer_query_set)
+        paired_id = next(iter(mapper.complex_id_to_complex_group))
+        saved_output = settings.saved_output_directory
+        saved_raw = settings.saved_colabfold_output_directory
+        saved_paired_raw = saved_raw / f"paired/{paired_id}/server-output.a3m"
+
+        def fail_during_paired_formatting(alignment):
+            if saved_paired_raw.exists():
+                raise RuntimeError("formatting failed")
+            return parse_msa_a3m(alignment)
+
+        with (
+            patch(
+                "openfold3.core.data.tools.colabfold_msa_server.parse_a3m",
+                side_effect=fail_during_paired_formatting,
+            ),
+            pytest.raises(RuntimeError, match="formatting failed"),
+        ):
+            preprocess_colabfold_msas(multimer_query_set, settings)
+
+        assert (saved_raw / "main/server-output.a3m").exists()
+        assert saved_paired_raw.exists()
+        assert not saved_output.exists()
+        settings.cleanup_workspace()
+
+    @patch(_MOCK_QUERY_TARGET)
+    @pytest.mark.parametrize(
+        "save_openfold,save_colabfold",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_saved_output_options_are_independent(
+        self, mock_query, tmp_path, save_openfold, save_colabfold
+    ):
+        mock_query.side_effect = self._construct_dummy_a3m_with_raw_output
+        saved_output_root = tmp_path / "saved"
+        settings = MsaComputationSettings(
+            msa_file_format="a3m",
+            save_openfold_outputs=save_openfold,
+            save_colabfold_outputs=save_colabfold,
+        )
+        settings.set_saved_output_root(saved_output_root)
+        workspace = settings.workspace_directory
+        saved_output = settings.saved_output_directory
+
+        query = self._construct_monomer_query("TEST")
+        processed = preprocess_colabfold_msas(query, settings)
+        saved_main = (
+            saved_output / "main" / get_sequence_hash("TEST") / "colabfold_main.a3m"
+        )
+        saved_raw = settings.saved_colabfold_output_directory / "main/server-output.a3m"
+
+        assert saved_main.exists() is save_openfold
+        assert saved_raw.exists() is save_colabfold
+        assert (saved_output / "mappings/seq_to_rep_id.json").exists() is save_openfold
+        expected_root = saved_output if save_openfold else workspace
+        assert (
+            processed.queries["query1"]
+            .chains[0]
+            .main_msa_file_paths[0]
+            .is_relative_to(expected_root)
+        )
+        assert settings.cleanup_workspace()
+
+    @patch(_MOCK_QUERY_TARGET)
+    def test_explicit_output_directory_survives_workspace_cleanup(
+        self, mock_query, tmp_path
+    ):
+        mock_query.side_effect = self._construct_dummy_a3m_with_raw_output
+        output_directory = tmp_path / "colabfold_msas"
+        output_directory.mkdir()
+        sentinel = output_directory / "existing.txt"
+        sentinel.write_text("keep")
+        settings = MsaComputationSettings(
+            msa_file_format="a3m",
+            msa_output_directory=output_directory,
+            cleanup_msa_dir=False,
+        )
+
+        query = self._construct_monomer_query("TEST")
+        processed = preprocess_colabfold_msas(query, settings)
+        assert settings.cleanup_workspace()
+
+        saved_msa = (
+            output_directory / "main" / get_sequence_hash("TEST") / "colabfold_main.a3m"
+        )
+        assert sentinel.read_text() == "keep"
+        assert saved_msa.exists()
+        assert (output_directory / "raw/main/server-output.a3m").exists()
+        assert processed.queries["query1"].chains[0].main_msa_file_paths == [saved_msa]
+
     @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
     @patch(_MOCK_QUERY_TARGET, side_effect=_construct_dummy_a3m)
     @pytest.mark.parametrize(
@@ -381,9 +491,8 @@ class TestColabFoldQueryRunner:
             server_user_agent="test-agent",
             server_url="https://dummy.url",
             save_mappings=True,
-            msa_output_directory=tmp_path,
-            cleanup_msa_dir=False,
         )
+        msa_compute_settings.set_saved_output_root(tmp_path / "saved-openfold")
 
         query = self._construct_monomer_query(sequence)
         augmented = augment_main_msa_with_query_sequence(query, msa_compute_settings)
@@ -393,7 +502,7 @@ class TestColabFoldQueryRunner:
             case "npz":
                 f = f"{get_sequence_hash(sequence)}.npz"
 
-        expected_file = tmp_path / "dummy" / f
+        expected_file = msa_compute_settings.saved_output_directory / "dummy" / f
         assert expected_file.exists(), f"Expected file {f} not found in main directory"
 
         paths_in_augmented = augmented.queries["query1"].chains[0].main_msa_file_paths
@@ -401,9 +510,11 @@ class TestColabFoldQueryRunner:
         assert expected_file == paths_in_augmented[0], (
             f"Unexpected MSA path in augmented query set: {paths_in_augmented[0]}"
         )
+        assert not msa_compute_settings.cleanup_workspace()
+        assert expected_file.exists()
 
     @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
-    @patch(_MOCK_QUERY_TARGET, side_effect=_construct_dummy_a3m)
+    @patch(_MOCK_QUERY_TARGET)
     @pytest.mark.parametrize(
         "msa_file_format", ["a3m", "npz"], ids=lambda fmt: f"{fmt}"
     )
@@ -415,6 +526,7 @@ class TestColabFoldQueryRunner:
         msa_file_format,
     ):
         """Integration test for making predictions with fake MSA data."""
+        mock_query.side_effect = self._construct_dummy_a3m_with_raw_output
         test_sequences = ["TEST", "LONGERTEST"]
 
         for sequence in test_sequences:
@@ -459,16 +571,11 @@ class TestColabFoldQueryRunner:
                 assert t == t_expected, f"Target length mismatch: {t} != {t_expected}"
                 assert e == e_expected, f"Feature size mismatch: {e} != {e_expected}"
 
-            # Clean up raw directory after running test
-            # This is normally performed in InferenceRunner.cleanup_msa_dir
-            # but that isn't called in this test.
-            shutil.rmtree(tmp_path / "raw", ignore_errors=True)
+            assert msa_compute_settings.cleanup_workspace()
 
-        # Test contents of mapping file after all runs
         with open(tmp_path / "mappings/seq_to_rep_id.json") as f:
-            assert set(json.load(f).keys()) == set(test_sequences), (
-                "Expected all test sequences to be present in the mapping file"
-            )
+            assert set(json.load(f)) == set(test_sequences)
+        assert (tmp_path / "raw/main").is_dir()
 
     @patch(_MOCK_QUERY_TARGET, side_effect=_construct_dummy_a3m)
     def test_empty_m8_file_handling(
@@ -535,149 +642,29 @@ class TestColabFoldQueryRunner:
                     f"is empty, but got {chain.template_entry_chain_ids}"
                 )
 
-    @pytest.mark.parametrize(
-        "raw_payload",
-        [
-            pytest.param(None, id="empty"),
-            pytest.param(b"existing raw output", id="populated"),
-        ],
-    )
     @patch(_MOCK_QUERY_TARGET)
-    def test_preprocess_rejects_raw_dir_before_side_effects(
-        self, mock_query, tmp_path, raw_payload
-    ):
-        """Existing raw output should stop preprocessing before disk writes."""
+    def test_preprocess_rejects_an_existing_workspace(self, mock_query, tmp_path):
         query = self._construct_monomer_query("TESTSEQUENCE")
         msa_compute_settings = MsaComputationSettings(
             msa_file_format="npz",
             server_user_agent="test-agent",
             server_url="https://dummy.url",
-            save_mappings=True,
-            msa_output_directory=tmp_path,
-            cleanup_msa_dir=False,
         )
+        workspace = msa_compute_settings.workspace_directory
+        workspace.mkdir(parents=True)
+        sentinel = workspace / "keep.txt"
+        sentinel.write_text("keep")
 
-        mapping_contents = {
-            "seq_to_rep_id.json": b'{"existing-sequence": "existing-rep"}\n',
-            "rep_id_to_seq.json": b'{"existing-rep": "existing-sequence"}\n',
-            "chain_id_to_rep_id.json": b'{"existing-chain": "existing-rep"}\n',
-            "query_name_to_complex_id.json": b'{"existing-query": "existing-complex"}\n',
-            "README.md": b"# Existing mapping files\n",
-        }
-        mappings_dir = tmp_path / "mappings"
-        mappings_dir.mkdir(parents=True)
-        for filename, contents in mapping_contents.items():
-            (mappings_dir / filename).write_bytes(contents)
-
-        stale_raw_dir = tmp_path / "raw"
-        stale_raw_dir.mkdir(parents=True)
-        if raw_payload is not None:
-            (stale_raw_dir / "out.tar.gz").write_bytes(raw_payload)
-        raw_contents = {
-            path.relative_to(stale_raw_dir): path.read_bytes()
-            for path in stale_raw_dir.rglob("*")
-            if path.is_file()
-        }
-
-        with pytest.raises(FileExistsError, match="raw"):
+        with pytest.raises(FileExistsError):
             preprocess_colabfold_msas(
                 inference_query_set=query, compute_settings=msa_compute_settings
             )
 
         mock_query.assert_not_called()
-        assert stale_raw_dir.is_dir()
-        assert {
-            path.relative_to(stale_raw_dir): path.read_bytes()
-            for path in stale_raw_dir.rglob("*")
-            if path.is_file()
-        } == raw_contents
-        assert {
-            path.name: path.read_bytes()
-            for path in mappings_dir.iterdir()
-            if path.is_file()
-        } == mapping_contents
-
-    @patch(_MOCK_QUERY_TARGET)
-    @patch(_MOCK_SAVE_MAPPINGS_TARGET)
-    def test_preprocess_reserves_raw_dir_before_mapping_write(
-        self, mock_save_mappings, mock_query, tmp_path
-    ):
-        """The raw directory should be claimed before persistent writes begin."""
-        query = self._construct_monomer_query("TESTSEQUENCE")
-        msa_compute_settings = MsaComputationSettings(
-            msa_file_format="npz",
-            server_user_agent="test-agent",
-            server_url="https://dummy.url",
-            save_mappings=True,
-            msa_output_directory=tmp_path,
-            cleanup_msa_dir=False,
-        )
-        retry_settings = msa_compute_settings.model_copy(
-            update={"save_mappings": False}
-        )
-        raw_dir = tmp_path / "raw"
-
-        def observe_reservation(*_args):
-            assert raw_dir.is_dir()
-            # Re-enter at the first persistent write. The second call must see
-            # the reservation before either caller reaches the server.
-            with pytest.raises(FileExistsError, match="raw output directory"):
-                preprocess_colabfold_msas(
-                    inference_query_set=query,
-                    compute_settings=retry_settings,
-                )
-            raise RuntimeError("reservation observed")
-
-        mock_save_mappings.side_effect = observe_reservation
-
-        with pytest.raises(RuntimeError, match="reservation observed"):
-            preprocess_colabfold_msas(
-                inference_query_set=query,
-                compute_settings=msa_compute_settings,
-            )
-
-        mock_save_mappings.assert_called_once()
-        mock_query.assert_not_called()
-        assert raw_dir.is_dir()
-
-    @patch(_MOCK_QUERY_TARGET)
-    def test_preprocess_validates_query_before_raw_dir(self, mock_query, tmp_path):
-        """Query validation should keep precedence over the raw-output guard."""
-        duplicate_chain_query = InferenceQuerySet.model_validate(
-            {
-                "queries": {
-                    "query1": {
-                        "chains": [
-                            {
-                                "molecule_type": "protein",
-                                "chain_ids": ["A"],
-                                "sequence": "FIRST",
-                            },
-                            {
-                                "molecule_type": "protein",
-                                "chain_ids": ["A"],
-                                "sequence": "FIRST",
-                            },
-                        ]
-                    }
-                }
-            }
-        )
-        msa_compute_settings = MsaComputationSettings(
-            server_user_agent="test-agent",
-            server_url="https://dummy.url",
-            msa_output_directory=tmp_path,
-            cleanup_msa_dir=False,
-        )
-        (tmp_path / "raw").mkdir(parents=True)
-
-        with pytest.raises(RuntimeError, match="Duplicate chain IDs"):
-            preprocess_colabfold_msas(
-                inference_query_set=duplicate_chain_query,
-                compute_settings=msa_compute_settings,
-            )
-
-        mock_query.assert_not_called()
+        assert not (workspace / "mappings").exists()
+        assert not msa_compute_settings.cleanup_workspace()
+        assert sentinel.exists()
+        shutil.rmtree(workspace)
 
 
 class _ValidationCase(NamedTuple):
@@ -750,6 +737,7 @@ class TestQueryColabFoldServerValidation:
         submit/download (no network) and go straight to extraction + validation.
         """
         self._write_tarball(tmp_path / "out.tar.gz", case.members)
+        callback_paths: list[Path] = []
 
         with pytest.raises(ColabFoldServerResultError, match=case.match):
             query_colabfold_msa_server(
@@ -757,7 +745,10 @@ class TestQueryColabFoldServerValidation:
                 prefix=tmp_path,
                 user_agent="test-agent",
                 use_pairing=case.use_pairing,
+                raw_output_callback=callback_paths.append,
             )
+
+        assert callback_paths == []
 
     def test_valid_paired_download_passes(self, tmp_path: Path) -> None:
         """A paired download containing a valid pair.a3m returns the alignments."""
@@ -765,15 +756,18 @@ class TestQueryColabFoldServerValidation:
             tmp_path / "out.tar.gz",
             {"pair.a3m": b">101\nAAAA\n\x00>102\nCCCC\n", "pair.sh": b"#\n"},
         )
+        callback_paths: list[Path] = []
 
         result = query_colabfold_msa_server(
             ["AAAA", "CCCC"],
             prefix=tmp_path,
             user_agent="test-agent",
             use_pairing=True,
+            raw_output_callback=callback_paths.append,
         )
 
         assert len(result) == 2
+        assert callback_paths == [tmp_path]
 
 
 class TestRemapObsoletePdb:
@@ -817,12 +811,32 @@ class TestRemapObsoletePdb:
 
 
 class TestMsaComputationSettings:
-    def test_cli_output_dir_overrides_config(self, tmp_path):
-        """Test that CLI output directory overrides config file setting."""
+    @pytest.mark.parametrize("cleanup_msa_dir", [False, True])
+    def test_workspace_cleanup_is_unconditional(self, cleanup_msa_dir):
+        settings = MsaComputationSettings(cleanup_msa_dir=cleanup_msa_dir)
+        settings.create_workspace()
+
+        assert settings.cleanup_workspace()
+
+        assert not settings.workspace_directory.exists()
+        assert not settings.cleanup_workspace()
+
+    def test_workspace_cleanup_reports_a_failed_removal(self):
+        settings = MsaComputationSettings()
+        settings.create_workspace()
+
+        with patch("shutil.rmtree"):
+            assert not settings.cleanup_workspace()
+
+        assert settings.workspace_directory.exists()
+        assert settings.cleanup_workspace()
+
+    def test_cli_output_dir_is_persistent(self, tmp_path):
         test_yaml_str = textwrap.dedent("""\
             msa_file_format: a3m
             server_user_agent: test-agent
             server_url: https://dummy.url
+            save_openfold_outputs: false
         """)
         cli_output_dir = tmp_path / "cli_dir"
         test_yaml_file = tmp_path / "runner.yml"
@@ -831,27 +845,62 @@ class TestMsaComputationSettings:
         msa_settings = MsaComputationSettings.from_config_with_cli_override(
             cli_output_dir, test_yaml_file
         )
+        assert msa_settings.save_openfold_outputs
+        assert msa_settings.save_colabfold_outputs
+        assert msa_settings.saved_output_directory == cli_output_dir
+        assert msa_settings.saved_colabfold_output_directory == cli_output_dir / "raw"
+        assert msa_settings.workspace_directory != cli_output_dir
 
-        assert Path(msa_settings.msa_output_directory) == cli_output_dir, (
-            "Expected CLI output directory to override default settings"
+    def test_cli_rejects_a_different_configured_output_directory(self, tmp_path):
+        config_file = tmp_path / "runner.yml"
+        config_file.write_text(
+            f"msa_output_directory: {tmp_path / 'configured-output'}\n"
         )
 
-    def test_cli_output_dir_conflict_raises(self, tmp_path):
-        """Test that conflict between CLI and config output dirs raises ValueError."""
-        test_yaml_str = textwrap.dedent(f"""\
-            msa_file_format: a3m
-            msa_output_directory: {tmp_path / "other_dir"}
-        """)
-        test_yaml_file = tmp_path / "runner.yml"
-        test_yaml_file.write_text(test_yaml_str)
-
-        cli_output_dir = tmp_path / "cli_dir"
-
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Output directory mismatch"):
             MsaComputationSettings.from_config_with_cli_override(
-                cli_output_dir, test_yaml_file
+                tmp_path / "cli-output", config_file
             )
 
-        assert "Output directory mismatch" in str(exc_info.value), (
-            "Expected ValueError on output directory conflict"
+    def test_workspace_and_default_records_share_one_run_id(self, tmp_path):
+        config = InferenceExperimentConfig.model_construct()
+        other_config = InferenceExperimentConfig.model_construct()
+        settings = config.msa_computation_settings
+        other_settings = other_config.msa_computation_settings
+        settings.set_saved_output_root(tmp_path / "saved")
+
+        assert settings.workspace_directory.name == settings.run_directory_name
+        assert settings.saved_output_directory.name == settings.run_directory_name
+        assert (
+            settings.saved_colabfold_output_directory.name
+            == settings.run_directory_name
         )
+        assert other_settings.run_directory_name != settings.run_directory_name
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_workspace_cannot_contain_openfold_output(self, nested):
+        settings = MsaComputationSettings(save_colabfold_outputs=False)
+        settings.msa_output_directory = (
+            settings.workspace_directory / "saved"
+            if nested
+            else settings.workspace_directory
+        )
+
+        with pytest.raises(ValueError, match="must not overlap"):
+            settings.validate_output_paths()
+
+        assert not settings.workspace_directory.exists()
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_workspace_cannot_contain_colabfold_output(self, nested):
+        settings = MsaComputationSettings(save_openfold_outputs=False)
+        settings.colabfold_output_dir = (
+            settings.workspace_directory
+            if nested
+            else settings.workspace_directory.parent
+        )
+
+        with pytest.raises(ValueError, match="must not overlap"):
+            settings.validate_output_paths()
+
+        assert not settings.workspace_directory.exists()

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -59,6 +59,9 @@ _MOCK_FETCH_TARGET = (
 _MOCK_QUERY_TARGET = (
     "openfold3.core.data.tools.colabfold_msa_server.query_colabfold_msa_server"
 )
+_MOCK_SAVE_MAPPINGS_TARGET = (
+    "openfold3.core.data.tools.colabfold_msa_server.save_colabfold_mappings"
+)
 
 # Realistic label->author mappings for test PDB entries.
 # 1RNB: label B -> author A (protein), label A -> author C (DNA)
@@ -532,28 +535,149 @@ class TestColabFoldQueryRunner:
                     f"is empty, but got {chain.template_entry_chain_ids}"
                 )
 
-    def test_preprocess_raises_if_raw_dir_exists(self, tmp_path):
-        """preprocess_colabfold_msas should raise FileExistsError if raw/ exists.
-
-        A leftover raw/ directory from a prior crashed run contains stale
-        out.tar.gz files that would be silently reused for the wrong query.
-        """
+    @pytest.mark.parametrize(
+        "raw_payload",
+        [
+            pytest.param(None, id="empty"),
+            pytest.param(b"existing raw output", id="populated"),
+        ],
+    )
+    @patch(_MOCK_QUERY_TARGET)
+    def test_preprocess_rejects_raw_dir_before_side_effects(
+        self, mock_query, tmp_path, raw_payload
+    ):
+        """Existing raw output should stop preprocessing before disk writes."""
         query = self._construct_monomer_query("TESTSEQUENCE")
         msa_compute_settings = MsaComputationSettings(
             msa_file_format="npz",
             server_user_agent="test-agent",
             server_url="https://dummy.url",
+            save_mappings=True,
             msa_output_directory=tmp_path,
             cleanup_msa_dir=False,
         )
 
+        mapping_contents = {
+            "seq_to_rep_id.json": b'{"existing-sequence": "existing-rep"}\n',
+            "rep_id_to_seq.json": b'{"existing-rep": "existing-sequence"}\n',
+            "chain_id_to_rep_id.json": b'{"existing-chain": "existing-rep"}\n',
+            "query_name_to_complex_id.json": b'{"existing-query": "existing-complex"}\n',
+            "README.md": b"# Existing mapping files\n",
+        }
+        mappings_dir = tmp_path / "mappings"
+        mappings_dir.mkdir(parents=True)
+        for filename, contents in mapping_contents.items():
+            (mappings_dir / filename).write_bytes(contents)
+
         stale_raw_dir = tmp_path / "raw"
         stale_raw_dir.mkdir(parents=True)
+        if raw_payload is not None:
+            (stale_raw_dir / "out.tar.gz").write_bytes(raw_payload)
+        raw_contents = {
+            path.relative_to(stale_raw_dir): path.read_bytes()
+            for path in stale_raw_dir.rglob("*")
+            if path.is_file()
+        }
 
         with pytest.raises(FileExistsError, match="raw"):
             preprocess_colabfold_msas(
                 inference_query_set=query, compute_settings=msa_compute_settings
             )
+
+        mock_query.assert_not_called()
+        assert stale_raw_dir.is_dir()
+        assert {
+            path.relative_to(stale_raw_dir): path.read_bytes()
+            for path in stale_raw_dir.rglob("*")
+            if path.is_file()
+        } == raw_contents
+        assert {
+            path.name: path.read_bytes()
+            for path in mappings_dir.iterdir()
+            if path.is_file()
+        } == mapping_contents
+
+    @patch(_MOCK_QUERY_TARGET)
+    @patch(_MOCK_SAVE_MAPPINGS_TARGET)
+    def test_preprocess_reserves_raw_dir_before_mapping_write(
+        self, mock_save_mappings, mock_query, tmp_path
+    ):
+        """The raw directory should be claimed before persistent writes begin."""
+        query = self._construct_monomer_query("TESTSEQUENCE")
+        msa_compute_settings = MsaComputationSettings(
+            msa_file_format="npz",
+            server_user_agent="test-agent",
+            server_url="https://dummy.url",
+            save_mappings=True,
+            msa_output_directory=tmp_path,
+            cleanup_msa_dir=False,
+        )
+        retry_settings = msa_compute_settings.model_copy(
+            update={"save_mappings": False}
+        )
+        raw_dir = tmp_path / "raw"
+
+        def observe_reservation(*_args):
+            assert raw_dir.is_dir()
+            # Re-enter at the first persistent write. The second call must see
+            # the reservation before either caller reaches the server.
+            with pytest.raises(FileExistsError, match="raw output directory"):
+                preprocess_colabfold_msas(
+                    inference_query_set=query,
+                    compute_settings=retry_settings,
+                )
+            raise RuntimeError("reservation observed")
+
+        mock_save_mappings.side_effect = observe_reservation
+
+        with pytest.raises(RuntimeError, match="reservation observed"):
+            preprocess_colabfold_msas(
+                inference_query_set=query,
+                compute_settings=msa_compute_settings,
+            )
+
+        mock_save_mappings.assert_called_once()
+        mock_query.assert_not_called()
+        assert raw_dir.is_dir()
+
+    @patch(_MOCK_QUERY_TARGET)
+    def test_preprocess_validates_query_before_raw_dir(self, mock_query, tmp_path):
+        """Query validation should keep precedence over the raw-output guard."""
+        duplicate_chain_query = InferenceQuerySet.model_validate(
+            {
+                "queries": {
+                    "query1": {
+                        "chains": [
+                            {
+                                "molecule_type": "protein",
+                                "chain_ids": ["A"],
+                                "sequence": "FIRST",
+                            },
+                            {
+                                "molecule_type": "protein",
+                                "chain_ids": ["A"],
+                                "sequence": "FIRST",
+                            },
+                        ]
+                    }
+                }
+            }
+        )
+        msa_compute_settings = MsaComputationSettings(
+            server_user_agent="test-agent",
+            server_url="https://dummy.url",
+            msa_output_directory=tmp_path,
+            cleanup_msa_dir=False,
+        )
+        (tmp_path / "raw").mkdir(parents=True)
+
+        with pytest.raises(RuntimeError, match="Duplicate chain IDs"):
+            preprocess_colabfold_msas(
+                inference_query_set=duplicate_chain_query,
+                compute_settings=msa_compute_settings,
+            )
+
+        mock_query.assert_not_called()
 
 
 class _ValidationCase(NamedTuple):

--- a/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
+++ b/openfold3/tests/core/data/tools/test_colabfold_msa_server.py
@@ -14,11 +14,13 @@
 
 """Tests for the ColabFold MSA server module."""
 
+import getpass
 import io
 import json
 import shutil
 import tarfile
 import textwrap
+from datetime import datetime
 from pathlib import Path
 from typing import NamedTuple
 from unittest.mock import patch
@@ -45,7 +47,6 @@ from openfold3.core.data.tools.colabfold_msa_server import (
     query_colabfold_msa_server,
     remap_colabfold_template_chain_ids,
 )
-from openfold3.entry_points.validator import InferenceExperimentConfig
 from openfold3.projects.of3_all_atom.config.dataset_config_components import MSASettings
 from openfold3.projects.of3_all_atom.config.dataset_configs import (
     InferenceDatasetSpec,
@@ -395,6 +396,8 @@ class TestColabFoldQueryRunner:
         )
         saved_raw = settings.saved_colabfold_output_directory / "main/server-output.a3m"
 
+        settings.cleanup_workspace()
+
         assert saved_main.exists() is save_openfold
         assert saved_raw.exists() is save_colabfold
         assert (saved_output / "mappings/seq_to_rep_id.json").exists() is save_openfold
@@ -405,7 +408,6 @@ class TestColabFoldQueryRunner:
             .main_msa_file_paths[0]
             .is_relative_to(expected_root)
         )
-        assert settings.cleanup_workspace()
 
     @patch(_MOCK_QUERY_TARGET)
     def test_explicit_output_directory_survives_workspace_cleanup(
@@ -424,7 +426,7 @@ class TestColabFoldQueryRunner:
 
         query = self._construct_monomer_query("TEST")
         processed = preprocess_colabfold_msas(query, settings)
-        assert settings.cleanup_workspace()
+        settings.cleanup_workspace()
 
         saved_msa = (
             output_directory / "main" / get_sequence_hash("TEST") / "colabfold_main.a3m"
@@ -510,7 +512,7 @@ class TestColabFoldQueryRunner:
         assert expected_file == paths_in_augmented[0], (
             f"Unexpected MSA path in augmented query set: {paths_in_augmented[0]}"
         )
-        assert not msa_compute_settings.cleanup_workspace()
+        msa_compute_settings.cleanup_workspace()
         assert expected_file.exists()
 
     @patch(_MOCK_FETCH_TARGET, side_effect=_mock_fetch_label_to_author)
@@ -571,7 +573,7 @@ class TestColabFoldQueryRunner:
                 assert t == t_expected, f"Target length mismatch: {t} != {t_expected}"
                 assert e == e_expected, f"Feature size mismatch: {e} != {e_expected}"
 
-            assert msa_compute_settings.cleanup_workspace()
+            msa_compute_settings.cleanup_workspace()
 
         with open(tmp_path / "mappings/seq_to_rep_id.json") as f:
             assert set(json.load(f)) == set(test_sequences)
@@ -662,7 +664,7 @@ class TestColabFoldQueryRunner:
 
         mock_query.assert_not_called()
         assert not (workspace / "mappings").exists()
-        assert not msa_compute_settings.cleanup_workspace()
+        msa_compute_settings.cleanup_workspace()
         assert sentinel.exists()
         shutil.rmtree(workspace)
 
@@ -816,20 +818,25 @@ class TestMsaComputationSettings:
         settings = MsaComputationSettings(cleanup_msa_dir=cleanup_msa_dir)
         settings.create_workspace()
 
-        assert settings.cleanup_workspace()
+        settings.cleanup_workspace()
 
         assert not settings.workspace_directory.exists()
-        assert not settings.cleanup_workspace()
+        settings.cleanup_workspace()
+        assert not settings.workspace_directory.exists()
 
-    def test_workspace_cleanup_reports_a_failed_removal(self):
+    def test_workspace_cleanup_raises_and_can_retry_after_failed_removal(self):
         settings = MsaComputationSettings()
         settings.create_workspace()
 
-        with patch("shutil.rmtree"):
-            assert not settings.cleanup_workspace()
+        with (
+            patch("shutil.rmtree", side_effect=OSError("failed")),
+            pytest.raises(OSError, match="failed"),
+        ):
+            settings.cleanup_workspace()
 
         assert settings.workspace_directory.exists()
-        assert settings.cleanup_workspace()
+        settings.cleanup_workspace()
+        assert not settings.workspace_directory.exists()
 
     def test_cli_output_dir_is_persistent(self, tmp_path):
         test_yaml_str = textwrap.dedent("""\
@@ -862,20 +869,41 @@ class TestMsaComputationSettings:
                 tmp_path / "cli-output", config_file
             )
 
-    def test_workspace_and_default_records_share_one_run_id(self, tmp_path):
-        config = InferenceExperimentConfig.model_construct()
-        other_config = InferenceExperimentConfig.model_construct()
-        settings = config.msa_computation_settings
-        other_settings = other_config.msa_computation_settings
-        settings.set_saved_output_root(tmp_path / "saved")
+    def test_msa_settings_keep_output_state_separate_with_readable_run_names(
+        self, tmp_path
+    ):
+        output_directory = tmp_path / "saved"
+        fixed_time = datetime.fromisoformat("2026-08-06T12:00:00+00:00")
+        with (
+            patch(
+                "openfold3.core.data.tools.colabfold_msa_server.datetime"
+            ) as mock_datetime,
+            patch(
+                "openfold3.core.data.tools.colabfold_msa_server.secrets.token_hex",
+                side_effect=["12345678", "abcdef01"],
+            ),
+        ):
+            mock_datetime.now.return_value = fixed_time
+            settings = MsaComputationSettings(msa_output_directory=output_directory)
+            other_settings = MsaComputationSettings()
+        run_name_prefix = f"msa-{getpass.getuser()}-"
 
-        assert settings.workspace_directory.name == settings.run_directory_name
-        assert settings.saved_output_directory.name == settings.run_directory_name
-        assert (
-            settings.saved_colabfold_output_directory.name
-            == settings.run_directory_name
-        )
-        assert other_settings.run_directory_name != settings.run_directory_name
+        assert settings.saved_output_directory == output_directory
+        assert settings.saved_colabfold_output_directory == output_directory / "raw"
+        assert settings.workspace_directory != output_directory
+        assert other_settings.saved_output_directory is None
+        for run_name in (
+            settings.run_directory_name,
+            other_settings.run_directory_name,
+        ):
+            assert run_name.startswith(run_name_prefix)
+            timestamp, random_suffix = run_name.removeprefix(run_name_prefix).rsplit(
+                "-", 1
+            )
+            datetime.strptime(timestamp, "%Y%m%dT%H%M%S%fZ")
+            assert len(random_suffix) == 8
+            int(random_suffix, 16)
+        assert other_settings.workspace_directory != settings.workspace_directory
 
     @pytest.mark.parametrize("nested", [False, True])
     def test_workspace_cannot_contain_openfold_output(self, nested):

--- a/openfold3/tests/inference/test_inference_full.py
+++ b/openfold3/tests/inference/test_inference_full.py
@@ -563,6 +563,23 @@ def test_inference_writes_outputs(case, mode, tmp_path):
         template_output_dir=tmp_path / "template_data",
     )
     logger.info("Checking output contents at %s", tmp_path)
+
+    msa_output_root = tmp_path / "msas"
+    msa_run_directories = [
+        path for path in msa_output_root.iterdir() if path.name != "raw"
+    ]
+    assert len(msa_run_directories) == 1
+    msa_run_directory = msa_run_directories[0]
+    expected_msa_directories = [
+        msa_run_directory / ("main" if mode.use_msa_server else "dummy")
+    ]
+    if mode.use_msa_server:
+        expected_msa_directories.append(
+            msa_output_root / "raw" / msa_run_directory.name / "main"
+        )
+    for directory in expected_msa_directories:
+        assert directory.is_dir(), f"Expected MSA directory not found: {directory}"
+
     for query_name in query_set.queries:
         seed_dir = prediction_dir(tmp_path, query_name)
         assert (seed_dir / "timing.json").exists(), (

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -630,6 +630,79 @@ class TestInferenceCommandLineSettings:
         assert expt_config.data_module_args.data_seed == expected_data_seed
 
 
+class TestInferenceCleanup:
+    @pytest.mark.parametrize(
+        "cleanup_msa_dir,use_msa_server,rank,should_remove",
+        [
+            pytest.param(False, True, 0, False, id="preserve"),
+            pytest.param(True, True, 0, True, id="remove"),
+            pytest.param(True, True, 1, False, id="nonzero-rank"),
+            pytest.param(True, False, 0, False, id="msa-server-disabled"),
+        ],
+    )
+    def test_cleanup_respects_msa_output_lifecycle(
+        self,
+        cleanup_msa_dir,
+        use_msa_server,
+        rank,
+        should_remove,
+        tmp_path,
+        dummy_ckpt_file,
+        capsys,
+    ):
+        msa_output_dir = tmp_path / "msa"
+        expt_config = InferenceExperimentConfig(
+            inference_ckpt_path=dummy_ckpt_file,
+            cache_path=tmp_path / "cache",
+            experiment_settings={
+                "output_dir": tmp_path / "inference",
+                "log_dir": tmp_path / "logs",
+                "use_msa_server": use_msa_server,
+                "use_templates": False,
+            },
+            msa_computation_settings={
+                "msa_output_directory": msa_output_dir,
+                "cleanup_msa_dir": cleanup_msa_dir,
+            },
+            template_preprocessor_settings={
+                "output_directory": tmp_path / "templates",
+            },
+        )
+        expt_runner = InferenceExperimentRunner(expt_config)
+
+        sentinel_contents = {
+            Path("raw/main/out.tar.gz"): b"raw server response",
+            Path("main/rep.npz"): b"main alignment",
+            Path("paired/complex/rep.npz"): b"paired alignment",
+            Path("mappings/seq_to_rep_id.json"): b'{"sequence": "rep"}\n',
+        }
+        for relative_path, contents in sentinel_contents.items():
+            sentinel_path = msa_output_dir / relative_path
+            sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+            sentinel_path.write_bytes(contents)
+
+        # Keep this test focused on MSA cleanup instead of empty-log cleanup.
+        (expt_runner.log_dir / "keep.log").write_text("keep")
+
+        with patch(
+            "openfold3.entry_points.experiment_runner._get_rank",
+            return_value=rank,
+        ):
+            expt_runner.cleanup()
+
+        captured = capsys.readouterr()
+        if should_remove:
+            assert not msa_output_dir.exists()
+        else:
+            assert msa_output_dir.is_dir()
+            assert {
+                path.relative_to(msa_output_dir): path.read_bytes()
+                for path in msa_output_dir.rglob("*")
+                if path.is_file()
+            } == sentinel_contents
+            assert "Cleaning up MSA directories..." not in captured.out
+
+
 class TestInferenceCheckpointLoading:
     def test_inference_ckpt_path_user_defined(self, dummy_ckpt_file):
         expt_config = InferenceExperimentConfig.model_validate(

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -29,7 +29,7 @@ from click.testing import CliRunner
 from pytorch_lightning.loggers import WandbLogger
 
 import openfold3.core.model.primitives.initialization as initialization
-from openfold3 import setup_openfold
+from openfold3 import run_openfold, setup_openfold
 from openfold3.core.config import config_utils
 from openfold3.core.data.framework.data_module import DataModuleConfig
 from openfold3.entry_points.experiment_runner import (
@@ -64,6 +64,16 @@ def dummy_ckpt_file(tmp_path: Path) -> Path:
     dummy_ckpt = tmp_path / "dummy.ckpt"
     dummy_ckpt.write_text("dummy content")
     return dummy_ckpt
+
+
+@pytest.fixture
+def minimal_query_json(tmp_path: Path) -> Path:
+    query_json = tmp_path / "query.json"
+    query_json.write_text(
+        '{"queries":{"query":{"chains":[{"molecule_type":"protein",'
+        '"chain_ids":["A"],"sequence":"TEST"}]}}}'
+    )
+    return query_json
 
 
 def _create_fake_file(path: Path) -> None:
@@ -578,6 +588,86 @@ class TestInferenceCommandLineSettings:
         num_seeds = 7
         expt_runner = InferenceExperimentRunner(expt_config, num_model_seeds=num_seeds)
         assert len(expt_runner.seeds) == num_seeds
+        msa_settings = expt_config.msa_computation_settings
+        assert msa_settings.saved_output_directory == (
+            expt_runner.output_dir / "msas" / msa_settings.run_directory_name
+        )
+
+    def test_predict_calls_cleanup_after_failure(
+        self, minimal_query_json, dummy_ckpt_file
+    ):
+        with (
+            patch("openfold3.run_openfold._torch_gpu_setup"),
+            patch(
+                "openfold3.entry_points.experiment_runner.InferenceExperimentRunner"
+            ) as mock_runner_class,
+        ):
+            mock_runner_class.return_value.run.side_effect = RuntimeError("failed")
+            result = CliRunner().invoke(
+                run_openfold.cli,
+                [
+                    "predict",
+                    "--query-json",
+                    str(minimal_query_json),
+                    "--inference-ckpt-path",
+                    str(dummy_ckpt_file),
+                ],
+            )
+
+        assert result.exit_code != 0
+        mock_runner_class.return_value.cleanup_msa_workspace.assert_called_once()
+
+    @pytest.mark.parametrize("fails", [False, True])
+    def test_align_msa_server_always_cleans_its_workspace(
+        self, tmp_path, minimal_query_json, fails
+    ):
+        output_dir = tmp_path / "alignments"
+        settings_yaml = tmp_path / "msa-settings.yml"
+        settings_yaml.write_text(f"msa_output_directory: {output_dir}\n")
+        workspaces = []
+
+        def fake_preprocess(inference_query_set, compute_settings):
+            workspace = compute_settings.workspace_directory
+            workspaces.append(workspace)
+            compute_settings.create_workspace()
+            if fails:
+                raise RuntimeError("failed")
+
+            compute_settings.saved_output_directory.mkdir(parents=True)
+            saved_msa = compute_settings.saved_output_directory / "main/alignment.a3m"
+            saved_msa.parent.mkdir(parents=True)
+            saved_msa.write_text(">query\nTEST")
+            inference_query_set.queries["query"].chains[0].main_msa_file_paths = [
+                saved_msa
+            ]
+            return inference_query_set
+
+        with (
+            patch("openfold3.run_openfold._torch_gpu_setup"),
+            patch(
+                "openfold3.core.data.tools.colabfold_msa_server.preprocess_colabfold_msas",
+                side_effect=fake_preprocess,
+            ),
+        ):
+            result = CliRunner().invoke(
+                run_openfold.cli,
+                [
+                    "align-msa-server",
+                    "--query-json",
+                    str(minimal_query_json),
+                    "--output-dir",
+                    str(output_dir),
+                    "--msa-computation-settings-yaml",
+                    str(settings_yaml),
+                ],
+            )
+
+        assert result.exit_code == (1 if fails else 0)
+        assert workspaces and not workspaces[0].exists()
+        if not fails:
+            saved_query = InferenceQuerySet.from_json(output_dir / "query_msa.json")
+            for chain in saved_query.queries["query"].chains:
+                assert all(path.exists() for path in chain.main_msa_file_paths)
 
     def test_seeding_from_list(self, tmp_path, dummy_ckpt_file):
         test_yaml_str = textwrap.dedent("""\
@@ -628,79 +718,6 @@ class TestInferenceCommandLineSettings:
         )
         assert expt_config.experiment_settings.seeds == [model_seed, 101]
         assert expt_config.data_module_args.data_seed == expected_data_seed
-
-
-class TestInferenceCleanup:
-    @pytest.mark.parametrize(
-        "cleanup_msa_dir,use_msa_server,rank,should_remove",
-        [
-            pytest.param(False, True, 0, False, id="preserve"),
-            pytest.param(True, True, 0, True, id="remove"),
-            pytest.param(True, True, 1, False, id="nonzero-rank"),
-            pytest.param(True, False, 0, False, id="msa-server-disabled"),
-        ],
-    )
-    def test_cleanup_respects_msa_output_lifecycle(
-        self,
-        cleanup_msa_dir,
-        use_msa_server,
-        rank,
-        should_remove,
-        tmp_path,
-        dummy_ckpt_file,
-        capsys,
-    ):
-        msa_output_dir = tmp_path / "msa"
-        expt_config = InferenceExperimentConfig(
-            inference_ckpt_path=dummy_ckpt_file,
-            cache_path=tmp_path / "cache",
-            experiment_settings={
-                "output_dir": tmp_path / "inference",
-                "log_dir": tmp_path / "logs",
-                "use_msa_server": use_msa_server,
-                "use_templates": False,
-            },
-            msa_computation_settings={
-                "msa_output_directory": msa_output_dir,
-                "cleanup_msa_dir": cleanup_msa_dir,
-            },
-            template_preprocessor_settings={
-                "output_directory": tmp_path / "templates",
-            },
-        )
-        expt_runner = InferenceExperimentRunner(expt_config)
-
-        sentinel_contents = {
-            Path("raw/main/out.tar.gz"): b"raw server response",
-            Path("main/rep.npz"): b"main alignment",
-            Path("paired/complex/rep.npz"): b"paired alignment",
-            Path("mappings/seq_to_rep_id.json"): b'{"sequence": "rep"}\n',
-        }
-        for relative_path, contents in sentinel_contents.items():
-            sentinel_path = msa_output_dir / relative_path
-            sentinel_path.parent.mkdir(parents=True, exist_ok=True)
-            sentinel_path.write_bytes(contents)
-
-        # Keep this test focused on MSA cleanup instead of empty-log cleanup.
-        (expt_runner.log_dir / "keep.log").write_text("keep")
-
-        with patch(
-            "openfold3.entry_points.experiment_runner._get_rank",
-            return_value=rank,
-        ):
-            expt_runner.cleanup()
-
-        captured = capsys.readouterr()
-        if should_remove:
-            assert not msa_output_dir.exists()
-        else:
-            assert msa_output_dir.is_dir()
-            assert {
-                path.relative_to(msa_output_dir): path.read_bytes()
-                for path in msa_output_dir.rglob("*")
-                if path.is_file()
-            } == sentinel_contents
-            assert "Cleaning up MSA directories..." not in captured.out
 
 
 class TestInferenceCheckpointLoading:


### PR DESCRIPTION
## Summary

This updates the MSA output workflow discussed in [aqlaboratory/openfold-3#31](https://github.com/aqlaboratory/openfold-3/issues/31).

MSA preparation now uses a unique temporary workspace. During prediction, OpenFold saves both the raw ColabFold files and its formatted alignments by default, with separate settings controlling which records prediction keeps. The temporary workspace is always removed during final cleanup.

## Changes

- Save raw ColabFold files as soon as the server response has been validated, before OpenFold starts formatting it.
- Save OpenFold-formatted alignments after MSA processing finishes.
- Add `save_openfold_outputs` and `save_colabfold_outputs` settings, both enabled by default.
- Add `colabfold_output_dir` for choosing a different parent directory for raw records.
- `cleanup_msa_dir` now controls temporary template preprocessing cleanup. The new save settings control which MSA records are kept.
- Keep existing explicit `msa_output_directory` destinations separate from the temporary workspace and reject paths that cleanup could delete.
- Keep `align-msa-server` outputs and the paths written to `query_msa.json` after temporary cleanup.
- Update the configuration reference, inference guide, and examples.

## Related Issues

Related to [aqlaboratory/openfold-3#31](https://github.com/aqlaboratory/openfold-3/issues/31).

## Testing

- Focused affected suite: `96 passed, 4 deselected`. The four deselected tests require external S3 setup and are unrelated to this change.
- Ruff formatting and lint passed.
- Mypy passed against the current baseline.
- All three changed YAML examples parsed successfully.
- Strict Sphinx documentation build passed.
- `git diff --check` passed.
- CUDA 13 validation on an NVIDIA GeForce RTX 5090 passed for server-backed prediction, prediction without the MSA server, and `align-msa-server`. The server-backed and alignment-only runs kept their saved outputs and removed their temporary workspaces. The no-server run saved the dummy formatted MSA without creating raw output.
