### PR TITLE
Fix link to AlphaFold3 in index.md

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,7 +14,7 @@
 ```
 
 Welcome to the Documentation for [OpenFold3-preview](https://github.com/aqlaboratory/openfold-3), a biological structure prediction model based on DeepMind's 
-[AlphaFold3](https://github.com/deepmind/alphafold3). Developed under a fully open source (Apache 2) license.
+[AlphaFold3](https://github.com/google-deepmind/alphafold3). Developed under a fully open source (Apache 2) license.
 
 ## Quick-Start Guide
 


### PR DESCRIPTION
**Summary**
Updated the link to AlphaFold3 in the documentation, as the previous one was permanently moved.
**Changes**
One deprecated link to the latest working one. 
**Related Issues**
/
**Testing**
Successfully followed the new link: https://github.com/google-deepmind/alphafold3
**Other Notes**
I checked the whole repo, this should be the only place that it's out of date. 
Thanks! 