### PR TITLE
Allow custom residue names for SMILES ligands

### DIFF
--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -199,7 +199,8 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
   {
     "molecule_type": "ligand",
     "chain_ids": "Z",
-    "smiles": "CC(=O)OC1C[NH+]2CCC1CC2"
+    "smiles": "CC(=O)OC1C[NH+]2CCC1CC2",
+    "residue_name": "DRG"
   }
   ```
 
@@ -221,6 +222,16 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
   - `smiles` *(str, required if ccd_codes not given)*
     - Canonical SMILES string of the ligand.
     - Mutually exclusive with `ccd_codes`.
+
+  - `residue_name` *(str, optional, SMILES ligands only)*
+    - Component identifier to use instead of the default `LIG0`, `LIG1`, ... name.
+    - Whitespace is stripped and letters are uppercased. The value must be ASCII
+      alphanumeric and cannot be a standard polymer residue name or `GAP`.
+    - Repeated instances of one SMILES must resolve to one name, and distinct SMILES
+      must resolve to distinct names. Explicit names cannot match a CCD or
+      non-canonical residue name in the same query.
+    - PDBx/mmCIF preserves the full name. Legacy PDB output uses its first three
+      characters, so choose names with distinct three-character prefixes.
 
   - `ccd_codes` *(str | list[str], required if smiles not given)*
     - Three-letter CCD code for the ligand component. 

--- a/docs/source/input_format_reference.md
+++ b/docs/source/input_format_reference.md
@@ -200,7 +200,7 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
     "molecule_type": "ligand",
     "chain_ids": "Z",
     "smiles": "CC(=O)OC1C[NH+]2CCC1CC2",
-    "residue_name": "DRG"
+    "ligand_name": "DRG"
   }
   ```
 
@@ -223,7 +223,7 @@ All chains must define a unique ```chain_ids``` field and appropriate sequence o
     - Canonical SMILES string of the ligand.
     - Mutually exclusive with `ccd_codes`.
 
-  - `residue_name` *(str, optional, SMILES ligands only)*
+  - `ligand_name` *(str, optional, SMILES ligands only)*
     - Component identifier to use instead of the default `LIG0`, `LIG1`, ... name.
     - Whitespace is stripped and letters are uppercased. The value must be ASCII
       alphanumeric and cannot be a standard polymer residue name or `GAP`.

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1331,7 +1331,6 @@ openfold3/core/data/primitives/structure/query.py:0: error: Incompatible default
 openfold3/core/data/primitives/structure/query.py:0: error: Incompatible types in assignment (expression has type "list[str]", variable has type "ndarray[tuple[Any, ...], dtype[Any]]")  [assignment]
 openfold3/core/data/primitives/structure/query.py:0: error: Incompatible types in assignment (expression has type "list[str]", variable has type "ndarray[tuple[Any, ...], dtype[Any]]")  [assignment]
 openfold3/core/data/primitives/structure/query.py:0: error: Incompatible types in assignment (expression has type "list[str]", variable has type "set[str]")  [assignment]
-openfold3/core/data/primitives/structure/query.py:0: error: Incompatible types in assignment (expression has type "list[str]", variable has type "set[str]")  [assignment]
 openfold3/core/data/primitives/structure/query.py:0: error: Invalid index type "str | None" for "dict[str, int]"; expected type "str"  [index]
 openfold3/core/data/primitives/structure/query.py:0: error: Item "None" of "AtomArray[Any] | None" has no attribute "coord"  [union-attr]
 openfold3/core/data/primitives/structure/query.py:0: error: Item "None" of "AtomArray[int] | None" has no attribute "bonds"  [union-attr]

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -171,7 +171,7 @@ class InferenceDataset(Dataset):
         given in the Query object. If a chain specifies multiple chain IDs, repeated
         identical chains with those IDs will be constructed and given the same entity
         ID. Residue names will be inferred from the sequence or CCD codes. SMILES
-        ligands use an explicit ``residue_name`` when provided and otherwise retain
+        ligands use an explicit ``ligand_name`` when provided and otherwise retain
         their deterministic ``LIG0``, ``LIG1``, ... defaults.
 
         Additionally, this method adds tokenization information (token IDs) and token

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -170,10 +170,9 @@ class InferenceDataset(Dataset):
         molecule components in the query. The returned AtomArray follows the chain IDs
         given in the Query object. If a chain specifies multiple chain IDs, repeated
         identical chains with those IDs will be constructed and given the same entity
