### PR TITLE
Reweighted Triton Ball-Query Smooth lDDT with 51-Structure Protein–RNA Validation

### DIFF
--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -1,4 +1,6 @@
-# cuEquivariance Kernels 
+# Kernels
+
+## cuEquivariance Kernels
 
 OF3 supports cuEquivariance [triangle_multiplicative_update](https://docs.nvidia.com/cuda/cuequivariance/api/generated/cuequivariance_torch.triangle_multiplicative_update.html) and [triangle_attention](https://docs.nvidia.com/cuda/cuequivariance/api/generated/cuequivariance_torch.triangle_attention.html) kernels which can speed up inference/training of the model.
 Note: cuEquivariance acceleration can be used while DeepSpeed acceleration is enabled. 
@@ -34,4 +36,37 @@ model_update:
           use_deepspeed_evo_attention: true  # set this to False to use cueq only
 ```
 
-This runner.yml is specifically for inference, but similar settings can be used for training. 
+This runner.yml is specifically for inference, but similar settings can be used for training.
+
+## Smooth lDDT Ball-Query Kernel
+
+OpenFold3 includes an opt-in Triton ball-query backend for the smooth lDDT
+training loss. It replaces the dense all-pairs distance tensors with at most
+`K` sampled in-radius neighbors per atom. The dense implementation remains the
+default.
+
+The backend requires Triton and a CUDA device. The existing
+`openfold3-cuda12`, `openfold3-cuda13`, and corresponding `*-pypi` pixi
+environments provide the required runtime.
+
+Enable it through the diffusion-loss configuration:
+
+```yaml
+model_update:
+  custom:
+    architecture:
+      loss_module:
+        diffusion:
+          chunk_size: null
+          smooth_lddt_backend: ball_query
+          smooth_lddt_top_k: 512
+```
+
+`smooth_lddt_top_k` is the maximum number of non-self neighbors sampled within
+the 15 Å protein or 30 Å nucleotide radius for each query atom and defaults to
+512. If it covers every in-radius neighbor, the result matches the dense loss
+up to floating-point reduction order. Lower values reduce memory and runtime
+but increase sampling error; higher values move the result toward dense parity.
+
+The ball-query backend does not support the diffusion loss `chunk_size` path;
+set `architecture.loss_module.diffusion.chunk_size` to `null` when enabling it.

--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -40,16 +40,17 @@ This runner.yml is specifically for inference, but similar settings can be used 
 
 ## Smooth lDDT Ball-Query Kernel
 
-OpenFold3 includes an opt-in Triton ball-query backend for the smooth lDDT
-training loss. It replaces the dense all-pairs distance tensors with at most
-`K` sampled in-radius neighbors per atom. The dense implementation remains the
-default.
+OpenFold3 includes a Triton ball-query backend for the smooth lDDT training
+loss. It replaces dense all-pairs distance tensors with sampled in-radius
+neighbors and is the all-atom model default. Dense remains available as the
+exact reference and chunked-execution fallback.
 
-The backend requires Triton and a CUDA device. The existing
-`openfold3-cuda12`, `openfold3-cuda13`, and corresponding `*-pypi` pixi
-environments provide the required runtime.
+The backend requires Triton and a PyTorch-visible GPU. The existing
+`openfold3-cuda12`, `openfold3-cuda13`, corresponding `*-pypi`, and
+`openfold3-rocm7` pixi environments provide the required dependencies. ROCm
+support must be verified by running the focused loss tests on AMD hardware.
 
-Enable it through the diffusion-loss configuration:
+Configure it through the diffusion loss:
 
 ```yaml
 model_update:
@@ -62,11 +63,24 @@ model_update:
           smooth_lddt_top_k: 512
 ```
 
-`smooth_lddt_top_k` is the maximum number of non-self neighbors sampled within
-the 15 Å protein or 30 Å nucleotide radius for each query atom and defaults to
-512. If it covers every in-radius neighbor, the result matches the dense loss
-up to floating-point reduction order. Lower values reduce memory and runtime
-but increase sampling error; higher values move the result toward dense parity.
+`smooth_lddt_top_k` defaults to 512. `ball_query` retains up to 512 in-radius
+neighbors per atom: 15 Å for non-nucleotide centers and 30 Å for nucleotide
+centers. Exact rows retain unit weight. For truncated rows, the base pair
+weights use cap-dependent scaling with a lower bound of 1:
 
-The ball-query backend does not support the diffusion loss `chunk_size` path;
-set `architecture.loss_module.diffusion.chunk_size` to `null` when enabling it.
+```text
+protein weight    = max(1, 512 / K)
+nucleotide weight = max(1, 2048 / K)
+```
+
+For `K = 256, 512, 1024, 2048`, the protein/nucleotide weights are respectively
+`2/8`, `1/4`, `1/2`, and `1/1`. The same pair weight is applied to the
+score numerator and pair-count denominator, keeping the loss normalized.
+
+The legacy and current ball-query paths use the same `A * K` reservoir capacity.
+The current reduction keeps only `O(A)` additional row metadata for reweighting,
+so both have the same dominant `O(A * K)` storage at the same `K`.
+
+Ball-query does not support the diffusion loss `chunk_size` path directly. If
+`chunk_size` is non-null, the diffusion loss automatically uses the chunked
+dense smooth lDDT calculation. Set `chunk_size: null` to run ball-query.

--- a/examples/example_runner_yamls/smooth_lddt_ball_query.yml
+++ b/examples/example_runner_yamls/smooth_lddt_ball_query.yml
@@ -1,0 +1,8 @@
+model_update:
+  custom:
+    architecture:
+      loss_module:
+        diffusion:
+          chunk_size: null
+          smooth_lddt_backend: ball_query
+          smooth_lddt_top_k: 512

--- a/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
+++ b/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
@@ -29,6 +29,8 @@ Radii default to protein 15 Å / nucleotide 30 Å.
 
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.utils.checkpoint
 
@@ -50,6 +52,8 @@ _BWD_BLOCK = 128
 
 DEFAULT_RADIUS_PROTEIN = 15.0
 DEFAULT_RADIUS_NUCLEOTIDE = 30.0
+DEFAULT_NEIGHBOR_CAP_PROTEIN = 512
+DEFAULT_NEIGHBOR_CAP_NUCLEOTIDE = 2048
 
 
 def is_ball_query_triton_installed() -> bool:
@@ -84,6 +88,7 @@ if _TRITON_AVAILABLE:
         do_not_specialize=[
             "N",
             "P1",
+            "P2",
             "K",
             "radius_protein",
             "radius_nucleotide",
@@ -101,13 +106,16 @@ if _TRITON_AVAILABLE:
         predy_ptr,
         predz_ptr,
         is_nuc_ptr,
+        query_idx_ptr,
         lengths1_ptr,
         lengths2_ptr,
         idx_ptr,
         dists_gt_ptr,
         dists_pred_ptr,
+        neighbor_count_ptr,
         N,
         P1,
+        P2,
         K,
         radius_protein,
         radius_nucleotide,
@@ -130,26 +138,28 @@ if _TRITON_AVAILABLE:
 
         len2 = tl.load(lengths2_ptr + n)
 
+        qi = tl.load(query_idx_ptr + n * P1 + i)
         is_nuc = tl.load(is_nuc_ptr + n * P1 + i)
         radius = tl.where(is_nuc > 0.5, radius_nucleotide, radius_protein)
         radius2 = radius * radius
 
         qi_base = n * P1 + i
+        pred_qi_base = n * P2 + qi
         qi_x = tl.load(p1x_ptr + qi_base)
         qi_y = tl.load(p1y_ptr + qi_base)
         qi_z = tl.load(p1z_ptr + qi_base)
 
         if PRED_IS_BF16:
-            pi_x = tl.load(predx_ptr + qi_base).to(tl.float32)
-            pi_y = tl.load(predy_ptr + qi_base).to(tl.float32)
-            pi_z = tl.load(predz_ptr + qi_base).to(tl.float32)
+            pi_x = tl.load(predx_ptr + pred_qi_base).to(tl.float32)
+            pi_y = tl.load(predy_ptr + pred_qi_base).to(tl.float32)
+            pi_z = tl.load(predz_ptr + pred_qi_base).to(tl.float32)
         else:
-            pi_x = tl.load(predx_ptr + qi_base)
-            pi_y = tl.load(predy_ptr + qi_base)
-            pi_z = tl.load(predz_ptr + qi_base)
+            pi_x = tl.load(predx_ptr + pred_qi_base)
+            pi_y = tl.load(predy_ptr + pred_qi_base)
+            pi_z = tl.load(predz_ptr + pred_qi_base)
 
         out_base = (n * P1 + i) * K
-        row_base = n * P1
+        row_base = n * P2
 
         count = tl.full((), 0, tl.int32)
         seen = tl.full((), 0, tl.int32)
@@ -173,7 +183,7 @@ if _TRITON_AVAILABLE:
             dist2_gt = dx * dx + dy * dy + dz * dz
             in_ball = (
                 in_range
-                & (offs != i)
+                & (offs != qi)
                 & (tl.abs(dx) <= radius)
                 & (tl.abs(dy) <= radius)
                 & (tl.abs(dz) <= radius)
@@ -235,7 +245,7 @@ if _TRITON_AVAILABLE:
                         d2g = ddx * ddx + ddy * ddy + ddz * ddz
                         ib = (
                             ok
-                            & (j != i)
+                            & (j != qi)
                             & (tl.abs(ddx) <= radius)
                             & (tl.abs(ddy) <= radius)
                             & (tl.abs(ddz) <= radius)
@@ -290,7 +300,7 @@ if _TRITON_AVAILABLE:
                     d2g = ddx * ddx + ddy * ddy + ddz * ddz
                     ib = (
                         ok
-                        & (j != i)
+                        & (j != qi)
                         & (tl.abs(ddx) <= radius)
                         & (tl.abs(ddy) <= radius)
                         & (tl.abs(ddz) <= radius)
@@ -324,16 +334,20 @@ if _TRITON_AVAILABLE:
                             else:
                                 tl.store(dists_pred_ptr + out_base + slot, s_d2p)
 
-    @triton.jit(do_not_specialize=["N", "P1", "K", "total"])
+        tl.store(neighbor_count_ptr + n * P1 + i, seen)
+
+    @triton.jit(do_not_specialize=["N", "P1", "P2", "K", "total"])
     def _ball_query_backward_kernel(
         predx_ptr,
         predy_ptr,
         predz_ptr,
         idx_ptr,
+        query_idx_ptr,
         grad_dists_ptr,
         grad_pred_ptr,
         N,
         P1,
+        P2,
         K,
         total,
         PRED_IS_BF16: tl.constexpr,
@@ -350,11 +364,12 @@ if _TRITON_AVAILABLE:
         i = rem // K
 
         j = tl.load(idx_ptr + offs, mask=mask, other=-1)
+        qi = tl.load(query_idx_ptr + n * P1 + i, mask=mask, other=-1)
         g = tl.load(grad_dists_ptr + offs, mask=mask, other=0.0)
-        active = mask & (j >= 0) & (g != 0.0)
+        active = mask & (j >= 0) & (qi >= 0) & (g != 0.0)
 
-        base_i = n * P1 + i
-        base_j = n * P1 + j
+        base_i = n * P2 + qi
+        base_j = n * P2 + j
         # grad_pred is still AoS [N,P,3]
         gbase_i = base_i * 3
         gbase_j = base_j * 3
@@ -385,19 +400,20 @@ if _TRITON_AVAILABLE:
         tl.atomic_add(grad_pred_ptr + gbase_j + 2, -gz, mask=active)
 
 
-def _query_with_pred(
+def _query_with_pred_compact(
     p1: torch.Tensor,
     p2: torch.Tensor,
     pred: torch.Tensor,
     is_nucleotide: torch.Tensor,
+    query_indices: torch.Tensor,
     lengths1: torch.Tensor,
     lengths2: torch.Tensor,
     k: int,
     radius_protein: float = DEFAULT_RADIUS_PROTEIN,
     radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
     seed: int = 0,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Launch forward kernel; returns ``(idx, dists_gt, dists_pred)``."""
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Query compact rows; return indices, squared distances, and true counts."""
     if not is_ball_query_triton_available():
         raise RuntimeError(
             "Triton ball-query smooth lDDT requires Triton and a CUDA device"
@@ -415,17 +431,24 @@ def _query_with_pred(
     p2 = p2.contiguous()
     pred = pred.contiguous()
     is_nucleotide = is_nucleotide.contiguous().to(dtype=torch.float32)
+    query_indices = query_indices.contiguous().long()
     lengths1 = lengths1.contiguous().long()
     lengths2 = lengths2.contiguous().long()
 
-    n_batch, n_atom, _ = p1.shape
-    idxs = torch.full((n_batch, n_atom, k), -1, device=p1.device, dtype=torch.long)
-    dists_gt = torch.zeros((n_batch, n_atom, k), device=p1.device, dtype=torch.float32)
-    dists_pred = torch.zeros((n_batch, n_atom, k), device=pred.device, dtype=pred.dtype)
+    n_batch, n_query, _ = p1.shape
+    n_atom = p2.shape[1]
+    idxs = torch.full((n_batch, n_query, k), -1, device=p1.device, dtype=torch.long)
+    dists_gt = torch.zeros((n_batch, n_query, k), device=p1.device, dtype=torch.float32)
+    dists_pred = torch.zeros(
+        (n_batch, n_query, k), device=pred.device, dtype=pred.dtype
+    )
+    neighbor_count = torch.zeros(
+        (n_batch, n_query), device=p1.device, dtype=torch.int32
+    )
 
-    total_atoms = n_batch * n_atom
+    total_atoms = n_batch * n_query
     if total_atoms == 0 or idxs.numel() == 0:
-        return idxs, dists_gt, dists_pred
+        return idxs, dists_gt, dists_pred, neighbor_count
 
     p1x, p1y, p1z = _as_soa(p1)
     p2x, p2y, p2z = _as_soa(p2)
@@ -442,12 +465,15 @@ def _query_with_pred(
         predy,
         predz,
         is_nucleotide,
+        query_indices,
         lengths1,
         lengths2,
         idxs,
         dists_gt,
         dists_pred,
+        neighbor_count,
         n_batch,
+        n_query,
         n_atom,
         k,
         float(radius_protein),
@@ -457,12 +483,44 @@ def _query_with_pred(
         BLOCK_J=_BLOCK_J,
         num_warps=_FWD_NUM_WARPS,
     )
-    return idxs, dists_gt, dists_pred
+    return idxs, dists_gt, dists_pred, neighbor_count
+
+
+def _query_with_pred(
+    p1: torch.Tensor,
+    p2: torch.Tensor,
+    pred: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    lengths1: torch.Tensor,
+    lengths2: torch.Tensor,
+    k: int,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+    seed: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Backward-compatible full-row query entry point."""
+    n_batch, n_query, _ = p1.shape
+    query_indices = torch.arange(n_query, device=p1.device).expand(n_batch, -1)
+    idx, dists_gt, dists_pred, _ = _query_with_pred_compact(
+        p1=p1,
+        p2=p2,
+        pred=pred,
+        is_nucleotide=is_nucleotide,
+        query_indices=query_indices,
+        lengths1=lengths1,
+        lengths2=lengths2,
+        k=k,
+        radius_protein=radius_protein,
+        radius_nucleotide=radius_nucleotide,
+        seed=seed,
+    )
+    return idx, dists_gt, dists_pred
 
 
 def _pred_backward(
     pred: torch.Tensor,
     idxs: torch.Tensor,
+    query_indices: torch.Tensor,
     grad_dists: torch.Tensor,
 ) -> torch.Tensor:
     """Backward for predicted squared distances (fp32 atomic scatter)."""
@@ -475,15 +533,17 @@ def _pred_backward(
 
     pred = pred.contiguous()
     idxs = idxs.contiguous().long()
+    query_indices = query_indices.contiguous().long()
     grad_dists = grad_dists.contiguous().float()
 
     n_batch, n_atom, _ = pred.shape
+    n_query = idxs.shape[1]
     k = idxs.shape[-1]
     grad_pred = torch.zeros(
         (n_batch, n_atom, 3), device=pred.device, dtype=torch.float32
     )
 
-    total = n_batch * n_atom * k
+    total = n_batch * n_query * k
     if total == 0:
         return grad_pred
 
@@ -494,9 +554,11 @@ def _pred_backward(
         predy,
         predz,
         idxs,
+        query_indices,
         grad_dists,
         grad_pred,
         n_batch,
+        n_query,
         n_atom,
         k,
         total,
@@ -527,6 +589,23 @@ def _validate_top_k(top_k: int | None, n_atom: int) -> int:
     return min(top_k, max(n_atom - 1, 0))
 
 
+def _validate_nucleotide_scale(nucleotide_scale: float) -> float:
+    if (
+        isinstance(nucleotide_scale, bool)
+        or not isinstance(nucleotide_scale, int | float)
+        or not math.isfinite(nucleotide_scale)
+        or nucleotide_scale < 1.0
+    ):
+        raise ValueError("smooth_lddt_nucleotide_scale must be finite and >= 1")
+    return float(nucleotide_scale)
+
+
+def _type_aware_top_ks(top_k: int, nucleotide_scale: float) -> tuple[int, int]:
+    """Return non-nucleotide and nucleotide capacities for a reference ``K``."""
+    protein_top_k = max(1, math.ceil(top_k / nucleotide_scale))
+    return protein_top_k, top_k
+
+
 class _BallQueryWithPredDist(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -535,6 +614,7 @@ class _BallQueryWithPredDist(torch.autograd.Function):
         p1_gt,
         p2_gt,
         is_nucleotide,
+        query_indices,
         lengths1,
         lengths2,
         k,
@@ -542,11 +622,12 @@ class _BallQueryWithPredDist(torch.autograd.Function):
         radius_nucleotide,
         seed,
     ):
-        idx, dists_gt, dists_pred = _query_with_pred(
+        idx, dists_gt, dists_pred, neighbor_count = _query_with_pred_compact(
             p1=p1_gt,
             p2=p2_gt,
             pred=pred,
             is_nucleotide=is_nucleotide,
+            query_indices=query_indices,
             lengths1=lengths1,
             lengths2=lengths2,
             k=k,
@@ -554,16 +635,30 @@ class _BallQueryWithPredDist(torch.autograd.Function):
             radius_nucleotide=radius_nucleotide,
             seed=seed,
         )
-        ctx.save_for_backward(pred, idx)
-        ctx.mark_non_differentiable(idx, dists_gt)
-        return dists_pred, dists_gt, idx
+        ctx.save_for_backward(pred, idx, query_indices)
+        ctx.mark_non_differentiable(idx, dists_gt, neighbor_count)
+        return dists_pred, dists_gt, idx, neighbor_count
 
     @staticmethod
     @torch.autograd.function.once_differentiable
-    def backward(ctx, grad_dists_pred, grad_dists_gt, grad_idx):
-        pred, idx = ctx.saved_tensors
-        grad_pred = _pred_backward(pred, idx, grad_dists_pred).to(pred.dtype)
-        return grad_pred, None, None, None, None, None, None, None, None, None
+    def backward(ctx, grad_dists_pred, grad_dists_gt, grad_idx, grad_neighbor_count):
+        pred, idx, query_indices = ctx.saved_tensors
+        grad_pred = _pred_backward(pred, idx, query_indices, grad_dists_pred).to(
+            pred.dtype
+        )
+        return (
+            grad_pred,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 def _score_from_dists(
@@ -601,7 +696,7 @@ def _score_from_dists(
     return (1 - lddt).reshape(out_shape)
 
 
-def ball_query_smooth_lddt_loss(
+def _legacy_ball_query_smooth_lddt_loss(
     x: torch.Tensor,
     x_gt: torch.Tensor,
     atom_mask_gt: torch.Tensor,
@@ -613,7 +708,7 @@ def ball_query_smooth_lddt_loss(
     radius_protein: float = DEFAULT_RADIUS_PROTEIN,
     radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
 ) -> torch.Tensor:
-    """Smooth lDDT via Triton ball-query.
+    """Legacy ball-query smooth lDDT retained for benchmark comparisons.
 
     Same argument contract as the CUDA package entry point. Radii default to
     15 Å (protein) / 30 Å (nucleotide).
@@ -653,11 +748,13 @@ def ball_query_smooth_lddt_loss(
         torch.full_like(flat_x_gt, 1.0e6),
     )
 
-    dists_pred, dists_gt, idx = _BallQueryWithPredDist.apply(
+    query_indices = torch.arange(n_atom, device=x.device).expand(flat_batch, -1)
+    dists_pred, dists_gt, idx, _ = _BallQueryWithPredDist.apply(
         flat_x,
         flat_x_gt,
         p2,
         flat_is_nucleotide,
+        query_indices,
         lengths,
         lengths,
         k,
@@ -694,3 +791,503 @@ def ball_query_smooth_lddt_loss(
             use_reentrant=False,
         )
     return _score_from_dists(*score_args)
+
+
+def _compact_query_group(
+    coordinates: torch.Tensor,
+    query_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compact selected query atoms and retain their global atom indices."""
+    lengths = query_mask.sum(dim=1, dtype=torch.long)
+    max_queries = int(lengths.max().item()) if lengths.numel() else 0
+    if max_queries == 0:
+        shape = (coordinates.shape[0], 0)
+        return (
+            coordinates[:, :0],
+            torch.empty(shape, device=coordinates.device, dtype=torch.long),
+            is_nucleotide[:, :0],
+            lengths,
+        )
+
+    order = torch.argsort((~query_mask).to(torch.int8), dim=1, stable=True)
+    query_indices = order[:, :max_queries]
+    gather_idx = query_indices[..., None].expand(-1, -1, 3)
+    query_coordinates = torch.gather(coordinates, 1, gather_idx)
+    query_is_nucleotide = torch.gather(is_nucleotide, 1, query_indices)
+    return query_coordinates, query_indices, query_is_nucleotide, lengths
+
+
+def _query_group_with_pred(
+    flat_x: torch.Tensor,
+    flat_x_gt: torch.Tensor,
+    valid_atom: torch.Tensor,
+    flat_is_nucleotide: torch.Tensor,
+    query_mask: torch.Tensor,
+    top_k: int,
+    query_radius_protein: float,
+    query_radius_nucleotide: float,
+    seed: int,
+) -> tuple[torch.Tensor, ...]:
+    query_gt, query_indices, query_is_nucleotide, query_lengths = _compact_query_group(
+        flat_x_gt, query_mask, flat_is_nucleotide
+    )
+    if query_gt.shape[1] == 0:
+        empty = flat_x.new_empty((flat_x.shape[0], 0, top_k))
+        return (
+            empty,
+            empty.float(),
+            torch.empty_like(empty, dtype=torch.long),
+            torch.empty(empty.shape[:-1], device=flat_x.device, dtype=torch.int32),
+            query_indices,
+            query_is_nucleotide,
+        )
+
+    candidates_gt = torch.where(
+        valid_atom[..., None], flat_x_gt, torch.full_like(flat_x_gt, 1.0e6)
+    )
+    candidate_lengths = torch.full(
+        (flat_x.shape[0],),
+        flat_x.shape[1],
+        device=flat_x.device,
+        dtype=torch.long,
+    )
+    dists_pred, dists_gt, idx, neighbor_count = _BallQueryWithPredDist.apply(
+        flat_x,
+        query_gt,
+        candidates_gt,
+        query_is_nucleotide,
+        query_indices,
+        query_lengths,
+        candidate_lengths,
+        top_k,
+        float(query_radius_protein),
+        float(query_radius_nucleotide),
+        seed,
+    )
+    return (
+        dists_pred,
+        dists_gt,
+        idx,
+        neighbor_count,
+        query_indices,
+        query_is_nucleotide,
+    )
+
+
+def _top_k_adjusted_type_group_weights(
+    top_k: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return dynamically scaled type weights with a lower bound of one."""
+    protein_weight = max(
+        1.0,
+        DEFAULT_NEIGHBOR_CAP_PROTEIN / top_k,
+    )
+    nucleotide_weight = max(
+        1.0,
+        DEFAULT_NEIGHBOR_CAP_NUCLEOTIDE / top_k,
+    )
+    return torch.tensor(
+        (1.0, protein_weight, nucleotide_weight),
+        device=device,
+        dtype=dtype,
+    )
+
+
+def _top_k_adjusted_type_row_weights(
+    neighbor_count: torch.Tensor,
+    retained_count: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    top_k: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return dynamically scaled, lower-bounded weights for truncated rows."""
+    group_weight = _top_k_adjusted_type_group_weights(
+        top_k, neighbor_count.device, dtype
+    )
+    adjusted_weight = torch.where(
+        query_is_nucleotide.bool(), group_weight[2], group_weight[1]
+    )
+    truncated = neighbor_count > retained_count
+    return torch.where(truncated, adjusted_weight, group_weight[0])
+
+
+def _type_group_indices(
+    neighbor_count: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    """Map rows to exact=0, truncated protein=1, or truncated nucleotide=2."""
+    truncated = (neighbor_count > top_k).long()
+    return truncated * (1 + query_is_nucleotide.long())
+
+
+def _group_row_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reduce retained pairs to one score and count per query atom."""
+    dx = torch.sqrt(eps + dists_pred.clamp_min(0.0))
+    dx_gt = torch.sqrt(eps + dists_gt.clamp_min(0.0))
+    delta = torch.abs(dx_gt - dx)
+    score = 0.25 * (
+        torch.sigmoid(0.5 - delta)
+        + torch.sigmoid(1.0 - delta)
+        + torch.sigmoid(2.0 - delta)
+        + torch.sigmoid(4.0 - delta)
+    )
+    cutoff = torch.where(
+        query_is_nucleotide.bool(),
+        torch.as_tensor(score_radius_nucleotide, device=dx.device, dtype=dx_gt.dtype),
+        torch.as_tensor(score_radius_protein, device=dx.device, dtype=dx_gt.dtype),
+    )
+    retained = idx >= 0
+    valid = retained & (dx_gt < cutoff[..., None])
+    return (
+        torch.sum(score * valid.to(score.dtype), dim=-1),
+        torch.sum(valid, dim=-1, dtype=score.dtype),
+    )
+
+
+def _type_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    type_group_index: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Aggregate query rows into the three reweighting categories."""
+    row_score_sum, row_pair_count = _group_row_sums(
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    out_shape = (*row_score_sum.shape[:-1], 3)
+    score_sum = torch.zeros(
+        out_shape, device=row_score_sum.device, dtype=row_score_sum.dtype
+    )
+    pair_count = torch.zeros_like(score_sum)
+    return (
+        score_sum.scatter_add(-1, type_group_index, row_score_sum),
+        pair_count.scatter_add(-1, type_group_index, row_pair_count),
+    )
+
+
+def _combine_type_group_sums(
+    score_sum: torch.Tensor,
+    pair_count: torch.Tensor,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply the three scalar category weights after pair reduction."""
+    group_weight = _top_k_adjusted_type_group_weights(
+        top_k, score_sum.device, score_sum.dtype
+    )
+    return (
+        torch.sum(score_sum * group_weight, dim=-1),
+        torch.sum(pair_count * group_weight, dim=-1),
+    )
+
+
+def _top_k_adjusted_type_reweighted_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    neighbor_count: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    top_k: int,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply type weights to three aggregate statistics."""
+    type_group_index = _type_group_indices(neighbor_count, query_is_nucleotide, top_k)
+    score_sum, pair_count = _type_group_sums(
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        type_group_index,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    return _combine_type_group_sums(score_sum, pair_count, top_k)
+
+
+def _unweighted_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    row_score_sum, row_pair_count = _group_row_sums(
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    return row_score_sum.sum(dim=-1), row_pair_count.sum(dim=-1)
+
+
+def _checkpointed_group_row_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    args = (
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    if dists_pred.requires_grad:
+        return torch.utils.checkpoint.checkpoint(
+            _group_row_sums, *args, use_reentrant=False
+        )
+    return _group_row_sums(*args)
+
+
+def _checkpointed_type_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    type_group_index: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    args = (
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        type_group_index,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    if dists_pred.requires_grad:
+        return torch.utils.checkpoint.checkpoint(
+            _type_group_sums, *args, use_reentrant=False
+        )
+    return _type_group_sums(*args)
+
+
+def _checkpointed_top_k_adjusted_type_reweighted_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    neighbor_count: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    top_k: int,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    type_group_index = _type_group_indices(neighbor_count, query_is_nucleotide, top_k)
+    score_sum, pair_count = _checkpointed_type_group_sums(
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        type_group_index,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    return _combine_type_group_sums(score_sum, pair_count, top_k)
+
+
+def _checkpointed_unweighted_group_sums(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    idx: torch.Tensor,
+    query_is_nucleotide: torch.Tensor,
+    eps: float,
+    score_radius_protein: float,
+    score_radius_nucleotide: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    row_score_sum, row_pair_count = _checkpointed_group_row_sums(
+        dists_pred,
+        dists_gt,
+        idx,
+        query_is_nucleotide,
+        eps,
+        score_radius_protein,
+        score_radius_nucleotide,
+    )
+    return row_score_sum.sum(dim=-1), row_pair_count.sum(dim=-1)
+
+
+def _finish_weighted_lddt(
+    score_sum: torch.Tensor,
+    pair_count: torch.Tensor,
+    valid_atom: torch.Tensor,
+    eps: float,
+    out_shape: tuple[int, ...],
+) -> torch.Tensor:
+    valid_count = valid_atom.sum(dim=-1).to(score_sum.dtype)
+    all_pair_count = valid_count * (valid_count - 1).clamp_min(0)
+    normalizer = all_pair_count + eps
+    score_mean = score_sum / normalizer
+    local_pair_mean = pair_count / normalizer
+    return (1 - score_mean / (local_pair_mean + eps)).reshape(out_shape)
+
+
+def _prepare_sparse_inputs(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask_gt: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    x_gt = _expand_to_x_batch(x_gt, x, trailing_dims=2)
+    atom_mask_gt = _expand_to_x_batch(atom_mask_gt, x, trailing_dims=1)
+    is_nucleotide = _expand_to_x_batch(is_nucleotide, x, trailing_dims=1)
+    loss_atom_mask = _expand_to_x_batch(loss_atom_mask, x, trailing_dims=1)
+    valid_atom = (loss_atom_mask * atom_mask_gt).bool()
+    return (
+        _flatten_batch(x, trailing_dims=2),
+        _flatten_batch(x_gt, trailing_dims=2),
+        _flatten_batch(valid_atom, trailing_dims=1),
+        _flatten_batch(is_nucleotide, trailing_dims=1),
+    )
+
+
+def ball_query_smooth_lddt_loss(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask_gt: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+    eps: float,
+    top_k: int | None = 512,
+    seed: int = 0,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+) -> torch.Tensor:
+    """Estimate smooth lDDT with top-k-adjusted type reweighting."""
+    if not is_ball_query_triton_available() or not x.is_cuda:
+        raise RuntimeError(
+            "Triton ball-query smooth lDDT requires Triton and a CUDA device"
+        )
+    if radius_protein <= 0 or radius_nucleotide <= 0:
+        raise ValueError("radius_protein and radius_nucleotide must be positive")
+    k = _validate_top_k(top_k, x.shape[-2])
+    if k == 0:
+        return torch.ones(x.shape[:-2], device=x.device, dtype=x.dtype) + x.sum() * 0
+    flat_x, flat_x_gt, valid_atom, flat_is_nucleotide = _prepare_sparse_inputs(
+        x, x_gt, atom_mask_gt, is_nucleotide, loss_atom_mask
+    )
+    group = _query_group_with_pred(
+        flat_x,
+        flat_x_gt,
+        valid_atom,
+        flat_is_nucleotide,
+        valid_atom,
+        k,
+        radius_protein,
+        radius_nucleotide,
+        seed,
+    )
+    score_sum, pair_count = _checkpointed_top_k_adjusted_type_reweighted_group_sums(
+        group[0],
+        group[1],
+        group[2],
+        group[3],
+        group[5],
+        k,
+        eps,
+        radius_protein,
+        radius_nucleotide,
+    )
+    return _finish_weighted_lddt(score_sum, pair_count, valid_atom, eps, x.shape[:-2])
+
+
+def _type_aware_ball_query_smooth_lddt_loss(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask_gt: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+    eps: float,
+    top_k: int | None = 2048,
+    nucleotide_scale: float = 4.0,
+    seed: int = 0,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+) -> torch.Tensor:
+    """Use ``K / s`` non-nucleotide and ``K`` nucleotide neighbors."""
+    if not is_ball_query_triton_available() or not x.is_cuda:
+        raise RuntimeError(
+            "Triton ball-query smooth lDDT requires Triton and a CUDA device"
+        )
+    if radius_protein <= 0 or radius_nucleotide <= 0:
+        raise ValueError("radius_protein and radius_nucleotide must be positive")
+    scale = _validate_nucleotide_scale(nucleotide_scale)
+    nucleotide_top_k = _validate_top_k(top_k, x.shape[-2])
+    if nucleotide_top_k == 0:
+        return torch.ones(x.shape[:-2], device=x.device, dtype=x.dtype) + x.sum() * 0
+    protein_top_k, nucleotide_top_k = _type_aware_top_ks(nucleotide_top_k, scale)
+    flat_x, flat_x_gt, valid_atom, flat_is_nucleotide = _prepare_sparse_inputs(
+        x, x_gt, atom_mask_gt, is_nucleotide, loss_atom_mask
+    )
+
+    score_sum = torch.zeros(flat_x.shape[0], device=x.device, dtype=x.dtype)
+    pair_count = torch.zeros_like(score_sum)
+    query_groups = (
+        (valid_atom & ~flat_is_nucleotide.bool(), protein_top_k),
+        (valid_atom & flat_is_nucleotide.bool(), nucleotide_top_k),
+    )
+    for group_index, (query_mask, group_top_k) in enumerate(query_groups):
+        group = _query_group_with_pred(
+            flat_x,
+            flat_x_gt,
+            valid_atom,
+            flat_is_nucleotide,
+            query_mask,
+            group_top_k,
+            radius_protein,
+            radius_nucleotide,
+            seed + group_index,
+        )
+        group_score_sum, group_pair_count = _checkpointed_unweighted_group_sums(
+            group[0],
+            group[1],
+            group[2],
+            group[5],
+            eps,
+            radius_protein,
+            radius_nucleotide,
+        )
+        score_sum = score_sum + group_score_sum
+        pair_count = pair_count + group_pair_count
+    return _finish_weighted_lddt(score_sum, pair_count, valid_atom, eps, x.shape[:-2])

--- a/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
+++ b/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
@@ -608,7 +608,7 @@ def ball_query_smooth_lddt_loss(
     is_nucleotide: torch.Tensor,
     loss_atom_mask: torch.Tensor,
     eps: float,
-    top_k: int | None,
+    top_k: int | None = 512,
     seed: int = 0,
     radius_protein: float = DEFAULT_RADIUS_PROTEIN,
     radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,

--- a/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
+++ b/openfold3/core/kernels/triton/smooth_lddt_ball_query.py
@@ -1,0 +1,696 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# by Liang Hong <lhong22@cse.cuhk.edu.hk>: length-generic Triton impl
+# of ball-query smooth lDDT for fast and low memory loss calc.
+
+"""Independent Triton ball-query smooth lDDT backend.
+
+Call directly::
+
+    from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+        ball_query_smooth_lddt_loss,
+    )
+    loss = ball_query_smooth_lddt_loss(...)
+
+Radii default to protein 15 Å / nucleotide 30 Å.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.utils.checkpoint
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None  # type: ignore[assignment]
+    tl = None  # type: ignore[assignment]
+    _TRITON_AVAILABLE = False
+
+# Length-invariant launch knobs (not autotuned per shape).
+_FWD_NUM_WARPS = 4
+_BWD_NUM_WARPS = 4
+_BLOCK_J = 128
+_BWD_BLOCK = 128
+
+DEFAULT_RADIUS_PROTEIN = 15.0
+DEFAULT_RADIUS_NUCLEOTIDE = 30.0
+
+
+def is_ball_query_triton_installed() -> bool:
+    """Return whether Triton is importable."""
+    return _TRITON_AVAILABLE
+
+
+def is_ball_query_triton_available() -> bool:
+    """Return whether this backend can run (Triton + CUDA)."""
+    return _TRITON_AVAILABLE and torch.cuda.is_available()
+
+
+def _as_soa(xyz: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split ``[N, P, 3]`` into contiguous x/y/z planes."""
+    return xyz[..., 0].contiguous(), xyz[..., 1].contiguous(), xyz[..., 2].contiguous()
+
+
+if _TRITON_AVAILABLE:
+
+    @triton.jit
+    def _hash_rng(state):
+        # Advance before mixing so zero is not an absorbing state.
+        state = state + 0x9E3779B9
+        state = state ^ (state >> 16)
+        state = state * 0x45D9F3B
+        state = state ^ (state >> 16)
+        state = state * 0x45D9F3B
+        state = state ^ (state >> 16)
+        return state
+
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "P1",
+            "K",
+            "radius_protein",
+            "radius_nucleotide",
+            "seed",
+        ]
+    )
+    def _ball_query_forward_kernel(
+        p1x_ptr,
+        p1y_ptr,
+        p1z_ptr,
+        p2x_ptr,
+        p2y_ptr,
+        p2z_ptr,
+        predx_ptr,
+        predy_ptr,
+        predz_ptr,
+        is_nuc_ptr,
+        lengths1_ptr,
+        lengths2_ptr,
+        idx_ptr,
+        dists_gt_ptr,
+        dists_pred_ptr,
+        N,
+        P1,
+        K,
+        radius_protein,
+        radius_nucleotide,
+        seed,
+        PRED_IS_BF16: tl.constexpr,
+        BLOCK_J: tl.constexpr,
+    ):
+        """One program / query atom: SoA tiled scan + Algorithm R."""
+        atom_flat = tl.program_id(0).to(tl.int64)
+        total_atoms = N * P1
+        if atom_flat >= total_atoms:
+            return
+
+        n = atom_flat // P1
+        i = atom_flat % P1
+
+        len1 = tl.load(lengths1_ptr + n)
+        if i >= len1:
+            return
+
+        len2 = tl.load(lengths2_ptr + n)
+
+        is_nuc = tl.load(is_nuc_ptr + n * P1 + i)
+        radius = tl.where(is_nuc > 0.5, radius_nucleotide, radius_protein)
+        radius2 = radius * radius
+
+        qi_base = n * P1 + i
+        qi_x = tl.load(p1x_ptr + qi_base)
+        qi_y = tl.load(p1y_ptr + qi_base)
+        qi_z = tl.load(p1z_ptr + qi_base)
+
+        if PRED_IS_BF16:
+            pi_x = tl.load(predx_ptr + qi_base).to(tl.float32)
+            pi_y = tl.load(predy_ptr + qi_base).to(tl.float32)
+            pi_z = tl.load(predz_ptr + qi_base).to(tl.float32)
+        else:
+            pi_x = tl.load(predx_ptr + qi_base)
+            pi_y = tl.load(predy_ptr + qi_base)
+            pi_z = tl.load(predz_ptr + qi_base)
+
+        out_base = (n * P1 + i) * K
+        row_base = n * P1
+
+        count = tl.full((), 0, tl.int32)
+        seen = tl.full((), 0, tl.int32)
+        rng = seed.to(tl.uint32)
+        rng = rng ^ (n.to(tl.uint32) * tl.full((), 1000003, tl.uint32))
+        rng = rng ^ (i.to(tl.uint32) * tl.full((), 997, tl.uint32))
+        rng = _hash_rng(rng)
+
+        for j0 in tl.range(0, len2, BLOCK_J):
+            offs = j0 + tl.arange(0, BLOCK_J)
+            in_range = offs < len2
+            j_ptr = row_base + offs
+
+            xj = tl.load(p2x_ptr + j_ptr, mask=in_range, other=1.0e6)
+            yj = tl.load(p2y_ptr + j_ptr, mask=in_range, other=1.0e6)
+            zj = tl.load(p2z_ptr + j_ptr, mask=in_range, other=1.0e6)
+
+            dx = qi_x - xj
+            dy = qi_y - yj
+            dz = qi_z - zj
+            dist2_gt = dx * dx + dy * dy + dz * dz
+            in_ball = (
+                in_range
+                & (offs != i)
+                & (tl.abs(dx) <= radius)
+                & (tl.abs(dy) <= radius)
+                & (tl.abs(dz) <= radius)
+                & (dist2_gt < radius2)
+            )
+
+            hits_i32 = in_ball.to(tl.int32)
+            n_hits = tl.sum(hits_i32)
+
+            if n_hits > 0 and count < K:
+                rem = K - count
+                excl = tl.cumsum(hits_i32) - hits_i32
+                take = in_ball & (excl < rem)
+                write_slot = count + excl
+
+                if PRED_IS_BF16:
+                    px = tl.load(predx_ptr + j_ptr, mask=take, other=0.0).to(tl.float32)
+                    py = tl.load(predy_ptr + j_ptr, mask=take, other=0.0).to(tl.float32)
+                    pz = tl.load(predz_ptr + j_ptr, mask=take, other=0.0).to(tl.float32)
+                else:
+                    px = tl.load(predx_ptr + j_ptr, mask=take, other=0.0)
+                    py = tl.load(predy_ptr + j_ptr, mask=take, other=0.0)
+                    pz = tl.load(predz_ptr + j_ptr, mask=take, other=0.0)
+                v_pdx = pi_x - px
+                v_pdy = pi_y - py
+                v_pdz = pi_z - pz
+                v_dist2_pred = v_pdx * v_pdx + v_pdy * v_pdy + v_pdz * v_pdz
+
+                tl.store(idx_ptr + out_base + write_slot, offs, mask=take)
+                tl.store(dists_gt_ptr + out_base + write_slot, dist2_gt, mask=take)
+                if PRED_IS_BF16:
+                    tl.store(
+                        dists_pred_ptr + out_base + write_slot,
+                        v_dist2_pred.to(tl.bfloat16),
+                        mask=take,
+                    )
+                else:
+                    tl.store(
+                        dists_pred_ptr + out_base + write_slot,
+                        v_dist2_pred,
+                        mask=take,
+                    )
+
+                n_take = tl.minimum(n_hits, rem)
+                count = count + n_take
+
+                if n_hits > n_take:
+                    hit_ord = 0
+                    for b in tl.static_range(BLOCK_J):
+                        j = j0 + b
+                        ok = j < len2
+                        jj = row_base + j
+                        x = tl.load(p2x_ptr + jj, mask=ok, other=1.0e6)
+                        y = tl.load(p2y_ptr + jj, mask=ok, other=1.0e6)
+                        z = tl.load(p2z_ptr + jj, mask=ok, other=1.0e6)
+                        ddx = qi_x - x
+                        ddy = qi_y - y
+                        ddz = qi_z - z
+                        d2g = ddx * ddx + ddy * ddy + ddz * ddz
+                        ib = (
+                            ok
+                            & (j != i)
+                            & (tl.abs(ddx) <= radius)
+                            & (tl.abs(ddy) <= radius)
+                            & (tl.abs(ddz) <= radius)
+                            & (d2g < radius2)
+                        )
+                        if ib:
+                            hit_ord = hit_ord + 1
+                            seen = seen + 1
+                            if hit_ord > n_take:
+                                if PRED_IS_BF16:
+                                    s_px = tl.load(predx_ptr + jj).to(tl.float32)
+                                    s_py = tl.load(predy_ptr + jj).to(tl.float32)
+                                    s_pz = tl.load(predz_ptr + jj).to(tl.float32)
+                                else:
+                                    s_px = tl.load(predx_ptr + jj)
+                                    s_py = tl.load(predy_ptr + jj)
+                                    s_pz = tl.load(predz_ptr + jj)
+                                s_pdx = pi_x - s_px
+                                s_pdy = pi_y - s_py
+                                s_pdz = pi_z - s_pz
+                                s_d2p = s_pdx * s_pdx + s_pdy * s_pdy + s_pdz * s_pdz
+                                rng = _hash_rng(rng)
+                                r = (rng % seen.to(tl.uint32)).to(tl.int32)
+                                if r < K:
+                                    slot = r.to(tl.int64)
+                                    tl.store(idx_ptr + out_base + slot, j)
+                                    tl.store(dists_gt_ptr + out_base + slot, d2g)
+                                    if PRED_IS_BF16:
+                                        tl.store(
+                                            dists_pred_ptr + out_base + slot,
+                                            s_d2p.to(tl.bfloat16),
+                                        )
+                                    else:
+                                        tl.store(
+                                            dists_pred_ptr + out_base + slot, s_d2p
+                                        )
+                else:
+                    seen = seen + n_hits
+
+            elif n_hits > 0:
+                # Reservoir phase (count == K).
+                for b in tl.static_range(BLOCK_J):
+                    j = j0 + b
+                    ok = j < len2
+                    jj = row_base + j
+                    x = tl.load(p2x_ptr + jj, mask=ok, other=1.0e6)
+                    y = tl.load(p2y_ptr + jj, mask=ok, other=1.0e6)
+                    z = tl.load(p2z_ptr + jj, mask=ok, other=1.0e6)
+                    ddx = qi_x - x
+                    ddy = qi_y - y
+                    ddz = qi_z - z
+                    d2g = ddx * ddx + ddy * ddy + ddz * ddz
+                    ib = (
+                        ok
+                        & (j != i)
+                        & (tl.abs(ddx) <= radius)
+                        & (tl.abs(ddy) <= radius)
+                        & (tl.abs(ddz) <= radius)
+                        & (d2g < radius2)
+                    )
+                    if ib:
+                        seen = seen + 1
+                        if PRED_IS_BF16:
+                            s_px = tl.load(predx_ptr + jj).to(tl.float32)
+                            s_py = tl.load(predy_ptr + jj).to(tl.float32)
+                            s_pz = tl.load(predz_ptr + jj).to(tl.float32)
+                        else:
+                            s_px = tl.load(predx_ptr + jj)
+                            s_py = tl.load(predy_ptr + jj)
+                            s_pz = tl.load(predz_ptr + jj)
+                        s_pdx = pi_x - s_px
+                        s_pdy = pi_y - s_py
+                        s_pdz = pi_z - s_pz
+                        s_d2p = s_pdx * s_pdx + s_pdy * s_pdy + s_pdz * s_pdz
+                        rng = _hash_rng(rng)
+                        r = (rng % seen.to(tl.uint32)).to(tl.int32)
+                        if r < K:
+                            slot = r.to(tl.int64)
+                            tl.store(idx_ptr + out_base + slot, j)
+                            tl.store(dists_gt_ptr + out_base + slot, d2g)
+                            if PRED_IS_BF16:
+                                tl.store(
+                                    dists_pred_ptr + out_base + slot,
+                                    s_d2p.to(tl.bfloat16),
+                                )
+                            else:
+                                tl.store(dists_pred_ptr + out_base + slot, s_d2p)
+
+    @triton.jit(do_not_specialize=["N", "P1", "K", "total"])
+    def _ball_query_backward_kernel(
+        predx_ptr,
+        predy_ptr,
+        predz_ptr,
+        idx_ptr,
+        grad_dists_ptr,
+        grad_pred_ptr,
+        N,
+        P1,
+        K,
+        total,
+        PRED_IS_BF16: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        pid = tl.program_id(0).to(tl.int64)
+        start = pid * BLOCK
+        offs = start + tl.arange(0, BLOCK)
+        mask = offs < total
+
+        pk = P1 * K
+        n = offs // pk
+        rem = offs % pk
+        i = rem // K
+
+        j = tl.load(idx_ptr + offs, mask=mask, other=-1)
+        g = tl.load(grad_dists_ptr + offs, mask=mask, other=0.0)
+        active = mask & (j >= 0) & (g != 0.0)
+
+        base_i = n * P1 + i
+        base_j = n * P1 + j
+        # grad_pred is still AoS [N,P,3]
+        gbase_i = base_i * 3
+        gbase_j = base_j * 3
+
+        if PRED_IS_BF16:
+            pi_x = tl.load(predx_ptr + base_i, mask=active, other=0.0).to(tl.float32)
+            pi_y = tl.load(predy_ptr + base_i, mask=active, other=0.0).to(tl.float32)
+            pi_z = tl.load(predz_ptr + base_i, mask=active, other=0.0).to(tl.float32)
+            pj_x = tl.load(predx_ptr + base_j, mask=active, other=0.0).to(tl.float32)
+            pj_y = tl.load(predy_ptr + base_j, mask=active, other=0.0).to(tl.float32)
+            pj_z = tl.load(predz_ptr + base_j, mask=active, other=0.0).to(tl.float32)
+        else:
+            pi_x = tl.load(predx_ptr + base_i, mask=active, other=0.0)
+            pi_y = tl.load(predy_ptr + base_i, mask=active, other=0.0)
+            pi_z = tl.load(predz_ptr + base_i, mask=active, other=0.0)
+            pj_x = tl.load(predx_ptr + base_j, mask=active, other=0.0)
+            pj_y = tl.load(predy_ptr + base_j, mask=active, other=0.0)
+            pj_z = tl.load(predz_ptr + base_j, mask=active, other=0.0)
+
+        gx = 2.0 * g * (pi_x - pj_x)
+        gy = 2.0 * g * (pi_y - pj_y)
+        gz = 2.0 * g * (pi_z - pj_z)
+        tl.atomic_add(grad_pred_ptr + gbase_i + 0, gx, mask=active)
+        tl.atomic_add(grad_pred_ptr + gbase_i + 1, gy, mask=active)
+        tl.atomic_add(grad_pred_ptr + gbase_i + 2, gz, mask=active)
+        tl.atomic_add(grad_pred_ptr + gbase_j + 0, -gx, mask=active)
+        tl.atomic_add(grad_pred_ptr + gbase_j + 1, -gy, mask=active)
+        tl.atomic_add(grad_pred_ptr + gbase_j + 2, -gz, mask=active)
+
+
+def _query_with_pred(
+    p1: torch.Tensor,
+    p2: torch.Tensor,
+    pred: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    lengths1: torch.Tensor,
+    lengths2: torch.Tensor,
+    k: int,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+    seed: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch forward kernel; returns ``(idx, dists_gt, dists_pred)``."""
+    if not is_ball_query_triton_available():
+        raise RuntimeError(
+            "Triton ball-query smooth lDDT requires Triton and a CUDA device"
+        )
+    if not (p1.is_cuda and p2.is_cuda and pred.is_cuda):
+        raise RuntimeError("Triton ball-query requires CUDA tensors")
+    if p1.dtype != torch.float32 or p2.dtype != torch.float32:
+        raise RuntimeError("p1/p2 must be float32")
+    if pred.dtype not in (torch.float32, torch.bfloat16):
+        raise RuntimeError("pred must be float32 or bfloat16")
+    if k <= 0:
+        raise ValueError("k must be a positive integer")
+
+    p1 = p1.contiguous()
+    p2 = p2.contiguous()
+    pred = pred.contiguous()
+    is_nucleotide = is_nucleotide.contiguous().to(dtype=torch.float32)
+    lengths1 = lengths1.contiguous().long()
+    lengths2 = lengths2.contiguous().long()
+
+    n_batch, n_atom, _ = p1.shape
+    idxs = torch.full((n_batch, n_atom, k), -1, device=p1.device, dtype=torch.long)
+    dists_gt = torch.zeros((n_batch, n_atom, k), device=p1.device, dtype=torch.float32)
+    dists_pred = torch.zeros((n_batch, n_atom, k), device=pred.device, dtype=pred.dtype)
+
+    total_atoms = n_batch * n_atom
+    if total_atoms == 0 or idxs.numel() == 0:
+        return idxs, dists_gt, dists_pred
+
+    p1x, p1y, p1z = _as_soa(p1)
+    p2x, p2y, p2z = _as_soa(p2)
+    predx, predy, predz = _as_soa(pred)
+
+    _ball_query_forward_kernel[(total_atoms,)](
+        p1x,
+        p1y,
+        p1z,
+        p2x,
+        p2y,
+        p2z,
+        predx,
+        predy,
+        predz,
+        is_nucleotide,
+        lengths1,
+        lengths2,
+        idxs,
+        dists_gt,
+        dists_pred,
+        n_batch,
+        n_atom,
+        k,
+        float(radius_protein),
+        float(radius_nucleotide),
+        int(seed) & 0xFFFFFFFF,
+        PRED_IS_BF16=pred.dtype == torch.bfloat16,
+        BLOCK_J=_BLOCK_J,
+        num_warps=_FWD_NUM_WARPS,
+    )
+    return idxs, dists_gt, dists_pred
+
+
+def _pred_backward(
+    pred: torch.Tensor,
+    idxs: torch.Tensor,
+    grad_dists: torch.Tensor,
+) -> torch.Tensor:
+    """Backward for predicted squared distances (fp32 atomic scatter)."""
+    if not is_ball_query_triton_available():
+        raise RuntimeError(
+            "Triton ball-query smooth lDDT requires Triton and a CUDA device"
+        )
+    if not pred.is_cuda:
+        raise RuntimeError("Triton ball-query requires CUDA tensors")
+
+    pred = pred.contiguous()
+    idxs = idxs.contiguous().long()
+    grad_dists = grad_dists.contiguous().float()
+
+    n_batch, n_atom, _ = pred.shape
+    k = idxs.shape[-1]
+    grad_pred = torch.zeros(
+        (n_batch, n_atom, 3), device=pred.device, dtype=torch.float32
+    )
+
+    total = n_batch * n_atom * k
+    if total == 0:
+        return grad_pred
+
+    predx, predy, predz = _as_soa(pred)
+    n_programs = (total + _BWD_BLOCK - 1) // _BWD_BLOCK
+    _ball_query_backward_kernel[(n_programs,)](
+        predx,
+        predy,
+        predz,
+        idxs,
+        grad_dists,
+        grad_pred,
+        n_batch,
+        n_atom,
+        k,
+        total,
+        PRED_IS_BF16=pred.dtype == torch.bfloat16,
+        BLOCK=_BWD_BLOCK,
+        num_warps=_BWD_NUM_WARPS,
+    )
+    return grad_pred
+
+
+def _expand_to_x_batch(
+    tensor: torch.Tensor, x: torch.Tensor, trailing_dims: int
+) -> torch.Tensor:
+    while tensor.ndim < len(x.shape[:-2]) + trailing_dims:
+        tensor = tensor.unsqueeze(-trailing_dims - 1)
+    return tensor.expand(*x.shape[:-2], *tensor.shape[-trailing_dims:])
+
+
+def _flatten_batch(tensor: torch.Tensor, trailing_dims: int) -> torch.Tensor:
+    return tensor.reshape(-1, *tensor.shape[-trailing_dims:])
+
+
+def _validate_top_k(top_k: int | None, n_atom: int) -> int:
+    if top_k is None:
+        raise ValueError("smooth_lddt_top_k must be set for ball-query smooth lDDT")
+    if not isinstance(top_k, int) or top_k <= 0:
+        raise ValueError("smooth_lddt_top_k must be a positive integer")
+    return min(top_k, max(n_atom - 1, 0))
+
+
+class _BallQueryWithPredDist(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        pred,
+        p1_gt,
+        p2_gt,
+        is_nucleotide,
+        lengths1,
+        lengths2,
+        k,
+        radius_protein,
+        radius_nucleotide,
+        seed,
+    ):
+        idx, dists_gt, dists_pred = _query_with_pred(
+            p1=p1_gt,
+            p2=p2_gt,
+            pred=pred,
+            is_nucleotide=is_nucleotide,
+            lengths1=lengths1,
+            lengths2=lengths2,
+            k=k,
+            radius_protein=radius_protein,
+            radius_nucleotide=radius_nucleotide,
+            seed=seed,
+        )
+        ctx.save_for_backward(pred, idx)
+        ctx.mark_non_differentiable(idx, dists_gt)
+        return dists_pred, dists_gt, idx
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_dists_pred, grad_dists_gt, grad_idx):
+        pred, idx = ctx.saved_tensors
+        grad_pred = _pred_backward(pred, idx, grad_dists_pred).to(pred.dtype)
+        return grad_pred, None, None, None, None, None, None, None, None, None
+
+
+def _score_from_dists(
+    dists_pred: torch.Tensor,
+    dists_gt: torch.Tensor,
+    valid_neighbor: torch.Tensor,
+    loss_atom_mask_i: torch.Tensor,
+    loss_atom_mask_j: torch.Tensor,
+    flat_is_nucleotide: torch.Tensor,
+    eps: float,
+    out_shape: tuple[int, ...],
+    radius_protein: float,
+    radius_nucleotide: float,
+) -> torch.Tensor:
+    dx = torch.sqrt(eps + dists_pred.clamp_min(0.0))
+    dx_gt = torch.sqrt(eps + dists_gt.clamp_min(0.0))
+    d = torch.abs(dx_gt - dx)
+    e = 0.25 * (
+        torch.sigmoid(0.5 - d)
+        + torch.sigmoid(1.0 - d)
+        + torch.sigmoid(2.0 - d)
+        + torch.sigmoid(4.0 - d)
+    )
+    cutoff = torch.where(
+        flat_is_nucleotide.bool(),
+        torch.tensor(radius_nucleotide, device=dx.device, dtype=dx_gt.dtype),
+        torch.tensor(radius_protein, device=dx.device, dtype=dx_gt.dtype),
+    )
+    c = dx_gt < cutoff[..., None]
+    mask = (valid_neighbor * loss_atom_mask_i * loss_atom_mask_j).bool()
+    mask_sum = torch.sum(mask, dim=(-1, -2)) + eps
+    ce_mean = torch.sum(c * e * mask, dim=(-1, -2)) / mask_sum
+    c_mean = torch.sum(c * mask, dim=(-1, -2)) / mask_sum
+    lddt = ce_mean / (c_mean + eps)
+    return (1 - lddt).reshape(out_shape)
+
+
+def ball_query_smooth_lddt_loss(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask_gt: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+    eps: float,
+    top_k: int | None,
+    seed: int = 0,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+) -> torch.Tensor:
+    """Smooth lDDT via Triton ball-query.
+
+    Same argument contract as the CUDA package entry point. Radii default to
+    15 Å (protein) / 30 Å (nucleotide).
+    """
+    if not is_ball_query_triton_available():
+        raise RuntimeError(
+            "Triton ball-query smooth lDDT requires Triton and a CUDA device"
+        )
+    if not x.is_cuda:
+        raise RuntimeError("Ball-query smooth lDDT requires CUDA tensors")
+    if radius_protein <= 0 or radius_nucleotide <= 0:
+        raise ValueError("radius_protein and radius_nucleotide must be positive")
+
+    n_atom = x.shape[-2]
+    k = _validate_top_k(top_k=top_k, n_atom=n_atom)
+    if k == 0:
+        return torch.ones(x.shape[:-2], device=x.device, dtype=x.dtype) + x.sum() * 0.0
+
+    x_gt = _expand_to_x_batch(x_gt, x, trailing_dims=2)
+    atom_mask_gt = _expand_to_x_batch(atom_mask_gt, x, trailing_dims=1)
+    is_nucleotide = _expand_to_x_batch(is_nucleotide, x, trailing_dims=1)
+    loss_atom_mask = _expand_to_x_batch(loss_atom_mask, x, trailing_dims=1)
+    loss_atom_mask = loss_atom_mask * atom_mask_gt
+
+    flat_x = _flatten_batch(x, trailing_dims=2)
+    flat_x_gt = _flatten_batch(x_gt, trailing_dims=2)
+    flat_atom_mask_gt = _flatten_batch(atom_mask_gt, trailing_dims=1)
+    flat_is_nucleotide = _flatten_batch(is_nucleotide, trailing_dims=1)
+    flat_loss_atom_mask = _flatten_batch(loss_atom_mask, trailing_dims=1)
+
+    flat_batch = flat_x.shape[0]
+    lengths = torch.full((flat_batch,), n_atom, device=x.device, dtype=torch.long)
+
+    p2 = torch.where(
+        flat_atom_mask_gt[..., None].bool(),
+        flat_x_gt,
+        torch.full_like(flat_x_gt, 1.0e6),
+    )
+
+    dists_pred, dists_gt, idx = _BallQueryWithPredDist.apply(
+        flat_x,
+        flat_x_gt,
+        p2,
+        flat_is_nucleotide,
+        lengths,
+        lengths,
+        k,
+        float(radius_protein),
+        float(radius_nucleotide),
+        seed,
+    )
+
+    safe_idx = idx.clamp_min(0)
+    flat_safe_idx = safe_idx.reshape(flat_batch, -1)
+    valid_neighbor = idx >= 0
+    loss_atom_mask_i = flat_loss_atom_mask[..., None]
+    loss_atom_mask_j = torch.gather(
+        flat_loss_atom_mask, dim=1, index=flat_safe_idx
+    ).reshape(flat_batch, n_atom, k)
+
+    out_shape = x.shape[:-2]
+    score_args = (
+        dists_pred,
+        dists_gt,
+        valid_neighbor,
+        loss_atom_mask_i,
+        loss_atom_mask_j,
+        flat_is_nucleotide,
+        eps,
+        out_shape,
+        float(radius_protein),
+        float(radius_nucleotide),
+    )
+    if dists_pred.requires_grad:
+        return torch.utils.checkpoint.checkpoint(
+            _score_from_dists,
+            *score_args,
+            use_reentrant=False,
+        )
+    return _score_from_dists(*score_args)

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -416,6 +416,54 @@ def smooth_lddt_loss(
     return 1 - lddt
 
 
+def smooth_lddt_loss_ball_query(
+    x: torch.Tensor,
+    batch: dict,
+    loss_token_mask: torch.Tensor,
+    eps: float,
+    top_k: int | None,
+) -> torch.Tensor:
+    """Compute smooth lDDT with the Triton ball-query backend."""
+    from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+        ball_query_smooth_lddt_loss,
+        is_ball_query_triton_available,
+        is_ball_query_triton_installed,
+    )
+
+    if not is_ball_query_triton_installed():
+        raise RuntimeError(
+            "smooth_lddt_backend='ball_query' requires Triton to be installed"
+        )
+    if not is_ball_query_triton_available():
+        raise RuntimeError(
+            "smooth_lddt_backend='ball_query' requires a CUDA device at runtime"
+        )
+
+    x_gt = batch["ground_truth"]["atom_positions"]
+    atom_mask_gt = batch["ground_truth"]["atom_resolved_mask"]
+    is_nucleotide = broadcast_token_feat_to_atoms(
+        token_mask=batch["token_mask"],
+        num_atoms_per_token=batch["num_atoms_per_token"],
+        token_feat=batch["is_dna"] + batch["is_rna"],
+    )
+    loss_atom_mask = broadcast_token_feat_to_atoms(
+        token_mask=batch["token_mask"],
+        num_atoms_per_token=batch["num_atoms_per_token"],
+        token_feat=loss_token_mask,
+    )
+    loss_atom_mask = loss_atom_mask * atom_mask_gt
+
+    return ball_query_smooth_lddt_loss(
+        x=x,
+        x_gt=x_gt,
+        atom_mask_gt=atom_mask_gt,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=loss_atom_mask,
+        eps=eps,
+        top_k=top_k,
+    )
+
+
 def run_low_mem_loss_fn(
     loss_fn: Callable, x: torch.Tensor, kwargs: dict, chunk_size: int
 ) -> torch.Tensor:
@@ -459,6 +507,8 @@ def diffusion_loss(
     eps: float = 1e-8,
     chunk_size: int | None = None,
     use_sparse_loss: bool | None = False,
+    smooth_lddt_backend: str = "dense",
+    smooth_lddt_top_k: int | None = 512,
     **kwargs,
 ) -> [torch.Tensor, dict]:
     """
@@ -486,6 +536,11 @@ def diffusion_loss(
             for smooth lddt and bond loss. Defaults to no chunking.
         use_sparse_loss:
             Whether to use sparse loss. Currently only implemented for bond_loss.
+        smooth_lddt_backend:
+            Smooth lDDT implementation to use. Options are "dense" and "ball_query".
+        smooth_lddt_top_k:
+            Maximum sampled in-radius neighbors per query atom for ball-query
+            smooth lDDT.
     Returns:
         mean_loss:
             Diffusion loss
@@ -523,15 +578,36 @@ def diffusion_loss(
     l_bond = 0.0
     l_smooth_lddt = 0.0
     bond_loss_fn = bond_loss if not use_sparse_loss else bond_loss_sparse
+    if smooth_lddt_backend not in {"dense", "ball_query"}:
+        raise ValueError(
+            "smooth_lddt_backend must be one of {'dense', 'ball_query'}, "
+            f"got {smooth_lddt_backend!r}"
+        )
+    if smooth_lddt_backend == "ball_query" and chunk_size is not None:
+        raise ValueError(
+            "Ball-query smooth lDDT does not support chunked loss execution. "
+            "Set architecture.loss_module.diffusion.chunk_size to null when "
+            'using smooth_lddt_backend="ball_query".'
+        )
+
     if chunk_size is None:
         if bond_weight.any():
             l_bond = bond_loss_fn(x=x, batch=batch, eps=eps)
             loss_breakdown["bond"] = l_bond.detach().clone().mean(dim=-1)
 
         if smooth_lddt_weight.any():
-            l_smooth_lddt = smooth_lddt_loss(
-                x=x, batch=batch, loss_token_mask=loss_token_mask, eps=eps
-            )
+            if smooth_lddt_backend == "ball_query":
+                l_smooth_lddt = smooth_lddt_loss_ball_query(
+                    x=x,
+                    batch=batch,
+                    loss_token_mask=loss_token_mask,
+                    eps=eps,
+                    top_k=smooth_lddt_top_k,
+                )
+            else:
+                l_smooth_lddt = smooth_lddt_loss(
+                    x=x, batch=batch, loss_token_mask=loss_token_mask, eps=eps
+                )
 
             # Mean over diffusion sample dimension
             loss_breakdown["smooth_lddt"] = l_smooth_lddt.detach().clone().mean(dim=-1)

--- a/openfold3/core/loss/diffusion.py
+++ b/openfold3/core/loss/diffusion.py
@@ -537,10 +537,13 @@ def diffusion_loss(
         use_sparse_loss:
             Whether to use sparse loss. Currently only implemented for bond_loss.
         smooth_lddt_backend:
-            Smooth lDDT implementation to use. Options are "dense" and "ball_query".
+            Smooth lDDT implementation to use. Options are "dense" and
+            "ball_query". The ball-query option uses top-k-adjusted type
+            reweighting. When chunk_size is set, it automatically
+            falls back to
+            the dense implementation for chunked execution.
         smooth_lddt_top_k:
-            Maximum sampled in-radius neighbors per query atom for ball-query
-            smooth lDDT.
+            Maximum sampled neighbors stored for every query atom.
     Returns:
         mean_loss:
             Diffusion loss
@@ -578,18 +581,12 @@ def diffusion_loss(
     l_bond = 0.0
     l_smooth_lddt = 0.0
     bond_loss_fn = bond_loss if not use_sparse_loss else bond_loss_sparse
-    if smooth_lddt_backend not in {"dense", "ball_query"}:
+    valid_backends = {"dense", "ball_query"}
+    if smooth_lddt_backend not in valid_backends:
         raise ValueError(
-            "smooth_lddt_backend must be one of {'dense', 'ball_query'}, "
+            f"smooth_lddt_backend must be one of {sorted(valid_backends)}, "
             f"got {smooth_lddt_backend!r}"
         )
-    if smooth_lddt_backend == "ball_query" and chunk_size is not None:
-        raise ValueError(
-            "Ball-query smooth lDDT does not support chunked loss execution. "
-            "Set architecture.loss_module.diffusion.chunk_size to null when "
-            'using smooth_lddt_backend="ball_query".'
-        )
-
     if chunk_size is None:
         if bond_weight.any():
             l_bond = bond_loss_fn(x=x, batch=batch, eps=eps)
@@ -624,6 +621,8 @@ def diffusion_loss(
             loss_breakdown["bond"] = l_bond.detach().clone().mean(dim=-1)
 
         if smooth_lddt_weight.any():
+            # Ball-query does not support sample-dimension chunking. Use the dense
+            # loss automatically when chunking is requested.
             l_smooth_lddt = run_low_mem_loss_fn(
                 loss_fn=smooth_lddt_loss,
                 x=x,

--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -502,7 +502,7 @@ model_config = mlc.ConfigDict(
                     "eps": eps,
                     "chunk_size": None,
                     "use_sparse_loss": False,
-                    "smooth_lddt_backend": "dense",
+                    "smooth_lddt_backend": "ball_query",
                     "smooth_lddt_top_k": 512,
                 },
                 "distogram": {

--- a/openfold3/projects/of3_all_atom/config/model_config.py
+++ b/openfold3/projects/of3_all_atom/config/model_config.py
@@ -502,6 +502,8 @@ model_config = mlc.ConfigDict(
                     "eps": eps,
                     "chunk_size": None,
                     "use_sparse_loss": False,
+                    "smooth_lddt_backend": "dense",
+                    "smooth_lddt_top_k": 512,
                 },
                 "distogram": {
                     "no_bins": 64,

--- a/openfold3/tests/test_diffusion_loss.py
+++ b/openfold3/tests/test_diffusion_loss.py
@@ -14,9 +14,13 @@
 
 import unittest
 
+import pytest
 import torch
 import torch.nn.functional as F
 
+from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+    is_ball_query_triton_available,
+)
 from openfold3.core.loss.diffusion import (
     bond_loss,
     diffusion_loss,
@@ -29,6 +33,17 @@ from openfold3.tests.config import consts
 
 
 class TestDiffusionLoss(unittest.TestCase):
+    @staticmethod
+    def to_device(obj, device):
+        if isinstance(obj, torch.Tensor):
+            return obj.to(device)
+        if isinstance(obj, dict):
+            return {
+                key: TestDiffusionLoss.to_device(value, device)
+                for key, value in obj.items()
+            }
+        return obj
+
     def setup_features(self):
         # Example: UNK UNK UNK ALA GLY/A A DT
         # NumAtoms: 1 1 1 5 4 22 21
@@ -192,6 +207,71 @@ class TestDiffusionLoss(unittest.TestCase):
 
         assert torch.equal(torch.nonzero(loss_masked), torch.nonzero(mostly_zeros_mask))
         assert torch.all(torch.not_equal(loss_masked, loss))
+
+    def test_diffusion_loss_ball_query_matches_dense(self):
+        if not is_ball_query_triton_available():
+            pytest.skip("Triton ball-query smooth lDDT requires Triton and CUDA")
+
+        sigma_data = 16
+        device = torch.device("cuda")
+        batch = self.to_device(self.setup_features(), device)
+        x_gt = batch["ground_truth"]["atom_positions"]
+        x = x_gt[:, None] + 0.1 * torch.randn((1, 2, *x_gt.shape[-2:]), device=device)
+        t = sigma_data * torch.exp(torch.randn(x.shape[0], device=device))
+
+        dense_loss, dense_breakdown = diffusion_loss(
+            batch=batch,
+            x=x,
+            t=t,
+            sigma_data=sigma_data,
+            smooth_lddt_backend="dense",
+        )
+        ball_query_loss, ball_query_breakdown = diffusion_loss(
+            batch=batch,
+            x=x,
+            t=t,
+            sigma_data=sigma_data,
+            smooth_lddt_backend="ball_query",
+        )
+
+        torch.testing.assert_close(ball_query_loss, dense_loss, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(
+            ball_query_breakdown["smooth_lddt_loss"],
+            dense_breakdown["smooth_lddt_loss"],
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_diffusion_loss_rejects_unknown_smooth_lddt_backend(self):
+        batch = self.setup_features()
+        x_gt = batch["ground_truth"]["atom_positions"]
+        x = x_gt[:, None].expand(-1, 2, -1, -1)
+        t = torch.ones(x.shape[0])
+
+        with pytest.raises(ValueError, match="smooth_lddt_backend"):
+            diffusion_loss(
+                batch=batch,
+                x=x,
+                t=t,
+                sigma_data=16,
+                smooth_lddt_backend="unknown",
+            )
+
+    def test_diffusion_loss_ball_query_rejects_chunking(self):
+        batch = self.setup_features()
+        x_gt = batch["ground_truth"]["atom_positions"]
+        x = x_gt[:, None].expand(-1, 2, -1, -1)
+        t = torch.ones(x.shape[0])
+
+        with pytest.raises(ValueError, match="chunked loss execution"):
+            diffusion_loss(
+                batch=batch,
+                x=x,
+                t=t,
+                sigma_data=16,
+                chunk_size=1,
+                smooth_lddt_backend="ball_query",
+            )
 
     def _test_diffusion_loss(self, batch):
         n_sample = 2

--- a/openfold3/tests/test_diffusion_loss.py
+++ b/openfold3/tests/test_diffusion_loss.py
@@ -208,7 +208,7 @@ class TestDiffusionLoss(unittest.TestCase):
         assert torch.equal(torch.nonzero(loss_masked), torch.nonzero(mostly_zeros_mask))
         assert torch.all(torch.not_equal(loss_masked, loss))
 
-    def test_diffusion_loss_ball_query_matches_dense(self):
+    def test_diffusion_loss_top_k_adjusted_matches_dense(self):
         if not is_ball_query_triton_available():
             pytest.skip("Triton ball-query smooth lDDT requires Triton and CUDA")
 
@@ -248,30 +248,48 @@ class TestDiffusionLoss(unittest.TestCase):
         x = x_gt[:, None].expand(-1, 2, -1, -1)
         t = torch.ones(x.shape[0])
 
-        with pytest.raises(ValueError, match="smooth_lddt_backend"):
-            diffusion_loss(
-                batch=batch,
-                x=x,
-                t=t,
-                sigma_data=16,
-                smooth_lddt_backend="unknown",
-            )
+        for backend in (
+            "unknown",
+            "ball_query_type_aware",
+            "ball_query_type_reweighted",
+        ):
+            with pytest.raises(ValueError, match="smooth_lddt_backend"):
+                diffusion_loss(
+                    batch=batch,
+                    x=x,
+                    t=t,
+                    sigma_data=16,
+                    smooth_lddt_backend=backend,
+                )
 
-    def test_diffusion_loss_ball_query_rejects_chunking(self):
+    def test_diffusion_loss_top_k_adjusted_falls_back_with_chunking(self):
         batch = self.setup_features()
         x_gt = batch["ground_truth"]["atom_positions"]
         x = x_gt[:, None].expand(-1, 2, -1, -1)
         t = torch.ones(x.shape[0])
 
-        with pytest.raises(ValueError, match="chunked loss execution"):
-            diffusion_loss(
-                batch=batch,
-                x=x,
-                t=t,
-                sigma_data=16,
-                chunk_size=1,
-                smooth_lddt_backend="ball_query",
-            )
+        dense_loss, dense_breakdown = diffusion_loss(
+            batch=batch,
+            x=x,
+            t=t,
+            sigma_data=16,
+            chunk_size=1,
+            smooth_lddt_backend="dense",
+        )
+        fallback_loss, fallback_breakdown = diffusion_loss(
+            batch=batch,
+            x=x,
+            t=t,
+            sigma_data=16,
+            chunk_size=1,
+            smooth_lddt_backend="ball_query",
+        )
+
+        torch.testing.assert_close(fallback_loss, dense_loss)
+        torch.testing.assert_close(
+            fallback_breakdown["smooth_lddt_loss"],
+            dense_breakdown["smooth_lddt_loss"],
+        )
 
     def _test_diffusion_loss(self, batch):
         n_sample = 2

--- a/openfold3/tests/test_smooth_lddt_ball_query_triton.py
+++ b/openfold3/tests/test_smooth_lddt_ball_query_triton.py
@@ -174,7 +174,6 @@ def test_forward_and_backward_match_dense():
         is_nucleotide=is_nucleotide,
         loss_atom_mask=loss_atom_mask,
         eps=eps,
-        top_k=x_gt.shape[-2] - 1,
     )
     dense_loss = _dense_smooth_lddt_loss(
         x=x_dense,

--- a/openfold3/tests/test_smooth_lddt_ball_query_triton.py
+++ b/openfold3/tests/test_smooth_lddt_ball_query_triton.py
@@ -4,7 +4,12 @@ import pytest
 import torch
 
 from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+    _legacy_ball_query_smooth_lddt_loss,
     _query_with_pred,
+    _top_k_adjusted_type_reweighted_group_sums,
+    _top_k_adjusted_type_row_weights,
+    _type_aware_top_ks,
+    _validate_nucleotide_scale,
     ball_query_smooth_lddt_loss,
     is_ball_query_triton_available,
     is_ball_query_triton_installed,
@@ -90,6 +95,154 @@ def test_unavailable_backend_has_clear_error():
             eps=1e-8,
             top_k=1,
         )
+
+
+@pytest.mark.parametrize("scale", [True, "4", 0.5, float("nan"), float("inf")])
+def test_rejects_invalid_nucleotide_scale(scale):
+    with pytest.raises(ValueError, match="smooth_lddt_nucleotide_scale"):
+        _validate_nucleotide_scale(scale)
+
+
+def test_type_aware_top_ks_apply_scale_to_non_nucleotide_capacity():
+    assert _type_aware_top_ks(top_k=128, nucleotide_scale=4.0) == (32, 128)
+    assert _type_aware_top_ks(top_k=3, nucleotide_scale=4.0) == (1, 3)
+
+
+def test_top_k_adjusted_type_weights_use_default_k_scaling():
+    neighbor_count = torch.tensor([[2, 1024, 2, 1024]])
+    retained_count = torch.tensor([[2, 512, 2, 512]])
+    is_nucleotide = torch.tensor([[False, False, True, True]])
+
+    weights = _top_k_adjusted_type_row_weights(
+        neighbor_count,
+        retained_count,
+        is_nucleotide,
+        top_k=512,
+        dtype=torch.float32,
+    )
+
+    torch.testing.assert_close(weights, torch.tensor([[1.0, 1.0, 1.0, 4.0]]))
+
+
+@pytest.mark.parametrize(
+    ("top_k", "expected"),
+    [
+        (256, (2.0, 8.0)),
+        (512, (1.0, 4.0)),
+        (1024, (1.0, 2.0)),
+        (2048, (1.0, 1.0)),
+        (4096, (1.0, 1.0)),
+    ],
+)
+def test_top_k_adjusted_type_weights_follow_lower_bounds(top_k, expected):
+    neighbor_count = torch.tensor([[top_k + 1, top_k + 1]])
+    retained_count = torch.tensor([[top_k, top_k]])
+    is_nucleotide = torch.tensor([[False, True]])
+
+    weights = _top_k_adjusted_type_row_weights(
+        neighbor_count,
+        retained_count,
+        is_nucleotide,
+        top_k=top_k,
+        dtype=torch.float32,
+    )
+
+    torch.testing.assert_close(weights, torch.tensor([expected]))
+
+
+def test_top_k_adjusted_type_reweighting_preserves_default_pair_mass():
+    eps = 1e-8
+    dists_gt = torch.ones((1, 3, 2))
+    dists_pred = torch.tensor([[[1.0, 1.0], [4.0, 4.0], [9.0, 9.0]]])
+    idx = torch.tensor([[[1, 2], [0, 2], [0, 1]]])
+    neighbor_count = torch.tensor([[1024, 1024, 2]])
+    query_is_nucleotide = torch.tensor([[False, True, True]])
+
+    score_sum, pair_count = _top_k_adjusted_type_reweighted_group_sums(
+        dists_pred=dists_pred,
+        dists_gt=dists_gt,
+        idx=idx,
+        neighbor_count=neighbor_count,
+        query_is_nucleotide=query_is_nucleotide,
+        top_k=512,
+        eps=eps,
+        score_radius_protein=15.0,
+        score_radius_nucleotide=30.0,
+    )
+
+    distance_errors = torch.tensor([0.0, 1.0, 2.0])
+    row_scores = 0.25 * sum(
+        torch.sigmoid(threshold - distance_errors) for threshold in (0.5, 1.0, 2.0, 4.0)
+    )
+    expected_score_sum = 2 * row_scores[0] + 8 * row_scores[1] + 2 * row_scores[2]
+
+    torch.testing.assert_close(score_sum, expected_score_sum[None])
+    torch.testing.assert_close(pair_count, torch.tensor([12.0]))
+
+
+def test_row_reweighting_matches_pairwise_reference_and_gradient():
+    eps = 1e-8
+    top_k = 512
+    dists_gt = torch.tensor(
+        [
+            [
+                [1.0, 4.0, 9.0],
+                [4.0, 9.0, 16.0],
+                [1.0, 9.0, 25.0],
+                [4.0, 16.0, 36.0],
+            ]
+        ]
+    )
+    base_dists_pred = dists_gt + torch.tensor(
+        [
+            [
+                [0.2, -0.1, 0.3],
+                [0.4, 0.2, -0.3],
+                [-0.2, 0.1, 0.5],
+                [0.3, -0.4, 0.2],
+            ]
+        ]
+    )
+    idx = torch.tensor([[[1, 2, -1], [0, 2, 3], [0, 1, 3], [0, 1, -1]]])
+    neighbor_count = torch.tensor([[2, 700, 700, 2]])
+    query_is_nucleotide = torch.tensor([[False, False, True, True]])
+
+    dists_pred = base_dists_pred.clone().requires_grad_(True)
+    score_sum, pair_count = _top_k_adjusted_type_reweighted_group_sums(
+        dists_pred=dists_pred,
+        dists_gt=dists_gt,
+        idx=idx,
+        neighbor_count=neighbor_count,
+        query_is_nucleotide=query_is_nucleotide,
+        top_k=top_k,
+        eps=eps,
+        score_radius_protein=15.0,
+        score_radius_nucleotide=30.0,
+    )
+
+    reference_dists_pred = base_dists_pred.clone().requires_grad_(True)
+    dx = torch.sqrt(eps + reference_dists_pred)
+    dx_gt = torch.sqrt(eps + dists_gt)
+    delta = torch.abs(dx_gt - dx)
+    score = 0.25 * sum(
+        torch.sigmoid(threshold - delta) for threshold in (0.5, 1.0, 2.0, 4.0)
+    )
+    row_weight = _top_k_adjusted_type_row_weights(
+        neighbor_count,
+        neighbor_count.clamp_max(top_k),
+        query_is_nucleotide,
+        top_k,
+        reference_dists_pred.dtype,
+    )
+    pair_weight = (idx >= 0).to(score.dtype) * row_weight[..., None]
+    reference_score_sum = (score * pair_weight).sum(dim=(-1, -2))
+    reference_pair_count = pair_weight.sum(dim=(-1, -2))
+
+    torch.testing.assert_close(score_sum, reference_score_sum)
+    torch.testing.assert_close(pair_count, reference_pair_count)
+    score_sum.sum().backward()
+    reference_score_sum.sum().backward()
+    torch.testing.assert_close(dists_pred.grad, reference_dists_pred.grad)
 
 
 @requires_triton_cuda
@@ -317,3 +470,73 @@ def test_adjustable_radius_changes_loss():
     assert torch.isfinite(default_loss).all()
     assert torch.isfinite(tight_loss).all()
     assert not torch.allclose(default_loss, tight_loss, atol=1e-6, rtol=1e-6)
+
+
+@requires_triton_cuda
+def test_top_k_adjusted_backend_matches_dense_with_exhaustive_reservoir():
+    torch.manual_seed(21)
+    n_atom = 48
+    x_gt = torch.randn((2, n_atom, 3), device="cuda") * 4.0
+    atom_mask = torch.ones((2, n_atom), device="cuda")
+    atom_mask[0, -3:] = 0
+    is_nucleotide = torch.zeros_like(atom_mask)
+    is_nucleotide[:, n_atom // 2 :] = 1
+    base = x_gt + 0.2 * torch.randn_like(x_gt)
+    x_dense = base.clone().requires_grad_(True)
+    x_sparse = base.clone().requires_grad_(True)
+
+    dense = _dense_smooth_lddt_loss(
+        x=x_dense,
+        x_gt=x_gt,
+        atom_mask=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=atom_mask,
+        eps=1e-8,
+    )
+    sparse = ball_query_smooth_lddt_loss(
+        x=x_sparse,
+        x_gt=x_gt,
+        atom_mask_gt=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=atom_mask,
+        eps=1e-8,
+        top_k=n_atom - 1,
+    )
+    dense.sum().backward()
+    sparse.sum().backward()
+
+    torch.testing.assert_close(sparse, dense, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(x_sparse.grad, x_dense.grad, atol=1e-3, rtol=5e-3)
+
+
+@requires_triton_cuda
+def test_type_reweighting_increases_high_degree_row_influence():
+    torch.manual_seed(22)
+    protein_atoms = 9
+    nucleotide_atoms = 33
+    protein = torch.randn((protein_atoms, 3), device="cuda")
+    nucleotide = torch.randn((nucleotide_atoms, 3), device="cuda") + torch.tensor(
+        [100.0, 0.0, 0.0], device="cuda"
+    )
+    x_gt = torch.cat((protein, nucleotide))[None]
+    atom_mask = torch.ones((1, protein_atoms + nucleotide_atoms), device="cuda")
+    is_nucleotide = torch.zeros_like(atom_mask)
+    is_nucleotide[:, protein_atoms:] = 1
+    x = x_gt.clone()
+    x[:, :protein_atoms] += 0.01 * torch.randn_like(x[:, :protein_atoms])
+    x[:, protein_atoms:] += 2.0 * torch.randn_like(x[:, protein_atoms:])
+
+    kwargs = {
+        "x": x,
+        "x_gt": x_gt,
+        "atom_mask_gt": atom_mask,
+        "is_nucleotide": is_nucleotide,
+        "loss_atom_mask": atom_mask,
+        "eps": 1e-8,
+        "top_k": 8,
+        "seed": 3,
+    }
+    unweighted = _legacy_ball_query_smooth_lddt_loss(**kwargs)
+    reweighted = ball_query_smooth_lddt_loss(**kwargs)
+
+    assert reweighted.item() > unweighted.item()

--- a/openfold3/tests/test_smooth_lddt_ball_query_triton.py
+++ b/openfold3/tests/test_smooth_lddt_ball_query_triton.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+    _query_with_pred,
+    ball_query_smooth_lddt_loss,
+    is_ball_query_triton_available,
+    is_ball_query_triton_installed,
+)
+
+requires_triton_cuda = pytest.mark.skipif(
+    not is_ball_query_triton_available(),
+    reason="Triton ball-query smooth lDDT requires Triton and CUDA",
+)
+
+
+def _inputs(
+    n_atom: int = 12,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(7)
+    x_gt = torch.randn((2, n_atom, 3), device="cuda", dtype=torch.float32) * 2.0
+    atom_mask = torch.ones((2, n_atom), device="cuda")
+    is_nucleotide = torch.zeros_like(atom_mask)
+    is_nucleotide[1] = 1
+    loss_atom_mask = atom_mask.clone()
+    return x_gt, atom_mask, is_nucleotide, loss_atom_mask
+
+
+def _dense_smooth_lddt_loss(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+    eps: float,
+    radius_protein: float = 15.0,
+    radius_nucleotide: float = 30.0,
+) -> torch.Tensor:
+    pred_delta = x[..., :, None, :] - x[..., None, :, :]
+    gt_delta = x_gt[..., :, None, :] - x_gt[..., None, :, :]
+    d_pred = torch.sqrt(eps + pred_delta.float().square().sum(dim=-1))
+    d_gt = torch.sqrt(eps + gt_delta.square().sum(dim=-1))
+    distance_error = torch.abs(d_gt - d_pred)
+    score = 0.25 * (
+        torch.sigmoid(0.5 - distance_error)
+        + torch.sigmoid(1.0 - distance_error)
+        + torch.sigmoid(2.0 - distance_error)
+        + torch.sigmoid(4.0 - distance_error)
+    )
+
+    radius = torch.where(
+        is_nucleotide.bool(),
+        torch.tensor(radius_nucleotide, device=x.device),
+        torch.tensor(radius_protein, device=x.device),
+    )
+    valid_atom = atom_mask.bool() & loss_atom_mask.bool()
+    non_self = ~torch.eye(x.shape[-2], device=x.device, dtype=torch.bool)
+    pair_mask = valid_atom[..., :, None] & valid_atom[..., None, :] & non_self
+    in_ball = d_gt < radius[..., :, None]
+    mask_sum = pair_mask.sum(dim=(-1, -2)) + eps
+    score_mean = (score * in_ball * pair_mask).sum(dim=(-1, -2)) / mask_sum
+    in_ball_mean = (in_ball * pair_mask).sum(dim=(-1, -2)) / mask_sum
+    return 1 - score_mean / (in_ball_mean + eps)
+
+
+def test_availability_flags_are_consistent():
+    installed = is_ball_query_triton_installed()
+    available = is_ball_query_triton_available()
+
+    assert isinstance(installed, bool)
+    assert isinstance(available, bool)
+    assert available == (installed and torch.cuda.is_available())
+
+
+def test_unavailable_backend_has_clear_error():
+    if is_ball_query_triton_available():
+        pytest.skip("Backend is available")
+
+    x = torch.zeros((1, 2, 3))
+    mask = torch.ones((1, 2))
+    with pytest.raises(RuntimeError, match="requires Triton and a CUDA device"):
+        ball_query_smooth_lddt_loss(
+            x=x,
+            x_gt=x,
+            atom_mask_gt=mask,
+            is_nucleotide=mask,
+            loss_atom_mask=mask,
+            eps=1e-8,
+            top_k=1,
+        )
+
+
+@requires_triton_cuda
+def test_seed_zero_advances_and_reservoir_excludes_self():
+    n_atom = 32
+    top_k = 8
+    coords = torch.zeros((1, n_atom, 3), device="cuda")
+    lengths = torch.tensor([n_atom], device="cuda")
+
+    idx, _, _ = _query_with_pred(
+        p1=coords,
+        p2=coords,
+        pred=coords,
+        is_nucleotide=torch.zeros((1, n_atom), device="cuda"),
+        lengths1=lengths,
+        lengths2=lengths,
+        k=top_k,
+        seed=0,
+    )
+
+    centers = torch.arange(n_atom, device="cuda").view(1, n_atom, 1)
+    sorted_idx = torch.sort(idx, dim=-1).values
+    assert idx.shape == (1, n_atom, top_k)
+    assert (idx >= 0).all()
+    assert not (idx == centers).any()
+    assert (sorted_idx[..., 1:] != sorted_idx[..., :-1]).all()
+    assert idx[0, 0].tolist() != [31, 2, 3, 4, 5, 6, 7, 8]
+
+
+@requires_triton_cuda
+@pytest.mark.parametrize("top_k", [None, 0, -1])
+def test_rejects_invalid_top_k(top_k):
+    x_gt, atom_mask, is_nucleotide, loss_atom_mask = _inputs(n_atom=4)
+
+    with pytest.raises(ValueError, match="smooth_lddt_top_k"):
+        ball_query_smooth_lddt_loss(
+            x=x_gt,
+            x_gt=x_gt,
+            atom_mask_gt=atom_mask,
+            is_nucleotide=is_nucleotide,
+            loss_atom_mask=loss_atom_mask,
+            eps=1e-8,
+            top_k=top_k,
+        )
+
+
+@requires_triton_cuda
+@pytest.mark.parametrize(
+    ("radius_protein", "radius_nucleotide"),
+    [(0.0, 30.0), (15.0, 0.0), (-1.0, 30.0)],
+)
+def test_rejects_nonpositive_radius(radius_protein, radius_nucleotide):
+    x_gt, atom_mask, is_nucleotide, loss_atom_mask = _inputs(n_atom=4)
+
+    with pytest.raises(ValueError, match="must be positive"):
+        ball_query_smooth_lddt_loss(
+            x=x_gt,
+            x_gt=x_gt,
+            atom_mask_gt=atom_mask,
+            is_nucleotide=is_nucleotide,
+            loss_atom_mask=loss_atom_mask,
+            eps=1e-8,
+            top_k=3,
+            radius_protein=radius_protein,
+            radius_nucleotide=radius_nucleotide,
+        )
+
+
+@requires_triton_cuda
+def test_forward_and_backward_match_dense():
+    eps = 1e-8
+    x_gt, atom_mask, is_nucleotide, loss_atom_mask = _inputs()
+    torch.manual_seed(11)
+    noise = 0.1 * torch.randn_like(x_gt)
+    x_triton = (x_gt + noise).requires_grad_(True)
+    x_dense = (x_gt + noise).requires_grad_(True)
+
+    triton_loss = ball_query_smooth_lddt_loss(
+        x=x_triton,
+        x_gt=x_gt,
+        atom_mask_gt=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=loss_atom_mask,
+        eps=eps,
+        top_k=x_gt.shape[-2] - 1,
+    )
+    dense_loss = _dense_smooth_lddt_loss(
+        x=x_dense,
+        x_gt=x_gt,
+        atom_mask=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=loss_atom_mask,
+        eps=eps,
+    )
+    triton_loss.sum().backward()
+    dense_loss.sum().backward()
+
+    torch.testing.assert_close(triton_loss, dense_loss, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(x_triton.grad, x_dense.grad, atol=1e-3, rtol=5e-3)
+
+
+@requires_triton_cuda
+def test_batch_and_sample_dimensions_match_loop():
+    torch.manual_seed(12)
+    batch_size = 2
+    n_sample = 3
+    n_atom = 12
+    x_gt = torch.randn((batch_size, n_atom, 3), device="cuda")
+    atom_mask = torch.ones((batch_size, n_atom), device="cuda")
+    is_nucleotide = torch.zeros_like(atom_mask)
+    loss_atom_mask = atom_mask.clone()
+    x_base = x_gt[:, None] + 0.1 * torch.randn(
+        (batch_size, n_sample, n_atom, 3), device="cuda"
+    )
+
+    x_batched = x_base.detach().clone().requires_grad_(True)
+    batched_loss = ball_query_smooth_lddt_loss(
+        x=x_batched,
+        x_gt=x_gt,
+        atom_mask_gt=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=loss_atom_mask,
+        eps=1e-8,
+        top_k=n_atom - 1,
+        seed=5,
+    )
+    batched_loss.sum().backward()
+
+    x_loop = x_base.detach().clone().requires_grad_(True)
+    loop_loss = torch.stack(
+        [
+            torch.stack(
+                [
+                    ball_query_smooth_lddt_loss(
+                        x=x_loop[b : b + 1, s],
+                        x_gt=x_gt[b : b + 1],
+                        atom_mask_gt=atom_mask[b : b + 1],
+                        is_nucleotide=is_nucleotide[b : b + 1],
+                        loss_atom_mask=loss_atom_mask[b : b + 1],
+                        eps=1e-8,
+                        top_k=n_atom - 1,
+                        seed=5,
+                    ).squeeze(0)
+                    for s in range(n_sample)
+                ]
+            )
+            for b in range(batch_size)
+        ]
+    )
+    loop_loss.sum().backward()
+
+    assert batched_loss.shape == (batch_size, n_sample)
+    torch.testing.assert_close(batched_loss, loop_loss, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(x_batched.grad, x_loop.grad, atol=1e-3, rtol=5e-3)
+
+
+@requires_triton_cuda
+def test_subsampling_is_repeatable_for_seed():
+    x_gt, atom_mask, is_nucleotide, loss_atom_mask = _inputs()
+    torch.manual_seed(13)
+    x = x_gt + 0.2 * torch.randn_like(x_gt)
+
+    kwargs = {
+        "x": x,
+        "x_gt": x_gt,
+        "atom_mask_gt": atom_mask,
+        "is_nucleotide": is_nucleotide,
+        "loss_atom_mask": loss_atom_mask,
+        "eps": 1e-8,
+        "top_k": 3,
+        "seed": 123,
+    }
+    first = ball_query_smooth_lddt_loss(**kwargs)
+    second = ball_query_smooth_lddt_loss(**kwargs)
+
+    torch.testing.assert_close(first, second, atol=0.0, rtol=0.0)
+
+
+@requires_triton_cuda
+def test_bfloat16_backward_is_finite():
+    x_gt, atom_mask, is_nucleotide, loss_atom_mask = _inputs()
+    x = (x_gt + 0.05 * torch.randn_like(x_gt)).bfloat16().requires_grad_(True)
+
+    loss = ball_query_smooth_lddt_loss(
+        x=x,
+        x_gt=x_gt,
+        atom_mask_gt=atom_mask,
+        is_nucleotide=is_nucleotide,
+        loss_atom_mask=loss_atom_mask,
+        eps=1e-8,
+        top_k=x_gt.shape[-2] - 1,
+    )
+    loss.sum().backward()
+
+    assert torch.isfinite(loss).all()
+    assert x.grad is not None
+    assert x.grad.dtype == torch.bfloat16
+    assert torch.isfinite(x.grad).all()
+
+
+@requires_triton_cuda
+def test_adjustable_radius_changes_loss():
+    n_atom = 8
+    x_gt = torch.zeros((1, n_atom, 3), device="cuda")
+    x_gt[0, :, 0] = torch.arange(n_atom, device="cuda") * 6.0
+    atom_mask = torch.ones((1, n_atom), device="cuda")
+    is_nucleotide = torch.zeros_like(atom_mask)
+    x = x_gt + 0.05 * torch.randn_like(x_gt)
+
+    kwargs = {
+        "x": x,
+        "x_gt": x_gt,
+        "atom_mask_gt": atom_mask,
+        "is_nucleotide": is_nucleotide,
+        "loss_atom_mask": atom_mask,
+        "eps": 1e-8,
+        "top_k": n_atom - 1,
+    }
+    default_loss = ball_query_smooth_lddt_loss(**kwargs)
+    tight_loss = ball_query_smooth_lddt_loss(
+        **kwargs,
+        radius_protein=5.0,
+        radius_nucleotide=5.0,
+    )
+
+    assert torch.isfinite(default_loss).all()
+    assert torch.isfinite(tight_loss).all()
+    assert not torch.allclose(default_loss, tight_loss, atol=1e-6, rtol=1e-6)

--- a/scripts/benchmark/__init__.py
+++ b/scripts/benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Repository benchmark entry points."""

--- a/scripts/benchmark/ball_query_smooth_lddt/__init__.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/__init__.py
@@ -1,0 +1,1 @@
+"""Ball-query smooth-lDDT benchmark tools."""

--- a/scripts/benchmark/ball_query_smooth_lddt/analyze_smooth_lddt_neighborhoods.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/analyze_smooth_lddt_neighborhoods.py
@@ -1,0 +1,187 @@
+"""Measure 15/30 Angstrom atom-neighborhood sizes in structure NPZ files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+RADIUS_NON_NUCLEOTIDE = 15.0
+RADIUS_NUCLEOTIDE = 30.0
+NUCLEOTIDE_MOLECULE_TYPE_IDS = (1, 2)
+
+
+def _histogram_quantile(histogram: Counter[int], quantile: float) -> int | None:
+    total = histogram.total()
+    if total == 0:
+        return None
+    rank = max(1, math.ceil(quantile * total))
+    cumulative = 0
+    for value, count in sorted(histogram.items()):
+        cumulative += count
+        if cumulative >= rank:
+            return value
+    raise AssertionError("unreachable")
+
+
+@dataclass
+class NeighborhoodStats:
+    centers: int = 0
+    total_15: int = 0
+    total_30: int = 0
+    histogram_15: Counter[int] = field(default_factory=Counter)
+    histogram_30: Counter[int] = field(default_factory=Counter)
+
+    def update(self, counts_15: np.ndarray, counts_30: np.ndarray) -> None:
+        self.centers += counts_15.size
+        self.total_15 += int(counts_15.sum(dtype=np.int64))
+        self.total_30 += int(counts_30.sum(dtype=np.int64))
+        values_15, frequencies_15 = np.unique(counts_15, return_counts=True)
+        values_30, frequencies_30 = np.unique(counts_30, return_counts=True)
+        self.histogram_15.update(
+            dict(zip(values_15.tolist(), frequencies_15.tolist(), strict=True))
+        )
+        self.histogram_30.update(
+            dict(zip(values_30.tolist(), frequencies_30.tolist(), strict=True))
+        )
+
+    def mean(self, radius: int) -> float | None:
+        if self.centers == 0:
+            return None
+        total = self.total_15 if radius == 15 else self.total_30
+        return total / self.centers
+
+    def _radius_summary(
+        self, total: int, histogram: Counter[int]
+    ) -> dict[str, float | int | None]:
+        return {
+            "total_ordered_pairs": total,
+            "mean_neighbors_per_center": total / self.centers if self.centers else None,
+            "p50_neighbors": _histogram_quantile(histogram, 0.50),
+            "p90_neighbors": _histogram_quantile(histogram, 0.90),
+            "p95_neighbors": _histogram_quantile(histogram, 0.95),
+        }
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "center_atoms": self.centers,
+            "neighbors_within_15_angstrom": self._radius_summary(
+                self.total_15, self.histogram_15
+            ),
+            "neighbors_within_30_angstrom": self._radius_summary(
+                self.total_30, self.histogram_30
+            ),
+            "same_center_30_to_15_pair_ratio": (
+                self.total_30 / self.total_15 if self.total_15 else None
+            ),
+        }
+
+
+def _neighbor_counts(coordinates: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    tree = cKDTree(coordinates)
+    radius_15 = np.nextafter(RADIUS_NON_NUCLEOTIDE, 0.0)
+    radius_30 = np.nextafter(RADIUS_NUCLEOTIDE, 0.0)
+    counts_15 = tree.query_ball_point(
+        coordinates, radius_15, return_length=True, workers=-1
+    )
+    counts_30 = tree.query_ball_point(
+        coordinates, radius_30, return_length=True, workers=-1
+    )
+    return counts_15 - 1, counts_30 - 1
+
+
+def analyze_structure_files(structure_files: list[Path]) -> dict[str, object]:
+    groups = {
+        "all": NeighborhoodStats(),
+        "nucleotide": NeighborhoodStats(),
+        "non_nucleotide": NeighborhoodStats(),
+    }
+    mixed_nucleotide = NeighborhoodStats()
+    mixed_non_nucleotide = NeighborhoodStats()
+    mixed_structure_count = 0
+    atom_count = 0
+    skipped_files: list[str] = []
+    for structure_file in structure_files:
+        with np.load(structure_file, allow_pickle=False) as structure:
+            if "coord" not in structure or "molecule_type_id" not in structure:
+                skipped_files.append(str(structure_file))
+                continue
+            coordinates = structure["coord"]
+            molecule_types = structure["molecule_type_id"]
+
+        resolved = np.isfinite(coordinates).all(axis=-1)
+        coordinates = coordinates[resolved]
+        molecule_types = molecule_types[resolved]
+        if coordinates.size == 0:
+            skipped_files.append(str(structure_file))
+            continue
+
+        counts_15, counts_30 = _neighbor_counts(coordinates)
+        is_nucleotide = np.isin(molecule_types, NUCLEOTIDE_MOLECULE_TYPE_IDS)
+        groups["all"].update(counts_15, counts_30)
+        groups["nucleotide"].update(counts_15[is_nucleotide], counts_30[is_nucleotide])
+        groups["non_nucleotide"].update(
+            counts_15[~is_nucleotide], counts_30[~is_nucleotide]
+        )
+        if is_nucleotide.any() and (~is_nucleotide).any():
+            mixed_structure_count += 1
+            mixed_nucleotide.update(counts_15[is_nucleotide], counts_30[is_nucleotide])
+            mixed_non_nucleotide.update(
+                counts_15[~is_nucleotide], counts_30[~is_nucleotide]
+            )
+        atom_count += coordinates.shape[0]
+
+    nucleotide_mean_30 = mixed_nucleotide.mean(30)
+    non_nucleotide_mean_15 = mixed_non_nucleotide.mean(15)
+    suggested_scale = (
+        nucleotide_mean_30 / non_nucleotide_mean_15
+        if nucleotide_mean_30 is not None and non_nucleotide_mean_15 not in (None, 0.0)
+        else None
+    )
+    return {
+        "structure_files_analyzed": len(structure_files) - len(skipped_files),
+        "resolved_atoms_analyzed": atom_count,
+        "skipped_files": skipped_files,
+        "groups": {name: stats.as_dict() for name, stats in groups.items()},
+        "mixed_structure_scale_estimate": {
+            "mixed_structure_count": mixed_structure_count,
+            "nucleotide": mixed_nucleotide.as_dict(),
+            "non_nucleotide": mixed_non_nucleotide.as_dict(),
+            "nucleotide_30_to_non_nucleotide_15_mean_neighbor_ratio": suggested_scale,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "structure_directory",
+        type=Path,
+        help="Directory recursively containing preprocessed structure NPZ files.",
+    )
+    parser.add_argument("--max-structures", type=int)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    structure_files = sorted(args.structure_directory.rglob("*.npz"))
+    if args.max_structures is not None:
+        structure_files = structure_files[: args.max_structures]
+    if not structure_files:
+        parser.error(f"No NPZ files found under {args.structure_directory}")
+
+    result = analyze_structure_files(structure_files)
+    output = json.dumps(result, indent=2) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output)
+    print(output, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/ball_query_smooth_lddt/benchmark_smooth_lddt.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/benchmark_smooth_lddt.py
@@ -1,0 +1,453 @@
+"""Benchmark dense and ball-query smooth-lDDT implementations on point clouds."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from openfold3.core.kernels.triton.smooth_lddt_ball_query import (
+    DEFAULT_RADIUS_NUCLEOTIDE,
+    DEFAULT_RADIUS_PROTEIN,
+    _checkpointed_type_group_sums,
+    _finish_weighted_lddt,
+    _legacy_ball_query_smooth_lddt_loss,
+    _prepare_sparse_inputs,
+    _query_group_with_pred,
+    _type_aware_ball_query_smooth_lddt_loss,
+    _type_group_indices,
+    _validate_top_k,
+    ball_query_smooth_lddt_loss,
+)
+from openfold3.core.loss.diffusion import smooth_lddt_loss
+
+EPS = 1e-8
+BENCHMARK_BACKENDS = (
+    "dense",
+    "ball_query_unweighted",
+    "ball_query",
+)
+OPTIONAL_BACKENDS = (
+    "ball_query_legacy",
+    "ball_query_type_aware",
+)
+
+
+def _dense_batch(
+    x_gt: torch.Tensor, atom_mask: torch.Tensor, is_nucleotide: torch.Tensor
+) -> dict:
+    n_atom = x_gt.shape[-2]
+    return {
+        "ground_truth": {
+            "atom_positions": x_gt,
+            "atom_resolved_mask": atom_mask,
+        },
+        "token_mask": torch.ones((1, n_atom), device=x_gt.device),
+        "num_atoms_per_token": torch.ones(
+            (1, n_atom), device=x_gt.device, dtype=torch.long
+        ),
+        "is_dna": is_nucleotide,
+        "is_rna": torch.zeros_like(is_nucleotide),
+    }
+
+
+def _matched_unweighted_ball_query_smooth_lddt_loss(
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask_gt: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    loss_atom_mask: torch.Tensor,
+    eps: float,
+    top_k: int | None = 512,
+    seed: int = 0,
+    radius_protein: float = DEFAULT_RADIUS_PROTEIN,
+    radius_nucleotide: float = DEFAULT_RADIUS_NUCLEOTIDE,
+) -> torch.Tensor:
+    """Run the current ball query and reduction without row reweighting."""
+    k = _validate_top_k(top_k, x.shape[-2])
+    if k == 0:
+        return torch.ones(x.shape[:-2], device=x.device, dtype=x.dtype) + x.sum() * 0
+    flat_x, flat_x_gt, valid_atom, flat_is_nucleotide = _prepare_sparse_inputs(
+        x, x_gt, atom_mask_gt, is_nucleotide, loss_atom_mask
+    )
+    group = _query_group_with_pred(
+        flat_x,
+        flat_x_gt,
+        valid_atom,
+        flat_is_nucleotide,
+        valid_atom,
+        k,
+        radius_protein,
+        radius_nucleotide,
+        seed,
+    )
+    type_group_index = _type_group_indices(group[3], group[5], k)
+    score_by_type, count_by_type = _checkpointed_type_group_sums(
+        group[0],
+        group[1],
+        group[2],
+        group[5],
+        type_group_index,
+        eps,
+        radius_protein,
+        radius_nucleotide,
+    )
+    score_sum = score_by_type.sum(dim=-1)
+    pair_count = count_by_type.sum(dim=-1)
+    return _finish_weighted_lddt(score_sum, pair_count, valid_atom, eps, x.shape[:-2])
+
+
+def _calculate_loss(
+    name: str,
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    seed: int,
+    top_k: int,
+    nucleotide_scale: float,
+) -> torch.Tensor:
+    if name == "dense":
+        return smooth_lddt_loss(
+            x=x,
+            batch=_dense_batch(x_gt, atom_mask, is_nucleotide),
+            loss_token_mask=atom_mask,
+            eps=EPS,
+        )
+
+    kwargs = {
+        "x": x,
+        "x_gt": x_gt,
+        "atom_mask_gt": atom_mask,
+        "is_nucleotide": is_nucleotide,
+        "loss_atom_mask": atom_mask,
+        "eps": EPS,
+        "seed": seed,
+    }
+    if name == "ball_query_unweighted":
+        return _matched_unweighted_ball_query_smooth_lddt_loss(**kwargs, top_k=top_k)
+    if name == "ball_query":
+        return ball_query_smooth_lddt_loss(**kwargs, top_k=top_k)
+    if name == "ball_query_legacy":
+        return _legacy_ball_query_smooth_lddt_loss(**kwargs, top_k=top_k)
+    if name == "ball_query_type_aware":
+        return _type_aware_ball_query_smooth_lddt_loss(
+            **kwargs, top_k=top_k, nucleotide_scale=nucleotide_scale
+        )
+    raise ValueError(name)
+
+
+def _run_backend(
+    name: str,
+    x_base: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    seed: int,
+    top_k: int,
+    nucleotide_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    x = x_base.detach().clone().requires_grad_(True)
+    loss = _calculate_loss(
+        name,
+        x,
+        x_gt,
+        atom_mask,
+        is_nucleotide,
+        seed,
+        top_k,
+        nucleotide_scale,
+    )
+    loss.sum().backward()
+    return loss.detach(), x.grad.detach()
+
+
+@torch.inference_mode()
+def _run_inference_backend(
+    name: str,
+    x_base: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    seed: int,
+    top_k: int,
+    nucleotide_scale: float,
+) -> torch.Tensor:
+    x = x_base.detach().clone()
+    return _calculate_loss(
+        name,
+        x,
+        x_gt,
+        atom_mask,
+        is_nucleotide,
+        seed,
+        top_k,
+        nucleotide_scale,
+    ).detach()
+
+
+def _timed_run(
+    name: str,
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    warmup: int,
+    repeats: int,
+    top_k: int,
+    nucleotide_scale: float,
+) -> tuple[float, int]:
+    for _ in range(warmup):
+        _run_backend(
+            name,
+            x,
+            x_gt,
+            atom_mask,
+            is_nucleotide,
+            seed=0,
+            top_k=top_k,
+            nucleotide_scale=nucleotide_scale,
+        )
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    elapsed = []
+    for _ in range(repeats):
+        start.record()
+        _run_backend(
+            name,
+            x,
+            x_gt,
+            atom_mask,
+            is_nucleotide,
+            seed=0,
+            top_k=top_k,
+            nucleotide_scale=nucleotide_scale,
+        )
+        end.record()
+        torch.cuda.synchronize()
+        elapsed.append(start.elapsed_time(end))
+    peak = max(0, torch.cuda.max_memory_allocated() - baseline)
+    return float(np.median(elapsed)), int(peak)
+
+
+def _timed_inference_run(
+    name: str,
+    x: torch.Tensor,
+    x_gt: torch.Tensor,
+    atom_mask: torch.Tensor,
+    is_nucleotide: torch.Tensor,
+    warmup: int,
+    repeats: int,
+    top_k: int,
+    nucleotide_scale: float,
+) -> tuple[float, int]:
+    for _ in range(warmup):
+        _run_inference_backend(
+            name,
+            x,
+            x_gt,
+            atom_mask,
+            is_nucleotide,
+            seed=0,
+            top_k=top_k,
+            nucleotide_scale=nucleotide_scale,
+        )
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    elapsed = []
+    for _ in range(repeats):
+        start.record()
+        _run_inference_backend(
+            name,
+            x,
+            x_gt,
+            atom_mask,
+            is_nucleotide,
+            seed=0,
+            top_k=top_k,
+            nucleotide_scale=nucleotide_scale,
+        )
+        end.record()
+        torch.cuda.synchronize()
+        elapsed.append(start.elapsed_time(end))
+    peak = max(0, torch.cuda.max_memory_allocated() - baseline)
+    return float(np.median(elapsed)), int(peak)
+
+
+def _gradient_metrics(
+    gradient: torch.Tensor, reference: torch.Tensor
+) -> tuple[float, float, float]:
+    delta = gradient.float() - reference.float()
+    relative_l2 = delta.norm() / reference.float().norm().clamp_min(EPS)
+    cosine = torch.nn.functional.cosine_similarity(
+        gradient.float().flatten(), reference.float().flatten(), dim=0
+    )
+    return float(relative_l2), float(cosine), float(delta.abs().max())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--reservoir-seeds", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--max-cases", type=int)
+    parser.add_argument("--top-k", type=int, default=512)
+    parser.add_argument("--nucleotide-scale", type=float, default=4.0)
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        choices=BENCHMARK_BACKENDS + OPTIONAL_BACKENDS,
+        default=list(BENCHMARK_BACKENDS),
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        parser.error("CUDA is required")
+    output_paths = (args.output, args.output.with_suffix(".csv"))
+    existing_outputs = [path for path in output_paths if path.exists()]
+    if existing_outputs:
+        parser.error(
+            "Refusing to overwrite existing output: "
+            + ", ".join(str(path) for path in existing_outputs)
+        )
+
+    manifest = json.loads((args.dataset_dir / "manifest.json").read_text())
+    if args.max_cases is not None:
+        manifest = manifest[: args.max_cases]
+
+    backends = args.backends
+    rows: list[dict[str, object]] = []
+    for case in manifest:
+        data = np.load(args.dataset_dir / case["file"])
+        device = torch.device("cuda")
+        x_gt = torch.from_numpy(data["x_gt"]).to(device)[None]
+        atom_mask = torch.from_numpy(data["atom_mask"]).to(device)[None].float()
+        is_nucleotide = torch.from_numpy(data["is_nucleotide"]).to(device)[None].float()
+        for noise_index, noise in enumerate(data["noise_levels"]):
+            x = torch.from_numpy(data["x_pred"][noise_index]).to(device)[None]
+            try:
+                reference_loss, reference_grad = _run_backend(
+                    "dense",
+                    x,
+                    x_gt,
+                    atom_mask,
+                    is_nucleotide,
+                    seed=0,
+                    top_k=args.top_k,
+                    nucleotide_scale=args.nucleotide_scale,
+                )
+            except torch.cuda.OutOfMemoryError:
+                torch.cuda.empty_cache()
+                reference_loss = reference_grad = None
+
+            for backend in backends:
+                seeds = [0] if backend == "dense" else args.reservoir_seeds
+                for seed in seeds:
+                    started = time.time()
+                    loss_value = dense_loss_value = None
+                    try:
+                        loss, gradient = _run_backend(
+                            backend,
+                            x,
+                            x_gt,
+                            atom_mask,
+                            is_nucleotide,
+                            seed,
+                            args.top_k,
+                            args.nucleotide_scale,
+                        )
+                        loss_value = float(loss.item())
+                        dense_loss_value = (
+                            float(reference_loss.item())
+                            if reference_loss is not None
+                            else None
+                        )
+                        if reference_loss is None:
+                            loss_error = grad_l2 = grad_cosine = grad_max = None
+                        else:
+                            loss_error = float((loss - reference_loss).abs().max())
+                            grad_l2, grad_cosine, grad_max = _gradient_metrics(
+                                gradient, reference_grad
+                            )
+                        runtime_ms, peak_memory = _timed_run(
+                            backend,
+                            x,
+                            x_gt,
+                            atom_mask,
+                            is_nucleotide,
+                            args.warmup,
+                            args.repeats,
+                            args.top_k,
+                            args.nucleotide_scale,
+                        )
+                        (
+                            inference_runtime_ms,
+                            inference_peak_memory,
+                        ) = _timed_inference_run(
+                            backend,
+                            x,
+                            x_gt,
+                            atom_mask,
+                            is_nucleotide,
+                            args.warmup,
+                            args.repeats,
+                            args.top_k,
+                            args.nucleotide_scale,
+                        )
+                        error = None
+                    except torch.cuda.OutOfMemoryError:
+                        torch.cuda.empty_cache()
+                        loss_error = grad_l2 = grad_cosine = grad_max = None
+                        runtime_ms = peak_memory = None
+                        inference_runtime_ms = inference_peak_memory = None
+                        error = "CUDA out of memory"
+                    rows.append(
+                        {
+                            **case,
+                            "noise": float(noise),
+                            "backend": backend,
+                            "reservoir_seed": seed,
+                            "top_k": args.top_k,
+                            "nucleotide_scale": args.nucleotide_scale,
+                            "loss": loss_value,
+                            "dense_loss": dense_loss_value,
+                            "loss_error": loss_error,
+                            "gradient_relative_l2": grad_l2,
+                            "gradient_cosine": grad_cosine,
+                            "gradient_max_abs": grad_max,
+                            "runtime_ms": runtime_ms,
+                            "peak_memory_bytes": peak_memory,
+                            "inference_runtime_ms": inference_runtime_ms,
+                            "inference_peak_memory_bytes": inference_peak_memory,
+                            "wall_seconds": time.time() - started,
+                            "error": error,
+                        }
+                    )
+                    print(json.dumps(rows[-1], sort_keys=True))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(rows, indent=2) + "\n")
+    csv_path = args.output.with_suffix(".csv")
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/ball_query_smooth_lddt/generate_smooth_lddt_point_clouds.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/generate_smooth_lddt_point_clouds.py
@@ -1,0 +1,140 @@
+"""Generate deterministic point clouds for smooth-lDDT backend benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+PROTEIN_RADIUS = 15.0
+NUCLEOTIDE_RADIUS = 30.0
+PROTEIN_NEIGHBORS = 512
+NUCLEOTIDE_NEIGHBORS = 2048
+
+
+def _uniform_cloud(
+    rng: np.random.Generator,
+    n_atom: int,
+    radius: float,
+    target_neighbors: int,
+) -> np.ndarray:
+    target = max(1, min(target_neighbors, n_atom - 1))
+    density = target / ((4.0 / 3.0) * math.pi * radius**3)
+    side = (n_atom / density) ** (1.0 / 3.0)
+    return rng.uniform(0.0, side, size=(n_atom, 3)).astype(np.float32)
+
+
+def generate_case(
+    profile: str,
+    n_atom: int,
+    seed: int,
+    noise_levels: tuple[float, ...],
+    resolved_fraction: float,
+) -> dict[str, np.ndarray]:
+    """Generate one controlled cloud and noisy predictions."""
+    rng = np.random.default_rng(seed)
+    if profile == "protein_only":
+        x_gt = _uniform_cloud(rng, n_atom, PROTEIN_RADIUS, PROTEIN_NEIGHBORS)
+        is_nucleotide = np.zeros(n_atom, dtype=np.bool_)
+    elif profile == "nucleotide_only":
+        x_gt = _uniform_cloud(rng, n_atom, NUCLEOTIDE_RADIUS, NUCLEOTIDE_NEIGHBORS)
+        is_nucleotide = np.ones(n_atom, dtype=np.bool_)
+    elif profile in {"mixed_separated", "overflow"}:
+        n_protein = n_atom // 2
+        n_nucleotide = n_atom - n_protein
+        multiplier = 1.5 if profile == "overflow" else 1.0
+        protein = _uniform_cloud(
+            rng,
+            n_protein,
+            PROTEIN_RADIUS,
+            int(PROTEIN_NEIGHBORS * multiplier),
+        )
+        nucleotide = _uniform_cloud(
+            rng,
+            n_nucleotide,
+            NUCLEOTIDE_RADIUS,
+            int(NUCLEOTIDE_NEIGHBORS * multiplier),
+        )
+        nucleotide[:, 0] += protein[:, 0].max(initial=0.0) + 65.0
+        x_gt = np.concatenate((protein, nucleotide))
+        is_nucleotide = np.zeros(n_atom, dtype=np.bool_)
+        is_nucleotide[n_protein:] = True
+    elif profile == "mixed_overlap":
+        x_gt = _uniform_cloud(rng, n_atom, PROTEIN_RADIUS, PROTEIN_NEIGHBORS)
+        is_nucleotide = np.zeros(n_atom, dtype=np.bool_)
+        is_nucleotide[rng.choice(n_atom, n_atom // 2, replace=False)] = True
+    else:
+        raise ValueError(f"Unknown profile {profile!r}")
+
+    atom_mask = rng.random(n_atom) < resolved_fraction
+    predictions = np.stack(
+        [
+            x_gt + rng.normal(0.0, noise, x_gt.shape).astype(np.float32)
+            for noise in noise_levels
+        ]
+    )
+    return {
+        "x_gt": x_gt,
+        "x_pred": predictions,
+        "is_nucleotide": is_nucleotide,
+        "atom_mask": atom_mask,
+        "loss_atom_mask": atom_mask.copy(),
+        "noise_levels": np.asarray(noise_levels, dtype=np.float32),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--n-atoms", type=int, nargs="+", default=[1024, 4096, 8192])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[7, 11, 19])
+    parser.add_argument("--noise", type=float, nargs="+", default=[0.1, 1.0, 3.0])
+    parser.add_argument("--resolved-fraction", type=float, default=0.9)
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=[
+            "protein_only",
+            "nucleotide_only",
+            "mixed_separated",
+            "mixed_overlap",
+            "overflow",
+        ],
+    )
+    args = parser.parse_args()
+    if not 0.0 < args.resolved_fraction <= 1.0:
+        parser.error("--resolved-fraction must be in (0, 1]")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict[str, object]] = []
+    for profile in args.profiles:
+        for n_atom in args.n_atoms:
+            for seed in args.seeds:
+                name = f"{profile}_n{n_atom}_seed{seed}.npz"
+                data = generate_case(
+                    profile=profile,
+                    n_atom=n_atom,
+                    seed=seed,
+                    noise_levels=tuple(args.noise),
+                    resolved_fraction=args.resolved_fraction,
+                )
+                np.savez_compressed(args.output_dir / name, **data)
+                manifest.append(
+                    {
+                        "file": name,
+                        "profile": profile,
+                        "n_atom": n_atom,
+                        "seed": seed,
+                        "resolved_fraction": args.resolved_fraction,
+                    }
+                )
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/ball_query_smooth_lddt/generate_smooth_lddt_structure_cases.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/generate_smooth_lddt_structure_cases.py
@@ -1,0 +1,156 @@
+"""Convert preprocessed structure NPZ files into smooth-lDDT benchmark cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+NUCLEOTIDE_MOLECULE_TYPE_IDS = (1, 2)
+
+
+def _spatial_crop(
+    coordinates: np.ndarray,
+    molecule_types: np.ndarray,
+    max_atoms: int | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    if max_atoms is None or coordinates.shape[0] <= max_atoms:
+        return coordinates, molecule_types
+
+    centroid = coordinates.mean(axis=0)
+    center_index = np.square(coordinates - centroid).sum(axis=-1).argmin()
+    tree = cKDTree(coordinates)
+    _, crop_indices = tree.query(coordinates[center_index], k=max_atoms)
+    crop_indices = np.sort(np.asarray(crop_indices))
+    return coordinates[crop_indices], molecule_types[crop_indices]
+
+
+def generate_structure_case(
+    structure_file: Path,
+    max_atoms: int | None,
+    noise_levels: tuple[float, ...],
+    seed: int,
+) -> tuple[dict[str, np.ndarray], dict[str, object]] | None:
+    with np.load(structure_file, allow_pickle=False) as structure:
+        if "coord" not in structure or "molecule_type_id" not in structure:
+            return None
+        coordinates = structure["coord"]
+        molecule_types = structure["molecule_type_id"]
+
+    resolved = np.isfinite(coordinates).all(axis=-1)
+    coordinates = coordinates[resolved].astype(np.float32, copy=False)
+    molecule_types = molecule_types[resolved]
+    if coordinates.shape[0] < 2:
+        return None
+
+    original_n_atom = coordinates.shape[0]
+    coordinates, molecule_types = _spatial_crop(coordinates, molecule_types, max_atoms)
+    rng = np.random.default_rng(seed)
+    predictions = np.stack(
+        [
+            coordinates + rng.normal(0.0, noise, coordinates.shape).astype(np.float32)
+            for noise in noise_levels
+        ]
+    )
+    is_nucleotide = np.isin(molecule_types, NUCLEOTIDE_MOLECULE_TYPE_IDS)
+    atom_mask = np.ones(coordinates.shape[0], dtype=np.bool_)
+    data = {
+        "x_gt": coordinates,
+        "x_pred": predictions,
+        "is_nucleotide": is_nucleotide,
+        "atom_mask": atom_mask,
+        "loss_atom_mask": atom_mask.copy(),
+        "noise_levels": np.asarray(noise_levels, dtype=np.float32),
+    }
+    metadata = {
+        "profile": (
+            "pulled_structure_full"
+            if max_atoms is None
+            else "pulled_structure_spatial_crop"
+        ),
+        "structure_id": structure_file.stem,
+        "n_atom": coordinates.shape[0],
+        "original_n_atom": original_n_atom,
+        "n_nucleotide": int(is_nucleotide.sum()),
+        "seed": seed,
+        "source_file": str(structure_file),
+    }
+    return data, metadata
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--structure-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--dataset-cache",
+        type=Path,
+        help="Only generate structures listed in this dataset cache.",
+    )
+    parser.add_argument("--max-atoms", type=int, default=3072)
+    parser.add_argument(
+        "--no-crop",
+        action="store_true",
+        help="Keep every resolved atom instead of applying --max-atoms.",
+    )
+    parser.add_argument("--noise", type=float, nargs="+", default=[1.0])
+    parser.add_argument("--seed", type=int, default=2026)
+    args = parser.parse_args()
+    if not args.no_crop and args.max_atoms < 2:
+        parser.error("--max-atoms must be at least 2")
+    max_atoms = None if args.no_crop else args.max_atoms
+
+    structure_files = sorted(args.structure_dir.rglob("*.npz"))
+    if not structure_files:
+        parser.error(f"No NPZ files found under {args.structure_dir}")
+
+    if args.dataset_cache is not None:
+        cache = json.loads(args.dataset_cache.read_text())
+        try:
+            selected_ids = set(cache["structure_data"])
+        except (KeyError, TypeError) as error:
+            parser.error(
+                f"{args.dataset_cache} does not contain a structure_data mapping: "
+                f"{error}"
+            )
+        structure_files_by_id = {path.stem: path for path in structure_files}
+        missing_ids = selected_ids - structure_files_by_id.keys()
+        if missing_ids:
+            parser.error(
+                "Missing selected structure files: " + ", ".join(sorted(missing_ids))
+            )
+        structure_files = [
+            structure_files_by_id[pdb_id] for pdb_id in sorted(selected_ids)
+        ]
+
+    if args.output_dir.exists() and any(args.output_dir.iterdir()):
+        parser.error(f"Refusing to overwrite non-empty output dir: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: list[dict[str, object]] = []
+    for structure_index, structure_file in enumerate(structure_files):
+        generated = generate_structure_case(
+            structure_file=structure_file,
+            max_atoms=max_atoms,
+            noise_levels=tuple(args.noise),
+            seed=args.seed + structure_index,
+        )
+        if generated is None:
+            continue
+        data, metadata = generated
+        suffix = "full" if args.no_crop else "spatial_crop"
+        output_name = f"{structure_file.stem}_{suffix}.npz"
+        np.savez_compressed(args.output_dir / output_name, **data)
+        manifest.append({"file": output_name, **metadata})
+
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+    print(json.dumps({"cases": len(manifest), "output_dir": str(args.output_dir)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/ball_query_smooth_lddt/pull_protein_rna_51_cases.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/pull_protein_rna_51_cases.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build and pull the pinned 51-structure protein-RNA benchmark dataset.
+
+Run from the repository root with::
+
+    python -m scripts.benchmark.ball_query_smooth_lddt.pull_protein_rna_51_cases
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.datasets.pdb_subset_helpers import (
+    download_full_cache,
+    stream_subset,
+    write_subset,
+)
+
+BOUNDED_PDB_IDS = (
+    "7t1n",
+    "7qdd",
+    "7zex",
+    "7sos",
+    "7sop",
+    "7sow",
+    "7f3l",
+    "7vrl",
+    "7sov",
+    "7f3j",
+    "7zew",
+    "7p0v",
+    "7rgu",
+    "7ozq",
+    "7eiu",
+    "7vsj",
+    "7vkl",
+    "7qde",
+    "7x34",
+    "7q4l",
+    "7s3b",
+    "7s3c",
+    "7zhh",
+    "7s3a",
+    "7wl0",
+    "7bah",
+    "8af0",
+    "7qr4",
+    "7qr3",
+    "7xs4",
+    "7f3i",
+    "8dzk",
+    "8edj",
+    "7uu4",
+    "7z55",
+    "7s02",
+    "7rzz",
+    "7v2z",
+    "8d29",
+    "7uo5",
+    "7uo2",
+    "6ww6",
+    "6wxq",
+    "8b0r",
+    "7e8o",
+)
+LARGE_PDB_TOKEN_COUNTS = {
+    "7vtn": 863,
+    "7r9f": 1158,
+    "7v93": 1344,
+    "8h2h": 1513,
+    "7ozs": 1824,
+    "7r7c": 2012,
+}
+PDB_IDS = (*BOUNDED_PDB_IDS, *LARGE_PDB_TOKEN_COUNTS)
+
+
+def _eligible_protein_rna_interfaces(entry: dict) -> list[str]:
+    eligible = []
+    for interface_id, interface in entry["interfaces"].items():
+        chain_ids = interface_id.split("_")
+        if len(chain_ids) != 2:
+            continue
+        molecule_types = {
+            entry["chains"][chain_id]["molecule_type"] for chain_id in chain_ids
+        }
+        if molecule_types == {"PROTEIN", "RNA"} and interface.get(
+            "metric_eligible", interface.get("use_metrics", True)
+        ):
+            eligible.append(interface_id)
+    return eligible
+
+
+def validate_selection(structure_data: dict) -> None:
+    """Validate exact membership and benchmark-specific metadata invariants."""
+    expected = set(PDB_IDS)
+    actual = set(structure_data)
+    if len(PDB_IDS) != 51 or len(expected) != 51:
+        raise ValueError("The pinned selection must contain 51 unique PDB IDs")
+    if actual != expected:
+        raise ValueError(
+            f"Cache membership mismatch: missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+
+    for pdb_id, entry in structure_data.items():
+        if not _eligible_protein_rna_interfaces(entry):
+            raise ValueError(f"{pdb_id} has no metric-eligible protein-RNA interface")
+
+    for pdb_id, expected_tokens in LARGE_PDB_TOKEN_COUNTS.items():
+        entry = structure_data[pdb_id]
+        if entry["token_count"] != expected_tokens:
+            raise ValueError(
+                f"{pdb_id} token count is {entry['token_count']}, "
+                f"expected {expected_tokens}"
+            )
+        molecule_types = {chain["molecule_type"] for chain in entry["chains"].values()}
+        if not molecule_types <= {"PROTEIN", "RNA"}:
+            raise ValueError(
+                f"{pdb_id} contains unexpected molecule types: {molecule_types}"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--full-cache",
+        type=Path,
+        default=Path("datasets/validation_cache_with_templates.json"),
+    )
+    parser.add_argument(
+        "--output-cache",
+        type=Path,
+        default=Path("datasets/validation_cache_with_templates_protein_rna_51.json"),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing output cache after validating the new selection.",
+    )
+    parser.add_argument(
+        "--asset-dir",
+        type=Path,
+        help="Download assets here instead of <output-cache parent>/pdb_training_set.",
+    )
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help="Build and validate the 51-entry cache without downloading its assets.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify previously downloaded assets instead of downloading them.",
+    )
+    args = parser.parse_args()
+
+    if args.output_cache.exists() and not args.force:
+        cache = json.loads(args.output_cache.read_text())
+        validate_selection(cache["structure_data"])
+        print(f"Validated existing cache: {args.output_cache}")
+    else:
+        download_full_cache(args.full_cache)
+        metadata, structure_data = stream_subset(args.full_cache, set(PDB_IDS))
+        missing = set(PDB_IDS) - set(structure_data)
+        if missing:
+            raise ValueError(f"PDB IDs missing from full cache: {sorted(missing)}")
+        validate_selection(structure_data)
+
+        output_metadata = {
+            **metadata,
+            "name": "protein-rna-validation-51",
+        }
+        args.output_cache.parent.mkdir(parents=True, exist_ok=True)
+        write_subset(
+            args.output_cache,
+            output_metadata,
+            {pdb_id: structure_data[pdb_id] for pdb_id in sorted(PDB_IDS)},
+        )
+
+    if args.cache_only:
+        return
+
+    repository_root = Path(__file__).resolve().parents[3]
+    command = [
+        sys.executable,
+        "-u",
+        str(repository_root / "scripts/datasets/download_subset.py"),
+        "--skip-train",
+        "--val-subset-cache",
+        str(args.output_cache),
+        "--target-dir",
+        str(args.output_cache.parent),
+        "--workers",
+        str(args.workers),
+    ]
+    if args.asset_dir is not None:
+        command.extend(("--output-dir", str(args.asset_dir)))
+    if args.verify:
+        command.append("--verify")
+    subprocess.run(command, cwd=repository_root, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/ball_query_smooth_lddt/run_protein_rna_51_benchmark.py
+++ b/scripts/benchmark/ball_query_smooth_lddt/run_protein_rna_51_benchmark.py
@@ -1,0 +1,158 @@
+"""Generate and benchmark the exact 51 protein-RNA structure cases.
+
+Pull the public OpenFold3 assets first with::
+
+    python -m scripts.benchmark.ball_query_smooth_lddt.pull_protein_rna_51_cases
+
+Then run this module from the repository root. Existing non-empty case and
+result paths are never overwritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.benchmark.ball_query_smooth_lddt.pull_protein_rna_51_cases import (
+    PDB_IDS,
+)
+
+
+def _run(command: list[str], repository_root: Path, env: dict[str, str]) -> None:
+    print(shlex.join(command), flush=True)
+    subprocess.run(command, cwd=repository_root, env=env, check=True)
+
+
+def _validate_cases(case_dir: Path) -> None:
+    manifest_path = case_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Case manifest not found: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text())
+    structure_ids = [case["structure_id"] for case in manifest]
+    expected = set(PDB_IDS)
+    actual = set(structure_ids)
+    if len(structure_ids) != 51 or len(actual) != 51 or actual != expected:
+        raise ValueError(
+            "Case membership mismatch: "
+            f"rows={len(structure_ids)}, unique={len(actual)}, "
+            f"missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+    cropped = [
+        case["structure_id"]
+        for case in manifest
+        if case["n_atom"] != case["original_n_atom"]
+    ]
+    if cropped:
+        raise ValueError(
+            f"Expected full structures, but these cases were cropped: {cropped}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset-cache",
+        type=Path,
+        default=Path("datasets/validation_cache_with_templates_protein_rna_51.json"),
+    )
+    parser.add_argument(
+        "--structure-dir",
+        type=Path,
+        default=Path(
+            "datasets/pdb_training_set/preprocessed_pdb_data/standard/structure_files"
+        ),
+    )
+    parser.add_argument(
+        "--case-dir",
+        type=Path,
+        default=Path("outputs/smooth_lddt_benchmark/protein_rna_51_cases_full"),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/smooth_lddt_benchmark"),
+    )
+    parser.add_argument("--output-prefix", default="protein_rna_51_strict_dynamic")
+    parser.add_argument("--top-k", type=int, nargs="+", default=[256, 512, 1024, 2048])
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--reservoir-seeds", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--noise", type=float, default=1.0)
+    parser.add_argument("--case-seed", type=int, default=20260804)
+    parser.add_argument("--cuda-visible-devices", default="0")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print commands without running them."
+    )
+    args = parser.parse_args()
+
+    if any(top_k <= 0 for top_k in args.top_k):
+        parser.error("--top-k values must be positive")
+    if len(set(args.top_k)) != len(args.top_k):
+        parser.error("--top-k values must be unique")
+
+    repository_root = Path(__file__).resolve().parents[3]
+    module_root = "scripts.benchmark.ball_query_smooth_lddt"
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+
+    manifest_path = args.case_dir / "manifest.json"
+    if not manifest_path.exists():
+        command = [
+            sys.executable,
+            "-u",
+            "-m",
+            f"{module_root}.generate_smooth_lddt_structure_cases",
+            "--structure-dir",
+            str(args.structure_dir),
+            "--output-dir",
+            str(args.case_dir),
+            "--dataset-cache",
+            str(args.dataset_cache),
+            "--no-crop",
+            "--noise",
+            str(args.noise),
+            "--seed",
+            str(args.case_seed),
+        ]
+        if args.dry_run:
+            print(shlex.join(command))
+        else:
+            _run(command, repository_root, env)
+
+    if not args.dry_run:
+        _validate_cases(args.case_dir)
+
+    for top_k in args.top_k:
+        output = args.output_dir / f"{args.output_prefix}_k{top_k}.json"
+        command = [
+            sys.executable,
+            "-u",
+            "-m",
+            f"{module_root}.benchmark_smooth_lddt",
+            "--dataset-dir",
+            str(args.case_dir),
+            "--output",
+            str(output),
+            "--warmup",
+            str(args.warmup),
+            "--repeats",
+            str(args.repeats),
+            "--reservoir-seeds",
+            *(str(seed) for seed in args.reservoir_seeds),
+            "--top-k",
+            str(top_k),
+        ]
+        if args.dry_run:
+            print(shlex.join(command))
+        else:
+            _run(command, repository_root, env)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/datasets/download_subset.py
+++ b/scripts/datasets/download_subset.py
@@ -69,6 +69,20 @@ def main():
         "--val-size", type=int, default=4, help="Validation subset size (default: 4)"
     )
     parser.add_argument(
+        "--val-subset-cache",
+        type=Path,
+        default=None,
+        help=(
+            "Explicit validation subset cache path. Overrides the path inferred "
+            "from --val-cache and --val-size."
+        ),
+    )
+    parser.add_argument(
+        "--skip-train",
+        action="store_true",
+        help="Download only validation assets; do not require a training subset cache.",
+    )
+    parser.add_argument(
         "--train-cache",
         type=Path,
         default=None,
@@ -95,10 +109,14 @@ def main():
     val_cache = args.val_cache or (target_dir / "validation_cache_with_templates.json")
     local_root = args.output_dir or (target_dir / "pdb_training_set")
 
-    cache_files = {
-        "train": subset_cache_path(train_cache, args.train_size, target_dir),
-        "val": subset_cache_path(val_cache, args.val_size, target_dir),
-    }
+    cache_files = {}
+    if not args.skip_train:
+        cache_files["train"] = subset_cache_path(
+            train_cache, args.train_size, target_dir
+        )
+    cache_files["val"] = args.val_subset_cache or subset_cache_path(
+        val_cache, args.val_size, target_dir
+    )
     missing = [str(p) for p in cache_files.values() if not p.exists()]
     if missing:
         sys.exit(

--- a/scripts/datasets/pdb_subset_helpers.py
+++ b/scripts/datasets/pdb_subset_helpers.py
@@ -296,15 +296,20 @@ def extract_ids_from_cache(cache_path: Path) -> dict:
 
     pdb_ids = set()
     alignment_rep_ids = set()
+    template_rep_ids = set()
     template_ids = set()
     reference_mol_ids = set()
 
     for pdb_id, entry in cache["structure_data"].items():
         pdb_ids.add(pdb_id)
         for chain_data in entry["chains"].values():
-            if rep_id := chain_data.get("alignment_representative_id"):
+            rep_id = chain_data.get("alignment_representative_id")
+            if rep_id:
                 alignment_rep_ids.add(rep_id)
-            for tmpl_id in chain_data.get("template_ids") or []:
+            chain_template_ids = chain_data.get("template_ids") or []
+            if rep_id and chain_template_ids:
+                template_rep_ids.add(rep_id)
+            for tmpl_id in chain_template_ids:
                 template_ids.add(tmpl_id)
             if ref_mol := chain_data.get("reference_mol_id"):
                 reference_mol_ids.add(ref_mol)
@@ -312,6 +317,7 @@ def extract_ids_from_cache(cache_path: Path) -> dict:
     return {
         "pdb_ids": pdb_ids,
         "alignment_rep_ids": alignment_rep_ids,
+        "template_rep_ids": template_rep_ids,
         "template_ids": template_ids,
         "reference_mol_ids": reference_mol_ids,
     }
@@ -357,7 +363,7 @@ def build_structure_manifest(
         manifest.append((s3_key, local))
 
     # Template cache: {rep_id}.npz
-    for rep_id in ids["alignment_rep_ids"]:
+    for rep_id in ids.get("template_rep_ids", ids["alignment_rep_ids"]):
         s3_key = f"{S3_PREFIX}/templates/{template_cache_subdir}/{rep_id}.npz"
         local = local_root / "templates" / template_cache_subdir / f"{rep_id}.npz"
         manifest.append((s3_key, local))


### PR DESCRIPTION
## Executive summary

This PR correlates to https://github.com/aqlaboratory/openfold-3/pull/261

This report combines two independent GPU evaluations of the reweighted Triton
ball-query implementation of smooth lDDT:

- the original **NVIDIA GeForce RTX 4090** study in `pr_reweighting.md`;
- the follow-up **NVIDIA H800** study in `pr_reweighting_h800.md`.

Both studies use the same pinned set of 51 full protein–RNA structures, the same
coordinate perturbations, four reservoir sizes, three reservoir seeds, and the
same dense smooth-lDDT definition. Together they evaluate numerical fidelity,
training and inference runtime, GPU memory, large-structure behavior, and the
trade-off controlled by the ball-query reservoir size `K`.

The central numerical finding is reproduced across both machines. At the
recommended default `K=512`, type-aware reweighting improves gradient agreement
with dense smooth lDDT:

- gradient relative L2: **`0.26738 → 0.25021`**;
- gradient cosine: **`0.95665 → 0.96995`**.

At `K=256` and `K=1024`, reweighting also improves both gradient metrics. At
`K=2048`, both reweighting factors equal one, so weighted and unweighted
reductions become equivalent apart from floating-point reduction order.

The two machines expose complementary deployment properties:

- On the 24 GiB RTX 4090, dense smooth lDDT runs out of memory on the
  20,016-atom `8h2h` case. Every sparse configuration completes.
- On the 80 GiB H800, dense completes all 51 structures, including `8h2h`, but
  its peak incremental training allocation reaches **24.45 GiB**, compared with
  **0.60 GiB** for reweighted `K=512` on the same case set.
- On the 50 structures shared by the dense references from both machines, the
  H800 dense training path is approximately **60% faster** than the RTX 4090.
- Sparse memory grows approximately linearly with `K`; dense memory grows
  quadratically with atom count.

A critical methodological distinction must be retained when interpreting the
runtime and memory comparisons:

1. The RTX 4090 study compares the reweighted current reduction with a
   **matched unweighted reduction running on the same current compacted
   ball-query kernel**. This isolates the incremental cost of reweighting.
2. The H800 study compares the current implementation at `778f30aa` with the
   **exact historical ball-query implementation at `074d75c2`**. This measures
   the complete historical-to-current change, including kernel and compaction
   changes as well as reweighting.

Consequently, the RTX study is the authoritative measurement of the isolated
reweighting overhead, while the H800 study is the authoritative end-to-end
comparison with the exact original implementation requested for regression
validation.

---

## 1. Background and motivation

The default dense smooth-lDDT loss constructs pairwise atom-distance data with
quadratic `O(A²)` scaling for `A` resolved atoms. This gives an exact reference,
but its memory cost becomes prohibitive for large all-atom structures.

The Triton ball-query backend instead scans candidates and retains at most `K`
in-radius neighbors for each center. Its dominant saved neighborhood storage is
therefore `O(AK)` rather than `O(A²)`.

The two center types use different physical cutoffs:

- non-nucleotide centers: **15 Å**;
- nucleotide centers: **30 Å**.

A 30 Å sphere has eight times the volume of a 15 Å sphere under a uniform-density
approximation. Using one fixed reservoir size therefore retains a smaller
fraction of an RNA-centered neighborhood than of a protein-centered
neighborhood. A simple unweighted truncated reduction can consequently
underrepresent nucleotide-centered rows.

The reweighted implementation corrects this imbalance for truncated rows while
preserving the normalization of the smooth-lDDT reduction. It applies the same
weight to each row's score sum and pair-count denominator.

For reservoir size `K`, the lower-bounded row weights are:

```text
non-nucleotide weight = max(1,  512 / K)
nucleotide weight     = max(1, 2048 / K)
```

The tested schedule is:

| K | Non-nucleotide weight | Nucleotide weight |
|---:|---:|---:|
| 256 | 2 | 8 |
| 512 | 1 | 4 |
| 1024 | 1 | 2 |
| 2048 | 1 | 1 |

Rows whose complete neighborhood fits in the reservoir retain weight one. The
additional weighted reduction uses `O(A)` metadata and does not add another
atom-by-`K` tensor.

---

## 2. Implementations under test

### 2.1 Dense reference

The dense reference is the default `smooth_lddt_loss`. It computes the complete
pairwise neighborhood and serves as the numerical target for scalar loss and
predicted-coordinate gradients.

### 2.2 Current reweighted ball query

The current implementation is commit:

```text
778f30aad9144dea57f7cee879e60b7418de71b8
feat: add reweighted ball-query smooth lDDT
```

It includes type-aware row reweighting and the current compacted ball-query
kernel/reduction implementation.

### 2.3 Matched current unweighted reduction

The RTX 4090 study disables row reweighting while retaining the current query,
compaction, and reduction machinery. This is the correct controlled comparison
for answering:

> What numerical and performance change comes from adding reweighting to the
> current implementation?

### 2.4 Exact historical ball query

The H800 study loads the exact historical implementation from commit:

```text
074d75c2
feat: wire Triton smooth lDDT into diffusion loss
```

It is executed from an isolated source snapshot in a fresh process, rather than
through the compatibility function retained in current code. This is the
correct comparison for answering:

> How does the current implementation behave relative to the actual original
> implementation before the reweighting update?

Because this historical comparison also includes intervening kernel and
compaction changes, it cannot isolate the cost of reweighting by itself.

---

## 3. Benchmark dataset

Both studies use the same pinned 51-structure protein–RNA validation set.

| Property | Value |
|---|---|
| Structures | 51 unique PDB entries, each present once |
| Representation | Every resolved atom; no spatial cropping |
| Composition | Every case contains protein and nucleotide atoms |
| Atom range | 666–20,016 |
| Coordinate perturbation | Independent Gaussian noise, σ = 1 Å |
| Large-structure ladder | `7vtn`, `7r9f`, `7v93`, `8h2h`, `7ozs`, `7r7c` |

The dataset setup verifies:

- exact PDB membership;
- one case per structure;
- no atom-count reduction relative to the source structure;
- 1,785 required structure, alignment, and template files;
- 47 reference-molecule entries.

The six large cases provide the strongest scaling test. The largest,
`8h2h`, contains 20,016 resolved atoms and is the only case on which the RTX
4090 dense reference runs out of memory.

---

## 4. Shared benchmark protocol

| Setting | Value |
|---|---|
| dtype | FP32 |
| Protein radius | 15 Å |
| Nucleotide radius | 30 Å |
| K | 256, 512, 1024, 2048 |
| Reservoir seeds | 0, 1, 2 |
| Warmups | 5 per backend block |
| Timed repetitions | 20 per backend block |
| Training measurement | Forward and backward |
| Inference measurement | Forward-only under inference mode |
| Timing statistic | Median CUDA-event time per case/seed block |
| Report aggregation | Mean of per-case, per-seed median timings |
| Memory | Incremental peak allocated CUDA memory above resident inputs |

For accuracy, each sparse scalar loss and predicted-coordinate gradient is
compared with dense smooth lDDT computed on the same structure and perturbed
coordinates.

The reported metrics are:

- absolute scalar-loss error;
- gradient relative L2 error;
- gradient cosine similarity;
- maximum absolute gradient difference in raw artifacts;
- training runtime;
- forward-only runtime;
- incremental peak training memory;
- incremental peak forward memory.

---

## 5. Hardware and software environments

| Property | RTX 4090 study | H800 study |
|---|---|---|
| GPU | NVIDIA GeForce RTX 4090 | NVIDIA H800 |
| Available memory | approximately 24 GiB | 81,559 MiB |
| Driver | recorded in original run artifacts | 550.144.03 |
| PyTorch | 2.5.1 | 2.5.1 |
| Triton | 3.1.0 | 3.1.0 |
| CUDA build | 12.4 | 12.4 |
| Sparse comparison | matched current unweighted | exact historical commit |
| Dense coverage | 50/51 structures | 51/51 structures |

### H800 isolation controls

The H800 host had two GPUs. One was occupied throughout the campaign and was
excluded. All measurements used only:

```text
GPU-6a04420a-ab52-b668-87ae-be5bbd2ca6fd
```

The campaign enforced:

- one benchmark process at a time;
- sequential backend/K blocks;
- an exclusive campaign lock;
- empty-GPU checks before and after each block;
- process and utilization sampling every two seconds;
- termination if a foreign compute process appeared;
- separate Triton caches for current and historical implementations;
- fresh processes to avoid Python module or compiled-kernel contamination.

No overlap was detected. The selected GPU returned to 4 MiB used and 0%
utilization after the campaign.

---

## 6. Validation coverage

### RTX 4090

The four K runs produced 1,428 result rows. All 1,224 sparse rows completed.
Dense completed 50 structures and OOMed only on `8h2h`.

### H800

The four K runs also produced 1,428 result rows:

- 612 current reweighted rows;
- 612 exact historical ball-query rows;
- 204 dense rows;
- 0 failed rows;
- 0 OOM rows.

The H800 therefore adds a dense reference for `8h2h` while reproducing the
50-case numerical comparison used by the RTX report.

---

## 7. Cross-hardware numerical reproducibility

The following table uses the 50-structure common subset because `8h2h` lacks a
dense reference on the RTX 4090. The values from both runs agree to the shown
precision.

| K | Unweighted/original loss error | Reweighted loss error | Unweighted/original gradient L2 | Reweighted gradient L2 | Unweighted/original cosine | Reweighted cosine |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 5.089e-4 | **3.408e-4** | 0.35873 | **0.25090** | 0.92736 | **0.96906** |
| 512 | **3.488e-4** | 4.278e-4 | 0.26738 | **0.25021** | 0.95665 | **0.96995** |
| 1024 | **1.444e-4** | 1.466e-4 | 0.12543 | **0.12198** | 0.98697 | **0.99096** |
| 2048 | 1.70e-5 | 1.71e-5 | 0.02398 | 0.02398 | 0.99884 | 0.99884 |

### Interpretation

- At `K=256`, reweighting improves scalar loss and both gradient metrics.
- At `K=512`, reweighting slightly worsens mean scalar-loss error but improves
  both gradient metrics.
- At `K=1024`, scalar loss is nearly unchanged while both gradient metrics
  improve.
- At `K=2048`, both weights equal one; differences reduce to floating-point
  order.

For training, gradient agreement is the more directly relevant signal. The
scalar loss and its gradient measure different properties, so the small scalar
regressions at `K=512` and `1024` should not be hidden or conflated with the
clear gradient improvement.

### H800 all-51 accuracy

With the H800 dense reference for `8h2h`, the complete 51-case means are:

| K | Exact original gradient L2 | Reweighted gradient L2 | Exact original cosine | Reweighted cosine |
|---:|---:|---:|---:|---:|
| 256 | 0.36025 | **0.25152** | 0.92682 | **0.96887** |
| 512 | 0.26947 | **0.25058** | 0.95608 | **0.96981** |
| 1024 | 0.12824 | **0.12406** | 0.98651 | **0.99062** |
| 2048 | 0.02596 | 0.02596 | 0.99871 | 0.99871 |

The complete-set result supports the same conclusion as the common subset.

---

## 8. Runtime on RTX 4090

The RTX runtime table is the controlled current-kernel comparison and therefore
the primary estimate of isolated reweighting overhead.

| K | Dense train | Matched unweighted train | Reweighted train | Dense forward | Matched unweighted forward | Reweighted forward |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 16.351 ms | 10.244 ms | 10.556 ms | 8.389 ms | 2.941 ms | 2.889 ms |
| 512 | 16.536 ms | 10.721 ms | 11.056 ms | 8.429 ms | 2.717 ms | 2.679 ms |
| 1024 | 16.419 ms | 10.850 ms | 11.187 ms | 8.425 ms | 2.572 ms | 2.537 ms |
| 2048 | 16.177 ms | 12.148 ms | 12.489 ms | 8.345 ms | 2.751 ms | 2.811 ms |

On RTX 4090:

- reweighted training is 2.8–3.1% slower than the matched unweighted current
  reduction;
- the absolute difference is approximately 0.31–0.34 ms;
- forward-only timing has no consistent penalty and remains within 2.2%;
- both sparse backends are faster than dense over the complete executable set.

This small training difference is consistent with the extra `O(A)` type-group
row reduction.

---

## 9. Runtime on H800

The H800 table compares the exact historical implementation with the current
reweighted implementation over all 51 cases.

| K | Dense train | Exact original train | Reweighted train | Dense forward | Exact original forward | Reweighted forward |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 8.584 ms | 8.805 ms | 9.371 ms | 4.946 ms | 3.167 ms | 3.544 ms |
| 512 | 8.552 ms | 8.383 ms | 8.931 ms | 4.959 ms | 2.501 ms | 2.761 ms |
| 1024 | 8.555 ms | 7.722 ms | 8.776 ms | 4.984 ms | 2.104 ms | 2.346 ms |
| 2048 | 8.374 ms | 8.848 ms | 9.325 ms | 4.967 ms | 1.778 ms | 1.846 ms |

Relative to the exact historical commit, the current reweighted implementation
is:

| K | Training difference | Forward difference |
|---:|---:|---:|
| 256 | +6.4% | +11.9% |
| 512 | +6.5% | +10.4% |
| 1024 | +13.7% | +11.5% |
| 2048 | +5.4% | +3.8% |

These percentages include all historical-to-current implementation changes.
They are not estimates of reweighting-only overhead. For that question, use the
RTX matched-current comparison above.

---

## 10. Cross-hardware runtime comparison

### 10.1 Dense

On the RTX-common 50 structures, H800 dense training averages 6.35–6.57 ms,
compared with 16.18–16.54 ms on RTX 4090. This is a reduction of approximately
60%.

Dense forward averages 3.72–3.76 ms on H800 versus 8.35–8.43 ms on RTX 4090,
roughly 55% lower.

### 10.2 Current reweighted sparse backend

Across all 51 H800 cases versus the corresponding RTX aggregate:

| K | RTX reweighted train | H800 reweighted train | Change | RTX reweighted forward | H800 reweighted forward | Change |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 10.556 ms | 9.371 ms | −11.2% | 2.889 ms | 3.544 ms | +22.7% |
| 512 | 11.056 ms | 8.931 ms | −19.2% | 2.679 ms | 2.761 ms | +3.1% |
| 1024 | 11.187 ms | 8.776 ms | −21.5% | 2.537 ms | 2.346 ms | −7.5% |
| 2048 | 12.489 ms | 9.325 ms | −25.3% | 2.811 ms | 1.846 ms | −34.3% |

Sparse forward timing is more launch- and shape-sensitive than dense timing.
The H800 advantage becomes clearer as K increases and each launch performs more
work. At low K, fixed launch overhead and aggregation across many small cases
can dominate.

### 10.3 Scope warning

The RTX and H800 runtime rows are not perfectly symmetric experimental objects:

- the RTX study's unweighted backend is the current matched kernel;
- the H800 study's original backend is historical code;
- H800 aggregates all 51 structures, including `8h2h`, unless stated otherwise;
- RTX dense aggregates only 50 structures.

Numerical comparisons use the common subset where needed. Runtime tables retain
each machine's complete successful coverage and explicitly state that scope.

---

## 11. RTX 4090 memory

The matched current unweighted and reweighted reductions have identical peak
memory in all 612 paired RTX comparisons. This establishes that reweighting
does not add another atom-by-`K` allocation.

| K | Sparse train mean/max | Sparse forward mean/max | Dense train mean/max | Dense forward mean/max |
|---:|---:|---:|---:|---:|
| 256 | 53.89 / 310.62 MiB | 36.54 / 210.56 MiB | 1140.21 / 12836.69 MiB | 569.53 / 6418.59 MiB |
| 512 | 108.12 / 618.58 MiB | 73.25 / 418.52 MiB | 1140.21 / 12836.69 MiB | 569.53 / 6418.59 MiB |
| 1024 | 213.84 / 1212.75 MiB | 144.87 / 821.75 MiB | 1140.21 / 12836.69 MiB | 569.53 / 6418.59 MiB |
| 2048 | 406.14 / 2424.66 MiB | 275.12 / 1642.72 MiB | 1140.21 / 12836.69 MiB | 569.53 / 6418.59 MiB |

Sparse maxima include `8h2h`; dense maxima do not, because RTX dense OOMs on
that case.

---

## 12. H800 memory

The H800 exact-historical comparison shows the effect of the complete current
implementation, including compaction changes.

| K | Reweighted train mean/max | Exact original train mean/max | Reweighted forward mean/max | Exact original forward mean/max |
|---:|---:|---:|---:|---:|
| 256 | 53.89 / 310.62 MiB | 59.17 / 340.39 MiB | 36.54 / 210.56 MiB | 48.76 / 280.62 MiB |
| 512 | 108.12 / 618.58 MiB | 118.42 / 673.59 MiB | 73.25 / 418.52 MiB | 97.63 / 554.73 MiB |
| 1024 | 213.84 / 1212.75 MiB | 234.18 / 1330.03 MiB | 144.87 / 821.75 MiB | 193.05 / 1095.70 MiB |
| 2048 | 406.14 / 2424.66 MiB | 445.12 / 2659.67 MiB | 275.12 / 1642.72 MiB | 366.63 / 2190.78 MiB |

Relative to the exact historical implementation, the current implementation
uses approximately:

- 8.8–9.0% less incremental training memory;
- 25% less incremental forward memory.

This does not conflict with the RTX finding that matched current weighted and
unweighted reductions use identical memory. The two statements answer
different questions:

- row reweighting itself adds no measurable peak allocation;
- the broader current implementation is more compact than the old commit.

---

## 13. Dense memory and the `8h2h` case

The H800 completes dense smooth lDDT on all structures. Across all 51 cases,
dense incremental memory is:

- training: **1597.34 MiB mean / 24453.83 MiB max**;
- forward: **798.11 MiB mean / 12227.26 MiB max**.

The maxima come from `8h2h`. On that structure alone:

| Backend/configuration | Train time | Forward time | Train peak | Forward peak |
|---|---:|---:|---:|---:|
| Dense | ~109.3 ms | ~66.2 ms | 24453.83 MiB | 12227.26 MiB |
| Reweighted K=256 | 33.35 ms | 28.06 ms | 310.62 MiB | 210.56 MiB |
| Reweighted K=512 | 32.23 ms | 25.05 ms | 618.58 MiB | 418.52 MiB |
| Reweighted K=1024 | 34.10 ms | 20.64 ms | 1212.75 MiB | 821.75 MiB |
| Reweighted K=2048 | 36.47 ms | 9.88 ms | 2424.66 MiB | 1642.72 MiB |

At the default `K=512`, sparse training uses about **39.5× less incremental
memory** than dense on `8h2h`, while completing substantially faster.

The RTX 4090 OOM is therefore expected: the measured H800 incremental dense
training peak alone is approximately 23.9 GiB, before accounting for resident
inputs, runtime context, allocator fragmentation, and other process memory.

---

## 14. Large-structure behavior

### 14.1 RTX 4090 large cases

The original RTX table reports reweighted accuracy over the five large cases
with dense references and runtime/memory over all six sparse cases.

| K | Reweighted loss error | Gradient L2 | Cosine | Train | Forward | Train/forward max memory |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 2.003e-4 | 0.27043 | 0.96297 | 13.379 ms | 7.043 ms | 310.62 / 210.56 MiB |
| 512 | 1.857e-4 | 0.22982 | 0.97270 | 13.971 ms | 6.189 ms | 618.58 / 418.52 MiB |
| 1024 | 1.232e-4 | 0.18106 | 0.98359 | 17.159 ms | 6.322 ms | 1212.75 / 821.75 MiB |
| 2048 | 8.049e-5 | 0.12761 | 0.99213 | 26.260 ms | 7.639 ms | 2424.66 / 1642.72 MiB |

### 14.2 H800 large cases

The H800 table includes dense accuracy for all six cases.

| K | Reweighted loss error | Gradient L2 | Cosine | Train | Forward | Train/forward max memory |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 1.836e-4 | 0.27244 | 0.96235 | 16.694 ms | 12.117 ms | 310.62 / 210.56 MiB |
| 512 | 1.681e-4 | 0.23641 | 0.97109 | 14.654 ms | 9.074 ms | 618.58 / 418.52 MiB |
| 1024 | 1.187e-4 | 0.18890 | 0.98193 | 14.993 ms | 7.266 ms | 1212.75 / 821.75 MiB |
| 2048 | 7.431e-5 | 0.12714 | 0.99217 | 16.958 ms | 4.858 ms | 2424.66 / 1642.72 MiB |

The accuracy difference between these tables primarily reflects inclusion of
`8h2h` in the H800 dense-reference set. Memory maxima are hardware-independent
allocator results and match across the current sparse implementation.

---

## 15. Scaling analysis

### 15.1 Sparse memory scales with K

Doubling K approximately doubles sparse memory:

- K=256: 53.89 MiB mean training memory;
- K=512: 108.12 MiB;
- K=1024: 213.84 MiB;
- K=2048: 406.14 MiB.

The relationship is not perfectly proportional because resident inputs and
`O(A)` metadata do not scale with K, but the dominant reservoir allocation does.

### 15.2 Dense memory scales with atom-pair count

Dense memory is independent of K and strongly dependent on structure size. Its
maximum rises from 12.84 GiB on the RTX-executable subset to 24.45 GiB when the
20,016-atom case is included.

### 15.3 Accuracy improves with K

Increasing K reduces truncation:

- gradient relative L2 falls from approximately 0.25 at K=256/512 to 0.122 at
  K=1024 and 0.024 at K=2048 for the reweighted common subset;
- cosine rises from approximately 0.969 to 0.991 and then 0.999;
- memory rises approximately linearly.

K therefore exposes a direct memory-versus-fidelity control.

---

## 16. Recommended default and operating points

### K=512: recommended default

`K=512` remains the recommended default when training memory and throughput are
important:

- it retains the intended 1:4 non-nucleotide/nucleotide correction;
- it improves gradient agreement over unweighted/original K=512;
- it uses about 108 MiB mean and 619 MiB maximum incremental training memory
  over this demanding 51-case set;
- isolated reweighting overhead on RTX 4090 is approximately 3%;
- it completes the 20,016-atom case with only 619 MiB incremental training
  allocation on H800.

### K=1024: higher-fidelity middle ground

Choose `K=1024` when roughly doubling K=512 reservoir memory is acceptable:

- gradient relative L2 improves from 0.250 to 0.122;
- cosine improves from 0.970 to 0.991;
- mean training memory rises from 108 to 214 MiB.

### K=2048: near-dense gradients

Choose `K=2048` when near-dense gradients justify the memory cost:

- relative L2 is approximately 0.024;
- cosine is approximately 0.999;
- both type weights equal one, so the correction is inactive;
- mean training memory is about 406 MiB and the largest case uses 2.42 GiB.

### K=256: minimum-memory mode

`K=256` minimizes reservoir memory and benefits most strongly from reweighting,
but gradient approximation remains less accurate than at larger K.

---

## 17. Conclusions

The combined RTX 4090 and H800 evidence supports the following conclusions.

1. **The numerical benefit is reproducible.** The H800 reproduces the RTX
   4090 accuracy table to displayed precision on the common 50 structures.
2. **Reweighting improves the training signal.** Gradient relative L2 and
   cosine improve at K=256, 512, and 1024.
3. **The scalar-loss trade-off is small and explicit.** Mean scalar error
   improves at K=256 but is slightly worse at K=512 and K=1024.
4. **Reweighting itself has low overhead.** On the controlled matched-current
   RTX comparison, training overhead is approximately 3% and forward overhead
   is inconsistent/negligible.
5. **Reweighting adds no atom-by-K memory allocation.** Matched current weighted
   and unweighted peaks are identical in all 612 RTX pairs.
6. **The current implementation is more compact than the historical one.** The
   H800 exact-commit comparison shows about 9% lower training memory and 25%
   lower forward memory.
7. **Sparse scaling removes the dense memory barrier.** Every sparse case
   completes on both GPUs. Dense fails on the largest case on RTX 4090 and
   consumes 24.45 GiB incremental training memory on H800.
8. **K=512 is a practical default.** It provides improved gradient fidelity,
   low overhead, and a large memory reduction while preserving configurability
   for higher-fidelity K values.

Overall, the reweighted ball-query smooth-lDDT backend provides a strong
replacement for dense smooth lDDT in memory-constrained all-atom training. It
preserves controllable fidelity, improves the bias introduced by a shared
truncated reservoir, and remains practical from RTX-class accelerators through
large-memory data-center GPUs.

---

## 18. Validation and artifact inventory

### RTX 4090 source report

```text
/inspire/ssd/tenant_predefaa-9a1b-4522-bb10-8850f313be13/global_user/3078-linziqian/projects/of3_workbench/pr_reweighting.md
```

### H800 source report

```text
/inspire/ssd/tenant_predefaa-9a1b-4522-bb10-8850f313be13/global_user/3078-linziqian/projects/of3_workbench/pr_reweighting_h800.md
```

### H800 benchmark bundle

```text
/inspire/ssd/tenant_predefaa-9a1b-4522-bb10-8850f313be13/global_user/3078-linziqian/projects/of3_workbench/h800-reweighting-benchmark/
```

The bundle contains:

- `results/`: raw JSON, CSV, and streaming JSONL rows;
- `analysis.json`: validated aggregates;
- `logs/`: environment, campaign, per-block, and GPU-monitor logs;
- `dataset/protein_rna_51_cases_full/`: immutable uncropped benchmark cases;
- `historical-074d75c2/`: exact historical source snapshot;
- `benchmark_one_backend.py`: isolated-process benchmark harness;
- `run_campaign.sh`: sequential single-GPU campaign runner;
- `analyze_results.py`: row validation and aggregation.

The OpenFold3 source checkout remained clean after testing.
