### PR TITLE
Fix assigned C=C planarity on the default inference path

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,27 @@
+# Third-party license
+
+## Boltz
+
+The analytical geometry is adapted from [Boltz](https://github.com/jwohlwend/boltz).
+
+MIT License
+
+Copyright (c) 2024 Jeremy Wohlwend, Gabriele Corso, Saro Passaro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -36,6 +36,9 @@ from openfold3.core.data.framework.single_datasets.dataset_utils import (
 from openfold3.core.data.pipelines.featurization.conformer import (
     featurize_reference_conformers_of3,
 )
+from openfold3.core.data.pipelines.featurization.ligand_planarity import (
+    featurize_ligand_planarity,
+)
 from openfold3.core.data.pipelines.featurization.msa import (
     MsaFeaturizerOF3,
     MsaFeaturizerOF3Config,
@@ -222,8 +225,17 @@ class InferenceDataset(Dataset):
             add_ref_space_uid_to_perm=False,
         )
 
+        ligand_planarity_features = featurize_ligand_planarity(
+            atom_array=atom_array,
+            processed_reference_molecules=processed_reference_molecules,
+        )
+
         # Wrap up features
-        structure_features = target_structure_features | reference_conformer_features
+        structure_features = (
+            target_structure_features
+            | reference_conformer_features
+            | ligand_planarity_features
+        )
 
         return structure_features
 

--- a/openfold3/core/data/pipelines/featurization/ligand_planarity.py
+++ b/openfold3/core/data/pipelines/featurization/ligand_planarity.py
@@ -1,0 +1,104 @@
+"""Assigned C=C planarity restraints for inference."""
+
+import itertools
+import math
+
+import numpy as np
+import torch
+from biotite.structure import AtomArray
+from rdkit import Chem
+from rdkit.Chem import rdMolTransforms
+from rdkit.Chem.rdchem import BondStereo, BondType, HybridizationType, Mol
+
+from openfold3.core.data.pipelines.sample_processing.conformer import (
+    ProcessedReferenceMolecule,
+)
+from openfold3.core.data.primitives.structure.labels import residue_view_iter
+from openfold3.core.data.resources.residues import MoleculeType
+
+
+def _assigned_cc_planarity_restraints(
+    mol: Mol, idx_map: dict[int, int]
+) -> tuple[list[tuple[int, int, int, int]], list[bool]]:
+    """Map every heavy-atom dihedral around assigned C=C bonds."""
+    mol = Chem.Mol(mol)
+    Chem.AssignStereochemistry(mol, cleanIt=True, force=True)
+    if mol.GetNumConformers() == 0:
+        raise ValueError("Assigned C=C planarity restraints require a conformer.")
+
+    conformer = mol.GetConformer()
+    atom_indices: list[tuple[int, int, int, int]] = []
+    trans_orientations: list[bool] = []
+    for bond in mol.GetBonds():
+        if bond.GetBondType() != BondType.DOUBLE or bond.GetIsAromatic():
+            continue
+        if bond.GetStereo() not in {BondStereo.STEREOE, BondStereo.STEREOZ}:
+            continue
+
+        start = bond.GetBeginAtom()
+        end = bond.GetEndAtom()
+        if (
+            start.GetAtomicNum() != 6
+            or end.GetAtomicNum() != 6
+            or start.GetHybridization() != HybridizationType.SP2
+            or end.GetHybridization() != HybridizationType.SP2
+        ):
+            continue
+
+        start_neighbors = [
+            atom.GetIdx()
+            for atom in start.GetNeighbors()
+            if atom.GetIdx() != end.GetIdx() and atom.GetAtomicNum() > 1
+        ]
+        end_neighbors = [
+            atom.GetIdx()
+            for atom in end.GetNeighbors()
+            if atom.GetIdx() != start.GetIdx() and atom.GetAtomicNum() > 1
+        ]
+        for start_neighbor, end_neighbor in itertools.product(
+            start_neighbors, end_neighbors
+        ):
+            quartet = (start_neighbor, start.GetIdx(), end.GetIdx(), end_neighbor)
+            if not all(index in idx_map for index in quartet):
+                continue
+            reference_angle = abs(rdMolTransforms.GetDihedralRad(conformer, *quartet))
+            mapped = tuple(idx_map[index] for index in quartet)
+            atom_indices.append((mapped[0], mapped[1], mapped[2], mapped[3]))
+            trans_orientations.append(reference_angle > math.pi / 2)
+
+    return atom_indices, trans_orientations
+
+
+def featurize_ligand_planarity(
+    atom_array: AtomArray,
+    processed_reference_molecules: list[ProcessedReferenceMolecule],
+) -> dict[str, torch.Tensor]:
+    """Create planarity restraints in the model atom axis."""
+    atom_indices = []
+    trans_orientations = []
+    global_atom_indices = np.arange(len(atom_array))
+    for residue, processed_mol in zip(
+        residue_view_iter(atom_array), processed_reference_molecules, strict=True
+    ):
+        if not np.all(residue.molecule_type_id == MoleculeType.LIGAND):
+            continue
+
+        reference_indices = np.flatnonzero(processed_mol.in_crop_mask)
+        residue_indices = global_atom_indices[residue.indices]
+        if len(reference_indices) != len(residue_indices):
+            raise ValueError("Processed ligand atoms must match the OF3 residue.")
+        idx_map = dict(
+            zip(reference_indices.tolist(), residue_indices.tolist(), strict=True)
+        )
+        residue_restraints, residue_orientations = _assigned_cc_planarity_restraints(
+            processed_mol.mol, idx_map
+        )
+        atom_indices.extend(residue_restraints)
+        trans_orientations.extend(residue_orientations)
+
+    return {
+        "ligand_planarity_index": torch.tensor(atom_indices, dtype=torch.long)
+        .reshape(-1, 4)
+        .T,
+        "ligand_planarity_trans": torch.tensor(trans_orientations, dtype=torch.bool),
+    }

--- a/openfold3/core/model/structure/diffusion_module.py
+++ b/openfold3/core/model/structure/diffusion_module.py
@@ -38,6 +38,12 @@ from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.structure.augmentation import (  # noqa: F401
     centre_random_augmentation,
 )
+from openfold3.core.model.structure.ligand_planarity import (
+    PLANARITY_START_FRACTION,
+    LigandPlanarityRestraints,
+    apply_ligand_planarity_restraints,
+    prepare_ligand_planarity_restraints,
+)
 from openfold3.core.model.structure.pocket_constraints import (
     _batch_scalar,
     _build_pocket_sampling_seeds,
@@ -297,6 +303,7 @@ class SampleDiffusion(nn.Module):
         noise_schedule: torch.Tensor,
         start_step: int,
         use_conditioning: bool,
+        planarity_restraints: LigandPlanarityRestraints | None = None,
         chunk_size: int | None = None,
         use_deepspeed_evo_attention: bool = False,
         use_cueq_triangle_kernels: bool = False,
@@ -339,9 +346,21 @@ class SampleDiffusion(nn.Module):
                 _mask_trans=_mask_trans,
             )
 
+            step_fraction = (tau + 1) / (len(noise_schedule) - 1)
+            if (
+                planarity_restraints is not None
+                and step_fraction >= PLANARITY_START_FRACTION
+            ):
+                xl_denoised = apply_ligand_planarity_restraints(
+                    xl_denoised, planarity_restraints
+                )
+
             delta = (xl_noisy - xl_denoised) / t
             dt = c_tau - t
             xl = xl_noisy + self.step_scale * dt * delta
+
+        if planarity_restraints is not None:
+            xl = apply_ligand_planarity_restraints(xl, planarity_restraints)
 
         return xl
 
@@ -397,6 +416,7 @@ class SampleDiffusion(nn.Module):
         batch_dim, num_atoms = atom_mask.shape[0], atom_mask.shape[-1]
 
         total_steps = len(noise_schedule) - 1
+        planarity_restraints = prepare_ligand_planarity_restraints(batch, atom_mask)
 
         xl = noise_schedule[0] * torch.randn(
             (batch_dim, no_rollout_samples, num_atoms, 3),
@@ -412,6 +432,7 @@ class SampleDiffusion(nn.Module):
             "zij_trunk": zij_trunk,
             "noise_schedule": noise_schedule,
             "use_conditioning": use_conditioning,
+            "planarity_restraints": planarity_restraints,
             "chunk_size": chunk_size,
             "use_deepspeed_evo_attention": use_deepspeed_evo_attention,
             "use_cueq_triangle_kernels": use_cueq_triangle_kernels,

--- a/openfold3/core/model/structure/ligand_planarity.py
+++ b/openfold3/core/model/structure/ligand_planarity.py
@@ -1,0 +1,133 @@
+"""Inference-time guidance for assigned C=C planarity."""
+
+import math
+from typing import NamedTuple
+
+import torch
+
+PLANARITY_START_FRACTION = 0.725
+_PLANARITY_BUFFER = math.radians(15.0)
+_PLANARITY_STEP_SIZE = 0.05
+_PLANARITY_STEPS = 20
+_GEOMETRY_EPSILON = 1e-6
+
+
+class LigandPlanarityRestraints(NamedTuple):
+    """Device-local atom quartets and their reference orientations."""
+
+    atom_indices: torch.Tensor
+    trans_orientations: torch.Tensor
+
+
+def _strip_leading_singletons(tensor: torch.Tensor, ndim: int) -> torch.Tensor:
+    while tensor.dim() > ndim and tensor.shape[0] == 1:
+        tensor = tensor[0]
+    return tensor
+
+
+def prepare_ligand_planarity_restraints(
+    batch: dict, atom_mask: torch.Tensor
+) -> LigandPlanarityRestraints | None:
+    """Validate and move restraint features to the sampling device."""
+    if "ligand_planarity_index" not in batch:
+        return None
+    if batch["ligand_planarity_index"].numel() == 0:
+        return None
+    if atom_mask.shape[0] != 1:
+        raise ValueError("Ligand planarity restraints require one query per batch.")
+
+    indices = _strip_leading_singletons(batch["ligand_planarity_index"], 2)
+    if indices.dim() != 2 or 4 not in indices.shape:
+        raise ValueError("'ligand_planarity_index' must have atom-index arity 4.")
+    if indices.shape[0] == 4:
+        indices = indices.T
+    if int(indices.min()) < 0 or int(indices.max()) >= atom_mask.shape[-1]:
+        raise ValueError("'ligand_planarity_index' contains an invalid atom index.")
+
+    trans = _strip_leading_singletons(batch["ligand_planarity_trans"], 1)
+    if trans.dim() != 1 or trans.shape[0] != indices.shape[0]:
+        raise ValueError(
+            "'ligand_planarity_trans' must contain one value per restraint."
+        )
+    return LigandPlanarityRestraints(
+        atom_indices=indices.to(device=atom_mask.device, dtype=torch.long),
+        trans_orientations=trans.to(device=atom_mask.device, dtype=torch.bool),
+    )
+
+
+def _absolute_dihedrals_and_gradients(
+    coords: torch.Tensor, atom_indices: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    points = coords[..., atom_indices, :]
+    p0, p1, p2, p3 = points.unbind(dim=-2)
+    r01 = p0 - p1
+    r21 = p2 - p1
+    r23 = p2 - p3
+    normal_1 = torch.cross(r01, r21, dim=-1)
+    normal_2 = torch.cross(r21, r23, dim=-1)
+    central_norm = torch.linalg.norm(r21, dim=-1).clamp_min(_GEOMETRY_EPSILON)
+    normal_1_norm = torch.linalg.norm(normal_1, dim=-1).clamp_min(_GEOMETRY_EPSILON)
+    normal_2_norm = torch.linalg.norm(normal_2, dim=-1).clamp_min(_GEOMETRY_EPSILON)
+
+    sine = (r21 * torch.cross(normal_1, normal_2, dim=-1)).sum(dim=-1) / (
+        central_norm * normal_1_norm * normal_2_norm
+    )
+    cosine = (normal_1 * normal_2).sum(dim=-1) / (normal_1_norm * normal_2_norm)
+    signed_angles = torch.atan2(sine, cosine)
+
+    central_norm_sq = central_norm.square().unsqueeze(-1)
+    projection_1 = (r01 * r21).sum(dim=-1, keepdim=True) / central_norm_sq
+    projection_2 = (r23 * r21).sum(dim=-1, keepdim=True) / central_norm_sq
+    grad_0 = normal_1 * (central_norm / normal_1_norm.square()).unsqueeze(-1)
+    grad_3 = -normal_2 * (central_norm / normal_2_norm.square()).unsqueeze(-1)
+    grad_1 = (projection_1 - 1) * grad_0 - projection_2 * grad_3
+    grad_2 = (projection_2 - 1) * grad_3 - projection_1 * grad_0
+    gradients = torch.stack((grad_0, grad_1, grad_2, grad_3), dim=-2)
+    gradients = torch.where(
+        (signed_angles < 0).unsqueeze(-1).unsqueeze(-1), -gradients, gradients
+    )
+    return signed_angles.abs(), gradients
+
+
+def _planarity_violations(
+    angles: torch.Tensor, trans_orientations: torch.Tensor
+) -> torch.Tensor:
+    return torch.where(
+        trans_orientations,
+        torch.relu(math.pi - _PLANARITY_BUFFER - angles),
+        torch.relu(angles - _PLANARITY_BUFFER),
+    )
+
+
+def _planarity_gradient(
+    coords: torch.Tensor, restraints: LigandPlanarityRestraints
+) -> torch.Tensor:
+    angles, angle_gradients = _absolute_dihedrals_and_gradients(
+        coords, restraints.atom_indices
+    )
+    violations = _planarity_violations(angles, restraints.trans_orientations)
+    derivatives = torch.where(
+        restraints.trans_orientations,
+        -violations,
+        violations,
+    )
+    scaled = angle_gradients * derivatives.unsqueeze(-1).unsqueeze(-1)
+    gradient = torch.zeros_like(coords)
+    for atom_slot in range(4):
+        index = restraints.atom_indices[:, atom_slot].view(
+            *((1,) * (coords.dim() - 2)), -1, 1
+        )
+        atom_gradient = scaled[..., atom_slot, :]
+        gradient.scatter_add_(-2, index.expand_as(atom_gradient), atom_gradient)
+    return gradient
+
+
+def apply_ligand_planarity_restraints(
+    xl_denoised: torch.Tensor, restraints: LigandPlanarityRestraints
+) -> torch.Tensor:
+    """Move a denoised estimate into the restraints' flat-bottom region."""
+    dtype = xl_denoised.dtype
+    guided = xl_denoised.detach().float()
+    for _ in range(_PLANARITY_STEPS):
+        guided = guided - _PLANARITY_STEP_SIZE * _planarity_gradient(guided, restraints)
+    return guided.to(dtype=dtype)

--- a/openfold3/tests/test_ligand_planarity.py
+++ b/openfold3/tests/test_ligand_planarity.py
@@ -1,0 +1,83 @@
+import torch
+
+from openfold3.core.data.framework.single_datasets.inference import (
+    InferenceDataset,
+)
+from openfold3.core.data.primitives.structure.query import (
+    structure_with_ref_mols_from_query,
+)
+from openfold3.core.data.primitives.structure.tokenization import get_token_count
+from openfold3.core.model.structure.ligand_planarity import (
+    _absolute_dihedrals_and_gradients,
+    _planarity_violations,
+    apply_ligand_planarity_restraints,
+    prepare_ligand_planarity_restraints,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+ISSUE_136_SMILES = "O=C1NC(=S)N(c2cccc(Br)c2)C(=O)/C1=C/c1ccco1"
+
+
+def _restraint_loss(coords, restraints):
+    angles, _ = _absolute_dihedrals_and_gradients(coords, restraints.atom_indices)
+    violations = _planarity_violations(angles, restraints.trans_orientations)
+    return 0.5 * violations.square().sum()
+
+
+def test_issue_136_implicit_hydrogen_alkene_is_fully_restrained():
+    query = Query.model_validate(
+        {
+            "chains": [
+                {
+                    "molecule_type": "protein",
+                    "chain_ids": ["A"],
+                    "sequence": "A",
+                },
+                {
+                    "molecule_type": "ligand",
+                    "chain_ids": ["C"],
+                    "smiles": ISSUE_136_SMILES,
+                },
+            ]
+        }
+    )
+    structure = structure_with_ref_mols_from_query(query)
+    dataset = InferenceDataset.__new__(InferenceDataset)
+    features = dataset.create_structure_features(
+        atom_array=structure.atom_array,
+        processed_reference_molecules=structure.processed_reference_mols,
+        n_tokens=get_token_count(structure.atom_array),
+    )
+    ligand_start = int((structure.atom_array.chain_id != "C").sum())
+
+    assert features["ligand_planarity_index"].T.tolist() == [
+        [ligand_start + index for index in (13, 15, 16, 17)],
+        [ligand_start + index for index in (1, 15, 16, 17)],
+    ]
+    assert features["ligand_planarity_trans"].tolist() == [True, False]
+
+    processed_mol = structure.processed_reference_mols[-1]
+    ligand_coords = torch.as_tensor(
+        processed_mol.mol.GetConformer().GetPositions()[processed_mol.in_crop_mask],
+        dtype=torch.float32,
+    )
+    coords = torch.zeros((len(structure.atom_array), 3))
+    coords[ligand_start:] = ligand_coords
+    central = ligand_start + 16
+    normal = torch.cross(
+        coords[ligand_start + 15] - coords[central],
+        coords[ligand_start + 17] - coords[central],
+        dim=0,
+    )
+    coords[ligand_start + 1] += normal / torch.linalg.norm(normal)
+    restraints = prepare_ligand_planarity_restraints(
+        features,
+        atom_mask=torch.ones((1, len(coords))),
+    )
+    before = _restraint_loss(coords[None, None], restraints)
+    guided = apply_ligand_planarity_restraints(coords[None, None], restraints)
+    after = _restraint_loss(guided, restraints)
+
+    assert before > 0
+    assert after < 1e-6
+    assert torch.equal(guided[0, 0, :ligand_start], coords[:ligand_start])

--- a/openfold3/tests/test_ligand_planarity.py
+++ b/openfold3/tests/test_ligand_planarity.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 
 from openfold3.core.data.framework.single_datasets.inference import (
     InferenceDataset,
@@ -7,6 +8,8 @@ from openfold3.core.data.primitives.structure.query import (
     structure_with_ref_mols_from_query,
 )
 from openfold3.core.data.primitives.structure.tokenization import get_token_count
+from openfold3.core.model.structure import diffusion_module
+from openfold3.core.model.structure.diffusion_module import SampleDiffusion
 from openfold3.core.model.structure.ligand_planarity import (
     _absolute_dihedrals_and_gradients,
     _planarity_violations,
@@ -81,3 +84,65 @@ def test_issue_136_implicit_hydrogen_alkene_is_fully_restrained():
     assert before > 0
     assert after < 1e-6
     assert torch.equal(guided[0, 0, :ligand_start], coords[:ligand_start])
+
+
+class _IdentityDiffusion(nn.Module):
+    def forward(self, *, xl_noisy: torch.Tensor, **_) -> torch.Tensor:
+        return xl_noisy
+
+
+def test_sampler_applies_planarity_only_late_and_absent_is_noop(monkeypatch):
+    sampler = SampleDiffusion(
+        gamma_0=0.0,
+        gamma_min=0.0,
+        noise_scale=0.0,
+        step_scale=1.5,
+        diffusion_module=_IdentityDiffusion(),
+    )
+    calls = []
+
+    def record_call(xl_denoised, restraints):
+        calls.append(restraints)
+        return apply_ligand_planarity_restraints(xl_denoised, restraints)
+
+    monkeypatch.setattr(
+        diffusion_module, "apply_ligand_planarity_restraints", record_call
+    )
+    batch = {
+        "token_mask": torch.ones((1, 1)),
+        "atom_mask": torch.ones((1, 4)),
+    }
+    sample_args = {
+        "si_input": torch.empty(0),
+        "si_trunk": torch.empty(0),
+        "zij_trunk": torch.empty(0),
+        "noise_schedule": torch.tensor([2.0, 1.0, 0.0]),
+        "no_rollout_samples": 1,
+        "use_conditioning": True,
+    }
+    torch.manual_seed(7)
+    absent = sampler(
+        batch={
+            **batch,
+            "ligand_planarity_index": torch.empty((1, 4, 0), dtype=torch.long),
+            "ligand_planarity_trans": torch.empty((1, 0), dtype=torch.bool),
+        },
+        **sample_args,
+    )
+    assert calls == []
+
+    torch.manual_seed(7)
+    present = sampler(
+        batch={
+            **batch,
+            "ligand_planarity_index": torch.tensor([[[0], [1], [2], [3]]]),
+            "ligand_planarity_trans": torch.tensor([[True]]),
+        },
+        **sample_args,
+    )
+
+    assert len(calls) == 2
+    assert calls[0].atom_indices.tolist() == [[0, 1, 2, 3]]
+    assert calls[0].trans_orientations.tolist() == [True]
+    assert _restraint_loss(absent, calls[0]) > 0
+    assert _restraint_loss(present, calls[0]) < 1e-6


### PR DESCRIPTION
@jandom @jnwei Addresses the flagless reproduction in [issue #136](https://github.com/aqlaboratory/openfold-3/issues/136).

## What changed

- Detect RDKit-assigned E/Z, non-aromatic sp2 C=C bonds and extract their heavy-atom dihedrals.
- Apply a flat-bottom correction late in diffusion, then project once more after rollout so the sampler does not undo it.
- Leave queries without matching bonds unchanged.

## Verification

- On a local RTX 5090 using OpenBind 174k, seed `2746317213`, and five samples, all 20 targeted dihedrals finished within `15.01°` of the assigned cis/trans plane. The worst deviation fell from `101.13°` to `15.0097°`.
- Two focused tests cover the reported implicit-hydrogen alkene, the default no-op path, late correction, and final projection.
- `1,025` unique non-slow tests and `18` subtests pass. Three setup tests were excluded because their mock target performs real S3 checkpoint downloads. Ruff, mypy baseline comparison, diff checks, and wheel inspection also pass.

## Credit

Builds on Peter Obi's (@peter-s-obi) [ligand chemical-steering work](https://github.com/aqlaboratory/openfold-3/pull/385). The analytical geometry is adapted from [Boltz](https://github.com/jwohlwend/boltz).