### PR TITLE
fix: fail on unknown molecule types

### DIFF
--- a/openfold3/core/data/primitives/structure/labels.py
+++ b/openfold3/core/data/primitives/structure/labels.py
@@ -475,36 +475,47 @@ def assign_molecule_type_ids(atom_array: AtomArray, cif_file: pdbx.CIFFile) -> N
             AtomArray containing the structure to assign molecule types to.
     """
     # Get chemical component-to-type mapping
-    # All type values are mapped to upper case to ensure case-insensitive matching
     chem_comp_ids = cif_file.block["chem_comp"]["id"].as_array()
     chem_comp_types = cif_file.block["chem_comp"]["type"].as_array()
-    try:
-        chem_comp_id_to_type = {
-            k: CHEM_COMP_TYPE_TO_MOLECULE_TYPE[v.upper()]
-            for k, v in zip(chem_comp_ids, chem_comp_types, strict=True)
-        }
-    except KeyError:
-        missing_types = chem_comp_types[
-            ~np.isin(
-                chem_comp_types, np.array(list(CHEM_COMP_TYPE_TO_MOLECULE_TYPE.keys()))
-            )
-        ]
 
-        logger.error(
-            "Found chemical component types that are missing from the "
-            "component type-to-molecule type map. Mapping the following "
-            f'types to "OTHER" i.e. MoleculeType.LIGAND: {missing_types}'
+    chem_comp_id_to_raw_type = {
+        k: v for k, v in zip(chem_comp_ids, chem_comp_types, strict=True)
+    }
+
+    referenced_comp_ids = np.unique(atom_array.res_name)
+
+    missing_comp_ids = sorted(set(referenced_comp_ids) - set(chem_comp_id_to_raw_type))
+
+    if missing_comp_ids:
+        raise ValueError(
+            "Found chemical components referenced by the structure "
+            "that are missing from the _chem_comp table: "
+            f"{missing_comp_ids}"
         )
-        chem_comp_id_to_type = {
-            k: CHEM_COMP_TYPE_TO_MOLECULE_TYPE.get(
-                v.upper(), CHEM_COMP_TYPE_TO_MOLECULE_TYPE["OTHER"]
-            )
-            for k, v in zip(chem_comp_ids, chem_comp_types, strict=True)
-        }
+
+    invalid_types = [
+        (comp_id, chem_comp_id_to_raw_type[comp_id])
+        for comp_id in referenced_comp_ids
+        if chem_comp_id_to_raw_type[comp_id].upper()
+        not in CHEM_COMP_TYPE_TO_MOLECULE_TYPE
+    ]
+
+    if invalid_types:
+        raise ValueError(
+            "Found chemical components with unrecognized _chem_comp.type "
+            f"values: {invalid_types}"
+        )
+
+    chem_comp_id_to_type = {
+        comp_id: CHEM_COMP_TYPE_TO_MOLECULE_TYPE[
+            chem_comp_id_to_raw_type[comp_id].upper()
+        ]
+        for comp_id in referenced_comp_ids
+    }
 
     @np.vectorize
     def get_mol_types(key: str) -> MoleculeType:
-        return chem_comp_id_to_type.get(key, MoleculeType.LIGAND)
+        return chem_comp_id_to_type[key]
 
     chain_start_idxs = struc.get_chain_starts(atom_array, add_exclusive_stop=True)
 

--- a/openfold3/tests/core/data/primitives/structure/test_labels.py
+++ b/openfold3/tests/core/data/primitives/structure/test_labels.py
@@ -15,12 +15,15 @@
 import numpy as np
 import pytest
 from biotite.structure import Atom, AtomArray, array
+from biotite.structure.io import pdbx
 
 from openfold3.core.data.primitives.structure.labels import (
     AtomArrayView,
     assign_atom_indices,
+    assign_molecule_type_ids,
     residue_view_iter,
 )
+from openfold3.core.data.resources.residues import MoleculeType
 from openfold3.tests.utils.custom_assert_utils import assert_atomarray_equal
 
 
@@ -142,3 +145,111 @@ class TestResidueViewIter:
         residue_views = list(residue_view_iter(empty_array))
 
         assert len(residue_views) == 0
+
+
+def _make_cif_file(ids, types):
+    cif_file = pdbx.CIFFile()
+    block = pdbx.CIFBlock()
+    block["chem_comp"] = pdbx.CIFCategory(
+        {
+            "id": np.array(ids),
+            "type": np.array(types),
+        }
+    )
+    cif_file["test"] = block
+    return cif_file
+
+
+def _make_atom_array(res_names, chain_ids):
+    atoms = AtomArray(len(res_names))
+    atoms.chain_id = np.array(chain_ids)
+    atoms.res_id = np.arange(1, len(res_names) + 1)
+    atoms.res_name = np.array(res_names)
+    atoms.atom_name = np.array(["CA"] * len(res_names))
+    atoms.element = np.array(["C"] * len(res_names))
+    return atoms
+
+
+class TestAssignMoleculeTypeIds:
+    """Tests for the assign_molecule_type_ids function."""
+
+    def test_valid_types_protein_and_ligand(self):
+        cif_file = _make_cif_file(
+            ["ALA", "GLY", "LIG"],
+            ["L-PEPTIDE LINKING", "L-PEPTIDE LINKING", "NON-POLYMER"],
+        )
+        atom_array = _make_atom_array(
+            ["ALA", "GLY", "LIG"],
+            ["A", "A", "B"],
+        )
+
+        assign_molecule_type_ids(atom_array, cif_file)
+
+        assert atom_array.molecule_type_id[0] == MoleculeType.PROTEIN
+        assert atom_array.molecule_type_id[1] == MoleculeType.PROTEIN
+        assert atom_array.molecule_type_id[2] == MoleculeType.LIGAND
+
+    @pytest.mark.parametrize("chem_comp_type", ["", ".", "?", "BOGUS_TYPE"])
+    def test_unknown_chem_comp_type_raises(self, chem_comp_type):
+        cif_file = _make_cif_file(["BAD"], [chem_comp_type])
+        atom_array = _make_atom_array(["BAD"], ["A"])
+
+        with pytest.raises(ValueError, match="BAD"):
+            assign_molecule_type_ids(atom_array, cif_file)
+
+    def test_missing_chem_comp_entry_raises(self):
+        cif_file = _make_cif_file(
+            ["ALA", "GLY"], ["L-PEPTIDE LINKING", "L-PEPTIDE LINKING"]
+        )
+        atom_array = _make_atom_array(["ALA", "GLY", "XYZ"], ["A", "A", "A"])
+
+        with pytest.raises(ValueError, match="XYZ"):
+            assign_molecule_type_ids(atom_array, cif_file)
+
+    def test_lowercase_valid_type(self):
+        cif_file = _make_cif_file(
+            ["ALA", "GLY"], ["l-peptide linking", "l-peptide linking"]
+        )
+        atom_array = _make_atom_array(["ALA", "GLY"], ["A", "A"])
+
+        assign_molecule_type_ids(atom_array, cif_file)
+        assert atom_array.molecule_type_id[0] == MoleculeType.PROTEIN
+        assert atom_array.molecule_type_id[1] == MoleculeType.PROTEIN
+
+    def test_multiple_invalid_components_reported_together(self):
+        cif_file = _make_cif_file(["BAD1", "BAD2"], ["BOGUS", ""])
+        atom_array = _make_atom_array(["BAD1", "BAD2"], ["A", "A"])
+
+        with pytest.raises(ValueError) as exc_info:
+            assign_molecule_type_ids(atom_array, cif_file)
+
+        message = str(exc_info.value)
+        assert "BAD1" in message
+        assert "BAD2" in message
+
+    def test_valid_OTHER_type(self):
+        cif_file = _make_cif_file(
+            ["OTH1", "OTH2"],
+            ["OTHER", "OTHER"],
+        )
+        atom_array = _make_atom_array(
+            ["OTH1", "OTH2"],
+            ["A", "A"],
+        )
+
+        assign_molecule_type_ids(atom_array, cif_file)
+        assert np.all(atom_array.molecule_type_id == MoleculeType.LIGAND)
+
+    def test_unreferenced_chem_comp_type_is_ignored(self):
+        cif_file = _make_cif_file(
+            ["ALA", "UNUSED"],
+            ["L-PEPTIDE LINKING", "BOGUS_TYPE"],
+        )
+        atom_array = _make_atom_array(
+            ["ALA", "ALA"],
+            ["A", "A"],
+        )
+
+        assign_molecule_type_ids(atom_array, cif_file)
+
+        assert np.all(atom_array.molecule_type_id == MoleculeType.PROTEIN)


### PR DESCRIPTION
## Summary

Addresses A3 from #278 by making molecule type assignment fail when referenced CCD components have missing or unrecognized `_chem_comp.type` metadata.

## Changes

- Validate that all components referenced by the structure are present in `_chem_comp`.
- Raise `ValueError` for referenced components with unrecognized `_chem_comp.type` values.
- Preserve case-insensitive matching of `_chem_comp.type`.
- Remove the silent fallback to `MoleculeType.LIGAND`.
- Add regression tests for missing components, unknown types, case-insensitive matching, `OTHER`, multiple invalid components, and unreferenced invalid components.

## Related Issues

Addresses A3 from #278.

## Testing

- `python -m pytest openfold3/tests/core/data/primitives/structure/test_labels.py`
- `python -m ruff format --check openfold3/core/data/primitives/structure/labels.py openfold3/tests/core/data/primitives/structure/test_labels.py`
- `python -m ruff check openfold3/core/data/primitives/structure/labels.py openfold3/tests/core/data/primitives/structure/test_labels.py`

All tests and Ruff checks pass.