### PR TITLE
docs: remove erroneous ccd_file_path from query.json example

### DIFF
--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -344,8 +344,7 @@ Below is a complete example of an input JSON file specifying a single bioassembl
                 }
             ],
         }
-    },
-    "ccd_file_path": "/path/to/CCD/file.cif"
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary

The `query.json` example in Section 5 of `input_format_reference.md` includes a top-level `ccd_file_path` key, which does not belong there. Its presence here is misleading, since it appears valid but is silently ignored when parsing `query.json`.

Per `openfold3/projects/of3_all_atom/config/dataset_configs.py` (`InferenceDatasetConfigKwargs.ccd_file_path`), `ccd_file_path` is a `runner.yml` setting under `dataset_config_kwargs`, not a `query.json` field. This is already correctly documented in [Configuration Reference §3.7, Dataset Config Kwargs](https://openfold-3.readthedocs.io/en/latest/configuration_reference.html#dataset-config-kwargs-dataset-config-kwargs).

## Fix

Removed the field from the Section 5 example.

## Diff

```diff
diff --git a/docs/source/input_format_reference.md b/docs/source/input_format_reference.md
index 952a540..d558046 100644
--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -346,4 +346,3 @@ Below is a complete example of an input JSON file specifying a single bioassembl
         }
-    },
-    "ccd_file_path": "/path/to/CCD/file.cif"
+    }
 }
```

## Testing

Docs-only change; no tests needed.
