### PR TITLE
Fix lowercase atom name encoding

### DIFF
--- a/openfold3/core/data/io/structure/cif.py
+++ b/openfold3/core/data/io/structure/cif.py
@@ -20,6 +20,7 @@ import pickle
 from pathlib import Path
 from typing import Literal, NamedTuple
 
+import numpy as np
 from biotite.structure import AtomArray, get_chain_count
 from biotite.structure.io import pdb, pdbx, save_structure
 
@@ -86,6 +87,17 @@ def _load_ciffile(file_path: Path | str) -> pdbx.CIFFile:
     return cif_class.read(file_path)
 
 
+def _normalize_element_symbols(
+    cif_data: pdbx.CIFBlock | pdbx.BinaryCIFBlock,
+) -> None:
+    """Normalize mmCIF element symbols to dictionary-compliant capitalization."""
+    element_symbols = cif_data["atom_site"]["type_symbol"].as_array().astype(str)
+    normalized_symbols = np.char.capitalize(element_symbols)
+
+    if not np.array_equal(element_symbols, normalized_symbols):
+        cif_data["atom_site"]["type_symbol"] = normalized_symbols
+
+
 # TODO: update docstring with new residue ID handling and preset fields
 @log_runtime_memory(runtime_dict_key="runtime-parse-mmcif", multicall=True)
 def parse_mmcif(
@@ -148,6 +160,7 @@ def parse_mmcif(
 
     cif_file = _load_ciffile(file_path)
     cif_data = get_cif_block(cif_file)
+    _normalize_element_symbols(cif_data)
 
     # Try predetermining from the CIF metadata if the structure has too many chains
     if max_polymer_chains is not None:

--- a/openfold3/core/data/pipelines/featurization/conformer.py
+++ b/openfold3/core/data/pipelines/featurization/conformer.py
@@ -129,7 +129,9 @@ def featurize_reference_conformers_of3(
             ref_space_uid.append(mol_idx)
 
             # Encoding of atom names
-            atom_name_padded = atom.GetProp("annot_atom_name").ljust(4)
+            # AF3's 64-char encoding (ASCII 32-95) excludes lowercase. 
+            # Uppercase for encoding, but preserve original casing for structure matching.
+            atom_name_padded = atom.GetProp("annot_atom_name").upper().ljust(4)
             chars = []
             for char in atom_name_padded:
                 chars.append(ord(char) - 32)

--- a/openfold3/core/data/pipelines/featurization/conformer.py
+++ b/openfold3/core/data/pipelines/featurization/conformer.py
@@ -129,8 +129,8 @@ def featurize_reference_conformers_of3(
             ref_space_uid.append(mol_idx)
 
             # Encoding of atom names
-            # AF3's 64-char encoding (ASCII 32-95) excludes lowercase. 
-            # Uppercase for encoding, but preserve original casing for structure matching.
+            # AF3's 64-char encoding (ASCII 32-95) excludes lowercase.
+            # Uppercase for encoding, but preserve the original case for matching.
             atom_name_padded = atom.GetProp("annot_atom_name").upper().ljust(4)
             chars = []
             for char in atom_name_padded:

--- a/openfold3/core/data/primitives/structure/labels.py
+++ b/openfold3/core/data/primitives/structure/labels.py
@@ -453,7 +453,24 @@ def assign_entity_ids(
     """
     # Cast entity IDs from string to int and shorten name
     if atom_array_source_format == "cif":
-        atom_array.set_annotation("entity_id", atom_array.label_entity_id.astype(int))
+        label_entity_ids = atom_array.label_entity_id
+        try:
+            entity_ids = label_entity_ids.astype(int)
+        except ValueError as error:
+            invalid_entity_ids = []
+            for entity_id in np.unique(label_entity_ids):
+                try:
+                    int(entity_id)
+                except ValueError:
+                    invalid_entity_ids.append(str(entity_id))
+
+            raise ValueError(
+                "`label_entity_id` values must be integers. Found non-numeric values: "
+                f"{invalid_entity_ids}. Renumber entities with integer IDs and update "
+                "all matching entity references in the mmCIF."
+            ) from error
+
+        atom_array.set_annotation("entity_id", entity_ids)
         atom_array.del_annotation("label_entity_id")
     elif atom_array_source_format == "pdb":
         raise NotImplementedError(

--- a/openfold3/tests/core/data/io/test_cif.py
+++ b/openfold3/tests/core/data/io/test_cif.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import numpy as np
+from biotite.structure.io.pdbx import CIFFile
+
+from openfold3.core.data.io.structure.cif import parse_mmcif
+
+MMCIF_DIR = Path(__file__).parents[3] / "test_data" / "mmcifs"
+
+
+def test_parse_mmcif_normalizes_uppercase_element_symbols(tmp_path):
+    cif_file = CIFFile.read(MMCIF_DIR / "1ubq.cif")
+    element_symbols = (
+        cif_file.block["atom_site"]["type_symbol"].as_array().astype("<U2")
+    )
+    element_symbols[:3] = ["BR", "CL", "FE"]
+    cif_file.block["atom_site"]["type_symbol"] = element_symbols
+
+    input_path = tmp_path / "uppercase_elements.cif"
+    cif_file.write(input_path)
+
+    parsed_structure = parse_mmcif(input_path, include_bonds=False)
+
+    assert parsed_structure.atom_array is not None
+    np.testing.assert_array_equal(
+        parsed_structure.atom_array.element[:3],
+        np.array(["Br", "Cl", "Fe"]),
+    )

--- a/openfold3/tests/core/data/primitives/structure/test_labels.py
+++ b/openfold3/tests/core/data/primitives/structure/test_labels.py
@@ -19,6 +19,7 @@ from biotite.structure import Atom, AtomArray, array
 from openfold3.core.data.primitives.structure.labels import (
     AtomArrayView,
     assign_atom_indices,
+    assign_entity_ids,
     residue_view_iter,
 )
 from openfold3.tests.utils.custom_assert_utils import assert_atomarray_equal
@@ -102,6 +103,33 @@ class TestAssignAtomIndices:
         assert np.array_equal(
             dummy_atom_array._atom_idx, np.arange(len(dummy_atom_array))
         )
+
+
+class TestAssignEntityIds:
+    def test_assigns_numeric_entity_ids(self):
+        atom_array = AtomArray(3)
+        atom_array.set_annotation("label_entity_id", np.array(["1", "2", "2"]))
+
+        assign_entity_ids(atom_array)
+
+        np.testing.assert_array_equal(atom_array.entity_id, np.array([1, 2, 2]))
+        assert "label_entity_id" not in atom_array.get_annotation_categories()
+
+    def test_rejects_all_non_numeric_entity_ids(self):
+        atom_array = AtomArray(3)
+        atom_array.set_annotation(
+            "label_entity_id",
+            np.array(["chain_A", "2", "chain_B"]),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"must be integers.*Found non-numeric values: "
+                r"\['chain_A', 'chain_B'\].*update all matching entity references"
+            ),
+        ):
+            assign_entity_ids(atom_array)
 
 
 class TestResidueViewIter:


### PR DESCRIPTION
## Summary

Fix issue 278 B2. Single line change that ensures all inputs are uppercase for the model. 

## Changes
Changed a single line from:  to ```atom.GetProp("annot_atom_name").ljust(4)``` to ```atom.GetProp("annot_atom_name").upper().ljust(4)```
## Related Issues

## Testing
Ensured the new line gives the model the uppercase text, while the original molecular data is unchanged. 
