### PR TITLE
Improve Pocket Constraints documentation

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -131,14 +131,14 @@ data_module_args:
 ```
 
 ---
-### 3.X Checkpoint Confiugration (`checkpoint_config`)
+### 3.6 Checkpoint Confiugration (`checkpoint_config`)
 
 Configures Checkpoint writing settings, which are passed to [pl.ModelCheckpoint callback](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html). 
 
+---
+### 3.7. Dataset Config Kwargs (`dataset_config_kwargs`)
 
-### 3.6. Dataset Config Kwargs (`dataset_config_kwargs`)
-
-Configures MSA and template feature generation.
+Configures MSA, template, and pocket sampling feature generation.
 
 **Pydantic Model**: [`InferenceDatasetConfigKwargs`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/projects/of3_all_atom/config/dataset_configs.py#L270)
 
@@ -146,8 +146,9 @@ Configures MSA and template feature generation.
 - `ccd_file_path` *(FilePath | None)*: Path to Chemical Component Dictionary file, uses CCD from Biotite if null (default: `null`)
 - `msa` *(MSASettings)*: MSA processing settings (see below)
 - `template` *(TemplateSettings)*: Template processing settings (see below)
+- `pocket_sampling` *(PocketSamplingSettings)*: Pocket-guided ligand proposal sampling settings (see below)
 
-#### 3.6.1. MSA Settings (`msa`)
+#### 3.7.1. MSA Settings (`msa`)
 
 Controls how MSAs are parsed and processed into features.
 
@@ -174,7 +175,7 @@ dataset_config_kwargs:
     moltypes: [0, 1]  # protein and RNA
 ```
 
-#### 3.6.2. Template Settings (`template`)
+#### 3.7.2. Template Settings (`template`)
 
 Controls template structure processing.
 
@@ -197,9 +198,41 @@ dataset_config_kwargs:
     take_top_k: true
 ```
 
+(full-ref-pocket-sampling-settings)=
+#### 3.7.3 Pocket Sampling Settings (`pocket_sampling`)
+
+Controls pocket-guided ligand proposal sampling and refinement. These settings only take effect when a query supplies a `pocket_constraint`; the presence of that constraint enables proposal sampling by default.
+
+**Pydantic Model**: [`PocketSamplingSettings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/config/pocket_sampling_config.py#L28)
+
+**All Options**:
+- `enabled` *(bool)*: Whether pocket-guided proposal sampling runs when a query provides a `pocket_constraint`; useful for ablations without changing the input JSON (default: `true`)
+- `num_parents` *(int)*: Number of de-novo rollout parents to seed refinement from, capped by `no_rollout_samples` at runtime (default: `16`, minimum: `1`)
+- `candidates` *(int)*: Number of random rigid ligand proposals to rank before diversity filtering (default: `1024`, minimum: `1`)
+- `noise_frac` *(float)*: Fraction of the diffusion schedule to complete before starting the refinement pass (default: `0.75`, range: `0.0`–`1.0`)
+- `ligand_jitter` *(float)*: Ligand-only coordinate jitter in Angstroms applied before refinement, so repeated samples from the same seed do not follow identical trajectories (default: `0.25`, minimum: `0.0`)
+- `center_jitter` *(float)*: Pocket-center proposal jitter in Angstroms, exploring placements around the residue set centroid (default: `4.0`, minimum: `0.0`)
+- `surface_jitter` *(float)*: Pocket-surface proposal jitter in Angstroms, exploring local contacts around individual pocket atoms (default: `1.5`, minimum: `0.0`)
+- `vdw_buffer` *(float)*: Clash screening uses van der Waals radii multiplied by `(1 - vdw_buffer)`, allowing imperfect poses while rejecting severe overlaps (default: `0.225`, minimum: `0.0`)
+- `diversity_rmsd` *(float)*: Minimum heavy-atom RMSD in Angstroms between selected ligand proposals (default: `0.5`, minimum: `0.0`)
+- `rdkit_num_conformers` *(int)*: Number of RDKit conformers to generate for the ligand ensemble; set to `0` to disable RDKit conformer generation (default: `32`, minimum: `0`)
+- `rdkit_conformer_rng` *(int)*: Random seed for deterministic RDKit conformer embedding (default: `0`)
+- `rdkit_conformer_prune_rmsd` *(float)*: RDKit embedding RMSD pruning threshold; disabled by default so OF3 proposal ranking, not RDKit, controls diversity (default: `0.0`, minimum: `0.0`)
+- `rdkit_conformer_max_iters` *(int)*: Maximum number of force-field optimization iterations per RDKit conformer (default: `200`, minimum: `1`)
+
+**Example**:
+```yaml
+dataset_config_kwargs:
+  pocket_sampling:
+    enabled: true
+    num_parents: 16
+    candidates: 1024
+    noise_frac: 0.75
+```
+
 ---
 
-### 3.7. Output Writer Settings (`output_writer_settings`)
+### 3.8. Output Writer Settings (`output_writer_settings`)
 
 Configures the format of output files.
 
@@ -222,7 +255,7 @@ output_writer_settings:
 
 ---
 
