### PR TITLE
Fix issue 278 C3: Enable recursive CIF file discovery in preprocessing pipeline

### DIFF
--- a/docs/source/data_pipeline_reference.md
+++ b/docs/source/data_pipeline_reference.md
@@ -21,7 +21,7 @@ For detailed format specifications on the metadata and training/validation datas
 
 ## 1. PDB Preprocessing
 ### 1.1 Structure Download
-Our structure preprocessing expects a flat directory of `.cif` files. We provide an example script to generate this at [scripts/download_pdb_mmcif.sh](https://github.com/aqlaboratory/openfold-3/blob/main/scripts/data_preprocessing/download_pdb_mmcif.sh).
+Structure preprocessing recursively discovers `.cif` files below the input directory. Each file must have a unique filename stem because the stem is used as its structure ID and output directory name. We provide an example download script at [scripts/download_pdb_mmcif.sh](https://github.com/aqlaboratory/openfold-3/blob/main/scripts/data_preprocessing/download_pdb_mmcif.sh).
 
 ### 1.2 CCD Preprocessing (recommended but optional)
 

--- a/openfold3/core/data/pipelines/preprocessing/structure.py
+++ b/openfold3/core/data/pipelines/preprocessing/structure.py
@@ -646,6 +646,35 @@ class _OF3PreprocessingWrapper:
                 return output_dict, empty_conformer_dict
 
 
+def _discover_cif_files(cif_dir: Path) -> list[Path]:
+    """Recursively discover CIF files with unique filename stems.
+
+    Structure metadata and output directories are keyed by the input filename stem.
+    Reject duplicate stems before preprocessing to prevent nested files from silently
+    overwriting each other's outputs.
+    """
+    cif_files = sorted(cif_dir.rglob("*.cif"))
+
+    files_by_stem: dict[str, list[Path]] = {}
+    for cif_file in cif_files:
+        files_by_stem.setdefault(cif_file.stem, []).append(cif_file)
+
+    duplicate_stems = {
+        stem: paths for stem, paths in files_by_stem.items() if len(paths) > 1
+    }
+    if duplicate_stems:
+        duplicate_details = "; ".join(
+            f"{stem}: {', '.join(str(path.relative_to(cif_dir)) for path in paths)}"
+            for stem, paths in duplicate_stems.items()
+        )
+        raise ValueError(
+            "CIF filenames must have unique stems because stems are used as structure "
+            f"IDs and output directory names. Duplicates: {duplicate_details}"
+        )
+
+    return cif_files
+
+
 def preprocess_cif_dir_of3(
     cif_dir: Path,
     ccd_path: Path,
@@ -668,7 +697,7 @@ def preprocess_cif_dir_of3(
 
     Args:
         cif_dir:
-            Path to the directory containing the PDB files to preprocess.
+            Path to the directory tree containing the PDB files to preprocess.
         ccd_path:
             Path to the CCD file.
         biotite_ccd_path:
@@ -701,9 +730,7 @@ def preprocess_cif_dir_of3(
     ccd = CIFFile.read(ccd_path)
 
     logger.debug("Reading CIF files")
-    cif_files = [
-        file for file in tqdm(cif_dir.glob("*.cif"), desc="Scanning CIF files")
-    ]
+    cif_files = _discover_cif_files(cif_dir)
 
     if early_stop is not None:
         cif_files = cif_files[:early_stop]

--- a/openfold3/tests/core/data/pipelines/preprocessing/test_structure.py
+++ b/openfold3/tests/core/data/pipelines/preprocessing/test_structure.py
@@ -1,0 +1,46 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from openfold3.core.data.pipelines.preprocessing.structure import _discover_cif_files
+
+
+def test_discover_cif_files_recursively_in_deterministic_order(tmp_path):
+    nested_dir = tmp_path / "nested" / "entry"
+    nested_dir.mkdir(parents=True)
+
+    top_level_cif = tmp_path / "2def.cif"
+    nested_cif = nested_dir / "1abc.cif"
+    ignored_file = nested_dir / "notes.txt"
+    top_level_cif.touch()
+    nested_cif.touch()
+    ignored_file.touch()
+
+    assert _discover_cif_files(tmp_path) == [top_level_cif, nested_cif]
+
+
+def test_discover_cif_files_rejects_duplicate_stems(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    (first_dir / "1abc.cif").touch()
+    (second_dir / "1abc.cif").touch()
+
+    with pytest.raises(
+        ValueError,
+        match=r"unique stems.*1abc: first/1abc\.cif, second/1abc\.cif",
+    ):
+        _discover_cif_files(tmp_path)

--- a/scripts/data_preprocessing/preprocess_pdb_of3.py
+++ b/scripts/data_preprocessing/preprocess_pdb_of3.py
@@ -16,7 +16,10 @@ from openfold3.core.utils.logging_utils import ContextInjectingFilter
     "--cif-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
     required=True,
-    help="Path to directory containing input mmCIF files.",
+    help=(
+        "Path to a directory tree containing input mmCIF files. Files are discovered "
+        "recursively and must have unique filename stems."
+    ),
 )
 @click.option(
     "--ccd-path",


### PR DESCRIPTION
## Summary
Addressed the issue raised in #278 C3. Changed the CIF file lookup from a flat directory search to a recursive tree search.

## Changes
Updated `openfold3/core/data/pipelines/preprocessing/structure.py` with a helper function (`_discover_cif_files`) that recursively finds all `.cif` files and performs checks to flag duplicate file stems across different directories.

## Related Issues

## Testing
Added `openfold3/tests/core/data/pipelines/preprocessing/test_structure.py` with test cases for `_discover_cif_files`.

## Other Notes