### PR TITLE
Fix naming of openbind parameter download

### DIFF
--- a/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
@@ -75,7 +75,7 @@ jobs:
           # need the AWS CLI installed (equivalent to `aws s3 cp --no-sign-request`).
           curl -fSL \
             https://openfold3-data.s3.amazonaws.com/openfold3-parameters/of3-ob-2025-06-30-174k.pt \
-            -o ~/.openfold3/ob-rc-v1.pt
+            -o ~/.openfold3/
 
       - name: Run integration test
         run: |


### PR DESCRIPTION
**Summary**
The AMD Integration CI failed because of an erroneous renaming step upon downloading the OpenBind parameters. Removing the rename will fix the integration test. 

This renaming issue was not present on the pixi-cuda workflows, only the amd workflow needs to be fixed.

**Related Issues**
Example workflow failure: https://github.com/aqlaboratory/openfold-3/actions/runs/32686976308/job/97316237360

