### PR TITLE
Parse a query entry from an mmcif file

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1340,6 +1340,7 @@ openfold3/core/data/primitives/structure/query.py:0: error: Item "None" of "Bina
 openfold3/core/data/primitives/structure/query.py:0: error: Item "None" of "BinaryCIFColumn | None" has no attribute "as_array"  [union-attr]
 openfold3/core/data/primitives/structure/query.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
 openfold3/core/data/primitives/structure/query.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+openfold3/core/data/primitives/structure/query_extraction.py:0: error: "AtomArray[Any]" has no attribute "label_asym_id"  [attr-defined]
 openfold3/core/data/primitives/structure/template.py:0: error: "AtomArray[Any]" has no attribute "label_asym_id"  [attr-defined]
 openfold3/core/data/primitives/structure/template.py:0: error: "AtomArray[Any]" has no attribute "molecule_type_id"  [attr-defined]
 openfold3/core/data/primitives/structure/template.py:0: error: "AtomArray[int]" has no attribute "token_position"  [attr-defined]

--- a/openfold3/core/data/primitives/structure/query_extraction.py
+++ b/openfold3/core/data/primitives/structure/query_extraction.py
@@ -1,0 +1,230 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Derives inference-query `Chain` entries from a parsed structure.
+
+This is the inverse direction of ``query.py`` (which turns a `Query` into an
+`AtomArray`): given a structure already read from a CIF file, classify each
+chain as protein/dna/rna or ligand and produce one `Chain` per polymer chain
+plus one `Chain` per distinct hetero/ligand group, suitable for assembling an
+inference `query.json` from an existing structure.
+"""
+
+from pathlib import Path
+from typing import NamedTuple
+
+import biotite.structure as struc
+import biotite.structure.io.pdbx as pdbx
+from biotite.structure import AtomArray
+
+from openfold3.core.data.resources.lists import (
+    CRYSTALLIZATION_AIDS,
+    IONS,
+    LIGAND_EXCLUSION_LIST,
+)
+from openfold3.core.data.resources.residues import (
+    DNA_RESTYPE_3TO1,
+    PROTEIN_RESTYPE_3TO1,
+    RNA_RESTYPE_3TO1,
+    MoleculeType,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Chain
+
+#: Crystallization aids, common additives, and monoatomic ions dropped from
+#: extracted ligand chains by default (AlphaFold3 SI Tables 9-10 + the ion list).
+EXCLUDED_HETERO_CODES = frozenset(
+    {*CRYSTALLIZATION_AIDS, *LIGAND_EXCLUSION_LIST, *IONS}
+)
+
+
+class ChainExtractionResult(NamedTuple):
+    """Chains extracted from a structure, plus warnings worth a human's attention."""
+
+    chains: list[Chain]
+    warnings: list[str]
+
+
+def _build_polymer_chain(
+    chain_id: str, res_names: list[str], is_nucleic: bool
+) -> Chain:
+    """Builds a protein/dna/rna `Chain` from an ordered list of 3-letter residue names.
+
+    Any residue name outside the canonical alphabet is recorded under
+    `non_canonical_residues` (1-based index -> 3-letter code) rather than
+    dropped, so the chain's sequence length always matches its residue count.
+    """
+    if not is_nucleic:
+        table, unknown_code, molecule_type = (
+            PROTEIN_RESTYPE_3TO1,
+            "X",
+            MoleculeType.PROTEIN,
+        )
+    else:
+        dna_votes = sum(r in DNA_RESTYPE_3TO1 for r in res_names)
+        rna_votes = sum(r in RNA_RESTYPE_3TO1 for r in res_names)
+        molecule_type = MoleculeType.DNA if dna_votes >= rna_votes else MoleculeType.RNA
+        table = (
+            DNA_RESTYPE_3TO1 if molecule_type == MoleculeType.DNA else RNA_RESTYPE_3TO1
+        )
+        unknown_code = "N"
+
+    seq_chars = []
+    non_canonical_residues: dict[int, str] = {}
+    for i, res_name in enumerate(res_names, start=1):
+        if res_name in table:
+            seq_chars.append(table[res_name])
+        else:
+            seq_chars.append(unknown_code)
+            non_canonical_residues[i] = res_name
+
+    return Chain(
+        molecule_type=molecule_type,
+        chain_ids=[chain_id],
+        sequence="".join(seq_chars),
+        non_canonical_residues=non_canonical_residues or None,
+    )
+
+
+def chains_from_atom_array(
+    atom_array: AtomArray, keep_excluded: bool = False
+) -> ChainExtractionResult:
+    """Classifies each chain in a parsed structure into inference-query `Chain`s.
+
+    Polymer chains (protein/dna/rna) are classified via biotite's CCD-based
+    amino-acid/nucleotide detection, which recognizes modified residues (e.g.
+    MSE, 5-iodouridine) as polymer residues rather than misfiling them as
+    ligands. Hetero (non-polymer) residues are grouped by `label_asym_id` --
+    not the author `chain_id` -- since ligands/ions frequently share the
+    polymer's author chain letter in a CIF file but are distinct entities.
+
+    Each polymer chain's `sequence` is built strictly from residues present in
+    `atom_array` -- i.e. residues with modeled coordinates in this particular
+    structure -- not from `entity_poly`'s canonical/SEQRES sequence. Disordered
+    termini or internal loop residues with no coordinates are simply absent, so
+    the sequence can be shorter than, and discontinuous with, the full
+    biological sequence. Reconstructing the canonical sequence would require
+    reading `entity_poly.pdbx_seq_one_letter_code_can` instead (see
+    `metadata.get_entity_to_canonical_seq_dict` for that direction); this
+    function does not do that.
+
+    Args:
+        atom_array:
+            Structure to extract chains from, expected to carry a
+            `label_asym_id` annotation (e.g. from
+            ``pdbx.get_structure(..., extra_fields=["label_asym_id"])``) and to
+            already have solvent removed.
+        keep_excluded:
+            If False (default), crystallization aids, common additives, and
+            monoatomic ions (see `EXCLUDED_HETERO_CODES`) are dropped instead
+            of becoming ligand chains, and reported in `warnings` instead.
+
+    Returns:
+        The extracted `Chain`s (polymer chains first, in chain order, then
+        ligand chains in first-appearance order) and any warnings about
+        non-canonical residues, multi-residue ligand groups, or dropped
+        hetero groups.
+    """
+    polymer_mask = struc.filter_amino_acids(atom_array) | struc.filter_nucleotides(
+        atom_array
+    )
+    polymer_atoms = atom_array[polymer_mask]
+    hetero_atoms = atom_array[~polymer_mask]
+
+    chains: list[Chain] = []
+    warnings: list[str] = []
+
+    for chain_atoms in struc.chain_iter(polymer_atoms):
+        chain_id = str(chain_atoms.chain_id[0])
+        _, raw_res_names = struc.get_residues(chain_atoms)
+        res_name_list = [str(r) for r in raw_res_names]
+        is_nucleic = (
+            struc.filter_nucleotides(chain_atoms).sum()
+            > struc.filter_amino_acids(chain_atoms).sum()
+        )
+
+        chain = _build_polymer_chain(chain_id, res_name_list, is_nucleic)
+        if chain.non_canonical_residues:
+            warnings.append(
+                f"chain {chain_id}: non-canonical residues at positions "
+                f"{chain.non_canonical_residues} - verify mapping."
+            )
+        chains.append(chain)
+
+    used_ids = {chain_id for chain in chains for chain_id in chain.chain_ids}
+    dropped: list[tuple[str, str]] = []
+    ligand_res_names: dict[str, list[str]] = {}
+    for res_atoms in struc.residue_iter(hetero_atoms):
+        res_name = str(res_atoms.res_name[0])
+        label_asym = str(res_atoms.label_asym_id[0])
+
+        if res_name in EXCLUDED_HETERO_CODES and not keep_excluded:
+            dropped.append((label_asym, res_name))
+            continue
+
+        ligand_res_names.setdefault(label_asym, []).append(res_name)
+
+    for label_asym, res_names in ligand_res_names.items():
+        out_id = label_asym if label_asym not in used_ids else f"{label_asym}_lig"
+        used_ids.add(out_id)
+        chains.append(
+            Chain(
+                molecule_type=MoleculeType.LIGAND,
+                chain_ids=[out_id],
+                ccd_codes=res_names,
+            )
+        )
+        if len(res_names) > 1:
+            warnings.append(
+                f"chain {label_asym}: multi-residue ligand group ({res_names}) - "
+                "polymeric ligand support in OF3 is limited, verify this is intended."
+            )
+
+    if dropped:
+        warnings.append(
+            "Dropped as crystallization aids / ions / common additives (AF3 SI "
+            "Tables 9-10 + ion list) - pass keep_excluded=True or add back "
+            f"manually if biologically relevant (e.g. a catalytic metal): {dropped}"
+        )
+
+    return ChainExtractionResult(chains=chains, warnings=warnings)
+
+
+def chains_from_cif(
+    cif_path: str | Path, keep_excluded: bool = False
+) -> ChainExtractionResult:
+    """Reads a CIF file and extracts inference-query `Chain`s from it.
+
+    Convenience wrapper around `chains_from_atom_array` for the common case of
+    starting from a file path rather than an already-parsed `AtomArray`. See
+    `chains_from_atom_array` for the extraction/classification behavior.
+
+    Args:
+        cif_path:
+            Path to a `.cif` file.
+        keep_excluded:
+            See `chains_from_atom_array`.
+
+    Returns:
+        See `chains_from_atom_array`.
+    """
+    cif_file = pdbx.CIFFile.read(cif_path)
+    atom_array = pdbx.get_structure(
+        cif_file,
+        model=1,
+        use_author_fields=True,
+        include_bonds=False,
+        extra_fields=["label_asym_id"],
+    )
+    atom_array = atom_array[~struc.filter_solvent(atom_array)]
+    return chains_from_atom_array(atom_array, keep_excluded=keep_excluded)