-### 3.8. MSA Computation Settings (`msa_computation_settings`)
+### 3.9. MSA Computation Settings (`msa_computation_settings`)
 
 Configures the ColabFold MSA server integration.
 
@@ -251,7 +284,7 @@ msa_computation_settings:
 
 ---
 
-### 3.9. Template Preprocessor Settings (`template_preprocessor_settings`)
+### 3.10. Template Preprocessor Settings (`template_preprocessor_settings`)
 
 Configures template structure preprocessing and filtering.
 
@@ -300,4 +333,5 @@ For the complete list of default values, see the Pydantic model classes in:
 - [`openfold3/projects/of3_all_atom/config/dataset_config_components.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/projects/of3_all_atom/config/dataset_config_components.py) - MSA and template settings
 - [`openfold3/core/data/tools/colabfold_msa_server.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py) - MSA server settings
 - [`openfold3/core/data/pipelines/preprocessing/template.py`](http://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/pipelines/preprocessing/template.py) - Template preprocessing settings
+- [`openfold3/core/config/pocket_sampling_config.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/config/pocket_sampling_config.py) - Pocket sampling settings
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -75,6 +75,7 @@ template_how_to
 
 contribution
 debugging_how_to
+modern-conda-environments-with-pixi
 ```
 
 ```{toctree}

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -460,6 +460,19 @@ msa_computation_settings:
   msa_file_format: a3m     # Options: a3m, npz (default: npz)
 ```
 
+(35-using-pocket-constraints)=
+### 3.5 Using Pocket Constraints
+
+Use Pocket Constraints to guide ligand binding in the pocket during inference time using directed diffusion seeds. See {ref}`Section 4 of the input format reference <4-pocket-constraints>` for more information on how to specify a pocket constraint.
+
+Pocket Constraints can be enabled / disabled using the following runner yaml settings. Other settings such as the amount of jitter and conformer settings may also be tuned, please see the {ref}`Pocket Sampling Settings reference <full-ref-pocket-sampling-settings>`.
+
+```yaml
+datset_config_kwargs:
+  pocket_sampling:
+    enabled: True  # default
+```
+
 ## 4. Model Outputs
 
 The inference pipeline creates a dedicated output directory for each query, named by the corresponding query key (for example, `query_1` or `3hfm` when a PDB ID is provided). Prediction results are stored there. By default, saved MSA records are stored under `<output_dir>/msas`.

--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -281,10 +281,8 @@ residues:
     specified pocket.
 
 Pocket constraints can be disabled for testing without editing the input
-JSON by setting `OF3_POCKET_SAMPLING=0` in the environment. Additional environment
-variables can override expert sampling defaults, but the default settings are
-intended to run without user-provided environment flags. Expert sampling defaults
-are defined in `openfold3/core/config/pocket_sampling_defaults.py`.
+JSON by toggling the pocket sampling option in the runner.yaml, see {ref}`Using Pocket Constraints <35-using-pocket-constraints>` for an example. Expert sampling defaults
+are defined in `openfold3/core/config/pocket_sampling_config.py`, more information can be found in the {ref}`Pocket Sampling Settings reference <full-ref-pocket-sampling-settings>`.
 
 ## 5. Example Input Json for a Single Query Complex
 

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -165,7 +165,7 @@ class TestUtils(unittest.TestCase):
         chunked = chunk_layer(l, {"input": x}, chunk_size=4, no_batch_dims=3)
         unchunked = l(x)
 
-        self.assertTrue(torch.all(chunked == unchunked))
+        torch.testing.assert_close(chunked, unchunked)
 
     def test_chunk_layer_dict(self):
         class LinearDictLayer(Linear):
@@ -179,8 +179,8 @@ class TestUtils(unittest.TestCase):
         chunked = chunk_layer(l, {"input": x}, chunk_size=4, no_batch_dims=3)
         unchunked = l(x)
 
-        self.assertTrue(torch.all(chunked["out"] == unchunked["out"]))
-        self.assertTrue(torch.all(chunked["inner"]["out"] == unchunked["inner"]["out"]))
+        torch.testing.assert_close(chunked["out"], unchunked["out"])
+        torch.testing.assert_close(chunked["inner"]["out"], unchunked["inner"]["out"])
 
     def test_chunk_slice_dict(self):
         x = torch.rand(3, 4, 3, 5)
@@ -195,7 +195,7 @@ class TestUtils(unittest.TestCase):
                 chunked = _chunk_slice(x, i, j, len(x.shape[:-1]))
                 chunked_flattened = x_flat[i:j]
 
-                self.assertTrue(torch.all(chunked == chunked_flattened))
+                torch.testing.assert_close(chunked, chunked_flattened)
 
     def test_chunk_size_tuner_caches(self):
         tuner = ChunkSizeTuner()


### PR DESCRIPTION
**Summary**

Following on the pocket constraints feature added in #324 , expand the documentation for pocket constraints to include the full configuration and add a section to the inference documentation. 

Also makes a small change to unit tests in `test_utils.py` to allow some tolerance in tensor equality. These tests would fail on Apple Silicon hardware otherwise.

**Testing**
- Reran all unit tests, passing on GB10, MI210, and M2 Apple hardware
- Rebuilt docs and verified no errors.
