### PR TITLE
Add optional fast_trimul fp16 triangle-multiply backend (inference, opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A summary of our supported features includes:
 - Pipelines for generating MSAs using the [ColabFold server](https://github.com/sokrypton/ColabFold) or using JackHMMER / hhblits following the AlphaFold3 protocol
 - [Structure templates](https://openfold-3.readthedocs.io/en/latest/template_how_to.html) for protein monomers
 - Kernel acceleration through [cuEquivariance](https://docs.nvidia.com/cuda/cuequivariance) and [DeepSpeed4Science](https://www.deepspeed.ai/tutorials/ds4sci_evoformerattention/) kernels - more details [here](https://openfold-3.readthedocs.io/en/latest/kernels.html)
+- Optional fp16 triangle-multiply acceleration via the third-party [`fast_trimul`](https://github.com/tiagomonteiro0715/fast_trimul) CuTe kernel (inference only) - see [kernels docs](https://openfold-3.readthedocs.io/en/latest/kernels.html)
 - Support for [multi-query jobs](https://openfold-3.readthedocs.io/en/latest/input_format.html) with [distributed predictions across multiple GPUs](https://openfold-3.readthedocs.io/en/latest/inference.html#inference-run-on-multiple-gpus)
 - Custom settings for [memory constrained GPU resources](https://openfold-3.readthedocs.io/en/latest/inference.html#inference-low-memory-mode)
 - [Training data processing](https://openfold-3.readthedocs.io/en/latest/data_pipeline_reference.html) and [model training](https://openfold-3.readthedocs.io/en/latest/training.html)

--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -35,3 +35,36 @@ model_update:
 ```
 
 This runner.yml is specifically for inference, but similar settings can be used for training. 
+
+# fast_trimul (optional, third-party)
+
+OF3 can optionally route the triangle multiplicative update through
+[`fast_trimul`](https://github.com/tiagomonteiro0715/fast_trimul), a fused fp16
+[CuTe DSL](https://github.com/NVIDIA/cutlass) kernel. It is **inference only** (its
+backward is a correct but slow torch recompute), and it holds an fp16 copy of the
+layer weights, so it is opt-in and off by default.
+
+Install the optional dependency:
+
+```bash
+pip install openfold3[fast_trimul]
+```
+
+Enable it per `TriangleMultiplicativeUpdate` module by setting the `use_fast_trimul`
+attribute on the built model (before inference, after loading weights):
+
+```python
+from openfold3.core.model.layers.triangular_multiplicative_update import (
+    TriangleMultiplicativeUpdate,
+)
+
+model.eval()
+for m in model.modules():
+    if isinstance(m, TriangleMultiplicativeUpdate):
+        m.use_fast_trimul = True
+```
+
+The fast path targets NVIDIA Ampere (sm80) with `N` divisible by 8; other
+hardware/shapes/dtypes use fast_trimul's built-in pure-torch fallback. If the
+package is not installed, or during training, the flag is ignored and the normal
+OF3 path runs.

--- a/openfold3/core/model/layers/triangular_multiplicative_update.py
+++ b/openfold3/core/model/layers/triangular_multiplicative_update.py
@@ -43,6 +43,13 @@ try:
 except ImportError:
     TRITON_AVAILABLE = False
 
+try:
+    import fast_trimul
+
+    FAST_TRIMUL_AVAILABLE = True
+except ImportError:
+    FAST_TRIMUL_AVAILABLE = False
+
 _TRITON_UNAVAILABLE_ERROR = (
     "Triton kernels requested (use_triton_triangle_kernels=True) but "
     "openfold3.core.kernels.triton is not available. Ensure the package is "
@@ -736,6 +743,19 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             self.c_z, self.c_hidden, **linear_init_params.linear_b_g
         )
 
+    def _ensure_fast_impl(self, z: torch.Tensor) -> None:
+        """Lazily build the fast_trimul module and load this layer's weights into
+        it once. Stored outside nn.Module registration (via __dict__) so it never
+        appears in state_dict / checkpoints."""
+        if self.__dict__.get("_fast_impl") is not None:
+            return
+        mode = "outgoing" if self._outgoing else "incoming"
+        impl = fast_trimul.FastTriangleMultiplication(
+            d_z=self.c_z, d_c=self.c_hidden, mode=mode, residual=False
+        ).to(z.device)
+        impl.load_weights(self.state_dict(), source="openfold3")
+        self.__dict__["_fast_impl"] = impl
+
     def _inference_forward(
         self,
         z: torch.Tensor,
@@ -1123,6 +1143,19 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
         """
         if use_triton_triangle_kernels and not TRITON_AVAILABLE:
             raise RuntimeError(_TRITON_UNAVAILABLE_ERROR)
+
+        # fast_trimul: optional third-party fp16 CuTe backend, opt-in per module
+        # via `self.use_fast_trimul`. Inference only (its backward is a correct
+        # but slow torch recompute and it holds a weight copy); when unavailable
+        # or during training this is skipped and the normal path runs.
+        if (
+            getattr(self, "use_fast_trimul", False)
+            and FAST_TRIMUL_AVAILABLE
+            and not self.training
+        ):
+            self._ensure_fast_impl(z)
+            update = self._fast_impl(z, mask=mask)
+            return z + update if _add_with_inplace else update
 
         ## NOTE: valid for inplace safe and use_cueq_triangle_kernels to be enabled
         ## inplace safe is used across the codebase and so should not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,10 @@ optional-dependencies.cuequivariance = [
 optional-dependencies.deepspeed = [
     "deepspeed>=0.18.7",
 ]
+optional-dependencies.fast_trimul = [
+    "fast_trimul>=2.1.2",
+    "cuda-python<13",
+]
 
 [project.scripts]
 run_openfold="openfold3.run_openfold:cli"


### PR DESCRIPTION
**Summary**

Adds an optional, off-by-default backend for the Triangle Multiplicative Update that routes the op through `fast_trimul` (https://github.com/tiagomonteiro0715/fast_trimul), a fused fp16 CuTe DSL kernel. 

It targets inference on launch-bound small-N and memory-bound long-N regimes, and complements the existing cuEquivariance / Triton paths rather than replacing them. 

The default behaviour of OF3 is unchanged. With the flag off (or the package not installed), the normal PyTorch path runs  exactly as before.

**Changes**

- `openfold3/core/model/layers/triangular_multiplicative_update.py`
  - Add a guarded optional import (`FAST_TRIMUL_AVAILABLE`), mirroring the existing Triton/cuEquivariance import guards.
  - Add `TriangleMultiplicativeUpdate._ensure_fast_impl(...)`, which lazily builds the fast_trimul module and loads this layer's weights into it once. It is stored off the `nn.Module` registry (via `__dict__`) so it never appears in `state_dict` or pollutes checkpoints.
  - Add a branch at the top of `TriangleMultiplicativeUpdate.forward` gated by `self.use_fast_trimul` (default off). It runs only for inference (`not self.training`) and honours the existing residual/inplace contract(returns `z + update` when `_add_with_inplace`, else `update`). When the flag is off, the package is missing, or during training, this is skipped.
- `pyproject.toml`: add an optional-dependency group `optional-dependencies.fast_trimul` (`fast_trimul`, `cuda-python<13`).
- `docs/source/kernels.md` and `README.md`: document the optional backend, how to install (`pip install openfold3[fast_trimul]`), how to enable it, and its limits.

Design note: OF3's kernel choices are boolean flags threaded through many modules. 

To keep this PR small and low-risk I gated the backend on a per-module attribute (`use_fast_trimul`) instead of threading a new flag through the config/runner. 

**If you'd prefer it wired as a first-class `use_fast_trimul_kernels` flag matching the `use_cueq_/triton_triangle_kernels` convention, I'm happy to expand it!**

**Testing**

- Local: the modified module imports and byte-compiles cleanly; with the flag off the existing code path is untouched (no behavioural change).
- Existing suite: `pytest openfold3/tests/test_triangular_multiplicative_update.py` 
- Correctness: fast_trimul is separately validated against reference TriMul outputs  (fp16 tolerance) in its own repo; enabling `use_fast_trimul` on an A100 produced
- The fast path is Ampere (sm80) + `N % 8 == 0` + fp16; other hardware/shapes/dtypes   use fast_trimul's built-in pure-torch fallback.

**Other Notes**

- Inference only by design: the fast_trimul backward is a correct but slow torch recompute, and the backend holds an fp16 copy of the weights — hence the   `not self.training` guard.
- The kernel is fp16 while OF3 typically runs bf16; the fast path casts to fp16 and  otherwise falls back to torch. Framed accordingly as an inference option.
- No new required dependency; everything is behind the optional extra and the flag.