--- a/openfold3/tests/core/data/primitives/structure/test_query_extraction.py
+++ b/openfold3/tests/core/data/primitives/structure/test_query_extraction.py
@@ -1,0 +1,193 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `query_extraction.py` against real mmCIF fixtures.
+
+Each case documents a specific behavior the fixture was chosen to exercise --
+see the module docstring of `query_extraction.py` for the extraction rules
+being verified.
+"""
+
+from pathlib import Path
+
+import biotite.structure.io.pdbx as pdbx
+
+import openfold3
+from openfold3.core.data.primitives.structure.metadata import get_cif_block
+from openfold3.core.data.primitives.structure.query_extraction import (
+    chains_from_cif,
+)
+from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
+)
+
+MMCIFS_DIR = Path(openfold3.__file__).parent / "tests" / "test_data" / "mmcifs"
+
+
+def _seqres_length(cif_path: Path) -> int:
+    """Independent oracle: the length of the full `entity_poly` canonical
+    (SEQRES) sequence, as opposed to `chains_from_cif`'s coordinate-derived
+    one. Only meaningful for single-polymer-entity fixtures like 7l39, where
+    there's no ambiguity about which entity's sequence this is.
+    """
+    cif_file = pdbx.CIFFile.read(cif_path)
+    cif_block = get_cif_block(cif_file)
+    seqres = cif_block["entity_poly"]["pdbx_seq_one_letter_code_can"].as_array()[0]
+    return len(seqres.replace("\n", ""))
+
+
+def test_1ubq_pure_protein_monomer():
+    """1ubq: single protein chain, no ligands/hetero groups, no missing density."""
+    result = chains_from_cif(MMCIFS_DIR / "1ubq.cif")
+
+    assert len(result.chains) == 1
+    (chain,) = result.chains
+    assert chain.chain_ids == ["A"]
+    assert chain.molecule_type == MoleculeType.PROTEIN
+    assert chain.sequence == (
+        "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG"
+    )
+    assert chain.non_canonical_residues is None
+    assert result.warnings == []
+
+
+def test_7l39_separates_ligand_from_protein_and_drops_crystallization_aids():
+    """7l39: TRS/CL/MBN/BME hetero groups all share author chain "A" with the
+    protein in the raw CIF. MBN (toluene) is the real ligand and must come out
+    as its own chain; TRS (buffer), CL (ion), and BME (reducing agent) are
+    crystallization aids/ions and should be dropped by default, not merged
+    into the protein sequence as "non-canonical residues".
+    """
+    result = chains_from_cif(MMCIFS_DIR / "7l39.cif")
+
+    by_id = {c.chain_ids[0]: c for c in result.chains}
+    assert set(by_id) == {"A", "D"}
+
+    protein = by_id["A"]
+    assert protein.molecule_type == MoleculeType.PROTEIN
+    # Ends at the last residue with resolved coordinates in this deposition;
+    # does not include unresolved C-terminal residues from the full construct.
+    assert protein.sequence.endswith("TGTWDAYK")
+    assert len(protein.sequence) == 162
+    assert protein.non_canonical_residues is None
+    # 7L39 is the L99A cavity mutant (the mutation that creates the pocket
+    # toluene binds in) -- position 99 (1-indexed) must read A, not wild-type L.
+    assert protein.sequence[98] == "A"
+
+    # Confirm against an independent oracle that this is really the
+    # coordinate-derived sequence, not the full entity_poly SEQRES sequence
+    # (which includes 2 more, unresolved, C-terminal residues here).
+    seqres_length = _seqres_length(MMCIFS_DIR / "7l39.cif")
+    assert seqres_length == 164
+    assert len(protein.sequence) != seqres_length
+
+    ligand = by_id["D"]
+    assert ligand.molecule_type == MoleculeType.LIGAND
+    assert ligand.ccd_codes == ["MBN"]
+
+    [warning] = result.warnings
+    assert all(code in warning for code in ("TRS", "CL", "BME"))
+    assert "MBN" not in warning
+
+
+def test_7l39_keep_excluded_restores_crystallization_aids_as_ligands():
+    """The same TRS/CL/BME groups become ligand chains when explicitly asked for."""
+    result = chains_from_cif(MMCIFS_DIR / "7l39.cif", keep_excluded=True)
+
+    ccd_codes_by_id = {
+        c.chain_ids[0]: c.ccd_codes
+        for c in result.chains
+        if c.molecule_type == MoleculeType.LIGAND
+    }
+    assert ccd_codes_by_id == {
+        "B": ["TRS"],
+        "C": ["CL"],
+        "D": ["MBN"],
+        "E": ["BME"],
+    }
+    assert result.warnings == []
+
+
+def test_1pzp_duplicate_ligand_copies_become_separate_chains():
+    """1pzp: FTA (the pocket-constraint example's ligand) is present in two
+    copies in the asymmetric unit, at distinct label_asym_ids -- both should
+    be kept as separate ligand chains, not deduplicated or merged.
+    """
+    result = chains_from_cif(MMCIFS_DIR / "1pzp.cif")
+
+    ligands = [c for c in result.chains if c.molecule_type == MoleculeType.LIGAND]
+    assert len(ligands) == 2
+    assert {c.ccd_codes[0] for c in ligands} == {"FTA"}
+    assert len({c.chain_ids[0] for c in ligands}) == 2
+
+    proteins = [c for c in result.chains if c.molecule_type == MoleculeType.PROTEIN]
+    assert len(proteins) == 1
+    assert len(proteins[0].sequence) == 263
+
+
+def test_2q2k_dna_with_non_canonical_residue_and_homomeric_protein():
+    """2q2k: DNA chain with 5-iodouridine (5IU, a modified nucleotide) at two
+    positions -- must be classified as DNA (not dropped as a ligand) with
+    those positions recorded under non_canonical_residues, and the two nearly-
+    identical protein chains (a real single-residue length difference, not a
+    bug) must both come through. EPE (a crystallization aid) must be dropped.
+    """
+    result = chains_from_cif(MMCIFS_DIR / "2q2k.cif")
+
+    by_id = {c.chain_ids[0]: c for c in result.chains}
+    assert set(by_id) == {"F", "A", "B"}
+
+    dna = by_id["F"]
+    assert dna.molecule_type == MoleculeType.DNA
+    assert dna.sequence == "AGTATANACNAGTATATACT"
+    assert dna.non_canonical_residues == {7: "5IU", 10: "5IU"}
+
+    assert by_id["A"].molecule_type == MoleculeType.PROTEIN
+    assert by_id["B"].molecule_type == MoleculeType.PROTEIN
+    assert len(by_id["A"].sequence) == 45
+    assert len(by_id["B"].sequence) == 44
+
+    assert not any(c.molecule_type == MoleculeType.LIGAND for c in result.chains)
+    dropped_warning = next(w for w in result.warnings if "Dropped" in w)
+    assert "EPE" in dropped_warning
+
+
+def test_5kc1_many_chains_and_ions_stress_case():
+    """5kc1: 12 short protein chains plus ~50 ion/crystallization-aid hetero
+    groups (NA, CL, NO3, EDO, IOD, NH4, SO4, ...) -- none of the ions should
+    survive as ligand chains, and no protein chain should be misclassified.
+    """
+    result = chains_from_cif(MMCIFS_DIR / "5kc1.cif")
+
+    proteins = [c for c in result.chains if c.molecule_type == MoleculeType.PROTEIN]
+    ligands = [c for c in result.chains if c.molecule_type == MoleculeType.LIGAND]
+    assert len(proteins) == 12
+    assert ligands == []
+
+    dropped_warning = next(w for w in result.warnings if "Dropped" in w)
+    for code in ("NA", "CL", "NO3", "EDO", "IOD", "NH4", "SO4"):
+        assert code in dropped_warning
+
+
+def test_extracted_chains_validate_as_a_real_inference_query():
+    """Extracted chains must be usable as-is to build a valid InferenceQuerySet
+    -- the actual downstream consumer of a query.json's chains list.
+    """
+    result = chains_from_cif(MMCIFS_DIR / "7l39.cif")
+
+    query_set = InferenceQuerySet.model_validate(
+        {"queries": {"pdb_7l39": {"chains": result.chains}}}
+    )
+    assert list(query_set.queries) == ["pdb_7l39"]


### PR DESCRIPTION
**Summary**
Support creating a inference query set from an mmcif file.

The intention is for this function to be used as a Claude skill to quickly perform benchmarks on a given cif file, rather than accepting a cif file as an input of `run_openfold predict`

**Changes**
- `query_extraction.py` containing functions for parsing cif files.
- Corresponding tests for `query_extraction.py` using the mmcifs in the `test_data` directory.

**Testing**
- Added `test_query_extraction,.py` passes.

**Other Notes**
See downstream PR for example usage.