### PR TITLE
Fix 278 C1 Add mmCIF preflight validation

### DIFF
--- a/docs/source/data_pipeline_reference.md
+++ b/docs/source/data_pipeline_reference.md
@@ -44,6 +44,27 @@ The core structure preprocessing converts raw PDB mmCIF files into an efficient 
 - **Generating reference molecules** with RDKit conformers for each unique ligand (saved as **SDF files\***)
 - **Extracting metadata** into a `metadata.json` with structure-level, chain-level, and interface-level information
 
+Before structure parsing, each input is checked against the minimum schema required by
+the preprocessing workflow. The validator reports all missing categories and data items
+in one error. Each file must contain exactly one named data block; this name becomes the
+structure ID. The required data items are:
+
+- `_atom_site`: `group_PDB`, `type_symbol`, `label_atom_id`, `label_comp_id`,
+  `label_asym_id`, `label_entity_id`, `label_seq_id`, `Cartn_x`, `Cartn_y`,
+  `Cartn_z`, and `pdbx_PDB_model_num`
+- `_chem_comp`: `id` and `type`
+- `_entity_poly`: `entity_id` and `pdbx_seq_one_letter_code_can`
+- `_entity_poly_seq`: `entity_id`, `num`, and `mon_id`
+- `_exptl`: `method`
+- `_pdbx_audit_revision_history`: `revision_date`
+
+Resolution metadata and `_struct_asym` are not read by the current ingestion path.
+Biological-assembly records may be omitted, in which case preprocessing uses the
+asymmetric unit. If `_pdbx_struct_assembly_gen` is present, its operation fields and
+the corresponding `_pdbx_struct_oper_list` are required. Using
+`--max-polymer-chains` additionally requires
+`_pdbx_struct_assembly.oligomeric_count`.
+
 Script: [scripts/data_preprocessing/preprocess_pdb_of3.py](https://github.com/aqlaboratory/openfold-3/blob/main/scripts/data_preprocessing/preprocess_pdb_of3.py)
 
 Output: per-structure directories with **NPZ\***, FASTA, and optionally CIF files, plus a **metadata.json\*** and **reference molecule SDF files\***:

--- a/openfold3/core/data/pipelines/preprocessing/mmcif.py
+++ b/openfold3/core/data/pipelines/preprocessing/mmcif.py
@@ -1,0 +1,142 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Preflight validation for mmCIF structure preprocessing inputs."""
+
+from pathlib import Path
+
+from biotite.structure.io.pdbx import CIFFile
+
+# Minimum structural schema expected by the OF3 preprocessing workflow. This includes
+# direct parser inputs, metadata read later in the pipeline, and categories that link
+# polymer entities to chains. Optional metadata (for example resolution and bioassembly
+# records) is intentionally omitted.
+REQUIRED_MMCIF_DATA_ITEMS: dict[str, tuple[str, ...]] = {
+    "atom_site": (
+        "group_PDB",
+        "type_symbol",
+        "label_atom_id",
+        "label_comp_id",
+        "label_asym_id",
+        "label_entity_id",
+        "label_seq_id",
+        "Cartn_x",
+        "Cartn_y",
+        "Cartn_z",
+        "pdbx_PDB_model_num",
+    ),
+    "chem_comp": ("id", "type"),
+    "entity_poly": ("entity_id", "pdbx_seq_one_letter_code_can"),
+    "entity_poly_seq": ("entity_id", "num", "mon_id"),
+    "exptl": ("method",),
+    "pdbx_audit_revision_history": ("revision_date",),
+}
+
+REQUIRED_BIOASSEMBLY_DATA_ITEMS: dict[str, tuple[str, ...]] = {
+    "pdbx_struct_assembly_gen": (
+        "assembly_id",
+        "oper_expression",
+        "asym_id_list",
+    ),
+    "pdbx_struct_oper_list": (
+        "id",
+        "matrix[1][1]",
+        "matrix[1][2]",
+        "matrix[1][3]",
+        "vector[1]",
+        "matrix[2][1]",
+        "matrix[2][2]",
+        "matrix[2][3]",
+        "vector[2]",
+        "matrix[3][1]",
+        "matrix[3][2]",
+        "matrix[3][3]",
+        "vector[3]",
+    ),
+}
+
+
+class MMCIFPreflightError(ValueError):
+    """Raised when an mmCIF lacks data required by structure preprocessing."""
+
+
+def validate_mmcif_for_preprocessing(
+    cif_file: CIFFile,
+    source: Path | str | None = None,
+    *,
+    expand_bioassembly: bool = True,
+    max_polymer_chains: int | None = None,
+) -> None:
+    """Validate the minimum mmCIF schema required by OF3 preprocessing.
+
+    All missing categories and data items are collected before an exception is raised,
+    so users can repair a custom mmCIF in one pass.
+
+    Args:
+        cif_file:
+            Parsed mmCIF file to validate.
+        source:
+            Optional source path used to make the error message more actionable.
+        expand_bioassembly:
+            Whether to validate biological-assembly data when it is present.
+        max_polymer_chains:
+            If set, require the assembly count used by the early chain-count filter.
+
+    Raises:
+        MMCIFPreflightError:
+            If the file does not contain exactly one named data block, or required
+            categories, data items, or rows are missing.
+    """
+    problems = []
+    block_names = list(cif_file.keys())
+
+    if len(block_names) != 1:
+        found_blocks = ", ".join(block_names) if block_names else "none"
+        problems.append(
+            "expected exactly one data block because its name is used as the "
+            f"structure ID; found {len(block_names)} ({found_blocks})"
+        )
+    else:
+        block_name = block_names[0]
+        if not block_name.strip():
+            problems.append("the data block name is empty")
+
+        cif_block = cif_file[block_name]
+        required_data_items = dict(REQUIRED_MMCIF_DATA_ITEMS)
+        if expand_bioassembly and "pdbx_struct_assembly_gen" in cif_block:
+            required_data_items.update(REQUIRED_BIOASSEMBLY_DATA_ITEMS)
+        if max_polymer_chains is not None:
+            required_data_items["pdbx_struct_assembly"] = ("oligomeric_count",)
+
+        for category_name, required_items in required_data_items.items():
+            if category_name not in cif_block:
+                problems.append(f"missing required category `_{category_name}`")
+                continue
+
+            category = cif_block[category_name]
+            if category.row_count == 0:
+                problems.append(f"required category `_{category_name}` has no rows")
+
+            for item_name in required_items:
+                if item_name not in category:
+                    problems.append(
+                        f"missing required data item `_{category_name}.{item_name}`"
+                    )
+
+    if problems:
+        location = f" for {source}" if source is not None else ""
+        details = "\n".join(f"- {problem}" for problem in problems)
+        raise MMCIFPreflightError(
+            f"mmCIF preflight validation failed{location}:\n{details}"
+        )

--- a/openfold3/core/data/pipelines/preprocessing/structure.py
+++ b/openfold3/core/data/pipelines/preprocessing/structure.py
@@ -56,6 +56,9 @@ from openfold3.core.data.io.structure.pdb import (
     parse_RNA_monomer_pdb_tmp,
 )
 from openfold3.core.data.io.utils import encode_numpy_types
+from openfold3.core.data.pipelines.preprocessing.mmcif import (
+    validate_mmcif_for_preprocessing,
+)
 from openfold3.core.data.pipelines.preprocessing.utils import SharedSet
 from openfold3.core.data.primitives.caches.format import (
     DisorderedPreprocessingDataCache,
@@ -450,6 +453,15 @@ def preprocess_structure_and_write_outputs_of3(
     """
     # Log how long this is taking
     start_time = time.perf_counter()
+
+    # Validate all required mmCIF data items before the parser or cleanup pipeline can
+    # fail on them individually.
+    validate_mmcif_for_preprocessing(
+        CIFFile.read(input_cif),
+        source=input_cif,
+        expand_bioassembly=True,
+        max_polymer_chains=max_polymer_chains,
+    )
 
     # Parse the input CIF file
     parsed_mmcif = parse_mmcif(

--- a/openfold3/tests/core/data/pipelines/preprocessing/test_mmcif.py
+++ b/openfold3/tests/core/data/pipelines/preprocessing/test_mmcif.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from biotite.structure.io.pdbx import CIFBlock, CIFCategory, CIFFile
+
+from openfold3.core.data.pipelines.preprocessing.mmcif import (
+    REQUIRED_MMCIF_DATA_ITEMS,
+    MMCIFPreflightError,
+    validate_mmcif_for_preprocessing,
+)
+
+
+def _valid_cif_file() -> CIFFile:
+    categories = {
+        category_name: CIFCategory(
+            {item_name: np.array(["1"]) for item_name in required_items}
+        )
+        for category_name, required_items in REQUIRED_MMCIF_DATA_ITEMS.items()
+    }
+    return CIFFile({"TEST": CIFBlock(categories)})
+
+
+def test_validate_mmcif_for_preprocessing_accepts_complete_schema():
+    validate_mmcif_for_preprocessing(_valid_cif_file())
+
+
+def test_validate_mmcif_for_preprocessing_reports_all_missing_items():
+    cif_file = _valid_cif_file()
+    del cif_file["TEST"]["exptl"]
+    del cif_file["TEST"]["atom_site"]["Cartn_x"]
+    del cif_file["TEST"]["entity_poly"]["pdbx_seq_one_letter_code_can"]
+
+    with pytest.raises(MMCIFPreflightError) as exc_info:
+        validate_mmcif_for_preprocessing(cif_file, source="custom.cif")
+
+    message = str(exc_info.value)
+    assert "custom.cif" in message
+    assert "missing required category `_exptl`" in message
+    assert "missing required data item `_atom_site.Cartn_x`" in message
+    assert (
+        "missing required data item `_entity_poly.pdbx_seq_one_letter_code_can`"
+        in message
+    )
+
+
+def test_validate_mmcif_for_preprocessing_rejects_multiple_data_blocks():
+    cif_file = _valid_cif_file()
+    cif_file["SECOND"] = CIFBlock({})
+
+    with pytest.raises(
+        MMCIFPreflightError,
+        match=r"expected exactly one data block.*found 2 \(TEST, SECOND\)",
+    ):
+        validate_mmcif_for_preprocessing(cif_file)
+
+
+def test_validate_mmcif_for_preprocessing_checks_partial_bioassembly_schema():
+    cif_file = _valid_cif_file()
+    cif_file["TEST"]["pdbx_struct_assembly_gen"] = CIFCategory(
+        {"assembly_id": np.array(["1"]), "asym_id_list": np.array(["A"])}
+    )
+
+    with pytest.raises(MMCIFPreflightError) as exc_info:
+        validate_mmcif_for_preprocessing(cif_file)
+
+    message = str(exc_info.value)
+    assert (
+        "missing required data item `_pdbx_struct_assembly_gen.oper_expression`"
+        in message
+    )
+    assert "missing required category `_pdbx_struct_oper_list`" in message
+
+
+def test_validate_mmcif_for_preprocessing_checks_requested_chain_count_metadata():
+    with pytest.raises(
+        MMCIFPreflightError,
+        match=r"missing required category `_pdbx_struct_assembly`",
+    ):
+        validate_mmcif_for_preprocessing(
+            _valid_cif_file(),
+            max_polymer_chains=1000,
+        )


### PR DESCRIPTION

## Summary

Fix issue 278 C1. Validate the required mmCIF schema before structure preprocessing begins.

## Changes
Added  ```openfold3/core/data/pipelines/preprocessing/mmcif.py``` which runs checks to ensure all mmCIF categories required are present. It accumalates all the missing categories into one errro message.  ```structure.py``` uses this new helper function. 
## Related Issues

## Testing
Added a 5 test suite at  ```openfold3/tests/core/data/pipelines/preprocessing/test_mmcif.py``` which validates the new helper function. 
