### PR TITLE
fix: use bin centers, not left edges, for pLDDT/PAE/PDE classificatio…

### DIFF
--- a/openfold3/core/loss/confidence.py
+++ b/openfold3/core/loss/confidence.py
@@ -257,7 +257,8 @@ def all_atom_plddt_loss(
     # Compute binned lddt
     # [*, N_atom, no_bins]
     bin_size = (bin_max - bin_min) / no_bins
-    v_bins = bin_min + torch.arange(no_bins, device=x.device) * bin_size
+    bin_min_offset = bin_min + bin_size / 2
+    v_bins = bin_min_offset + torch.arange(no_bins, device=x.device) * bin_size
     lddt_b = binned_one_hot(lddt, v_bins).to(dtype=x.dtype)
 
     errors = softmax_cross_entropy(logits, lddt_b)
@@ -344,7 +345,8 @@ def pae_loss(
     # Compute binned alignment error
     # [*, N_token, N_token, no_bins]
     bin_size = (bin_max - bin_min) / no_bins
-    v_bins = bin_min + torch.arange(no_bins, device=logits.device) * bin_size
+    bin_min_offset = bin_min + bin_size / 2
+    v_bins = bin_min_offset + torch.arange(no_bins, device=logits.device) * bin_size
     e_b = binned_one_hot(e, v_bins).to(dtype=logits.dtype)
 
     # Compute predicted alignment error
@@ -414,7 +416,8 @@ def pde_loss(
 
     # Compute binned prediction target
     bin_size = (bin_max - bin_min) / no_bins
-    v_bins = bin_min + torch.arange(no_bins, device=e.device) * bin_size
+    bin_min_offset = bin_min + bin_size / 2
+    v_bins = bin_min_offset + torch.arange(no_bins, device=e.device) * bin_size
     e_b = binned_one_hot(e, v_bins).to(dtype=e.dtype)
 
     pair_mask = (rep_atom_mask_gt[..., None] * rep_atom_mask_gt[..., None, :]).bool()

--- a/openfold3/tests/test_confidence_loss.py
+++ b/openfold3/tests/test_confidence_loss.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
@@ -24,6 +25,8 @@ from openfold3.core.loss.confidence import (
     pae_loss,
     pde_loss,
 )
+from openfold3.core.metrics.confidence import get_bin_centers
+from openfold3.core.utils.tensor_utils import binned_one_hot
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 
 
@@ -154,6 +157,133 @@ class TestConfidenceLoss(unittest.TestCase):
         )
 
         self.assertTrue(l_pde.shape == (batch_size,))
+
+    def test_plddt_loss_target_bins_match_decoder_bin_centers(self):
+        """Regression test: the bin grid used to assign classification targets in
+        all_atom_plddt_loss must match the bin grid get_bin_centers uses to decode
+        predicted bin probabilities back into a pLDDT score at inference time.
+
+        Previously the target grid used bin left-edges (bin_min + k*bin_size) instead
+        of bin centers (bin_min + (k+0.5)*bin_size), so the network was trained
+        against a grid shifted half a bin width from the one its output is decoded
+        against.
+        """
+        no_bins = 50
+        eps = 1e-8
+        bin_min = 0
+        bin_max = 1
+
+        batch = self.setup_features()
+        batch_size, n_atom = batch["ground_truth"]["atom_resolved_mask"].shape
+
+        x = torch.randn_like(batch["ground_truth"]["atom_positions"])
+        logits = torch.randn((batch_size, n_atom, no_bins))
+
+        with patch(
+            "openfold3.core.loss.confidence.binned_one_hot", wraps=binned_one_hot
+        ) as mock_binned_one_hot:
+            all_atom_plddt_loss(
+                batch=batch,
+                x=x,
+                logits=logits,
+                no_bins=no_bins,
+                bin_min=bin_min,
+                bin_max=bin_max,
+                eps=eps,
+            )
+
+        v_bins_used = mock_binned_one_hot.call_args.args[1]
+        expected_bin_centers = get_bin_centers(
+            bin_min=bin_min,
+            bin_max=bin_max,
+            no_bins=no_bins,
+            device=v_bins_used.device,
+            dtype=v_bins_used.dtype,
+        )
+
+        torch.testing.assert_close(v_bins_used, expected_bin_centers)
+
+    def test_pae_loss_target_bins_match_decoder_bin_centers(self):
+        """Regression test: see test_plddt_loss_target_bins_match_decoder_bin_centers.
+        Same left-edge-vs-center bug, in pae_loss.
+        """
+        angle_threshold = 25
+        no_bins = 64
+        bin_min = 0
+        bin_max = 32
+        eps = 1e-8
+        inf = 1e10
+
+        batch = self.setup_features()
+        batch_size, n_token = batch["token_mask"].shape
+
+        x = torch.randn_like(batch["ground_truth"]["atom_positions"])
+        logits = torch.randn((batch_size, n_token, n_token, no_bins))
+
+        with patch(
+            "openfold3.core.loss.confidence.binned_one_hot", wraps=binned_one_hot
+        ) as mock_binned_one_hot:
+            pae_loss(
+                batch=batch,
+                x=x,
+                logits=logits,
+                angle_threshold=angle_threshold,
+                no_bins=no_bins,
+                bin_min=bin_min,
+                bin_max=bin_max,
+                eps=eps,
+                inf=inf,
+            )
+
+        v_bins_used = mock_binned_one_hot.call_args.args[1]
+        expected_bin_centers = get_bin_centers(
+            bin_min=bin_min,
+            bin_max=bin_max,
+            no_bins=no_bins,
+            device=v_bins_used.device,
+            dtype=v_bins_used.dtype,
+        )
+
+        torch.testing.assert_close(v_bins_used, expected_bin_centers)
+
+    def test_pde_loss_target_bins_match_decoder_bin_centers(self):
+        """Regression test: see test_plddt_loss_target_bins_match_decoder_bin_centers.
+        Same left-edge-vs-center bug, in pde_loss.
+        """
+        no_bins = 64
+        bin_min = 0
+        bin_max = 32
+        eps = 1e-8
+
+        batch = self.setup_features()
+        batch_size, n_token = batch["token_mask"].shape
+
+        x = torch.randn_like(batch["ground_truth"]["atom_positions"])
+        logits = torch.randn((batch_size, n_token, n_token, no_bins))
+
+        with patch(
+            "openfold3.core.loss.confidence.binned_one_hot", wraps=binned_one_hot
+        ) as mock_binned_one_hot:
+            pde_loss(
+                batch=batch,
+                x=x,
+                logits=logits,
+                no_bins=no_bins,
+                bin_min=bin_min,
+                bin_max=bin_max,
+                eps=eps,
+            )
+
+        v_bins_used = mock_binned_one_hot.call_args.args[1]
+        expected_bin_centers = get_bin_centers(
+            bin_min=bin_min,
+            bin_max=bin_max,
+            no_bins=no_bins,
+            device=v_bins_used.device,
+            dtype=v_bins_used.dtype,
+        )
+
+        torch.testing.assert_close(v_bins_used, expected_bin_centers)
 
     def test_resolved_loss(self):
         no_bins = 2


### PR DESCRIPTION
## Summary

`all_atom_plddt_loss`, `pae_loss`, and `pde_loss` each discretize a continuous error value into classification bins via `binned_one_hot(x, v_bins)`, which assigns `x` to whichever entry of `v_bins` is nearest. All three built
`v_bins` as `bin_min + arange(no_bins) * bin_size` — the **left edge** of each bin — instead of the bin center.

`get_bin_centers` (`core/metrics/confidence.py`), which decodes predicted bin probabilities back into pLDDT/PAE/PDE scores at inference time, and `all_atom_distogram_loss`'s target-binning both correctly use `bin_min + bin_size/2 + arange(no_bins) * bin_size`.

## Impact

The mismatch meant these three losses were trained against a grid shifted half a bin width from the grid their own output is decoded against, on essentially every training step (confidence losses are enabled by default). This is a systematic, silent miscalibration of every reported pLDDT/PAE/PDE score — it doesn't affect predicted coordinates (distogram/diffusion/FAPE
losses are unaffected), only the confidence heads' training signal and the scores derived from them.

## Changes

- `openfold3/core/loss/confidence.py`: add the `bin_size / 2` offset in `all_atom_plddt_loss`, `pae_loss`, and `pde_loss`, mirroring the pattern `distogram.py` already uses correctly.

## Testing

Added one regression test per loss in `openfold3/tests/test_confidence_loss.py` that patches `binned_one_hot` to capture the `v_bins` it's actually called with and asserts it matches `get_bin_centers`'s output for the same `bin_min`/`bin_max`/`no_bins`. Confirmed each new test fails against the pre-fix code and passes after. Full existing test suite for these losses (`test_confidence_loss.py`, `test_distogram_loss.py`, `test_diffusion_loss.py`, `test_loss_weights.py`) passes with no regressions. `ruff format --check` and `ruff check` clean.