### PR TITLE
Fix issue 278 C4: Add minimal CCD builder for faster preprocessing

### DIFF
--- a/docs/source/data_pipeline_reference.md
+++ b/docs/source/data_pipeline_reference.md
@@ -36,6 +36,27 @@ gunzip components.cif.gz
 python scripts/data_preprocessing/preprocess_ccd_biotite.py components.cif components.bcif
 ```
 
+For small custom datasets, parsing and converting the complete wwPDB CCD can dominate
+preprocessing time and memory. The same script can stream only the standard protein,
+RNA, and DNA residues plus explicitly requested custom components into a minimal CIF,
+then build the matching BinaryCIF from that reduced file:
+
+```bash
+python scripts/data_preprocessing/preprocess_ccd_biotite.py \
+    augmented_components.cif minimal_components.bcif \
+    --minimal-cif-output minimal_components.cif \
+    --component-id LIG \
+    --component-id ABC
+```
+
+Additional component IDs can be supplied with `--component-ids-file` using one ID per
+line. Blank lines are ignored and comments are not supported. Pass
+`minimal_components.cif` to `preprocess_pdb_of3.py` as `--ccd-path` and
+`minimal_components.bcif` as `--biotite-ccd-path`. The source CCD is scanned line by
+line, so it is not loaded into memory before the requested blocks are extracted. The
+command fails without replacing an existing output if any requested component is
+missing.
+
 ### 1.3 Structure Preprocessing
 The core structure preprocessing converts raw PDB mmCIF files into an efficient `.npz` format storing Biotite `AtomArray`s, as well as a JSON index of all PDB contents. It performs the following steps:
 

--- a/openfold3/tests/scripts/data_preprocessing/test_preprocess_ccd_biotite.py
+++ b/openfold3/tests/scripts/data_preprocessing/test_preprocess_ccd_biotite.py
@@ -1,0 +1,106 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+
+import pytest
+from biotite.structure.io.pdbx import BinaryCIFFile, CIFFile
+
+from openfold3.core.data.resources.residues import STANDARD_RESIDUES_3
+from scripts.data_preprocessing.preprocess_ccd_biotite import (
+    CCD_CATEGORIES,
+    build_minimal_ccd,
+    concatenate_ccd,
+    extract_ccd_components,
+    read_component_ids_file,
+)
+
+
+def _ccd_block(component_id: str) -> str:
+    return f"""data_{component_id}
+_chem_comp.id {component_id}
+_chem_comp.type 'NON-POLYMER'
+_chem_comp.pdbx_synonyms
+;
+;
+#
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.type_symbol
+_chem_comp_atom.charge
+{component_id} C1 C 0
+{component_id} O1 O 0
+#
+loop_
+_chem_comp_bond.comp_id
+_chem_comp_bond.atom_id_1
+_chem_comp_bond.atom_id_2
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
+{component_id} C1 O1 SING N
+#
+"""
+
+
+def test_build_minimal_ccd_selects_standard_and_custom_components(tmp_path):
+    source_ccd = tmp_path / "components.cif"
+    minimal_ccd = tmp_path / "minimal.cif"
+    minimal_bcif = tmp_path / "minimal.bcif"
+    source_ccd.write_text(
+        "".join(_ccd_block(component_id) for component_id in STANDARD_RESIDUES_3)
+        + _ccd_block("LIG")
+        + _ccd_block("OMIT")
+    )
+
+    found_ids = build_minimal_ccd(
+        source_ccd_path=source_ccd,
+        output_ccd_path=minimal_ccd,
+        custom_component_ids=["lig"],
+    )
+
+    expected_ids = set(STANDARD_RESIDUES_3) | {"LIG"}
+    assert found_ids == expected_ids
+    parsed_minimal_ccd = CIFFile.read(StringIO(minimal_ccd.read_text()))
+    assert set(parsed_minimal_ccd.keys()) == expected_ids
+
+    compressed_ccd = concatenate_ccd(minimal_ccd, categories=CCD_CATEGORIES)
+    compressed_ccd.write(minimal_bcif)
+    parsed_bcif = BinaryCIFFile.read(minimal_bcif)
+    component_ids = parsed_bcif["components"]["chem_comp"]["id"].as_array()
+    assert set(component_ids.tolist()) == expected_ids
+
+
+def test_extract_ccd_components_preserves_existing_output_when_id_is_missing(
+    tmp_path,
+):
+    source_ccd = tmp_path / "components.cif"
+    output_ccd = tmp_path / "minimal.cif"
+    source_ccd.write_text(_ccd_block("ALA"))
+    output_ccd.write_text("existing output")
+
+    with pytest.raises(
+        ValueError,
+        match="Requested CCD components were not found: MISSING",
+    ):
+        extract_ccd_components(source_ccd, output_ccd, ["ALA", "missing"])
+
+    assert output_ccd.read_text() == "existing output"
+
+
+def test_read_component_ids_file_ignores_blank_lines(tmp_path):
+    component_ids_file = tmp_path / "component_ids.txt"
+    component_ids_file.write_text("lig\n\nATP\nlig\n")
+
+    assert read_component_ids_file(component_ids_file) == {"LIG", "ATP"}

--- a/scripts/data_preprocessing/preprocess_ccd_biotite.py
+++ b/scripts/data_preprocessing/preprocess_ccd_biotite.py
@@ -37,7 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import argparse
 import contextlib
 import logging
+import re
+import tempfile
 from collections import defaultdict
+from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 
@@ -51,6 +54,111 @@ from biotite.structure.io.pdbx import (
     MaskValue,
     compress,
 )
+
+from openfold3.core.data.resources.residues import STANDARD_RESIDUES_3
+
+CCD_CATEGORIES = ["chem_comp", "chem_comp_atom", "chem_comp_bond"]
+_DATA_BLOCK_PATTERN = re.compile(r"^data_(\S+)\s*(?:#.*)?$", re.IGNORECASE)
+
+
+def _normalize_component_ids(component_ids: Iterable[str]) -> set[str]:
+    """Normalize and validate CCD component IDs."""
+    normalized_ids = {component_id.strip().upper() for component_id in component_ids}
+    normalized_ids.discard("")
+    if not normalized_ids:
+        raise ValueError("At least one CCD component ID must be provided.")
+    return normalized_ids
+
+
+def read_component_ids_file(component_ids_file: Path) -> set[str]:
+    """Read one CCD component ID per line, ignoring blank lines."""
+    lines = component_ids_file.read_text().splitlines()
+    component_ids = [line.strip() for line in lines if line.strip()]
+    return _normalize_component_ids(component_ids)
+
+
+def extract_ccd_components(
+    source_ccd_path: Path,
+    output_ccd_path: Path,
+    component_ids: Iterable[str],
+) -> set[str]:
+    """Stream selected component blocks into a minimal multi-block CCD.
+
+    The source is scanned line by line instead of being parsed into memory. A temporary
+    file is atomically moved into place only after every requested component is found.
+    """
+    requested_ids = _normalize_component_ids(component_ids)
+    output_ccd_path.parent.mkdir(parents=True, exist_ok=True)
+
+    found_ids: set[str] = set()
+    write_current_block = False
+    in_multiline_value = False
+    temporary_path: Path | None = None
+
+    try:
+        with (
+            source_ccd_path.open(encoding="utf-8") as source_file,
+            tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=output_ccd_path.parent,
+                prefix=f".{output_ccd_path.name}.",
+                delete=False,
+            ) as output_file,
+        ):
+            temporary_path = Path(output_file.name)
+
+            for line in source_file:
+                if not in_multiline_value:
+                    block_match = _DATA_BLOCK_PATTERN.match(line.rstrip("\n"))
+                    if block_match is not None:
+                        component_id = block_match.group(1).upper()
+                        write_current_block = component_id in requested_ids
+                        if write_current_block:
+                            if component_id in found_ids:
+                                raise ValueError(
+                                    f"Duplicate CCD data block for '{component_id}'."
+                                )
+                            found_ids.add(component_id)
+                            if output_file.tell() > 0:
+                                output_file.write("\n")
+
+                if write_current_block:
+                    output_file.write(line)
+
+                if line.startswith(";"):
+                    in_multiline_value = not in_multiline_value
+
+        missing_ids = sorted(requested_ids - found_ids)
+        if missing_ids:
+            raise ValueError(
+                "Requested CCD components were not found: " + ", ".join(missing_ids)
+            )
+
+        assert temporary_path is not None
+        temporary_path.replace(output_ccd_path)
+    except Exception:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
+
+    return found_ids
+
+
+def build_minimal_ccd(
+    source_ccd_path: Path,
+    output_ccd_path: Path,
+    custom_component_ids: Iterable[str] = (),
+    standard_component_ids: Iterable[str] = STANDARD_RESIDUES_3,
+) -> set[str]:
+    """Build a minimal CCD containing standard residues and requested components."""
+    component_ids = set(standard_component_ids)
+    component_ids.update(custom_component_ids)
+    return extract_ccd_components(
+        source_ccd_path=source_ccd_path,
+        output_ccd_path=output_ccd_path,
+        component_ids=component_ids,
+    )
 
 
 def concatenate_ccd(ccd_path: Path, categories=None):
@@ -201,7 +309,8 @@ def main():
     parser = argparse.ArgumentParser(
         description=(
             "Converts a CCD CIF-file into BinaryCIF format that can be used with "
-            "biotite's set_ccd_path."
+            "biotite's set_ccd_path. Optionally builds a minimal CCD containing "
+            "standard residues and selected custom components before conversion."
         )
     )
     parser.add_argument(
@@ -214,15 +323,66 @@ def main():
         type=Path,
         help="Output file path.",
     )
+    parser.add_argument(
+        "--minimal-cif-output",
+        type=Path,
+        help=(
+            "Write a minimal multi-block CIF to this path and build the BinaryCIF from "
+            "it. The minimal CCD always includes standard protein, RNA, and DNA "
+            "residues."
+        ),
+    )
+    parser.add_argument(
+        "--component-id",
+        action="append",
+        default=[],
+        help=(
+            "Additional CCD component ID to include in the minimal CCD. May be passed "
+            "more than once."
+        ),
+    )
+    parser.add_argument(
+        "--component-ids-file",
+        type=Path,
+        help=(
+            "Text file containing additional CCD component IDs, one per line. "
+            "Blank lines are ignored; comments are not supported."
+        ),
+    )
 
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
     args.output.parent.mkdir(parents=True, exist_ok=True)
 
+    custom_ids_provided = args.component_id or args.component_ids_file
+    if custom_ids_provided and args.minimal_cif_output is None:
+        parser.error(
+            "--minimal-cif-output is required when custom component IDs are provided."
+        )
+
+    ccd_path = args.ccd_path
+    if args.minimal_cif_output is not None:
+        custom_component_ids = set(args.component_id)
+        if args.component_ids_file is not None:
+            custom_component_ids.update(
+                read_component_ids_file(args.component_ids_file)
+            )
+        found_ids = build_minimal_ccd(
+            source_ccd_path=args.ccd_path,
+            output_ccd_path=args.minimal_cif_output,
+            custom_component_ids=custom_component_ids,
+        )
+        logging.info(
+            "Wrote minimal CCD with %d components to %s.",
+            len(found_ids),
+            args.minimal_cif_output,
+        )
+        ccd_path = args.minimal_cif_output
+
     compressed_ccd = concatenate_ccd(
-        ccd_path=args.ccd_path,
-        categories=["chem_comp", "chem_comp_atom", "chem_comp_bond"],
+        ccd_path=ccd_path,
+        categories=CCD_CATEGORIES,
     )
     compressed_ccd.write(args.output)
 


### PR DESCRIPTION
## Summary
Addressed item C4 in #278. Added support for creating a minimal CCD containing standard residues and selected custom components to accelerate preprocessing for smaller fine-tuning datasets.

## Changes
- Stream selected components from the source CCD into a minimal CIF without loading the full reference dictionary into memory.
- Include standard residues (amino acids, DNA, RNA) automatically.
- Accept custom component IDs via CLI arguments or a text file.
- Clean up temporary files and preserve existing outputs when extraction fails.
- Added test suite and updated `docs/source/data_pipeline_reference.md` with custom CCD builder instructions.

## Related Issues

## Testing
- Added tests in `openfold3/tests/scripts/data_preprocessing/test_preprocess_ccd_biotite.py`