-        ID. Residue names will be inferred from the sequence or CCD codes. If a ligand
-        is specified through a SMILES string, it will be named as "LIG-X", where X
-        starts at 1 and is incremented for each unnamed ligand entity found in the
-        Query.
+        ID. Residue names will be inferred from the sequence or CCD codes. SMILES
+        ligands use an explicit ``residue_name`` when provided and otherwise retain
+        their deterministic ``LIG0``, ``LIG1``, ... defaults.
 
         Additionally, this method adds tokenization information (token IDs) and token
         positions to the AtomArray, which are required by other functions in the

--- a/openfold3/core/data/primitives/structure/query.py
+++ b/openfold3/core/data/primitives/structure/query.py
@@ -527,13 +527,13 @@ def _build_smiles_comp_id_mapping(query: Query) -> dict[str, str]:
 
     explicit_names: dict[str, str] = {}
     for chain in query.chains:
-        if chain.smiles is None or chain.residue_name is None:
+        if chain.smiles is None or chain.ligand_name is None:
             continue
 
         previous_name = explicit_names.get(chain.smiles)
-        if previous_name is not None and previous_name != chain.residue_name:
-            raise ValueError("The same SMILES string cannot use multiple residue names")
-        explicit_names[chain.smiles] = chain.residue_name
+        if previous_name is not None and previous_name != chain.ligand_name:
+            raise ValueError("The same SMILES string cannot use multiple ligand names")
+        explicit_names[chain.smiles] = chain.ligand_name
 
     reserved_component_ids = {
         component_id.upper()
@@ -546,14 +546,14 @@ def _build_smiles_comp_id_mapping(query: Query) -> dict[str, str]:
     collisions = set(explicit_names.values()) & reserved_component_ids
     if collisions:
         raise ValueError(
-            "Explicit SMILES residue names conflict with CCD or non-canonical "
+            "Explicit SMILES ligand names conflict with CCD or non-canonical "
             f"residue names: {sorted(collisions)}"
         )
 
     smiles_to_comp_id.update(explicit_names)
     component_ids = list(smiles_to_comp_id.values())
     if len(component_ids) != len(set(component_ids)):
-        raise ValueError("Distinct SMILES strings must use distinct residue names")
+        raise ValueError("Distinct SMILES strings must use distinct ligand names")
 
     return smiles_to_comp_id
 
@@ -569,7 +569,7 @@ def structure_with_ref_mols_from_query(query: Query) -> StructureWithReferenceMo
     constructed and given the same entity ID.
 
     Residue names will be inferred from the sequence or CCD codes. SMILES ligands use
-    an explicit ``residue_name`` when provided and otherwise retain their deterministic
+    an explicit ``ligand_name`` when provided and otherwise retain their deterministic
     ``LIG0``, ``LIG1``, ... defaults.
 
     Args:

--- a/openfold3/core/data/primitives/structure/query.py
+++ b/openfold3/core/data/primitives/structure/query.py
@@ -518,6 +518,46 @@ def structure_with_ref_mol_from_smiles(
     )
 
 
+def _build_smiles_comp_id_mapping(query: Query) -> dict[str, str]:
+    """Build the component-ID mapping for SMILES ligands."""
+    all_smiles = sorted(
+        {chain.smiles for chain in query.chains if chain.smiles is not None}
+    )
+    smiles_to_comp_id = {smiles: f"LIG{i}" for i, smiles in enumerate(all_smiles)}
+
+    explicit_names: dict[str, str] = {}
+    for chain in query.chains:
+        if chain.smiles is None or chain.residue_name is None:
+            continue
+
+        previous_name = explicit_names.get(chain.smiles)
+        if previous_name is not None and previous_name != chain.residue_name:
+            raise ValueError("The same SMILES string cannot use multiple residue names")
+        explicit_names[chain.smiles] = chain.residue_name
+
+    reserved_component_ids = {
+        component_id.upper()
+        for chain in query.chains
+        for component_id in [
+            *(chain.ccd_codes or []),
+            *(chain.non_canonical_residues or {}).values(),
+        ]
+    }
+    collisions = set(explicit_names.values()) & reserved_component_ids
+    if collisions:
+        raise ValueError(
+            "Explicit SMILES residue names conflict with CCD or non-canonical "
+            f"residue names: {sorted(collisions)}"
+        )
+
+    smiles_to_comp_id.update(explicit_names)
+    component_ids = list(smiles_to_comp_id.values())
+    if len(component_ids) != len(set(component_ids)):
+        raise ValueError("Distinct SMILES strings must use distinct residue names")
+
+    return smiles_to_comp_id
+
+
 def structure_with_ref_mols_from_query(query: Query) -> StructureWithReferenceMolecules:
     """Builds an AtomArray and processed reference molecules from a Query object.
 
@@ -528,8 +568,9 @@ def structure_with_ref_mols_from_query(query: Query) -> StructureWithReferenceMo
     specifies multiple chain IDs, repeated identical chains with those IDs will be
     constructed and given the same entity ID.
 
-    Residue names will be inferred from the sequence or CCD codes. If a ligand is
-    specified through a SMILES string, it will be named as "LIG".
+    Residue names will be inferred from the sequence or CCD codes. SMILES ligands use
+    an explicit ``residue_name`` when provided and otherwise retain their deterministic
+    ``LIG0``, ``LIG1``, ... defaults.
 
     Args:
         query (Query):
@@ -557,17 +598,7 @@ def structure_with_ref_mols_from_query(query: Query) -> StructureWithReferenceMo
     all_entities = sorted(all_entities)
     entity_to_id = {e: i + 1 for i, e in enumerate(all_entities)}
 
-    # Create smiles->comp ID mapping to allow for distinguishing different ligands
-    # specified by smiles
-    all_smiles = set()
-    for chain in query.chains:
-        if chain.smiles is not None:
-            all_smiles.add(chain.smiles)
-    if len(all_smiles) > 0:
-        all_smiles = sorted(all_smiles)
-        smiles_to_comp_id = {s: f"LIG{i}" for i, s in enumerate(all_smiles)}
-    else:
-        smiles_to_comp_id = {}
+    smiles_to_comp_id = _build_smiles_comp_id_mapping(query)
 
     # Build the structure segment-wise from all chains in the query.
     for chain in query.chains:

--- a/openfold3/projects/of3_all_atom/config/inference_query_format.py
+++ b/openfold3/projects/of3_all_atom/config/inference_query_format.py
@@ -86,7 +86,7 @@ class Chain(BaseModel):
         Annotated[dict[int, str], BeforeValidator(_cast_keys_to_int)] | None
     ) = None
     smiles: str | None = None
-    residue_name: str | None = None
+    ligand_name: str | None = None
     ccd_codes: Annotated[list[str], BeforeValidator(_ensure_list)] | None = None
     paired_msa_file_paths: (
         Annotated[list[FilePath | DirectoryPath], BeforeValidator(_ensure_list)] | None
@@ -111,37 +111,35 @@ class Chain(BaseModel):
     def serialize_enum_name(self, v: MoleculeType, _info):
         return v.name
 
-    @field_validator("residue_name")
+    @field_validator("ligand_name")
     @classmethod
-    def normalize_residue_name(cls, value: str | None) -> str | None:
-        """Normalize and validate a SMILES ligand residue name."""
+    def normalize_ligand_name(cls, value: str | None) -> str | None:
+        """Normalize and validate a SMILES ligand name."""
         if value is None:
             return None
 
         value = value.strip()
         if not value.isascii() or not value.isalnum():
-            raise ValueError(
-                "'residue_name' must contain only ASCII letters and digits"
-            )
+            raise ValueError("'ligand_name' must contain only ASCII letters and digits")
 
         value = value.upper()
         if value in STANDARD_RESIDUES_WITH_GAP_3:
             raise ValueError(
-                f"'residue_name' cannot use the standard residue name {value!r}"
+                f"'ligand_name' cannot use the standard residue name {value!r}"
             )
 
         return value
 
     @model_validator(mode="after")
-    def validate_residue_name_input(self) -> "Chain":
-        """Restrict residue names to SMILES-only ligand chains."""
-        if self.residue_name is not None and not (
+    def validate_ligand_name_input(self) -> "Chain":
+        """Restrict ligand names to SMILES-only ligand chains."""
+        if self.ligand_name is not None and not (
             self.molecule_type == MoleculeType.LIGAND
             and self.smiles is not None
             and self.ccd_codes is None
         ):
             raise ValueError(
-                "'residue_name' can only be specified for a ligand using 'smiles' "
+                "'ligand_name' can only be specified for a ligand using 'smiles' "
                 "without 'ccd_codes'"
             )
 

--- a/openfold3/projects/of3_all_atom/config/inference_query_format.py
+++ b/openfold3/projects/of3_all_atom/config/inference_query_format.py
@@ -20,6 +20,7 @@ from pydantic import (
     DirectoryPath,
     FilePath,
     field_serializer,
+    field_validator,
     model_validator,
 )
 
@@ -29,7 +30,10 @@ from openfold3.core.config.config_utils import (
     _convert_molecule_type,
     _ensure_list,
 )
-from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.core.data.resources.residues import (
+    STANDARD_RESIDUES_WITH_GAP_3,
+    MoleculeType,
+)
 
 
 # Definition for Bonds
@@ -82,6 +86,7 @@ class Chain(BaseModel):
         Annotated[dict[int, str], BeforeValidator(_cast_keys_to_int)] | None
     ) = None
     smiles: str | None = None
+    residue_name: str | None = None
     ccd_codes: Annotated[list[str], BeforeValidator(_ensure_list)] | None = None
     paired_msa_file_paths: (
         Annotated[list[FilePath | DirectoryPath], BeforeValidator(_ensure_list)] | None
@@ -105,6 +110,42 @@ class Chain(BaseModel):
     @field_serializer("molecule_type", return_type=str)
     def serialize_enum_name(self, v: MoleculeType, _info):
         return v.name
+
+    @field_validator("residue_name")
+    @classmethod
+    def normalize_residue_name(cls, value: str | None) -> str | None:
+        """Normalize and validate a SMILES ligand residue name."""
+        if value is None:
+            return None
+
+        value = value.strip()
+        if not value.isascii() or not value.isalnum():
+            raise ValueError(
+                "'residue_name' must contain only ASCII letters and digits"
+            )
+
+        value = value.upper()
+        if value in STANDARD_RESIDUES_WITH_GAP_3:
+            raise ValueError(
+                f"'residue_name' cannot use the standard residue name {value!r}"
+            )
+
+        return value
+
+    @model_validator(mode="after")
+    def validate_residue_name_input(self) -> "Chain":
+        """Restrict residue names to SMILES-only ligand chains."""
+        if self.residue_name is not None and not (
+            self.molecule_type == MoleculeType.LIGAND
+            and self.smiles is not None
+            and self.ccd_codes is None
+        ):
+            raise ValueError(
+                "'residue_name' can only be specified for a ligand using 'smiles' "
+                "without 'ccd_codes'"
+            )
+
+        return self
 
     @model_validator(mode="after")
     def validate_template_inputs(self) -> "Chain":

--- a/openfold3/tests/test_structure_from_query.py
+++ b/openfold3/tests/test_structure_from_query.py
@@ -189,18 +189,18 @@ def test_smiles_ligand_cif_auth_seq_id_is_numeric(tmp_path):
     assert set(atom_site["auth_seq_id"].as_array()[ligand_mask]) == {"1"}
 
 
-def _smiles_ligand(chain_id, smiles, residue_name=None, **extra):
+def _smiles_ligand(chain_id, smiles, ligand_name=None, **extra):
     chain = {
         "molecule_type": "ligand",
         "chain_ids": chain_id,
         "smiles": smiles,
     }
-    if residue_name is not None:
-        chain["residue_name"] = residue_name
+    if ligand_name is not None:
+        chain["ligand_name"] = ligand_name
     return chain | extra
 
 
-def test_smiles_residue_names_override_defaults_and_write_outputs(tmp_path):
+def test_smiles_ligand_names_override_defaults_and_write_outputs(tmp_path):
     query = Query.model_validate(
         {
             "chains": [
@@ -234,17 +234,17 @@ def test_smiles_residue_names_override_defaults_and_write_outputs(tmp_path):
     ("overrides", "match"),
     [
         pytest.param(
-            {"residue_name": "DR-G"},
+            {"ligand_name": "DR-G"},
             "ASCII letters and digits",
             id="invalid-character",
         ),
         pytest.param(
-            {"residue_name": "ß"},
+            {"ligand_name": "ß"},
             "ASCII letters and digits",
             id="unicode-case-expansion",
         ),
         pytest.param(
-            {"residue_name": "ALA"},
+            {"ligand_name": "ALA"},
             "standard residue name",
             id="standard-residue",
         ),
@@ -252,19 +252,19 @@ def test_smiles_residue_names_override_defaults_and_write_outputs(tmp_path):
             {
                 "molecule_type": "protein",
                 "sequence": "A",
-                "residue_name": "DRG",
+                "ligand_name": "DRG",
             },
             "only be specified for a ligand",
             id="polymer",
         ),
         pytest.param(
-            {"ccd_codes": "ATP", "residue_name": "DRG"},
+            {"ccd_codes": "ATP", "ligand_name": "DRG"},
             "only be specified for a ligand",
             id="smiles-and-ccd",
         ),
     ],
 )
-def test_smiles_residue_name_validation(overrides, match):
+def test_smiles_ligand_name_validation(overrides, match):
     chain = _smiles_ligand("X", "CCO") | overrides
     with pytest.raises(ValueError, match=match):
         Query.model_validate({"chains": [chain]})
@@ -310,7 +310,7 @@ def test_smiles_residue_name_validation(overrides, match):
         ),
     ],
 )
-def test_smiles_residue_name_conflicts(chains, match):
+def test_smiles_ligand_name_conflicts(chains, match):
     query = Query.model_validate({"chains": chains})
     with pytest.raises(ValueError, match=match):
         structure_with_ref_mols_from_query(query)

--- a/openfold3/tests/test_structure_from_query.py
+++ b/openfold3/tests/test_structure_from_query.py
@@ -15,7 +15,7 @@
 # TODO: Add more tests for general inference inputs
 import numpy as np
 import pytest
-from biotite.structure.io import pdbx
+from biotite.structure.io import pdb, pdbx
 from rdkit import Chem
 
 from openfold3.core.data.io.structure.cif import write_structure
@@ -187,3 +187,130 @@ def test_smiles_ligand_cif_auth_seq_id_is_numeric(tmp_path):
     assert ligand_mask.any()
     assert set(atom_site["label_seq_id"].as_array()[ligand_mask]) == {"."}
     assert set(atom_site["auth_seq_id"].as_array()[ligand_mask]) == {"1"}
+
+
+def _smiles_ligand(chain_id, smiles, residue_name=None, **extra):
+    chain = {
+        "molecule_type": "ligand",
+        "chain_ids": chain_id,
+        "smiles": smiles,
+    }
+    if residue_name is not None:
+        chain["residue_name"] = residue_name
+    return chain | extra
+
+
+def test_smiles_residue_names_override_defaults_and_write_outputs(tmp_path):
+    query = Query.model_validate(
+        {
+            "chains": [
+                _smiles_ligand("X", "CCO", " abc123 "),
+                _smiles_ligand("Y", "CCN"),
+                _smiles_ligand("Z", "CCC"),
+            ]
+        }
+    )
+    atom_array = structure_with_ref_mols_from_query(query).atom_array
+    expected_names = {"X": "ABC123", "Y": "LIG1", "Z": "LIG0"}
+
+    cif_path = tmp_path / "custom_smiles_residue_names.cif"
+    write_structure(atom_array, cif_path)
+    cif_block = get_cif_block(pdbx.CIFFile.read(cif_path))
+    atom_site = cif_block["atom_site"]
+    for chain_id, residue_name in expected_names.items():
+        chain_mask = atom_site["label_asym_id"].as_array() == chain_id
+        assert set(atom_site["label_comp_id"].as_array()[chain_mask]) == {residue_name}
+    assert set(expected_names.values()) <= set(cif_block["chem_comp"]["id"].as_array())
+
+    pdb_path = tmp_path / "custom_smiles_residue_names.pdb"
+    atom_array.b_factor[:] = 0.0
+    write_structure(atom_array, pdb_path)
+    pdb_array = pdb.PDBFile.read(pdb_path).get_structure(model=1)
+    for chain_id, residue_name in {"X": "ABC", "Y": "LIG", "Z": "LIG"}.items():
+        assert set(pdb_array.res_name[pdb_array.chain_id == chain_id]) == {residue_name}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        pytest.param(
+            {"residue_name": "DR-G"},
+            "ASCII letters and digits",
+            id="invalid-character",
+        ),
+        pytest.param(
+            {"residue_name": "ß"},
+            "ASCII letters and digits",
+            id="unicode-case-expansion",
+        ),
+        pytest.param(
+            {"residue_name": "ALA"},
+            "standard residue name",
+            id="standard-residue",
+        ),
+        pytest.param(
+            {
+                "molecule_type": "protein",
+                "sequence": "A",
+                "residue_name": "DRG",
+            },
+            "only be specified for a ligand",
+            id="polymer",
+        ),
+        pytest.param(
+            {"ccd_codes": "ATP", "residue_name": "DRG"},
+            "only be specified for a ligand",
+            id="smiles-and-ccd",
+        ),
+    ],
+)
+def test_smiles_residue_name_validation(overrides, match):
+    chain = _smiles_ligand("X", "CCO") | overrides
+    with pytest.raises(ValueError, match=match):
+        Query.model_validate({"chains": [chain]})
+
+
+@pytest.mark.parametrize(
+    ("chains", "match"),
+    [
+        pytest.param(
+            [
+                _smiles_ligand("X", "CCO", "DRG"),
+                _smiles_ligand("Y", "CCO", "INH"),
+            ],
+            "same SMILES string",
+            id="same-smiles-different-names",
+        ),
+        pytest.param(
+            [
+                _smiles_ligand("X", "CCO", "LIG0"),
+                _smiles_ligand("Y", "CCN"),
+            ],
+            "Distinct SMILES strings",
+            id="different-smiles-same-name",
+        ),
+        pytest.param(
+            [
+                _smiles_ligand("X", "CCO", "ATP"),
+                _smiles_ligand("Y", "CCN", "MHO"),
+                {
+                    "molecule_type": "ligand",
+                    "chain_ids": "Z",
+                    "ccd_codes": "ATP",
+                },
+                {
+                    "molecule_type": "protein",
+                    "chain_ids": "P",
+                    "sequence": "A",
+                    "non_canonical_residues": {1: "MHO"},
+                },
+            ],
+            r"\['ATP', 'MHO'\]",
+            id="non-smiles-component-names",
+        ),
+    ],
+)
+def test_smiles_residue_name_conflicts(chains, match):
+    query = Query.model_validate({"chains": chains})
+    with pytest.raises(ValueError, match=match):
+        structure_with_ref_mols_from_query(query)


### PR DESCRIPTION
**Summary**

Adds optional `ligand_name` for SMILES ligands without changing `LIG#` defaults.

**Changes**

- Trims and uppercases explicit names, accepts only ASCII alphanumeric characters, and rejects standard polymer residue names.
- Carries explicit names into the SMILES component mapping and rejects ambiguous SMILES mappings or explicit-name collisions with CCD and non-canonical residues.
- Documents full component names in mmCIF and three-character truncation in legacy PDB output.
- Corrects the query-construction docstring and updates the mypy baseline for the optional field.

**Related Issues**

 issue #323

**Testing**

- `ruff check --no-cache .` and `ruff format --check --no-cache .`
- Exact mypy baseline filter: 0 new and 0 fixed errors
- Full unit suite in CUDA 12, CUDA 13, and legacy Conda CUDA 12.1 images: 996 passed, 90 skipped in each
- Focused structure/query file in all three images: 13 passed in each
- Full slow suite on the RTX 5090 in CUDA 12 and CUDA 13: 55 passed, 2 skipped in each
- Strict Sphinx HTML build with warnings treated as errors
- Production CUDA 13 inference on the RTX 5090 using the current 174k checkpoint: `DRG123` was preserved in the generated mmCIF

The legacy Conda image's pinned PyTorch supports GPU architectures through `sm_90`, so its slow GPU suite cannot execute on the RTX 5090 (`sm_120`). Its full unit suite and focused tests pass.

@jandom @jnwei 