### PR TITLE
automatically load user-default runner.yml from cache directory

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -9,6 +9,7 @@ The configuration file is organized into several main sections. Each section cor
 ## 2. Important Notes
 
 - **Selective Configuration**: Only specify the settings you want to override in your runner YAML file. All unspecified options will use their default values.
+- **Default Cache Configuration**: Placing a `runner.yml` in `$OPENFOLD_CACHE` (or `~/.openfold3/runner.yml`) automatically sets it as the baseline configuration for all inference runs. This is merged with any explicitly passed `--runner-yaml` file.
 - **Command-line Priority**: Command-line arguments take precedence and will override any values specified in the YAML file.
 - **Reference Implementation**: The full configuration file serves as a reference - create your own simplified runner YAML based on your specific needs. See `examples/example_runner_yamls/` for common usage examples.
 
@@ -107,6 +108,7 @@ model_update:
   - Must be a key in `OPENFOLD_MODEL_CHECKPOINT_REGISTRY`(https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/entry_points/parameters.py#L29)
 - `cache_path` *(Path | None)*: Directory for storing cached model parameters
   - Default: `$HOME/.openfold3/`
+- `user_default_runner_yaml_path` *(Path | None)*: Path to the automatically loaded user-default `runner.yml`. Recorded in `experiment_config.json` for run traceability.
 
 ---
 

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -215,6 +215,12 @@ The model parameters section of the configuration may by passing an update in th
 
 Note that CLI arguments take precedence over configuration file settings.
 
+#### 🏠 Persistent User-Default Configuration
+
+OpenFold3 automatically searches for a base `runner.yml` at `$OPENFOLD_CACHE/runner.yml` (defaults to `~/.openfold3/runner.yml`). If found, it applies these settings globally without requiring the `--runner-yaml` flag.
+
+*Note: The path of the loaded default configuration is tracked in `experiment_config.json` under `"user_default_runner_yaml_path"`.*
+
 Below we'll walk through some of the most common configuration scenarios and how to implement them:
 
 

--- a/openfold3/entry_points/validator.py
+++ b/openfold3/entry_points/validator.py
@@ -297,6 +297,7 @@ class ExperimentConfig(BaseModel):
     experiment_settings: ExperimentSettings
     pl_trainer_args: PlTrainerArgs = PlTrainerArgs()
     model_update: ModelUpdate
+    user_default_runner_yaml_path: Path | None = None
 
 
 class TrainingExperimentConfig(ExperimentConfig):

--- a/openfold3/run_openfold.py
+++ b/openfold3/run_openfold.py
@@ -20,12 +20,14 @@ Main run script for OpenFold3. Please see the README for usage details.
 # ruff: noqa: F821
 
 import logging
+import os
 from pathlib import Path
 
 import click
 
 from openfold3.core.config import config_utils
 from openfold3.entry_points.import_utils import _torch_gpu_setup
+from openfold3.entry_points.parameters import DEFAULT_CACHE_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -177,11 +179,25 @@ def predict(
     )
 
     logging.basicConfig(level=logging.INFO)
-    runner_args = config_utils.load_yaml(runner_yaml) if runner_yaml else dict()
+
+    default_yml = (
+        Path(os.environ.get("OPENFOLD_CACHE") or DEFAULT_CACHE_PATH) / "runner.yml"
+    )
+    user_default_runner_path = None
+
+    if default_yml.exists():
+        runner_args = config_utils.load_yaml(default_yml)
+        user_default_runner_path = default_yml.resolve()
+    else:
+        runner_args = dict()
+
+    if runner_yaml:
+        config_utils.deep_update(runner_args, config_utils.load_yaml(runner_yaml))
 
     expt_config = InferenceExperimentConfig(
         inference_ckpt_path=inference_ckpt_path,
         inference_ckpt_name=inference_ckpt_name,
+        user_default_runner_yaml_path=user_default_runner_path,
         **runner_args,
     )
     expt_runner = InferenceExperimentRunner(

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -831,12 +831,11 @@ class TestUserDefaultRunnerYaml:
     def test_no_default_runner_yaml(self, tmp_path, dummy_ckpt_file):
         """Scenario 1: no runner.yml in cache → defaults, path is None."""
         cache = tmp_path / ".openfold3"
-        
+
         cfg = _build_inference_config(dummy_ckpt_file, cache_path=cache)
 
         assert cfg.user_default_runner_yaml_path is None
         assert cfg.output_writer_settings.structure_format == "cif"
-
 
     def test_default_runner_yaml_applied(self, tmp_path, dummy_ckpt_file):
         """Scenario 2: runner.yml in cache → settings applied, path recorded."""
@@ -896,10 +895,10 @@ class TestUserDefaultRunnerYaml:
     def test_corrupted_runner_yaml_raises_error(self, tmp_path, dummy_ckpt_file):
         """Scenario 4: cache runner.yml is corrupted → fails gracefully with yaml error."""
         import yaml
-        
+
         cache = tmp_path / ".openfold3"
         cache.mkdir()
-        
+
         # Write an intentionally malformed YAML (indentation error)
         (cache / "runner.yml").write_text(
             textwrap.dedent("""\
@@ -909,7 +908,7 @@ class TestUserDefaultRunnerYaml:
                 """)
         )
 
-        # Verify that when attempting to build the configuration, 
+        # Verify that when attempting to build the configuration,
         # the system raises a YAML error, preventing silent failures.
         with pytest.raises(yaml.YAMLError):
             _build_inference_config(dummy_ckpt_file, cache_path=cache)

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -799,40 +799,12 @@ class TestRemoveQuerySetDuplicates:
         assert set(deduplicated_set.queries.keys()) == set(["query_2", "query_3"])
 
 
-def _build_inference_config(
-    ckpt_path: Path,
-    cache_path: Path,
-    runner_yaml: Path | None = None,
-) -> InferenceExperimentConfig:
-    """Mirrors the default-yaml resolution logic in ``run_openfold.predict``."""
-    default_yml = cache_path / "runner.yml"
-    user_default_runner_path = None
-
-    if default_yml.exists():
-        runner_args = config_utils.load_yaml(default_yml)
-        user_default_runner_path = default_yml.resolve()
-    else:
-        runner_args = {}
-
-    if runner_yaml:
-        config_utils.deep_update(runner_args, config_utils.load_yaml(runner_yaml))
-
-    return InferenceExperimentConfig(
-        inference_ckpt_path=ckpt_path,
-        cache_path=cache_path,
-        user_default_runner_yaml_path=user_default_runner_path,
-        **runner_args,
-    )
-
-
 class TestUserDefaultRunnerYaml:
     """Tests for the automatic loading of ``~/.openfold3/runner.yml``."""
 
-    def test_no_default_runner_yaml(self, tmp_path, dummy_ckpt_file):
+    def test_no_default_runner_yaml(self, dummy_ckpt_file):
         """Scenario 1: no runner.yml in cache → defaults, path is None."""
-        cache = tmp_path / ".openfold3"
-
-        cfg = _build_inference_config(dummy_ckpt_file, cache_path=cache)
+        cfg = InferenceExperimentConfig(inference_ckpt_path=dummy_ckpt_file)
 
         assert cfg.user_default_runner_yaml_path is None
         assert cfg.output_writer_settings.structure_format == "cif"
@@ -841,7 +813,8 @@ class TestUserDefaultRunnerYaml:
         """Scenario 2: runner.yml in cache → settings applied, path recorded."""
         cache = tmp_path / ".openfold3"
         cache.mkdir()
-        (cache / "runner.yml").write_text(
+        runner_yaml = cache / "runner.yml"
+        runner_yaml.write_text(
             textwrap.dedent("""\
                 output_writer_settings:
                     structure_format: pdb
@@ -851,7 +824,11 @@ class TestUserDefaultRunnerYaml:
                     num_workers: 4
                 """)
         )
-        cfg = _build_inference_config(dummy_ckpt_file, cache_path=cache)
+        cfg = InferenceExperimentConfig(
+            inference_ckpt_path=dummy_ckpt_file,
+            user_default_runner_yaml_path=runner_yaml.resolve(),
+            **config_utils.load_yaml(runner_yaml)
+        )
 
         assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()
         assert cfg.output_writer_settings.structure_format == "pdb"
@@ -862,7 +839,8 @@ class TestUserDefaultRunnerYaml:
         """Scenario 3: cache runner.yml + explicit override → merge, CLI wins."""
         cache = tmp_path / ".openfold3"
         cache.mkdir()
-        (cache / "runner.yml").write_text(
+        runner_yaml = cache / "runner.yml"
+        runner_yaml.write_text(
             textwrap.dedent("""\
                 output_writer_settings:
                     structure_format: pdb
@@ -881,8 +859,14 @@ class TestUserDefaultRunnerYaml:
                     num_workers: 8
                 """)
         )
-        cfg = _build_inference_config(
-            dummy_ckpt_file, cache_path=cache, runner_yaml=override
+        
+        runner_args = config_utils.load_yaml(runner_yaml)
+        config_utils.deep_update(runner_args, config_utils.load_yaml(override))
+
+        cfg = InferenceExperimentConfig(
+            inference_ckpt_path=dummy_ckpt_file,
+            user_default_runner_yaml_path=runner_yaml.resolve(),
+            **runner_args
         )
 
         assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()
@@ -899,8 +883,10 @@ class TestUserDefaultRunnerYaml:
         cache = tmp_path / ".openfold3"
         cache.mkdir()
 
+        runner_yaml = cache / "runner.yml"
+
         # Write an intentionally malformed YAML (indentation error)
-        (cache / "runner.yml").write_text(
+        runner_yaml.write_text(
             textwrap.dedent("""\
                 output_writer_settings:
                   structure_format: pdb
@@ -911,7 +897,7 @@ class TestUserDefaultRunnerYaml:
         # Verify that when attempting to build the configuration,
         # the system raises a YAML error, preventing silent failures.
         with pytest.raises(yaml.YAMLError):
-            _build_inference_config(dummy_ckpt_file, cache_path=cache)
+            config_utils.load_yaml(runner_yaml)
 
 
 class TestSetupOpenFold:

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -799,6 +799,122 @@ class TestRemoveQuerySetDuplicates:
         assert set(deduplicated_set.queries.keys()) == set(["query_2", "query_3"])
 
 
+def _build_inference_config(
+    ckpt_path: Path,
+    cache_path: Path,
+    runner_yaml: Path | None = None,
+) -> InferenceExperimentConfig:
+    """Mirrors the default-yaml resolution logic in ``run_openfold.predict``."""
+    default_yml = cache_path / "runner.yml"
+    user_default_runner_path = None
+
+    if default_yml.exists():
+        runner_args = config_utils.load_yaml(default_yml)
+        user_default_runner_path = default_yml.resolve()
+    else:
+        runner_args: dict = {}
+
+    if runner_yaml:
+        config_utils.deep_update(runner_args, config_utils.load_yaml(runner_yaml))
+
+    return InferenceExperimentConfig(
+        inference_ckpt_path=ckpt_path,
+        cache_path=cache_path,
+        user_default_runner_yaml_path=user_default_runner_path,
+        **runner_args,
+    )
+
+
+class TestUserDefaultRunnerYaml:
+    """Tests for the automatic loading of ``~/.openfold3/runner.yml``."""
+
+    def test_no_default_runner_yaml(self, tmp_path, dummy_ckpt_file):
+        """Scenario 1: no runner.yml in cache → defaults, path is None."""
+        cache = tmp_path / ".openfold3"
+        
+        cfg = _build_inference_config(dummy_ckpt_file, cache_path=cache)
+
+        assert cfg.user_default_runner_yaml_path is None
+        assert cfg.output_writer_settings.structure_format == "cif"
+
+
+    def test_default_runner_yaml_applied(self, tmp_path, dummy_ckpt_file):
+        """Scenario 2: runner.yml in cache → settings applied, path recorded."""
+        cache = tmp_path / ".openfold3"
+        cache.mkdir()
+        (cache / "runner.yml").write_text(
+            textwrap.dedent("""\
+                output_writer_settings:
+                    structure_format: pdb
+                experiment_settings:
+                    skip_existing: true
+                data_module_args:
+                    num_workers: 4
+                """)
+        )
+        cfg = _build_inference_config(dummy_ckpt_file, cache_path=cache)
+
+        assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()
+        assert cfg.output_writer_settings.structure_format == "pdb"
+        assert cfg.experiment_settings.skip_existing is True
+        assert cfg.data_module_args.num_workers == 4
+
+    def test_explicit_runner_yaml_overrides_cache(self, tmp_path, dummy_ckpt_file):
+        """Scenario 3: cache runner.yml + explicit override → merge, CLI wins."""
+        cache = tmp_path / ".openfold3"
+        cache.mkdir()
+        (cache / "runner.yml").write_text(
+            textwrap.dedent("""\
+                output_writer_settings:
+                    structure_format: pdb
+                experiment_settings:
+                    skip_existing: true
+                data_module_args:
+                    num_workers: 4
+                """)
+        )
+        override = tmp_path / "override.yml"
+        override.write_text(
+            textwrap.dedent("""\
+                experiment_settings:
+                    skip_existing: false
+                data_module_args:
+                    num_workers: 8
+                """)
+        )
+        cfg = _build_inference_config(
+            dummy_ckpt_file, cache_path=cache, runner_yaml=override
+        )
+
+        assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()
+        # inherited from cache default
+        assert cfg.output_writer_settings.structure_format == "pdb"
+        # overridden by explicit yaml
+        assert cfg.experiment_settings.skip_existing is False
+        assert cfg.data_module_args.num_workers == 8
+
+    def test_corrupted_runner_yaml_raises_error(self, tmp_path, dummy_ckpt_file):
+        """Scenario 4: cache runner.yml is corrupted → fails gracefully with yaml error."""
+        import yaml
+        
+        cache = tmp_path / ".openfold3"
+        cache.mkdir()
+        
+        # Write an intentionally malformed YAML (indentation error)
+        (cache / "runner.yml").write_text(
+            textwrap.dedent("""\
+                output_writer_settings:
+                  structure_format: pdb
+                 bad_indentation: true
+                """)
+        )
+
+        # Verify that when attempting to build the configuration, 
+        # the system raises a YAML error, preventing silent failures.
+        with pytest.raises(yaml.YAMLError):
+            _build_inference_config(dummy_ckpt_file, cache_path=cache)
+
+
 class TestSetupOpenFold:
     def test_non_interactive(self, tmp_path):
         env_patch = patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=False)

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -827,7 +827,7 @@ class TestUserDefaultRunnerYaml:
         cfg = InferenceExperimentConfig(
             inference_ckpt_path=dummy_ckpt_file,
             user_default_runner_yaml_path=runner_yaml.resolve(),
-            **config_utils.load_yaml(runner_yaml)
+            **config_utils.load_yaml(runner_yaml),
         )
 
         assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()
@@ -859,14 +859,14 @@ class TestUserDefaultRunnerYaml:
                     num_workers: 8
                 """)
         )
-        
+
         runner_args = config_utils.load_yaml(runner_yaml)
         config_utils.deep_update(runner_args, config_utils.load_yaml(override))
 
         cfg = InferenceExperimentConfig(
             inference_ckpt_path=dummy_ckpt_file,
             user_default_runner_yaml_path=runner_yaml.resolve(),
-            **runner_args
+            **runner_args,
         )
 
         assert cfg.user_default_runner_yaml_path == (cache / "runner.yml").resolve()

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -812,7 +812,7 @@ def _build_inference_config(
         runner_args = config_utils.load_yaml(default_yml)
         user_default_runner_path = default_yml.resolve()
     else:
-        runner_args: dict = {}
+        runner_args = {}
 
     if runner_yaml:
         config_utils.deep_update(runner_args, config_utils.load_yaml(runner_yaml))


### PR DESCRIPTION

**Summary**

This PR addresses Issue #40 by implementing the automatic detection and loading of a base runner.yml configuration file from the user's cache directory (defaulting to ~/.openfold3/runner.yml).

The primary motivation is to allow users to set defaults (such as disabling use_deepspeed_evo_attention) without the friction of passing a custom --runner-yaml flag on every single execution.

Additionally, to maintain traceability, this PR records the path of the loaded base file in the final experiment_config.json, making it easier to audit the trail of config updates.

Note: While the original issue stems from memory constraints, the manual tests below use output formats to verify the same underlying behavior.

**Changes**

1. **Automatic base configuration detection (`openfold3/run_openfold.py`)**:
   - Added logic to detect if a `runner.yml` file exists in the path specified by the `$OPENFOLD_CACHE` environment variable or in `DEFAULT_CACHE_PATH`.
   - If the file exists, its values are loaded as the base configuration.
   - If the user additionally provides a file via the `--runner-yaml` CLI flag, it is applied on top of the base configuration using `config_utils.deep_update`.
2. **Configuration traceability (`openfold3/entry_points/validator.py`)**:
   - Added the optional `user_default_runner_yaml_path` field to the `ExperimentConfig` model. This allows the path of the local `runner.yml` to be recorded in the final `experiment_config.json`, making it easier to audit the parameters applied during each run.

**Related Issues**

Solves #40 

**Testing**

**Manual Tests**
Three testing scenarios were executed, assuming the OpenFold cache is located at `~/.openfold3`:

- **Scenario 1 (No default configuration file):**
   - **Condition**: No `runner.yml` exists in the local cache.
   - **Result**: The inference pipeline ran correctly with the application's default parameters. In the generated `experiment_config.json`, the `"user_default_runner_yaml_path"` field was set to `null`.
   - **Output format**: `cif.gz` (default).

- **Scenario 2 (With configuration file in cache):**
   - **Condition**: The following `runner.yml` was placed at `~/.openfold3/runner.yml`:
     ```yaml
     # 1. Output structures directly in PDB format for PyMOL/ChimeraX
     output_writer_settings:
       structure_format: pdb
       full_confidence_output_format: npz
     # 2. Skip queries that are already generated (saves re-running time)
     experiment_settings:
       skip_existing: true
     # 3. CPU threads optimization
     data_module_args:
       num_workers: 4
     # 4. Optional GPU attention tweak (if needed)
     model_update:
       custom:
         settings:
           memory:
             eval:
               use_deepspeed_evo_attention: false
     ```
   - **Result**: The parameters were successfully applied. The output structures were generated in **PDB** format. In the generated `experiment_config.json`, the field was properly recorded as `"user_default_runner_yaml_path": "/home/$USER/.openfold3/runner.yml"`.

- **Scenario 3 (Merging default configuration with explicit `--runner-yaml`):**
   - **Condition**: Keeping the base file in the cache (`~/.openfold3/runner.yml` with `structure_format: pdb`), inference was run by explicitly passing the `--runner-yaml override.yml` flag. The local `override.yml` file contained the following configuration:
     ```yaml
     experiment_settings:
       skip_existing: false
     data_module_args:
       num_workers: 8
     ```
   - **Result**: The merge was performed successfully. In the generated `experiment_config.json`, it was verified that:
     1. `"user_default_runner_yaml_path"` correctly pointed to the cached file (`/home/$USER/.openfold3/runner.yml`).
     2. `"structure_format"` was inherited as `"pdb"` (from the base configuration).
     3. `"skip_existing"` was set to `false` and `"num_workers"` to `8` (successfully overwritten/added by the explicit `override.yml` file).

### ⚙️ **Automated Tests**
The unit test suite was executed using the following command:
```bash
pixi run -e openfold3-cuda12 pytest openfold3/tests/*
```
- **Hardware used**: NVIDIA GeForce RTX 3060 (12GB VRAM).
- **Results**: 
   - The vast majority of tests completed successfully.
   - Two expected Out of Memory (OOM) failures occurred due to the VRAM limitations of the GPU used:
     - `test_shape_large_bf16_train` (requires more than ~11.6GB).
     - `test_lma_vs_attention` (requires more than ~11.6GB).


**Other Notes**

Linting and Formatting
Code validation commands were run successfully:
```bash
ruff format && ruff check --fix