### PR TITLE
Specify file destination path of AMD parameter

### DIFF
--- a/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
@@ -75,7 +75,7 @@ jobs:
           # need the AWS CLI installed (equivalent to `aws s3 cp --no-sign-request`).
           curl -fSL \
             https://openfold3-data.s3.amazonaws.com/openfold3-parameters/of3-ob-2025-06-30-174k.pt \
-            -o ~/.openfold3/
+            -o ~/.openfold3/of3-ob-2025-06-30-174k.pt
 
       - name: Run integration test
         run: |


### PR DESCRIPTION
**Summary**
My fix in #380 failed because curl needs an explicit path as the destination output, it will not accept a directory

**Changes**
Fixes curl command for downloading of3 parameters.

**Related Issues**
#380 

**Testing**
- [x] manually triggered AMD workflow passes
