### PR TITLE
Fix 278 B6 missing standard AA reference SDFs

### DIFF
--- a/docs/source/data_pipeline_reference.md
+++ b/docs/source/data_pipeline_reference.md
@@ -141,6 +141,12 @@ The metadata cache generated in PDB preprocessing creates an index of the whole 
 
 Script: [scripts/data_preprocessing/create_pdb-weighted_training_dataset_cache.py](https://github.com/aqlaboratory/openfold-3/blob/main/scripts/data_preprocessing/create_pdb-weighted_training_dataset_cache.py)
 
+Every standard amino acid requires both an entry in `reference_molecule_data` and a
+matching SDF file during featurization. The cache builder checks all 20 canonical amino
+acids and generates any incomplete entries from `--ccd-path`. By default, generated
+SDFs are written to the `reference_mols` directory next to `--preprocessed-dir`; use
+`--reference-molecule-dir` to select a different location.
+
 Clustering follows AF3 SI §2.5.3:
 
 - **Protein chains**: 40% sequence identity (MMSeqs2)

--- a/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
+++ b/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
@@ -64,7 +64,19 @@ def _get_interface_type(
     interface_id: str,
     structure_data,
 ) -> str | None:
-    """Get the interface type string from an interface ID and structure data."""
+    """Get the interface type string from an interface ID and structure data.
+    
+    Args:
+        interface_id:
+            Labels of the two interface chains separated by a '_'. E.g. "A_B"
+        structure_data:
+            Single structure containing a chains dictionary
+            that maps chain IDs to their corresponding metadata
+
+
+    Returns:
+        String with the type of interface, e.g. if its two proteins: "protein-protein"
+    """
     chain_1, chain_2 = interface_id.split("_")
     molecule_types = [
         structure_data.chains[chain_1].molecule_type,
@@ -317,7 +329,6 @@ def select_monomer_cache(
 
 
 # TODO: Could expose more arguments?
-# TODO: Add docstring!
 def create_pdb_val_dataset_cache_of3(
     metadata_cache_path: Path,
     preprocessed_dir: Path,
@@ -338,6 +349,52 @@ def create_pdb_val_dataset_cache_of3(
     tanimoto_threshold: float = 0.85,
     random_seed: int = 12345,
 ) -> None:
+    """Generates the validation set for the model.
+
+    Args:
+        metadata_cache_path:
+            Path to the preprocessed metadata cache
+        preprocessed_dir:
+            Preprocessing output directory with preprocessed structure and fasta files.
+        train_cache_path: 
+            Path to the preprocessed training cache data
+        alignment_representatives_fasta: 
+        output_path: 
+            Path to where validation set is generatted
+        dataset_name: 
+            Name of the dataset, e.g. "Validation"
+        min_release_date:
+            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a datetime object
+        max_release_date:
+            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a datetime object
+        max_resolution: 
+            Maximum resolution for structures in the dataset in Å.
+        max_polymer_chains: 
+            Maximum number of polymer chains for included structures.
+        filter_missing_alignment:
+            Whether to filter out chains (and their corresponding structures) whose
+            sequences do not match to a representative in the
+            alignment_representatives_fasta.
+        missing_alignment_log: 
+            Path to write a JSON file containing all chains that were filtered out
+            because they do not have a corresponding alignment.
+        max_tokens_initial:
+            Filter out entries with token count higher than this value before clustering.
+        max_tokens_final: 
+            Filter out entries with token count higher than this value post clustering.
+        ranking_fit_threshold: 
+            The minimum ranking model fit for ligands to be included. Default is 0.5.
+        seq_identity_threshold:
+            Sequence identity threshold. Chains with sequence identity strictly greater
+            than this value are considered homologous.
+        tanimoto_threshold:
+            Tanimoto similarity threshold. Ligands with Tanimoto similarity strictly
+            greater than this value are considered homologous.
+        random_seed:
+            Random seed for reproducibility.
+    Returns:
+        None
+    """
     metadata_cache = PreprocessingDataCache.from_json(metadata_cache_path)
 
     # TODO: Following code has quite a bit of redundancy with training code, consider

--- a/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
+++ b/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
@@ -64,19 +64,7 @@ def _get_interface_type(
     interface_id: str,
     structure_data,
 ) -> str | None:
-    """Get the interface type string from an interface ID and structure data.
-    
-    Args:
-        interface_id:
-            Labels of the two interface chains separated by a '_'. E.g. "A_B"
-        structure_data:
-            Single structure containing a chains dictionary
-            that maps chain IDs to their corresponding metadata
-
-
-    Returns:
-        String with the type of interface, e.g. if its two proteins: "protein-protein"
-    """
+    """Get the interface type string from an interface ID and structure data."""
     chain_1, chain_2 = interface_id.split("_")
     molecule_types = [
         structure_data.chains[chain_1].molecule_type,
@@ -329,6 +317,7 @@ def select_monomer_cache(
 
 
 # TODO: Could expose more arguments?
+# TODO: Add docstring!
 def create_pdb_val_dataset_cache_of3(
     metadata_cache_path: Path,
     preprocessed_dir: Path,
@@ -349,54 +338,6 @@ def create_pdb_val_dataset_cache_of3(
     tanimoto_threshold: float = 0.85,
     random_seed: int = 12345,
 ) -> None:
-    """Generates the validation set for the model.
-
-    Args:
-        metadata_cache_path:
-            Path to the preprocessed metadata cache
-        preprocessed_dir:
-            Preprocessing output directory with preprocessed structure and fasta files.
-        train_cache_path: 
-            Path to the preprocessed training cache data
-        alignment_representatives_fasta: 
-        output_path: 
-            Path to where validation set is generatted
-        dataset_name: 
-            Name of the dataset, e.g. "Validation"
-        min_release_date:
-            Minimum release date for included structures, formatted as 'YYYY-MM-DD' or a
-            datetime object
-        max_release_date:
-            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a
-            datetime object
-        max_resolution: 
-            Maximum resolution for structures in the dataset in Å
-        max_polymer_chains: 
-            Maximum number of polymer chains for included structures
-        filter_missing_alignment:
-            Whether to filter out chains (and their corresponding structures) whose
-            sequences do not match to a representative in the
-            alignment_representatives_fasta.
-        missing_alignment_log: 
-            Path to write a JSON file containing all chains that were filtered out
-            because they do not have a corresponding alignment
-        max_tokens_initial:
-            Filter out entries with token count higher than this value before clustering
-        max_tokens_final: 
-            Filter out entries with token count higher than this value post clustering
-        ranking_fit_threshold: 
-            The minimum ranking model fit for ligands to be included. Default is 0.5
-        seq_identity_threshold:
-            Sequence identity threshold. Chains with sequence identity strictly greater
-            than this value are considered homologous
-        tanimoto_threshold:
-            Tanimoto similarity threshold. Ligands with Tanimoto similarity strictly
-            greater than this value are considered homologous
-        random_seed:
-            Random seed for reproducibility
-    Returns:
-        None
-    """
     metadata_cache = PreprocessingDataCache.from_json(metadata_cache_path)
 
     # TODO: Following code has quite a bit of redundancy with training code, consider

--- a/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
+++ b/openfold3/core/data/pipelines/preprocessing/caches/pdb_val.py
@@ -364,34 +364,36 @@ def create_pdb_val_dataset_cache_of3(
         dataset_name: 
             Name of the dataset, e.g. "Validation"
         min_release_date:
-            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a datetime object
+            Minimum release date for included structures, formatted as 'YYYY-MM-DD' or a
+            datetime object
         max_release_date:
-            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a datetime object
+            Maximum release date for included structures, formatted as 'YYYY-MM-DD' or a
+            datetime object
         max_resolution: 
-            Maximum resolution for structures in the dataset in Å.
+            Maximum resolution for structures in the dataset in Å
         max_polymer_chains: 
-            Maximum number of polymer chains for included structures.
+            Maximum number of polymer chains for included structures
         filter_missing_alignment:
             Whether to filter out chains (and their corresponding structures) whose
             sequences do not match to a representative in the
             alignment_representatives_fasta.
         missing_alignment_log: 
             Path to write a JSON file containing all chains that were filtered out
-            because they do not have a corresponding alignment.
+            because they do not have a corresponding alignment
         max_tokens_initial:
-            Filter out entries with token count higher than this value before clustering.
+            Filter out entries with token count higher than this value before clustering
         max_tokens_final: 
-            Filter out entries with token count higher than this value post clustering.
+            Filter out entries with token count higher than this value post clustering
         ranking_fit_threshold: 
-            The minimum ranking model fit for ligands to be included. Default is 0.5.
+            The minimum ranking model fit for ligands to be included. Default is 0.5
         seq_identity_threshold:
             Sequence identity threshold. Chains with sequence identity strictly greater
-            than this value are considered homologous.
+            than this value are considered homologous
         tanimoto_threshold:
             Tanimoto similarity threshold. Ligands with Tanimoto similarity strictly
-            greater than this value are considered homologous.
+            greater than this value are considered homologous
         random_seed:
-            Random seed for reproducibility.
+            Random seed for reproducibility
     Returns:
         None
     """

--- a/openfold3/core/data/pipelines/preprocessing/caches/pdb_weighted.py
+++ b/openfold3/core/data/pipelines/preprocessing/caches/pdb_weighted.py
@@ -19,12 +19,18 @@ from dataclasses import asdict
 from functools import partial
 from pathlib import Path
 
+from biotite.structure.io.pdbx import CIFFile
+
 from openfold3.core.data.io.dataset_cache import (
     format_nested_dict_for_json,
     write_datacache_to_json,
 )
 from openfold3.core.data.io.sequence.fasta import (
     consolidate_preprocessed_fastas,
+)
+from openfold3.core.data.io.structure.mol import write_annotated_sdf
+from openfold3.core.data.pipelines.preprocessing.reference_molecules import (
+    prepare_reference_molecule,
 )
 from openfold3.core.data.primitives.caches.clustering import (
     add_cluster_data,
@@ -42,14 +48,20 @@ from openfold3.core.data.primitives.caches.filtering import (
 )
 from openfold3.core.data.primitives.caches.format import (
     PreprocessingDataCache,
+    PreprocessingReferenceMoleculeData,
     PreprocessingStructureDataCache,
 )
+from openfold3.core.data.primitives.structure.component import mol_from_ccd_entry
+from openfold3.core.data.resources.residues import STANDARD_PROTEIN_RESIDUES_3
 
 logger = logging.getLogger(__name__)
 
+CANONICAL_AMINO_ACID_RESIDUES_3 = tuple(
+    residue for residue in STANDARD_PROTEIN_RESIDUES_3 if residue != "UNK"
+)
+
 
 # TODO: reorganize metadata cache creation pipelines into a caches module
-# TODO: Make docstring more complete for new args
 def filter_structure_metadata_of3(
     structure_cache: PreprocessingStructureDataCache,
     max_release_date: datetime.date | str | None = None,
@@ -61,8 +73,6 @@ def filter_structure_metadata_of3(
 ) -> PreprocessingStructureDataCache:
     """Filter the structure metadata cache for training or validation.
 
-    TODO: Update docstring
-
     Applies the following filters from the AF3 SI 2.5.4 that have not yet been applied
     in preprocessing:
     - release date <= max_release_date
@@ -72,6 +82,19 @@ def filter_structure_metadata_of3(
     Args:
         structure_cache:
             Structure metadata cache to filter.
+        max_release_date:
+            Maximum release date for included structures, formatted as 'YYYY-MM-DD'
+        min_release_date:
+            Minimum release date for included structures, formatted as 'YYYY-MM-DD'
+        max_resolution:
+            Maximum resolution for structures in the dataset in Å.
+        ignore_nmr:
+            If True, ignore NMR structures when filtering (which have no resolution),
+            meaning that they will be kept always. Default is True.
+        max_polymer_chains:
+            Filter out entries with more polymer chains than this value.
+        max_tokens:
+            Filter out entries with token count higher than this value.
 
     Returns:
         Filtered structure metadata cache.
@@ -114,7 +137,71 @@ def filter_structure_metadata_of3(
     return filtered_cache
 
 
-# TODO: Add docstring!
+def ensure_standard_amino_acid_reference_molecules(
+    preprocessing_cache: PreprocessingDataCache,
+    reference_molecule_dir: Path,
+    ccd_path: Path | None,
+) -> None:
+    """Ensure cache metadata and SDFs exist for the 20 canonical amino acids.
+    
+    Args:
+        preprocessing_cache:
+            Preprocessing cache to ensure standard amino-acid reference molecules for.
+        reference_molecule_dir:
+            Directory to write reference molecule SDF files to.
+        ccd_path:
+            Path to the base CCD used to generate missing standard amino-acid reference
+            molecule metadata and SDF files.
+    Returns:
+        None
+    
+    """
+    missing_metadata = {
+        residue
+        for residue in CANONICAL_AMINO_ACID_RESIDUES_3
+        if residue not in preprocessing_cache.reference_molecule_data
+    }
+    missing_sdfs = {
+        residue
+        for residue in CANONICAL_AMINO_ACID_RESIDUES_3
+        if not (reference_molecule_dir / f"{residue}.sdf").is_file()
+    }
+    incomplete_residues = [
+        residue
+        for residue in CANONICAL_AMINO_ACID_RESIDUES_3
+        if residue in missing_metadata or residue in missing_sdfs
+    ]
+    if not incomplete_residues:
+        return
+
+    if ccd_path is None:
+        raise ValueError(
+            "Standard amino-acid reference molecules are incomplete. Provide "
+            "`ccd_path` so the missing metadata and SDF files can be generated. "
+            f"Missing or incomplete residues: {incomplete_residues}"
+        )
+
+    reference_molecule_dir.mkdir(parents=True, exist_ok=True)
+    ccd = CIFFile.read(ccd_path)
+
+    for residue in incomplete_residues:
+        mol = mol_from_ccd_entry(residue, ccd)
+        mol, metadata = prepare_reference_molecule(mol)
+
+        if residue in missing_metadata:
+            preprocessing_cache.reference_molecule_data[residue] = (
+                PreprocessingReferenceMoleculeData(**metadata)
+            )
+        if residue in missing_sdfs:
+            write_annotated_sdf(mol, reference_molecule_dir / f"{residue}.sdf")
+
+    logger.info(
+        "Generated standard amino-acid references (metadata=%s, SDFs=%s)",
+        sorted(missing_metadata),
+        sorted(missing_sdfs),
+    )
+
+
 def create_pdb_training_dataset_cache_of3(
     metadata_cache_path: Path,
     preprocessed_dir: Path,
@@ -127,6 +214,8 @@ def create_pdb_training_dataset_cache_of3(
     max_polymer_chains: int | None = None,
     filter_missing_alignment: bool = True,
     missing_alignment_log: Path = None,
+    ccd_path: Path | None = None,
+    reference_molecule_dir: Path | None = None,
 ) -> None:
     """Create a training cache from a metadata cache.
 
@@ -161,11 +250,27 @@ def create_pdb_training_dataset_cache_of3(
         missing_alignment_log:
             Path to write a JSON file containing all chains that were filtered out
             because they do not have a corresponding alignment.
+        ccd_path:
+            Path to the base CCD used to generate missing standard amino-acid reference
+            molecule metadata and SDF files.
+        reference_molecule_dir:
+            Directory containing reference molecule SDF files. Defaults to the
+            `reference_mols` directory next to `preprocessed_dir`.
+    
+    Returns:
+        None
     """
     if max_conformer_release_date is None:
         max_conformer_release_date = max_release_date
 
     metadata_cache = PreprocessingDataCache.from_json(metadata_cache_path)
+    if reference_molecule_dir is None:
+        reference_molecule_dir = preprocessed_dir.parent / "reference_mols"
+    ensure_standard_amino_acid_reference_molecules(
+        preprocessing_cache=metadata_cache,
+        reference_molecule_dir=reference_molecule_dir,
+        ccd_path=ccd_path,
+    )
 
     # Read in FASTAs of all sequences in the training set
     logger.info("Scanning FASTA directories...")

--- a/openfold3/core/data/pipelines/preprocessing/caches/pdb_weighted.py
+++ b/openfold3/core/data/pipelines/preprocessing/caches/pdb_weighted.py
@@ -143,7 +143,7 @@ def ensure_standard_amino_acid_reference_molecules(
     ccd_path: Path | None,
 ) -> None:
     """Ensure cache metadata and SDFs exist for the 20 canonical amino acids.
-    
+
     Args:
         preprocessing_cache:
             Preprocessing cache to ensure standard amino-acid reference molecules for.
@@ -154,7 +154,7 @@ def ensure_standard_amino_acid_reference_molecules(
             molecule metadata and SDF files.
     Returns:
         None
-    
+
     """
     missing_metadata = {
         residue
@@ -256,7 +256,7 @@ def create_pdb_training_dataset_cache_of3(
         reference_molecule_dir:
             Directory containing reference molecule SDF files. Defaults to the
             `reference_mols` directory next to `preprocessed_dir`.
-    
+
     Returns:
         None
     """

--- a/openfold3/core/data/pipelines/preprocessing/reference_molecules.py
+++ b/openfold3/core/data/pipelines/preprocessing/reference_molecules.py
@@ -1,0 +1,37 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared reference-molecule preparation helpers."""
+
+from openfold3.core.data.primitives.structure.component import (
+    AnnotatedMol,
+    get_reference_molecule_metadata,
+)
+from openfold3.core.data.primitives.structure.conformer import (
+    resolve_and_format_fallback_conformer,
+)
+
+
+def prepare_reference_molecule(
+    mol: AnnotatedMol,
+    residue_count: int = 1,
+) -> tuple[AnnotatedMol, dict]:
+    """Prepare a fallback conformer and its cache metadata."""
+    mol, conformer_strategy = resolve_and_format_fallback_conformer(mol)
+    metadata = get_reference_molecule_metadata(
+        mol,
+        conformer_strategy,
+        residue_count,
+    )
+    return mol, metadata

--- a/openfold3/core/data/pipelines/preprocessing/structure.py
+++ b/openfold3/core/data/pipelines/preprocessing/structure.py
@@ -56,6 +56,9 @@ from openfold3.core.data.io.structure.pdb import (
     parse_RNA_monomer_pdb_tmp,
 )
 from openfold3.core.data.io.utils import encode_numpy_types
+from openfold3.core.data.pipelines.preprocessing.reference_molecules import (
+    prepare_reference_molecule,
+)
 from openfold3.core.data.pipelines.preprocessing.utils import SharedSet
 from openfold3.core.data.primitives.caches.format import (
     DisorderedPreprocessingDataCache,
@@ -88,12 +91,8 @@ from openfold3.core.data.primitives.structure.cleanup import (
 )
 from openfold3.core.data.primitives.structure.component import (
     get_component_info,
-    get_reference_molecule_metadata,
     mol_from_atomarray,
     mol_from_ccd_entry,
-)
-from openfold3.core.data.primitives.structure.conformer import (
-    resolve_and_format_fallback_conformer,
 )
 from openfold3.core.data.primitives.structure.interface import (
     get_interface_chain_id_pairs,
@@ -375,9 +374,9 @@ def extract_component_data_of3(
     # conformer coordinates
     for mol_id, mol in all_component_mols.items():
         residue_count = non_std_ligands_to_rescount.get(mol_id, 1)
-        mol, conformer_strategy = resolve_and_format_fallback_conformer(mol)
-        reference_mol_metadata[mol_id] = get_reference_molecule_metadata(
-            mol, conformer_strategy, residue_count
+        mol, reference_mol_metadata[mol_id] = prepare_reference_molecule(
+            mol,
+            residue_count,
         )
 
         # Write SDF file

--- a/openfold3/tests/core/data/pipelines/preprocessing/test_pdb_weighted.py
+++ b/openfold3/tests/core/data/pipelines/preprocessing/test_pdb_weighted.py
@@ -1,0 +1,175 @@
+import pytest
+
+from openfold3.core.data.pipelines.preprocessing.caches import pdb_weighted
+from openfold3.core.data.primitives.caches.format import (
+    PreprocessingDataCache,
+    PreprocessingReferenceMoleculeData,
+)
+
+
+def test_canonical_amino_acid_residues_contains_twenty_residues():
+    assert len(pdb_weighted.CANONICAL_AMINO_ACID_RESIDUES_3) == 20
+    assert "UNK" not in pdb_weighted.CANONICAL_AMINO_ACID_RESIDUES_3
+
+
+def test_ensure_standard_amino_acid_reference_molecules_seeds_missing_entries(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        pdb_weighted,
+        "CANONICAL_AMINO_ACID_RESIDUES_3",
+        ("ALA", "GLY"),
+    )
+    ccd = object()
+    monkeypatch.setattr(
+        pdb_weighted.CIFFile,
+        "read",
+        lambda _: ccd,
+    )
+
+    generated_residues = []
+
+    def fake_mol_from_ccd_entry(residue, actual_ccd):
+        assert actual_ccd is ccd
+        generated_residues.append(residue)
+        return f"mol-{residue}"
+
+    monkeypatch.setattr(
+        pdb_weighted,
+        "mol_from_ccd_entry",
+        fake_mol_from_ccd_entry,
+    )
+    monkeypatch.setattr(
+        pdb_weighted,
+        "prepare_reference_molecule",
+        lambda mol: (
+            mol,
+            {
+                "conformer_gen_strategy": "use_fallback",
+                "fallback_conformer_pdb_id": None,
+                "canonical_smiles": mol,
+                "residue_count": 1,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        pdb_weighted,
+        "write_annotated_sdf",
+        lambda _, path: path.touch(),
+    )
+
+    cache = PreprocessingDataCache(structure_data={}, reference_molecule_data={})
+    reference_molecule_dir = tmp_path / "reference_mols"
+    ccd_path = tmp_path / "components.cif"
+
+    pdb_weighted.ensure_standard_amino_acid_reference_molecules(
+        preprocessing_cache=cache,
+        reference_molecule_dir=reference_molecule_dir,
+        ccd_path=ccd_path,
+    )
+
+    assert generated_residues == ["ALA", "GLY"]
+    assert set(cache.reference_molecule_data) == {"ALA", "GLY"}
+    assert cache.reference_molecule_data["GLY"].canonical_smiles == "mol-GLY"
+    assert (reference_molecule_dir / "ALA.sdf").is_file()
+    assert (reference_molecule_dir / "GLY.sdf").is_file()
+
+    dataset_cache = pdb_weighted.build_provisional_clustered_dataset_cache(
+        preprocessing_cache=cache,
+        dataset_name="test",
+    )
+    assert set(dataset_cache.reference_molecule_data) == {"ALA", "GLY"}
+    assert not dataset_cache.reference_molecule_data["GLY"].set_fallback_to_nan
+
+    pdb_weighted.ensure_standard_amino_acid_reference_molecules(
+        preprocessing_cache=cache,
+        reference_molecule_dir=reference_molecule_dir,
+        ccd_path=None,
+    )
+    assert generated_residues == ["ALA", "GLY"]
+
+
+def test_ensure_standard_amino_acid_references_preserves_existing_artifacts(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        pdb_weighted,
+        "CANONICAL_AMINO_ACID_RESIDUES_3",
+        ("ALA", "GLY"),
+    )
+    existing_ala_metadata = PreprocessingReferenceMoleculeData(
+        conformer_gen_strategy="use_fallback",
+        fallback_conformer_pdb_id=None,
+        canonical_smiles="existing-ALA",
+        residue_count=1,
+    )
+    cache = PreprocessingDataCache(
+        structure_data={},
+        reference_molecule_data={"ALA": existing_ala_metadata},
+    )
+    reference_molecule_dir = tmp_path / "reference_mols"
+    reference_molecule_dir.mkdir()
+    existing_gly_sdf = reference_molecule_dir / "GLY.sdf"
+    existing_gly_sdf.write_text("existing GLY SDF")
+
+    monkeypatch.setattr(pdb_weighted.CIFFile, "read", lambda _: object())
+    monkeypatch.setattr(
+        pdb_weighted,
+        "mol_from_ccd_entry",
+        lambda residue, _: f"mol-{residue}",
+    )
+    monkeypatch.setattr(
+        pdb_weighted,
+        "prepare_reference_molecule",
+        lambda mol: (
+            mol,
+            {
+                "conformer_gen_strategy": "use_fallback",
+                "fallback_conformer_pdb_id": None,
+                "canonical_smiles": mol,
+                "residue_count": 1,
+            },
+        ),
+    )
+    written_sdfs = []
+
+    def fake_write_sdf(_, path):
+        written_sdfs.append(path.name)
+        path.touch()
+
+    monkeypatch.setattr(pdb_weighted, "write_annotated_sdf", fake_write_sdf)
+
+    pdb_weighted.ensure_standard_amino_acid_reference_molecules(
+        preprocessing_cache=cache,
+        reference_molecule_dir=reference_molecule_dir,
+        ccd_path=tmp_path / "components.cif",
+    )
+
+    assert cache.reference_molecule_data["ALA"] is existing_ala_metadata
+    assert cache.reference_molecule_data["GLY"].canonical_smiles == "mol-GLY"
+    assert written_sdfs == ["ALA.sdf"]
+    assert existing_gly_sdf.read_text() == "existing GLY SDF"
+
+
+def test_ensure_standard_amino_acid_reference_molecules_requires_ccd(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        pdb_weighted,
+        "CANONICAL_AMINO_ACID_RESIDUES_3",
+        ("GLY",),
+    )
+    cache = PreprocessingDataCache(structure_data={}, reference_molecule_data={})
+
+    with pytest.raises(
+        ValueError,
+        match=r"Provide `ccd_path`.*Missing or incomplete residues: \['GLY'\]",
+    ):
+        pdb_weighted.ensure_standard_amino_acid_reference_molecules(
+            preprocessing_cache=cache,
+            reference_molecule_dir=tmp_path / "reference_mols",
+            ccd_path=None,
+        )

--- a/scripts/data_preprocessing/create_pdb-weighted_training_dataset_cache.py
+++ b/scripts/data_preprocessing/create_pdb-weighted_training_dataset_cache.py
@@ -25,6 +25,24 @@ from openfold3.core.data.pipelines.preprocessing.caches.pdb_weighted import (
     help="Path to directory of directories containing preprocessed mmCIF files.",
 )
 @click.option(
+    "--ccd-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Path to the base Chemical Component Dictionary. Required when standard "
+        "amino-acid reference molecule metadata or SDF files are missing."
+    ),
+)
+@click.option(
+    "--reference-molecule-dir",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help=(
+        "Directory containing reference molecule SDF files. Defaults to the "
+        "'reference_mols' directory next to --preprocessed-dir."
+    ),
+)
+@click.option(
     "--alignment-representatives-fasta",
     type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
     required=True,
@@ -114,6 +132,8 @@ from openfold3.core.data.pipelines.preprocessing.caches.pdb_weighted import (
 def main(
     metadata_cache_path: Path,
     preprocessed_dir: Path,
+    ccd_path: Path | None,
+    reference_molecule_dir: Path | None,
     alignment_representatives_fasta: Path,
     output_path: Path,
     dataset_name: str,
@@ -151,6 +171,9 @@ def main(
                 applies to the very special case where the fallback conformer was
                 derived from CCD model coordinates coming from a PDB-ID that was
                 released outside of the time cutoff (see AF3 SI 2.8)
+
+        Missing standard amino-acid reference molecules are generated from ccd_path and
+        written to reference_molecule_dir.
     """
     if max_release_date is not None:
         parsed_max_release_date = datetime.strptime(max_release_date, "%Y-%m-%d").date()
@@ -188,6 +211,8 @@ def main(
     create_pdb_training_dataset_cache_of3(
         metadata_cache_path=metadata_cache_path,
         preprocessed_dir=preprocessed_dir,
+        ccd_path=ccd_path,
+        reference_molecule_dir=reference_molecule_dir,
         alignment_representatives_fasta=alignment_representatives_fasta,
         output_path=output_path,
         dataset_name=dataset_name,


### PR DESCRIPTION
## Summary

Fix issue 278 B6. When building the training dataset cache, OpenFold3 looks up reference data for all 20 canonical amino acids. Incomplete metadata or missing SDF files triggers a vague error. With the changes, all missing standard AA SDFs are caught and automatically built from the CCD.

## Changes
- Refactored conformer generation and metadata extraction in `structure.py` into `prepare_reference_molecule()`.
- Detect incomplete canonical residues and generate missing metadata and 3D SDF files from the CCD.
- Added new flags:
  - `--ccd-path`: Optional path to the CCD CIF file
  - `--reference-molecule-dir`: Target SDF directory
- Error messages are more detailed.

## Related Issues


## Testing
Test suite added at `openfold3/tests/core/data/pipelines/preprocessing/test_pdb_weighted.py`