### PR TITLE
Chemical steering: gradient guidance toward valid ligand chemistry

### DIFF
--- a/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-amd-reusable.yml
@@ -100,7 +100,7 @@ jobs:
             -v ${{ github.workspace }}:/opt/openfold3 \
             -v ~/.openfold3:/root/.openfold3 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-pixi-${{ inputs.pixi_env }}-${{ github.sha }} \
-            pytest -x openfold3/tests/ -m slow -vvv
+            pytest -x openfold3/tests/ openfold3/steering/tests/ -m slow -vvv
 
       - name: Reclaim workspace ownership
         # The container runs as root and writes .pytest_cache / __pycache__ into the

--- a/.github/workflows/ci-integration-test-pixi-cuda-reusable.yml
+++ b/.github/workflows/ci-integration-test-pixi-cuda-reusable.yml
@@ -123,7 +123,7 @@ jobs:
             -v ${{ github.workspace }}:/opt/openfold3 \
             -v ~/.openfold3:/root/.openfold3 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-pixi-${{ inputs.pixi_env }}-${{ github.sha }} \
-            pytest -x openfold3/tests/ -m slow -vvv
+            pytest -x openfold3/tests/ openfold3/steering/tests/ -m slow -vvv
 
   stop-aws-runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-test-pixi-reusable.yml
+++ b/.github/workflows/ci-test-pixi-reusable.yml
@@ -101,7 +101,7 @@ jobs:
           docker run \
             -v ${{ github.workspace }}:/opt/openfold3 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-pixi-${{ inputs.pixi_env }}-${{ github.sha }} \
-            pytest openfold3/tests -vvv -n auto --cov=openfold3 --cov-report=xml --cov-report=term
+            pytest openfold3/tests openfold3/steering/tests/ -vvv -n auto --cov=openfold3 --cov-report=xml --cov-report=term
 
       - name: Debug - List files and find coverage
         if: always()

--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -140,7 +140,7 @@ Configures Checkpoint writing settings, which are passed to [pl.ModelCheckpoint 
 ---
 ### 3.7. Dataset Config Kwargs (`dataset_config_kwargs`)
 
-Configures MSA, template, and pocket sampling feature generation.
+Configures MSA, template, pocket sampling, and chemical steering feature generation.
 
 **Pydantic Model**: [`InferenceDatasetConfigKwargs`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/projects/of3_all_atom/config/dataset_configs.py#L270)
 
@@ -149,6 +149,7 @@ Configures MSA, template, and pocket sampling feature generation.
 - `msa` *(MSASettings)*: MSA processing settings (see below)
 - `template` *(TemplateSettings)*: Template processing settings (see below)
 - `pocket_sampling` *(PocketSamplingSettings)*: Pocket-guided ligand proposal sampling settings (see below)
+- `steering` *(SteeringSettings)*: Chemical steering of ligand geometry during diffusion (see below)
 
 #### 3.7.1. MSA Settings (`msa`)
 
@@ -230,6 +231,44 @@ dataset_config_kwargs:
     num_parents: 16
     candidates: 1024
     noise_frac: 0.75
+```
+
+(full-ref-steering-settings)=
+#### 3.7.4 Chemical Steering Settings (`steering`)
+
+Guides the diffusion sampler toward chemically valid ligand geometry. At each
+denoising step, the predicted clean coordinates are nudged down the gradient
+of a flat-bottom restraint energy built from RDKit's distance-geometry bounds
+for the ligand: distances inside their permitted window contribute nothing, so
+guidance is inert on ligands the model already got right.
+
+Steering is off by default, and is a property of the run rather than of an
+individual query — enabling it steers every ligand in the run. That makes a
+steered/unsteered comparison a change to this block alone, with the query
+JSONs untouched. Queries with no ligand are unaffected.
+
+Only the primary rollout is steered; the pocket-sampling refinement pass is
+deliberately left unsteered.
+
+**Pydantic Model**: [`SteeringSettings`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/steering/config.py)
+
+**All Options**:
+- `enabled` *(bool)*: Whether chemical steering runs (default: `false`)
+- `num_gd_steps` *(int)*: Gradient-descent steps applied to the denoised coordinates at each denoising step. With the default weight this bounds the per-step correction to `num_gd_steps * weight` Angstrom (default: `20`, minimum: `1`)
+- `terms` *(dict)*: Per-restraint-family settings, keyed by the potential's snake_case registry name. Unknown names are rejected. Currently available: `distance_bounds_potential`
+  - `enabled` *(bool)*: Whether this term contributes to the guidance gradient (default: `true`)
+  - `weight` *(float)*: Coordinate-update weight. Because the flat-bottom subgradient is exactly ±1, this is literally the step size: a violating atom moves `weight` Angstrom per gradient-descent step (default: `0.01`, minimum: `0.0`)
+  - `interval` *(int)*: Apply this term every Nth gradient-descent step, for terms too expensive to evaluate every step (default: `1`, minimum: `1`)
+
+**Example**:
+```yaml
+dataset_config_kwargs:
+  steering:
+    enabled: true
+    num_gd_steps: 20
+    terms:
+      distance_bounds_potential:
+        weight: 0.01
 ```
 
 ---
@@ -336,4 +375,5 @@ For the complete list of default values, see the Pydantic model classes in:
 - [`openfold3/core/data/tools/colabfold_msa_server.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/tools/colabfold_msa_server.py) - MSA server settings
 - [`openfold3/core/data/pipelines/preprocessing/template.py`](http://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/data/pipelines/preprocessing/template.py) - Template preprocessing settings
 - [`openfold3/core/config/pocket_sampling_config.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/core/config/pocket_sampling_config.py) - Pocket sampling settings
+- [`openfold3/steering/config.py`](https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/steering/config.py) - Chemical steering settings
 

--- a/examples/example_runner_yamls/chemical_steering.yml
+++ b/examples/example_runner_yamls/chemical_steering.yml
@@ -1,0 +1,29 @@
+# Chemical steering of ligand geometry during diffusion.
+#
+# At each denoising step the predicted clean coordinates are nudged down the
+# gradient of a flat-bottom restraint energy built from RDKit's
+# distance-geometry bounds for the ligand. Distances already inside their
+# permitted window contribute nothing, so guidance is inert on ligands the
+# model already got right.
+#
+# Steering is a run-level setting: enabling it steers every ligand in the
+# run, and queries without a ligand are unaffected. A steered/unsteered
+# comparison is therefore this file with `enabled` flipped, with the query
+# JSONs left untouched.
+#
+# SteeringSettings: openfold3/steering/config.py
+dataset_config_kwargs:
+  steering:
+    enabled: True
+    # Gradient-descent steps per denoising step. The per-step correction is
+    # bounded by num_gd_steps * weight Angstrom.
+    num_gd_steps: 20
+    terms:
+      # Flat-bottom restraints on interatomic distances, with bounds from the
+      # RDKit distance-geometry bounds matrix.
+      distance_bounds_potential:
+        enabled: True
+        # The flat-bottom subgradient is exactly +-1, so the weight is
+        # literally the step size in Angstrom per gradient-descent step.
+        weight: 0.01
+        interval: 1

--- a/examples/reference_full_config/full_config.yml
+++ b/examples/reference_full_config/full_config.yml
@@ -131,6 +131,17 @@ dataset_config_kwargs:
     rdkit_conformer_rng: 0
     rdkit_conformer_prune_rmsd: 0.0
     rdkit_conformer_max_iters: 200
+  # SteeringSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/steering/config.py
+  # Chemical steering of ligand geometry during diffusion. Off by default;
+  # applies to every query in the run when enabled.
+  steering:
+    enabled: False
+    num_gd_steps: 20
+    terms:
+      distance_bounds_potential:
+        enabled: True
+        weight: 0.01
+        interval: 1
 
 # OutputWriterSettings: https://github.com/aqlaboratory/openfold-3/blob/main/openfold3/entry_points/validator.py#L141
 # Configure the output formats / content

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -49,7 +49,6 @@ openfold3/core/data/framework/single_datasets/base_of3.py:0: error: callable? no
 openfold3/core/data/framework/single_datasets/base_of3.py:0: error: callable? not callable  [misc]
 openfold3/core/data/framework/single_datasets/base_of3.py:0: note: did you mean to use ',' instead of ':' ?
 openfold3/core/data/framework/single_datasets/inference.py:0: error: "dict" expects 2 type arguments, but 1 given  [type-arg]
-openfold3/core/data/framework/single_datasets/inference.py:0: error: Argument 1 to "update" of "MutableMapping" has incompatible type "dict[str, Tensor]"; expected "SupportsKeysAndGetItem[str, AtomArray[Any]]"  [arg-type]
 openfold3/core/data/framework/single_datasets/inference.py:0: error: Incompatible types in assignment (expression has type "BiotiteCCDWrapper", variable has type "CIFFile")  [assignment]
 openfold3/core/data/framework/single_datasets/inference.py:0: error: Invalid type comment or annotation  [valid-type]
 openfold3/core/data/framework/single_datasets/inference.py:0: note: did you mean to use ',' instead of ':' ?

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -71,6 +71,7 @@ from openfold3.core.data.primitives.structure.tokenization import (
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     Query,
 )
+from openfold3.steering.featurization import maybe_create_steering_features
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +117,9 @@ class InferenceDataset(Dataset):
 
         # Pocket sampling
         self.pocket_sampling_settings = dataset_config.pocket_sampling
+
+        # Chemical steering
+        self.steering_settings = dataset_config.steering
 
         # Parse CCD
         if dataset_config.ccd_file_path is not None:
@@ -304,7 +308,9 @@ class InferenceDataset(Dataset):
     ) -> dict:
         """Creates all features for a single datapoint."""
 
-        features = {}
+        # Annotated because the first assignment below is the AtomArray
+        # pseudo-feature, which would otherwise fix the value type to it.
+        features: dict = {}
 
         # Create initial AtomArray and ReferenceMolecules from query entry
         structure_objs = self.get_structure_with_ref_mols(
@@ -342,6 +348,14 @@ class InferenceDataset(Dataset):
                 query=query,
                 atom_array=preprocessed_atom_array,
                 processed_reference_molecules=processed_reference_molecules,
+            )
+        )
+
+        features.update(
+            maybe_create_steering_features(
+                atom_array=preprocessed_atom_array,
+                processed_reference_molecules=processed_reference_molecules,
+                settings=self.steering_settings,
             )
         )
 

--- a/openfold3/core/metrics/ligand_geometry.py
+++ b/openfold3/core/metrics/ligand_geometry.py
@@ -1,0 +1,175 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal geometry of a predicted ligand.
+
+Answers "is this molecule built correctly?" rather than "is it in the right
+place" -- no experimental reference is involved, only the predicted
+coordinates and the molecule's own chemistry. That makes these metrics
+complementary to :mod:`openfold3.core.metrics.alignment`, which scores
+placement against experiment.
+
+Two families, matching the two ways a predicted ligand goes wrong:
+
+* :func:`worst_bounds_violation` -- how far any atom pair sits outside the
+  window RDKit's distance-geometry bounds allow. Covers bond lengths, bond
+  angles and internal clashes at once, the same way PoseBusters' internal
+  validity checks do.
+* :func:`saturated_ring_atom_names` and :func:`mean_ring_torsion` -- whether a
+  saturated ring kept its pucker. A chair sits near 55 degrees at every ring
+  bond and a flattened ring at 0, the failure mode surveyed at
+  https://www.rbvi.ucsf.edu/chimerax/data/ligchem-feb2026/badchem.html
+
+Coordinates come in as plain arrays keyed by atom name rather than as an
+``AtomArray``, so a caller can map a prediction onto a reference molecule by
+name -- which is what makes these safe to use across structures whose atom
+ordering differs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+import torch
+from rdkit.Chem.rdchem import Mol
+
+from openfold3.steering.types import RestraintSet
+
+
+def worst_bounds_violation(coords: torch.Tensor, restraints: RestraintSet) -> float:
+    """Largest distance-bounds violation among a molecule's restrained pairs.
+
+    Args:
+        coords: ``[n_atoms, 3]`` coordinates, indexed the way
+            ``restraints.atom_index`` expects. Atoms no restraint references
+            are never read, so a caller may lay a ligand out on a whole
+            complex's atom axis and leave the rest at the origin.
+        restraints: pairs and their permitted ``[lower, upper]`` windows, as
+            built by ``openfold3.steering.featurization.build_context``.
+
+    Returns:
+        The largest amount, in Angstrom, by which any pair sits outside its
+        window; ``0.0`` when every pair is inside one. An infinite upper bound
+        -- what a nonbonded pair carries, since it may be arbitrarily far
+        apart -- needs no special case: ``distance - inf`` is ``-inf``, which
+        the clamp takes to zero.
+    """
+    separation = (
+        coords[restraints.atom_index[:, 0]] - coords[restraints.atom_index[:, 1]]
+    )
+    distance = torch.linalg.norm(separation, dim=-1)
+    below = (restraints.lower - distance).clamp(min=0)
+    above = (distance - restraints.upper).clamp(min=0)
+    return float((below + above).max())
+
+
+def saturated_ring_atom_names(mol: Mol) -> list[tuple[str, ...]]:
+    """Atom names of every saturated all-carbon six-ring in ``mol``.
+
+    Restricted to that one ring class because :func:`mean_ring_torsion` is
+    calibrated against a chair: an aromatic ring is flat by right, a
+    heteroatom ring or one carrying a double bond puckers differently, and a
+    five-ring puckers to a smaller amplitude. Including any of them would make
+    the mean meaningless.
+
+    Args:
+        mol: a molecule whose atoms carry the ``annot_atom_name`` property,
+            i.e. one of the pipeline's processed reference molecules.
+
+    Returns:
+        One tuple of atom names per qualifying ring, in ring-traversal order
+        so consecutive names are bonded. Empty if the molecule has no such
+        ring.
+    """
+    names = {atom.GetIdx(): atom.GetProp("annot_atom_name") for atom in mol.GetAtoms()}
+    rings = []
+    for ring in mol.GetRingInfo().AtomRings():
+        if len(ring) != 6:
+            continue
+        if not all(mol.GetAtomWithIdx(index).GetSymbol() == "C" for index in ring):
+            continue
+        # Every ring bond single. This is also what excludes aromatic rings,
+        # whose bonds are order 1.5 -- including a ring fused to one, since the
+        # shared bond is aromatic and such a ring is a half-chair anyway.
+        if not all(
+            mol.GetBondBetweenAtoms(ring[i], ring[(i + 1) % 6]).GetBondTypeAsDouble()
+            == 1.0
+            for i in range(6)
+        ):
+            continue
+        rings.append(tuple(names[index] for index in ring))
+    return rings
+
+
+def torsion_degrees(points: np.ndarray) -> float:
+    """Signed dihedral angle of four points, in degrees.
+
+    Args:
+        points: ``[4, 3]`` coordinates in bonded order.
+
+    Returns:
+        The angle in ``(-180, 180]``, signed: a molecule and its mirror image
+        give opposite signs, which is what makes the dihedral -- unlike a bond
+        angle -- able to tell them apart.
+    """
+    b0, b1, b2 = points[0] - points[1], points[2] - points[1], points[3] - points[2]
+    b1 = b1 / np.linalg.norm(b1)
+    projected_first = b0 - np.dot(b0, b1) * b1
+    projected_last = b2 - np.dot(b2, b1) * b1
+    return float(
+        np.degrees(
+            np.arctan2(
+                np.dot(np.cross(b1, projected_first), projected_last),
+                np.dot(projected_first, projected_last),
+            )
+        )
+    )
+
+
+def mean_ring_torsion(
+    coords_by_name: Mapping[str, np.ndarray],
+    rings: Sequence[Sequence[str]],
+) -> float:
+    """Mean absolute torsion around one or more six-rings, in degrees.
+
+    Absolute because a chair's six ring torsions alternate in sign; averaging
+    them signed would cancel to zero and report a perfect chair as flat.
+
+    Args:
+        coords_by_name: coordinates of at least every atom named in ``rings``.
+        rings: ring atom names in traversal order, as
+            :func:`saturated_ring_atom_names` returns them.
+
+    Returns:
+        The mean over every ring and every bond in it: about 55 degrees for an
+        ideal chair, 0 for a planar ring. Averaging across rings means one
+        flattened ring among several shows up as a partial drop rather than
+        not at all.
+    """
+    angles = [
+        abs(
+            torsion_degrees(
+                np.array(
+                    [
+                        coords_by_name[ring[(position + offset) % 6]]
+                        for offset in range(4)
+                    ]
+                )
+            )
+        )
+        for ring in rings
+        for position in range(6)
+    ]
+    return float(np.mean(angles))

--- a/openfold3/core/model/structure/diffusion_module.py
+++ b/openfold3/core/model/structure/diffusion_module.py
@@ -44,6 +44,8 @@ from openfold3.core.model.structure.pocket_constraints import (
     _feature_mask,
     _pocket_sampling_enabled,
 )
+from openfold3.steering import PreparedSteering, prepare_steering
+from openfold3.steering.types import StepState
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +300,8 @@ class SampleDiffusion(nn.Module):
         start_step: int,
         use_conditioning: bool,
         chunk_size: int | None = None,
+        use_steering: bool = False,
+        steering: PreparedSteering | None = None,
         use_deepspeed_evo_attention: bool = False,
         use_cueq_triangle_kernels: bool = False,
         use_triton_triangle_kernels: bool = False,
@@ -306,6 +310,13 @@ class SampleDiffusion(nn.Module):
         _mask_trans: bool = True,
     ) -> torch.Tensor:
         """Run the standard OF3 denoising loop from a chosen schedule index."""
+        if use_steering and steering is None:
+            raise ValueError(
+                "use_steering=True requires a prepared steering object; "
+                "SampleDiffusion.forward builds one with prepare_steering"
+            )
+
+        num_denoising_steps = len(noise_schedule) - 1
         for tau, c_tau in enumerate(noise_schedule[1:]):
             if tau < start_step:
                 continue
@@ -338,6 +349,35 @@ class SampleDiffusion(nn.Module):
                 use_high_precision_attention=use_high_precision_attention,
                 _mask_trans=_mask_trans,
             )
+
+            # The `is not None` is for the type checker only: a True flag
+            # with nothing prepared already raised at the top of this method.
+            if use_steering and steering is not None:
+                # Guidance corrects the denoised estimate, not the noisy state,
+                # so it flows through the Euler step below rather than fighting
+                # it. Dtype handling lives here so the steering engine never
+                # deals with it. pass_name is "primary" because only the
+                # primary rollout sets use_steering -- the pocket-refinement
+                # call below passes False.
+                update = steering.engine.on_denoised(
+                    xl_denoised.float(),
+                    StepState(
+                        xl_noisy=xl_noisy,
+                        noise=noise,
+                        t=t,
+                        c_tau=c_tau,
+                        step_index=tau,
+                        num_steps=num_denoising_steps,
+                        start_step=start_step,
+                        pass_name="primary",
+                        atom_mask=atom_mask,
+                        ctx=steering.ctx,
+                    ),
+                )
+                if update is not None:
+                    xl_denoised = (xl_denoised.float() + update.delta).to(
+                        xl_denoised.dtype
+                    )
 
             delta = (xl_noisy - xl_denoised) / t
             dt = c_tau - t
@@ -398,6 +438,11 @@ class SampleDiffusion(nn.Module):
 
         total_steps = len(noise_schedule) - 1
 
+        # Called before any allocation or denoiser call, so a malformed
+        # steering batch raises before compute is spent.
+        steering = prepare_steering(batch, atom_mask)
+        use_steering = steering is not None
+
         xl = noise_schedule[0] * torch.randn(
             (batch_dim, no_rollout_samples, num_atoms, 3),
             device=atom_mask.device,
@@ -421,14 +466,23 @@ class SampleDiffusion(nn.Module):
             "_mask_trans": _mask_trans,
         }
 
+        # Steering is passed per-call rather than through rollout_kwargs: only
+        # the primary rollout is steered, so guidance effects stay
+        # attributable rather than entangled with pocket refinement below.
+        xl = self._sample_rollout(
+            xl=xl,
+            start_step=0,
+            use_steering=use_steering,
+            steering=steering,
+            **rollout_kwargs,
+        )
+
         pocket_sampling_enabled = _pocket_sampling_enabled(batch)
         if pocket_sampling_enabled and batch_dim != 1:
             raise ValueError(
                 "Pocket proposal/refinement currently supports one query per "
                 "model batch"
             )
-
-        xl = self._sample_rollout(xl=xl, start_step=0, **rollout_kwargs)
 
         if pocket_sampling_enabled:
             seed = _build_pocket_sampling_seeds(
@@ -473,9 +527,14 @@ class SampleDiffusion(nn.Module):
                 pocket_sampling_jitter,
                 seed.shape[1],
             )
+            # Pocket refinement is deliberately unsteered for now, so that a
+            # benchmark can attribute a change to guidance rather than to
+            # guidance interacting with the second pass.
             xl = self._sample_rollout(
                 xl=xl,
                 start_step=pocket_sampling_start_step,
+                use_steering=False,
+                steering=None,
                 **rollout_kwargs,
             )
 

--- a/openfold3/entry_points/experiment_runner.py
+++ b/openfold3/entry_points/experiment_runner.py
@@ -841,6 +841,7 @@ class InferenceExperimentRunner(ExperimentRunner):
             template=self.dataset_config_kwargs.template,
             template_preprocessor_settings=self.experiment_config.template_preprocessor_settings,
             pocket_sampling=self.dataset_config_kwargs.pocket_sampling,
+            steering=self.dataset_config_kwargs.steering,
         )
         inference_spec = InferenceDatasetSpec(config=inference_config)
         return DataModuleConfig(

--- a/openfold3/projects/of3_all_atom/config/dataset_configs.py
+++ b/openfold3/projects/of3_all_atom/config/dataset_configs.py
@@ -64,6 +64,7 @@ from openfold3.projects.of3_all_atom.config.dataset_config_components import (
 from openfold3.projects.of3_all_atom.config.inference_query_format import (
     InferenceQuerySet,
 )
+from openfold3.steering.config import SteeringSettings
 
 
 class TrainingDatasetPaths(BaseModel):
@@ -367,12 +368,14 @@ class TrainingDatasetSpec(DatasetSpec):
 
 
 class InferenceDatasetConfigKwargs(BaseModel):
-    """Class to hold msa, template, and pocket sampling kwargs for inference pipeline"""
+    """Class to hold msa, template, pocket sampling, and steering kwargs for
+    inference pipeline"""
 
     ccd_file_path: FilePathOrNone = None
     msa: MSASettings = MSASettings(subsample_main=False)
     template: TemplateSettings = TemplateSettings(take_top_k=True)
     pocket_sampling: PocketSamplingSettings = PocketSamplingSettings()
+    steering: SteeringSettings = SteeringSettings()
 
 
 class InferenceJobConfig(BaseModel):
@@ -385,6 +388,7 @@ class InferenceJobConfig(BaseModel):
     template: TemplateSettings = TemplateSettings()
     template_preprocessor_settings: TemplatePreprocessorSettings
     pocket_sampling: PocketSamplingSettings = PocketSamplingSettings()
+    steering: SteeringSettings = SteeringSettings()
 
 
 class InferenceDatasetSpec(DatasetSpec):

--- a/openfold3/steering/README.md
+++ b/openfold3/steering/README.md
@@ -1,0 +1,98 @@
+# Chemical steering
+
+Gradient guidance of the diffusion sampler toward valid ligand chemistry.
+Full design: see the project's steering design doc; this file covers what's
+actually in the directory and where it came from.
+
+## Architecture
+
+Three phases, and the split between them is the central decision:
+
+```
+FEATURIZATION (CPU, once per query, RDKit)
+    ProcessedReferenceMolecule.mol  +  in_crop_mask
+        --> featurization.py --> RestraintSet per term  --> SteeringContext
+
+SAMPLING LOOP (GPU, every denoising step, tensors only)
+    x0_hat = diffusion_module(...)
+    update = steering.on_denoised(x0_hat, StepState(...))
+    x0_hat = x0_hat + update.delta
+```
+
+**RDKit never enters the sampling loop.** Constraint extraction is chemistry
+and runs once on CPU (`featurization.py`); the loop sees index tensors and
+bounds (`engine.py`, `potentials.py`). Weights and intervals can be scheduled
+over the trajectory (`schedules.py`); bounds cannot without re-extraction.
+
+## Status
+
+One restraint family, `DistanceBoundsPotential` (`distance_bounds_potential`
+in a runner yaml), wired end to end: a run
+turns steering on with `dataset_config_kwargs.steering.enabled` (see
+`examples/example_runner_yamls/chemical_steering.yml`), the inference dataset
+emits restraints, and the hook in `diffusion_module.py` applies them during
+the primary rollout. The pocket-refinement pass is deliberately left
+unsteered.
+
+`openfold3/tests/inference/test_chemical_steering.py` is the end-to-end
+check: FKBP12 with rapamycin, run with steering on and off, measuring the
+predicted ligand's internal geometry. Marked slow; needs an accelerator and
+weights.
+
+Follow-on work: the remaining restraint families (VDW overlap, chiral atom,
+stereo bond, planar bond), the science tests that go with them, and
+Feynman-Kac resampling.
+
+Module map:
+
+| file | role |
+|---|---|
+| `types.py` | `RestraintSet`, `SteeringContext`, `StepState`, `SteeringUpdate` |
+| `defaults.py` | derived parameter table; referenced, never restated |
+| `schedules.py` | time-varying per-term weights |
+| `potentials.py` | `Potential` ABC, the registry, `DistanceBoundsPotential` |
+| `engine.py` | `ChemicalSteering.on_denoised`, the guidance loop |
+| `featurization.py` | RDKit chemistry and `maybe_create_steering_features` (data side; the only module importing RDKit) |
+| `batch_features.py` | the batch contract: flatten a context out, rebuild it in the sampler (shared by both sides) |
+| `config.py` | `SteeringSettings` |
+
+## Provenance policy
+
+The boundary is drawn on **derivation, not topic**, and it runs *through*
+this directory rather than around it:
+
+- **Derived** — `potentials.py`, `engine.py`, the extraction rules in
+  `featurization.py`,
+  `schedules.py`, `defaults.py`, and the tests that were ported alongside
+  them. These adapt one or more of the three prior projects below.
+- **Original OpenFold3, deriving from nothing** — `types.py`, `config.py`,
+  `batch_features.py`, and `maybe_create_steering_features` in
+  `featurization.py`. These are plumbing: the settings model,
+  the batch wire format, and the featurization entry point. They live here
+  for cohesion (steering is one feature, kept in one place) rather than
+  because they carry upstream content.
+
+Outside this directory, code merely *invokes* steering rather than
+implementing it and carries no derived content.
+
+See `THIRD_PARTY_NOTICES.md` for full license texts and a per-subject
+breakdown. Summary:
+
+- **Boltz** (MIT) — the flat-bottom formulation, the default weights and
+  buffers (`defaults.py`), and the RDKit extraction rules
+  (`featurization.py`).
+- **Protenix** (Apache 2.0) — the potential-class registry structure
+  (`CLASS_REGISTRY` / `register` in `potentials.py`).
+- **foldsteer** (Apache 2.0) — the engine (`engine.py`) and schedule types
+  (`schedules.py`), and the broadcast-regression test pattern.
+
+**Derived defaults live in `defaults.py` and nowhere else.** Config models
+outside this directory must reference them, never restate the numeric
+values — that duplication is exactly how a derived constant ends up
+uncredited outside the directory boundary.
+
+Credit: constraint extraction and the acceptance test suite this package's
+tests are ported from originate with Peter Obi (OpenFold3 PR #385); the
+engine, registry, and schedule design originate with Etowah Adams
+(foldsteer). See `THIRD_PARTY_NOTICES.md` and this repository's
+`CITATION.cff`.

--- a/openfold3/steering/THIRD_PARTY_NOTICES.md
+++ b/openfold3/steering/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,91 @@
+# Third-Party Notices
+
+This directory (`openfold3/steering/`) adapts design, default parameters, and
+in places source code from three prior open-source projects. None of the
+three is affiliated with or endorses OpenFold3.
+
+The per-project sections below list exactly which files derive from what.
+Files not listed in any section — `types.py`, `config.py`,
+`batch_features.py`, and their tests — are original OpenFold3 code and
+derive from none of these projects. `featurization.py` is mixed: its
+extraction rules are Boltz-derived (listed below), its
+`maybe_create_steering_features` entry point is not.
+
+## Boltz
+
+The flat-bottom potential formulation, the default restraint weights and
+buffers (`defaults.py`), and the RDKit distance-geometry extraction rules
+(`featurization.py`) are adapted from Boltz:
+
+- `openfold3/steering/defaults.py`
+- `openfold3/steering/potentials.py`
+- `openfold3/steering/featurization.py`
+- `openfold3/steering/engine.py`
+
+<https://github.com/jwohlwend/boltz> (`src/boltz/model/potentials/potentials.py`,
+`src/boltz/model/modules/diffusion.py`).
+
+MIT License
+
+Copyright (c) 2024 Jeremy Wohlwend, Gabriele Corso, Saro Passaro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Protenix
+
+The separation of steering into a standalone, config-driven module with a
+potential class registry (`CLASS_REGISTRY` / `register` in `potentials.py`)
+follows the structure of `protenix/tfg/`. The chemistry criteria for terms not
+yet implemented here (sp2/sp3 planarity, conjugated-torsion planarity) are
+expected to follow the revised validity criteria from the Protenix-v2
+technical report when those terms land.
+
+<https://github.com/bytedance/Protenix>
+
+Copyright (c) ByteDance Ltd. and/or its affiliates
+
+Licensed under the Apache License, Version 2.0. The full license text is at
+<https://github.com/aqlaboratory/openfold-3/blob/main/LICENSE> (OpenFold3 is
+itself Apache 2.0, so redistribution here needs no separate license copy per
+License §4; this section preserves the attribution notice per §4(d)).
+
+## foldsteer
+
+The registry-driven engine (`engine.py`, `ChemicalSteering.on_denoised`), the
+schedule types (`schedules.py`: `Constant`, `ExponentialInterpolation`,
+`PiecewiseStepFunction`), and the broadcast-regression test sweep
+(`tests/test_potentials.py`) are adapted from foldsteer, itself an independent
+reimplementation deriving from Boltz and Protenix (see foldsteer's own
+`NOTICE`).
+
+- `openfold3/steering/engine.py`
+- `openfold3/steering/schedules.py`
+- `openfold3/steering/tests/test_potentials.py`
+
+<https://github.com/etowahadams/foldsteer>
+
+Copyright 2026 the foldsteer authors
+
+Licensed under the Apache License, Version 2.0. The full license text is at
+<https://github.com/aqlaboratory/openfold-3/blob/main/LICENSE> (see note
+above); this section preserves the attribution notice per §4(d).
+
+## RDKit
+
+Constraint extraction uses RDKit (BSD 3-Clause), <https://www.rdkit.org/>.

--- a/openfold3/steering/__init__.py
+++ b/openfold3/steering/__init__.py
@@ -1,0 +1,46 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chemical steering: gradient guidance toward valid ligand chemistry.
+
+See README.md for the architecture and provenance policy, and
+THIRD_PARTY_NOTICES.md for full license texts.
+
+This module deliberately exports only the sampling-loop side, which is
+torch-only. `featurization` pulls in RDKit, biotite and the
+data pipeline, so it is imported directly by the featurization path
+rather than re-exported here -- otherwise every importer of this package,
+including the model stack, would pay for them.
+"""
+
+from openfold3.steering.batch_features import (
+    PreparedSteering,
+    prepare_steering,
+    steering_enabled,
+)
+from openfold3.steering.config import SteeringSettings, TermSettings
+from openfold3.steering.engine import ChemicalSteering, Term
+from openfold3.steering.types import RestraintSet, SteeringContext
+
+__all__ = [
+    "ChemicalSteering",
+    "PreparedSteering",
+    "RestraintSet",
+    "SteeringContext",
+    "SteeringSettings",
+    "Term",
+    "TermSettings",
+    "prepare_steering",
+    "steering_enabled",
+]

--- a/openfold3/steering/batch_features.py
+++ b/openfold3/steering/batch_features.py
@@ -1,0 +1,327 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The batch wire format for chemical steering.
+
+Steering restraints are built during featurization (CPU, per query) but
+applied in the sampler (GPU, per denoising step), and the only channel
+between the two is the feature batch. A ``SteeringContext`` cannot travel
+that channel as an object: the collator sends every entry through
+``pad_sequence(...).squeeze(-1)`` (``core/data/framework/data_module.py``)
+and the model then ``unsqueeze(1)``s every leaf, and only two hardcoded keys
+have a non-tensor escape hatch.
+
+So the context is taken apart into plain tensors by ``context_to_features``
+in the featurizer, and reassembled by ``prepare_steering`` in the sampler.
+Both functions live in this module so that the key names they agree on are
+defined once. Splitting them would make a rename on one side silently
+disagree with the other, and the symptom would be steering quietly doing
+nothing rather than an error.
+
+Reassembly does not trust incoming shapes. Because the collator pads and
+squeezes, an emitted ``[n, 2]`` may arrive as ``[1, n, 2]`` or
+``[1, 1, n, 2]``, and an emitted ``[n]`` collapses to ``[1]`` when
+``n == 1``. Every tensor is therefore reshaped using an explicitly emitted
+``_count``, never by inferring which axis is which.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch
+
+from openfold3.steering.config import SteeringSettings
+from openfold3.steering.engine import ChemicalSteering, Term
+from openfold3.steering.potentials import CLASS_REGISTRY
+from openfold3.steering.schedules import Constant
+from openfold3.steering.types import RestraintSet, SteeringContext
+
+STEERING_ENABLED_KEY = "steering_enabled"
+STEERING_NUM_GD_STEPS_KEY = "steering_num_gd_steps"
+STEERING_N_ATOMS_KEY = "steering_n_atoms"
+
+
+def term_key(term_name: str, suffix: str) -> str:
+    """Batch feature key for one field of one restraint family.
+
+    >>> term_key("distance_bounds_potential", "lower")
+    'steering_distance_bounds_potential_lower'
+    """
+    return f"steering_{term_name}_{suffix}"
+
+
+@dataclass(frozen=True)
+class PreparedSteering:
+    """Everything the sampler needs, rebuilt from a collated batch."""
+
+    engine: ChemicalSteering
+    ctx: SteeringContext
+
+
+def context_to_features(
+    ctx: SteeringContext,
+    settings: SteeringSettings,
+) -> dict[str, torch.Tensor]:
+    """Flatten a SteeringContext plus its settings into batch tensors.
+
+    Scalars are emitted as 1-element tensors, matching the convention the
+    collator and `_batch_scalar` expect.
+
+    Args:
+        ctx: the restraints extracted for this query, plus the atom-axis
+            length they were built against.
+        settings: the run's steering settings. Only terms that are enabled,
+            carry a non-zero weight, and have restraints in ``ctx`` are
+            emitted; a term configured here but absent from ``ctx`` is
+            skipped rather than emitted empty.
+
+    Returns:
+        Batch features, or ``{}`` when no term has any restraints -- emitting
+        no keys at all is what makes disabled steering a structural no-op.
+    """
+    active = {
+        name: term
+        for name, term in settings.active_terms().items()
+        if ctx.restraints.get(name) is not None
+        and ctx.restraints[name].atom_index.numel() > 0
+    }
+    if not active:
+        return {}
+
+    features: dict[str, torch.Tensor] = {
+        STEERING_ENABLED_KEY: torch.tensor([True], dtype=torch.bool),
+        STEERING_NUM_GD_STEPS_KEY: torch.tensor(
+            [settings.num_gd_steps], dtype=torch.long
+        ),
+        STEERING_N_ATOMS_KEY: torch.tensor([ctx.n_atoms], dtype=torch.long),
+    }
+    for name, term in active.items():
+        restraints = ctx.restraints[name]
+        features[term_key(name, "atom_index")] = restraints.atom_index.to(torch.int64)
+        features[term_key(name, "lower")] = restraints.lower.to(torch.float32)
+        features[term_key(name, "upper")] = restraints.upper.to(torch.float32)
+        features[term_key(name, "count")] = torch.tensor(
+            [restraints.atom_index.shape[0]], dtype=torch.long
+        )
+        features[term_key(name, "weight")] = torch.tensor(
+            [term.weight], dtype=torch.float32
+        )
+        features[term_key(name, "interval")] = torch.tensor(
+            [term.interval], dtype=torch.long
+        )
+    return features
+
+
+def steering_enabled(batch: Mapping[str, torch.Tensor]) -> bool:
+    """Whether this batch carries steering features.
+
+    Probes with ``.get`` because the key is absent entirely when steering is
+    off; every other key is then required, and a missing one raises.
+    """
+    enabled = batch.get(STEERING_ENABLED_KEY)
+    return enabled is not None and bool(enabled.flatten()[0].item())
+
+
+def _required(batch: Mapping[str, torch.Tensor], key: str) -> torch.Tensor:
+    if key not in batch:
+        raise ValueError(f"steering feature {key!r} is missing from the batch")
+    return batch[key]
+
+
+def _scalar_int(batch: Mapping[str, torch.Tensor], key: str) -> int:
+    return int(_required(batch, key).flatten()[0].item())
+
+
+def _scalar_float(batch: Mapping[str, torch.Tensor], key: str) -> float:
+    return float(_required(batch, key).flatten()[0].item())
+
+
+def _restraints_from_batch(
+    batch: Mapping[str, torch.Tensor],
+    term_name: str,
+    *,
+    n_atoms: int,
+    device: torch.device,
+) -> RestraintSet:
+    """Rebuild one term's RestraintSet from its four batch features.
+
+    Reads ``steering_<term>_count`` first and treats it as the shape
+    authority: the collator pads and the model unsqueezes a sample axis, so
+    the stored shape of ``atom_index`` is not trustworthy and orientation is
+    never inferred from it. Every other field is then checked against that
+    count, which is what turns a silently mangled feature into an error.
+
+    Args:
+        batch: collated batch carrying this term's features.
+        term_name: registry key of the potential, e.g.
+            ``"distance_bounds_potential"``. Supplies the arity.
+        n_atoms: size of the model's atom axis; atom indices must fall inside
+            it.
+        device: device to place the rebuilt tensors on.
+
+    Returns:
+        The term's restraints, indices as int64 and bounds as float32.
+
+    Raises:
+        ValueError: if a feature is missing, has the wrong dtype, has an
+            element count inconsistent with ``count``, or indexes an atom
+            outside ``[0, n_atoms)``.
+    """
+    arity = CLASS_REGISTRY[term_name].arity
+    count = _scalar_int(batch, term_key(term_name, "count"))
+    if count < 0:
+        raise ValueError(
+            f"steering term {term_name!r} has a negative restraint count {count}"
+        )
+
+    index_key = term_key(term_name, "atom_index")
+    raw_index = _required(batch, index_key)
+    if raw_index.dtype not in (torch.int32, torch.int64):
+        raise ValueError(
+            f"steering feature {index_key!r} must be an integer tensor; "
+            f"got {raw_index.dtype}"
+        )
+    if raw_index.numel() != count * arity:
+        raise ValueError(
+            f"steering feature {index_key!r} has {raw_index.numel()} elements, "
+            f"expected {count * arity} for {count} restraint(s) of arity {arity}"
+        )
+    atom_index = raw_index.reshape(count, arity).to(device=device, dtype=torch.int64)
+    if count and (int(atom_index.min()) < 0 or int(atom_index.max()) >= n_atoms):
+        raise ValueError(
+            f"steering feature {index_key!r} indexes atoms outside [0, {n_atoms}): "
+            f"[{int(atom_index.min())}, {int(atom_index.max())}]"
+        )
+
+    bounds = []
+    for suffix in ("lower", "upper"):
+        key = term_key(term_name, suffix)
+        raw = _required(batch, key)
+        if not raw.is_floating_point():
+            raise ValueError(
+                f"steering feature {key!r} must be a float tensor; got {raw.dtype}"
+            )
+        if raw.numel() != count:
+            raise ValueError(
+                f"steering feature {key!r} has {raw.numel()} elements, expected {count}"
+            )
+        bounds.append(raw.reshape(count).to(device=device, dtype=torch.float32))
+
+    return RestraintSet(atom_index=atom_index, lower=bounds[0], upper=bounds[1])
+
+
+def prepare_steering(
+    batch: Mapping[str, torch.Tensor],
+    atom_mask: torch.Tensor,
+) -> PreparedSteering | None:
+    """Rebuild the steering engine and context from a collated batch.
+
+    Called once per forward, before the first denoiser call, so a malformed
+    batch fails before any compute is spent.
+
+    The batch keys consumed, all produced by ``context_to_features`` (which
+    emits none of them when steering is off -- hence the ``.get`` probe):
+
+    ==================================  =======  ==========================
+    key                                 dtype    meaning
+    ==================================  =======  ==========================
+    ``steering_enabled``                bool     master switch; absence
+                                                 means no steering
+    ``steering_num_gd_steps``           int64    gradient steps per
+                                                 denoising step
+    ``steering_n_atoms``                int64    atom axis the restraints
+                                                 were built for
+    ``steering_<term>_atom_index``      int64    ``count * arity`` atom
+                                                 indices
+    ``steering_<term>_lower/_upper``    float32  ``count`` bounds each
+    ``steering_<term>_count``           int64    restraint count; the shape
+                                                 authority
+    ``steering_<term>_weight``          float32  per-step step size (A)
+    ``steering_<term>_interval``        int64    apply every Nth GD step
+    ==================================  =======  ==========================
+
+    ``<term>`` is a ``CLASS_REGISTRY`` key, so a registered term with no
+    ``atom_index`` key in this batch was simply disabled or produced no
+    restraints -- not an error.
+
+    Args:
+        batch: collated batch, one query per model batch.
+        atom_mask: the model's atom mask, ``[batch, ..., n_atoms]``. Supplies
+            the batch size, the atom-axis length to validate against, and the
+            device the restraints are placed on. Its *values* are not read:
+            guidance gradients are not masked, matching upstream.
+
+    Returns:
+        A ``PreparedSteering``, or ``None`` when this batch is simply not
+        steered. That is an ordinary outcome, not a failure, and covers three
+        cases: the run has steering off (`SteeringSettings.enabled` is
+        False); the query had nothing to restrain, e.g. no ligand, so
+        featurization emitted no keys (see
+        ``featurization.maybe_create_steering_features``); or the batch
+        carries an enable flag but no registered term has restraints in it.
+
+    Raises:
+        ValueError: if the batch holds more than one query, if steering
+            features are present but malformed, or if ``steering_n_atoms``
+            disagrees with the model's atom axis.
+    """
+    # The enable probe comes first, and the order matters: everything below
+    # applies only to runs that actually steer. In particular the batch-size
+    # restriction is a steering restriction, not a sampler-wide one -- an
+    # unsteered multi-query rollout is ordinary and must not raise here.
+    if not steering_enabled(batch):
+        return None
+
+    batch_dim, n_atoms = atom_mask.shape[0], atom_mask.shape[-1]
+    if batch_dim != 1:
+        raise ValueError(
+            "Chemical steering currently supports one query per model batch"
+        )
+
+    emitted_n_atoms = _scalar_int(batch, STEERING_N_ATOMS_KEY)
+    if emitted_n_atoms != n_atoms:
+        raise ValueError(
+            f"steering features were built for {emitted_n_atoms} atoms but the "
+            f"model's atom axis has {n_atoms}"
+        )
+
+    device = atom_mask.device
+    restraints: dict[str, RestraintSet] = {}
+    terms: dict[str, Term] = {}
+    for term_name, potential_cls in CLASS_REGISTRY.items():
+        # A registered term with no features in this batch was disabled or
+        # produced no restraints for this query, which is not an error.
+        if term_key(term_name, "atom_index") not in batch:
+            continue
+        restraints[term_name] = _restraints_from_batch(
+            batch, term_name, n_atoms=n_atoms, device=device
+        )
+        terms[term_name] = Term(
+            potential=potential_cls(),
+            weight=Constant(_scalar_float(batch, term_key(term_name, "weight"))),
+            interval=_scalar_int(batch, term_key(term_name, "interval")),
+        )
+
+    if not terms:
+        return None
+
+    engine = ChemicalSteering(
+        terms=terms, num_gd_steps=_scalar_int(batch, STEERING_NUM_GD_STEPS_KEY)
+    )
+    return PreparedSteering(
+        engine=engine,
+        ctx=SteeringContext(restraints=restraints, n_atoms=n_atoms),
+    )

--- a/openfold3/steering/config.py
+++ b/openfold3/steering/config.py
@@ -1,0 +1,108 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run-level settings for chemical steering.
+
+Every numeric default is referenced from ``defaults.py`` rather than
+restated here, so the derived parameter table stays in exactly one place
+(see THIRD_PARTY_NOTICES.md).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic import ConfigDict as PydanticConfigDict
+
+from openfold3.steering import defaults
+from openfold3.steering.potentials import CLASS_REGISTRY, DistanceBoundsPotential
+
+
+class TermSettings(BaseModel):
+    """Settings for one restraint family.
+
+    Attributes:
+        enabled (bool):
+            Whether this term contributes to the guidance gradient. A
+            disabled term emits no restraints, so the sampler never sees it.
+        weight (float):
+            Coordinate-update weight. Because the flat-bottom subgradient is
+            exactly +-1 and a distance has |dv/dx| = 1, this is literally the
+            step size: a violating atom moves `weight` Angstrom per
+            gradient-descent step.
+        interval (int):
+            Apply this term every Nth gradient-descent step. Intended for
+            terms too expensive to evaluate every step; 1 means every step.
+    """
+
+    model_config = PydanticConfigDict(extra="forbid", allow_inf_nan=False)
+
+    enabled: bool = True
+    weight: float = Field(default=defaults.DISTANCE_WEIGHT, ge=0.0)
+    interval: int = Field(default=1, ge=1)
+
+
+class SteeringSettings(BaseModel):
+    """Settings for inference-time chemical steering of ligand geometry.
+
+    Consumed by `maybe_create_steering_features` in
+    `openfold3.steering.featurization`. Reachable from an inference
+    experiment config via `dataset_config_kwargs.steering`.
+
+    Steering is off by default and applies to every query in the run when
+    enabled: whether ligands are steered is a property of the run, not of an
+    individual query, which also makes a steered/unsteered ablation a yaml
+    toggle rather than a second set of query JSONs.
+
+    Attributes:
+        enabled (bool):
+            Whether chemical steering runs at all. Off by default.
+        num_gd_steps (int):
+            Gradient-descent steps applied to the denoised coordinates at
+            each denoising step. With the default weight this bounds the
+            per-step correction to `num_gd_steps * weight` Angstrom.
+        terms (dict[str, TermSettings]):
+            Per-restraint-family settings, keyed by the potential's
+            snake_case registry name (a key of
+            `openfold3.steering.potentials.CLASS_REGISTRY`, e.g.
+            `distance_bounds_potential`). Unknown keys are rejected.
+    """
+
+    model_config = PydanticConfigDict(extra="forbid", allow_inf_nan=False)
+
+    enabled: bool = False
+    num_gd_steps: int = Field(default=defaults.NUM_GD_STEPS, ge=1)
+    terms: dict[str, TermSettings] = Field(
+        default_factory=lambda: {DistanceBoundsPotential.name: TermSettings()}
+    )
+
+    @field_validator("terms")
+    @classmethod
+    def _validate_term_names(
+        cls, value: dict[str, TermSettings]
+    ) -> dict[str, TermSettings]:
+        unknown = sorted(set(value) - set(CLASS_REGISTRY))
+        if unknown:
+            raise ValueError(
+                f"unknown steering term(s) {unknown}; available terms are "
+                f"{sorted(CLASS_REGISTRY)}"
+            )
+        return value
+
+    def active_terms(self) -> dict[str, TermSettings]:
+        """Terms that are enabled and carry a non-zero weight."""
+        return {
+            name: term
+            for name, term in self.terms.items()
+            if term.enabled and term.weight > 0.0
+        }

--- a/openfold3/steering/defaults.py
+++ b/openfold3/steering/defaults.py
@@ -1,0 +1,27 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# DERIVED VALUES. Boltz (MIT), src/boltz/model/potentials/potentials.py.
+# See THIRD_PARTY_NOTICES.md. Config models reference these; they never
+# restate them.
+# ---------------------------------------------------------------------------
+
+DISTANCE_WEIGHT = 0.01
+BOND_BUFFER = 0.125
+ANGLE_BUFFER = 0.125
+CLASH_BUFFER = 0.10
+VDW_PAIR_CUTOFF_OFFSET = 0.35
+
+NUM_GD_STEPS = 20

--- a/openfold3/steering/engine.py
+++ b/openfold3/steering/engine.py
@@ -1,0 +1,105 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The gradient-descent guidance loop.
+
+Follows Boltz's guidance step (``src/boltz/model/modules/diffusion.py``,
+MIT). See THIRD_PARTY_NOTICES.md for full provenance.
+
+The weight is the step size: the energy's gradient with respect to the
+restrained variable is +-w (see ``potentials.Potential.energy_and_gradient``),
+and for a distance restraint ``|dv/dx| = 1``, so an update of
+``x -= grad`` moves a violating atom by exactly ``w`` Angstrom per gradient
+step, with no separate learning rate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch
+
+from openfold3.steering.potentials import Potential
+from openfold3.steering.schedules import Schedule
+from openfold3.steering.types import SteeringUpdate, StepState
+
+
+@dataclass(frozen=True)
+class Term:
+    """One potential plus its weight schedule and evaluation cadence."""
+
+    potential: Potential
+    weight: Schedule
+    interval: int = 1  # apply every Nth gradient-descent step
+
+
+class ChemicalSteering:
+    """Gradient-descent guidance on the denoised coordinate estimate.
+
+    Terms are keyed by potential class name, matching
+    ``potentials.CLASS_REGISTRY`` and the restraint-family keys on
+    ``SteeringContext.restraints`` — so a term with no matching restraints in
+    the context (or with a restraint family that produced zero restraints
+    per-query) is silently skipped rather than erroring, and a disabled or
+    all-zero-weight configuration returns ``None`` structurally.
+    """
+
+    def __init__(self, terms: Mapping[str, Term], num_gd_steps: int):
+        self.terms = terms
+        self.num_gd_steps = num_gd_steps
+
+    def on_denoised(self, x0: torch.Tensor, step: StepState) -> SteeringUpdate | None:
+        t = step.steering_t
+
+        # Resolve once per call: weight and interval are both functions of
+        # `t` (fixed for this call) and the context (fixed for this call),
+        # never of `gd_step`. A term stays out of every remaining gd_step
+        # once excluded here -- there is no scenario where it would start
+        # contributing partway through. This also gives the structural
+        # no-op: an empty `usable` returns None without looping.
+        #
+        # NOTE: an earlier version of this loop instead checked "did any
+        # term fire on THIS gd_step" and `break`-ed the whole loop when it
+        # hadn't. That is wrong whenever a term's `interval > 1` and no
+        # other term covers the gap: the loop would terminate at the first
+        # skipped step instead of resuming on the next step the interval
+        # permits (e.g. interval=2 firing on steps 0, 2, 4, ... 18 of 20).
+        usable = []
+        for name, term in self.terms.items():
+            w = term.weight.at(t)
+            if w <= 0.0:
+                continue
+            restraints = step.ctx.restraints.get(name)
+            if restraints is None or restraints.atom_index.numel() == 0:
+                continue
+            usable.append((term, restraints, w))
+
+        if not usable:
+            return None
+
+        update = torch.zeros_like(x0)
+        for gd_step in range(self.num_gd_steps):
+            grad = torch.zeros_like(x0)
+            step_active = False
+            for term, restraints, w in usable:
+                if gd_step % max(1, term.interval):
+                    continue
+                _, g = term.potential.energy_and_gradient(x0 + update, restraints, w)
+                grad = grad + g
+                step_active = True
+            if step_active:
+                update = update - grad
+
+        return SteeringUpdate(delta=update, n_active_terms=len(usable))

--- a/openfold3/steering/featurization.py
+++ b/openfold3/steering/featurization.py
@@ -1,0 +1,410 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Featurization: RDKit chemistry to steering batch features.
+
+The data-side entry point (``maybe_create_steering_features``) and the chemistry
+it wraps. Runs once per query on CPU; RDKit never enters the sampling loop,
+and everything downstream of this module is index and bounds tensors. This
+is the only module in the package that imports RDKit, which is what keeps
+it off the model's import path -- see ``batch_features``.
+
+Bounds come from RDKit's distance-geometry bounds matrix on the intact,
+H-containing reference molecule, exactly as Boltz computes them
+(``src/boltz/model/potentials/potentials.py``, MIT). See
+THIRD_PARTY_NOTICES.md. Buffers are applied per pair classification (bond /
+1-3 angle / neither) rather than uniformly, and the reference molecule is
+never rebuilt from an ``AtomArray`` — a round trip through RDKit valence
+perception drops molecules with formal charges RDKit cannot reassign (e.g.
+quaternary nitrogen, boron).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+
+import numpy as np
+import torch
+from biotite.structure import AtomArray, get_residue_count
+from rdkit import Chem
+from rdkit.Chem.rdchem import Mol
+from rdkit.Chem.rdDistGeom import GetMoleculeBoundsMatrix
+
+from openfold3.core.data.pipelines.sample_processing.conformer import (
+    ProcessedReferenceMolecule,
+)
+from openfold3.core.data.primitives.structure.component import PERIODIC_TABLE
+from openfold3.core.data.primitives.structure.labels import residue_view_iter
+from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.steering import defaults
+from openfold3.steering.batch_features import context_to_features
+from openfold3.steering.config import SteeringSettings
+from openfold3.steering.potentials import DistanceBoundsPotential
+from openfold3.steering.types import RestraintSet, SteeringContext
+
+
+class MissingReferenceMoleculeError(ValueError):
+    """Raised when reference molecules do not line up 1:1 with the residues
+    in the structure.
+
+    Subclasses ``ValueError`` so callers that already catch ``ValueError``
+    around featurization keep working unchanged.
+    """
+
+    pass
+
+
+@dataclass
+class _DistanceConstraints:
+    """Mutable accumulator for one or more ligand chains' distance pairs.
+
+    One entry per field per pair, all lists the same length. Ethanol (``CCO``,
+    heavy atoms only, at global offset 18 behind a protein chain) produces
+    three entries -- both bonds and the single 1-3 pair across them::
+
+        index            [(18, 19),  (18, 20),  (19, 20)]   # C1-C2, C1..O1, C2-O1
+        lower            [1.504,     2.336,     1.384]      # raw bounds-matrix
+        upper            [1.524,     2.416,     1.404]      #   values, unbuffered
+        bond_mask        [True,      False,     True]
+        angle_mask       [False,     True,      False]
+        pair_vdw_cutoffs [2.05,      1.975,     1.975]
+
+    ``_tensorize_distance_constraints`` then widens these into the restraint
+    set: the two bonded pairs take the bond buffer and the 1-3 pair the angle
+    buffer, giving ``[1.316, 1.715]``, ``[2.044, 2.718]`` and
+    ``[1.211, 1.579]``. The vdW cutoffs cap the bonded upper bounds, but on a
+    molecule this small none of them binds.
+    """
+
+    index: list[tuple[int, int]] = field(default_factory=list)
+    lower: list[float] = field(default_factory=list)
+    upper: list[float] = field(default_factory=list)
+    bond_mask: list[bool] = field(default_factory=list)
+    angle_mask: list[bool] = field(default_factory=list)
+    pair_vdw_cutoffs: list[float] = field(default_factory=list)
+
+    def extend(self, other: _DistanceConstraints) -> None:
+        for constraint_field in fields(self):
+            getattr(self, constraint_field.name).extend(
+                getattr(other, constraint_field.name)
+            )
+
+
+def _compute_distance_constraints(
+    mol: Mol,
+    idx_map: dict[int, int],
+    *,
+    vdw_pair_cutoff_offset: float,
+) -> _DistanceConstraints:
+    """RDKit distance-geometry bounds for one ligand, in the model atom axis.
+
+    Args:
+        mol: RDKit reference molecule containing the ligand bond graph.
+        idx_map: mapping from reference-molecule atom indices to model
+            (global) atom indices. Only pairs where both atoms are present
+            survive the crop.
+        vdw_pair_cutoff_offset: additive offset (Angstrom) on the mean
+            pairwise van der Waals radius, used as a per-pair floor/ceiling
+            during buffering.
+
+    Raises:
+        ValueError: if a mapped atom has an unsupported atomic number.
+
+    Returns:
+        Unbuffered distance bounds and pair classifications for every atom
+        pair with both atoms present in ``idx_map``, on the model atom axis.
+    """
+    constraints = _DistanceConstraints()
+    if mol.GetNumAtoms() <= 1:
+        return constraints
+
+    mapped_atomic_numbers = {
+        atom_idx: mol.GetAtomWithIdx(atom_idx).GetAtomicNum() for atom_idx in idx_map
+    }
+    if any(
+        atomic_number < 1 or atomic_number > PERIODIC_TABLE.GetMaxAtomicNumber()
+        for atomic_number in mapped_atomic_numbers.values()
+    ):
+        raise ValueError(
+            "Chemical steering requires ligand atoms with supported atomic numbers."
+        )
+
+    mol.UpdatePropertyCache(strict=False)
+    Chem.GetSymmSSSR(mol)
+    bounds = GetMoleculeBoundsMatrix(
+        mol,
+        set15bounds=True,
+        scaleVDW=True,
+        doTriangleSmoothing=True,
+        useMacrocycle14config=False,
+    )
+    bonds = {
+        tuple(sorted(match))
+        for match in mol.GetSubstructMatches(Chem.MolFromSmarts("*~*"))
+    }
+    angles = {
+        tuple(sorted((match[0], match[2])))
+        for match in mol.GetSubstructMatches(Chem.MolFromSmarts("*~*~*"))
+    }
+
+    for i, j in zip(*np.triu_indices(mol.GetNumAtoms(), k=1), strict=True):
+        i_idx, j_idx = int(i), int(j)
+        if i_idx not in idx_map or j_idx not in idx_map:
+            continue
+        atomic_numbers = (mapped_atomic_numbers[i_idx], mapped_atomic_numbers[j_idx])
+        atom_pair = tuple(sorted((i_idx, j_idx)))
+        constraints.index.append((idx_map[i_idx], idx_map[j_idx]))
+        constraints.upper.append(float(bounds[i_idx, j_idx]))
+        constraints.lower.append(float(bounds[j_idx, i_idx]))
+        constraints.bond_mask.append(atom_pair in bonds)
+        constraints.angle_mask.append(atom_pair in angles)
+        pair_radii = [PERIODIC_TABLE.GetRvdw(number) for number in atomic_numbers]
+        constraints.pair_vdw_cutoffs.append(
+            vdw_pair_cutoff_offset + sum(pair_radii) / len(pair_radii)
+        )
+
+    return constraints
+
+
+def _tensorize_distance_constraints(
+    constraints: _DistanceConstraints,
+    *,
+    bond_buffer: float,
+    angle_buffer: float,
+    clash_buffer: float,
+) -> RestraintSet:
+    """Apply per-pair-class buffers and the VDW floor/ceiling.
+
+    Four pair classes, each buffered differently:
+      - bond only: tighten both bounds by ``bond_buffer``.
+      - 1-3 angle only: tighten both bounds by ``angle_buffer``.
+      - both (a 3-membered ring): tighten by ``min(bond_buffer, angle_buffer)``.
+      - neither (nonbonded): loosen the lower (clash) bound by
+        ``clash_buffer`` and drop the upper bound to +inf.
+    Then, regardless of class, the lower bound on any non-bonded pair is
+    floored at the VDW cutoff carried on ``constraints``, and the upper bound
+    on any bonded pair is capped at it.
+
+    Args:
+        constraints: unbuffered bounds, pair classifications and per-pair VDW
+            cutoffs from ``_compute_distance_constraints``, already expressed
+            on the model atom axis.
+        bond_buffer: relative tolerance for 1-2 bonded pairs, applied
+            multiplicatively as ``[lower * (1 - buffer), upper * (1 + buffer)]``
+            so a restraint accommodates the spread of a real conformer
+            ensemble instead of pinning one idealized geometry.
+        angle_buffer: the same, for 1-3 (angle-defined) pairs. A pair that is
+            both bonded and angle-defined, as in a three-membered ring, takes
+            the tighter of the two.
+        clash_buffer: relative slack on the lower bound of pairs that are
+            neither bonded nor angle-defined. These keep only a lower
+            (clash) bound; their upper bound is dropped.
+
+    Returns:
+        A ``RestraintSet`` with buffered bounds, or an empty one if
+        ``constraints`` held no pairs.
+    """
+    if not constraints.index:
+        return RestraintSet(
+            atom_index=torch.empty((0, 2), dtype=torch.int64),
+            lower=torch.empty((0,), dtype=torch.float32),
+            upper=torch.empty((0,), dtype=torch.float32),
+        )
+
+    index = torch.tensor(constraints.index, dtype=torch.int64)
+    lower = torch.tensor(constraints.lower, dtype=torch.float32)
+    upper = torch.tensor(constraints.upper, dtype=torch.float32)
+    bond = torch.tensor(constraints.bond_mask, dtype=torch.bool)
+    angle = torch.tensor(constraints.angle_mask, dtype=torch.bool)
+    pair_vdw_cutoff = torch.tensor(constraints.pair_vdw_cutoffs, dtype=torch.float32)
+
+    lower[bond & ~angle] *= 1.0 - bond_buffer
+    upper[bond & ~angle] *= 1.0 + bond_buffer
+    lower[~bond & angle] *= 1.0 - angle_buffer
+    upper[~bond & angle] *= 1.0 + angle_buffer
+    shared_buffer = min(bond_buffer, angle_buffer)
+    lower[bond & angle] *= 1.0 - shared_buffer
+    upper[bond & angle] *= 1.0 + shared_buffer
+    lower[~bond & ~angle] *= 1.0 - clash_buffer
+    upper[~bond & ~angle] = float("inf")
+    lower[~bond] = torch.maximum(lower[~bond], pair_vdw_cutoff[~bond])
+    upper[bond] = torch.minimum(upper[bond], pair_vdw_cutoff[bond])
+
+    return RestraintSet(atom_index=index, lower=lower, upper=upper)
+
+
+def extract_distance_bounds(
+    mol: Mol,
+    atom_index: torch.Tensor,
+    *,
+    bond_buffer: float = defaults.BOND_BUFFER,
+    angle_buffer: float = defaults.ANGLE_BUFFER,
+    clash_buffer: float = defaults.CLASH_BUFFER,
+    vdw_pair_cutoff_offset: float = defaults.VDW_PAIR_CUTOFF_OFFSET,
+) -> RestraintSet:
+    """Bounds matrix on the intact, H-containing reference molecule.
+
+    Args:
+        mol: RDKit reference molecule (``ProcessedReferenceMolecule.mol``).
+        atom_index: int64 ``[n_local]``; global (model) atom index per local
+            RDKit atom, or ``-1`` for an atom that was cropped out.
+        bond_buffer: relative tolerance for 1-2 bonded pairs.
+        angle_buffer: relative tolerance for 1-3 (angle-defined) pairs.
+        clash_buffer: relative slack on the lower bound of nonbonded pairs.
+        vdw_pair_cutoff_offset: additive offset (Angstrom) on the mean
+            pairwise van der Waals radius, which floors the lower bound of
+            nonbonded pairs and caps the upper bound of bonded ones.
+
+    Returns:
+        A ``RestraintSet`` of buffered distance bounds on the model atom axis.
+    """
+    idx_map = {
+        local: int(global_idx)
+        for local, global_idx in enumerate(atom_index.tolist())
+        if global_idx >= 0
+    }
+    constraints = _compute_distance_constraints(
+        mol, idx_map, vdw_pair_cutoff_offset=vdw_pair_cutoff_offset
+    )
+    return _tensorize_distance_constraints(
+        constraints,
+        bond_buffer=bond_buffer,
+        angle_buffer=angle_buffer,
+        clash_buffer=clash_buffer,
+    )
+
+
+def build_context(
+    atom_array: AtomArray,
+    processed_reference_molecules: list[ProcessedReferenceMolecule],
+    *,
+    n_atoms: int,
+    bond_buffer: float = defaults.BOND_BUFFER,
+    angle_buffer: float = defaults.ANGLE_BUFFER,
+    clash_buffer: float = defaults.CLASH_BUFFER,
+    vdw_pair_cutoff_offset: float = defaults.VDW_PAIR_CUTOFF_OFFSET,
+) -> SteeringContext:
+    """Build a SteeringContext from every ligand residue in ``atom_array``.
+
+    The local -> global atom-index bridge (``in_crop_mask`` positionally
+    zipped against each ligand residue) is load-bearing: it is what lets
+    restraints skip atoms that were cropped out without rebuilding the
+    molecule from ``atom_array``.
+
+    Args:
+        atom_array: preprocessed structure whose atom axis the model uses.
+            Only residues whose atoms are all ligands contribute restraints.
+        processed_reference_molecules: reference molecules positionally
+            aligned with the residues of ``atom_array``, one per residue.
+        n_atoms: size of the model's atom axis, recorded on the context so
+            the sampler can reject a batch built for a different structure.
+        bond_buffer: relative tolerance for 1-2 bonded pairs.
+        angle_buffer: relative tolerance for 1-3 (angle-defined) pairs.
+        clash_buffer: relative slack on the lower bound of nonbonded pairs.
+        vdw_pair_cutoff_offset: additive offset (Angstrom) on the mean
+            pairwise van der Waals radius, which floors the lower bound of
+            nonbonded pairs and caps the upper bound of bonded ones.
+
+    Raises:
+        MissingReferenceMoleculeError: if the reference molecules do not line
+            up 1:1 with the residues in ``atom_array``.
+        ValueError: if a processed reference molecule's crop-surviving atom
+            count does not match its residue's atom count.
+
+    Returns:
+        A ``SteeringContext`` with one ``distance_bounds_potential``
+        restraint set spanning every ligand residue in ``atom_array``.
+    """
+    n_residues = get_residue_count(atom_array)
+    if len(processed_reference_molecules) != n_residues:
+        raise MissingReferenceMoleculeError(
+            "Chemical steering needs one processed reference molecule per residue, "
+            f"but got {len(processed_reference_molecules)} reference molecule(s) "
+            f"for {n_residues} residue(s)."
+        )
+
+    all_constraints = _DistanceConstraints()
+    global_atom_indices = np.arange(len(atom_array))
+    for residue, processed_mol in zip(
+        residue_view_iter(atom_array), processed_reference_molecules, strict=True
+    ):
+        if not np.all(residue.molecule_type_id == MoleculeType.LIGAND):
+            continue
+
+        reference_indices = np.flatnonzero(processed_mol.in_crop_mask)
+        residue_indices = global_atom_indices[residue.indices]
+        if len(reference_indices) != len(residue_indices):
+            raise ValueError(
+                "Processed ligand reference atoms must match the OF3 residue."
+            )
+        idx_map = dict(
+            zip(reference_indices.tolist(), residue_indices.tolist(), strict=True)
+        )
+        mol_constraints = _compute_distance_constraints(
+            processed_mol.mol, idx_map, vdw_pair_cutoff_offset=vdw_pair_cutoff_offset
+        )
+        all_constraints.extend(mol_constraints)
+
+    restraint_set = _tensorize_distance_constraints(
+        all_constraints,
+        bond_buffer=bond_buffer,
+        angle_buffer=angle_buffer,
+        clash_buffer=clash_buffer,
+    )
+    return SteeringContext(
+        restraints={DistanceBoundsPotential.name: restraint_set}, n_atoms=n_atoms
+    )
+
+
+def maybe_create_steering_features(
+    atom_array: AtomArray,
+    processed_reference_molecules: list[ProcessedReferenceMolecule],
+    settings: SteeringSettings | None = None,
+) -> dict[str, torch.Tensor]:
+    """Create inference-time chemical steering features, if there are any.
+
+    ``maybe_`` because three ordinary situations produce no features at all:
+    steering off, every term off, or a query with no ligand to restrain.
+
+    Steering is a run-level setting, so this applies to every query in the
+    run. Queries with no ligand produce no restraints and are handled by the
+    same empty return as a disabled run.
+
+    Args:
+        atom_array: preprocessed structure whose atom axis the model uses.
+        processed_reference_molecules: reference molecules aligned with the
+            residues in ``atom_array``.
+        settings: validated run-level settings; defaults to steering off.
+
+    Raises:
+        MissingReferenceMoleculeError: if the reference molecules do not line
+            up 1:1 with the residues in ``atom_array``.
+
+    Returns:
+        Batch features for the sampler, or ``{}`` when steering is disabled,
+        every term is disabled, or the query yielded no restraints. Emitting
+        no keys at all is what makes a disabled run bit-identical to one
+        without steering compiled in: the sampler probes for its enable key
+        with ``.get`` and never runs.
+    """
+    settings = settings if settings is not None else SteeringSettings()
+    if not settings.enabled or not settings.active_terms():
+        return {}
+
+    ctx = build_context(
+        atom_array,
+        processed_reference_molecules,
+        n_atoms=len(atom_array),
+    )
+    return context_to_features(ctx, settings)

--- a/openfold3/steering/potentials.py
+++ b/openfold3/steering/potentials.py
@@ -1,0 +1,165 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flat-bottom chemical potentials with analytic gradients.
+
+Every potential is a flat-bottom restraint: zero energy inside a permitted
+interval, linear penalty outside it. The energy is
+
+    U = sum_k w_k * [max(0, l_k - v_k) + max(0, v_k - u_k)]
+
+so dU/dv = -w inside the violated-below region and +w inside violated-above,
+and zero in the window. Gradients are analytic, not autograd: the sampler runs
+under ``torch.no_grad()`` / inference mode (see
+``openfold3/projects/of3_all_atom/model.py``), where autograd on the denoised
+tensor would raise, and the guidance loop evaluates each term
+``num_gd_steps`` times per denoising step — taping that through autograd would
+cost memory proportional to the graph for no benefit, since these are
+closed-form derivatives.
+
+Formulation and default parameters are derived from Boltz
+(``src/boltz/model/potentials/potentials.py``, MIT). The registry pattern is
+derived from Protenix. See THIRD_PARTY_NOTICES.md.
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import ClassVar
+
+import torch
+from torch import Tensor
+
+from openfold3.steering.types import RestraintSet
+
+CLASS_REGISTRY: dict[str, type[Potential]] = {}
+
+_TERM_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
+
+
+def register(name: str) -> Callable[[type[Potential]], type[Potential]]:
+    """Register a potential under a snake_case name.
+
+    That one string is load-bearing in three places: it is the key users
+    write in the runner yaml, the prefix of this term's batch feature keys,
+    and how the sampler matches a configured term to its restraints. Since
+    users type it, it is snake_case rather than the class name -- and it is
+    declared rather than derived from the class, because deriving mangles
+    acronyms (`VDWOverlapPotential` would become `v_d_w_overlap_potential`)
+    and would silently rename a config key when a class is renamed.
+
+    A silent overwrite would make one potential unreachable and misroute the
+    other's restraints, so a collision is rejected outright. Re-registering
+    the identical class is a no-op, so a module re-import does not fail.
+
+    Args:
+        name: the term's public name, snake_case (`[a-z][a-z0-9_]*`).
+
+    Returns:
+        A class decorator that records the name on the class as ``name`` and
+        adds it to ``CLASS_REGISTRY``.
+
+    Raises:
+        ValueError: if the name is not snake_case, or if a different class is
+            already registered under it.
+    """
+    if not _TERM_NAME_PATTERN.match(name):
+        raise ValueError(
+            f"potential name {name!r} must be snake_case, e.g. 'distance_bounds'"
+        )
+
+    def _register(cls: type[Potential]) -> type[Potential]:
+        registered = CLASS_REGISTRY.get(name)
+        if registered is not None and registered is not cls:
+            raise ValueError(
+                f"a different potential is already registered as {name!r}: "
+                f"{registered.__module__}.{registered.__qualname__}"
+            )
+        cls.name = name
+        CLASS_REGISTRY[name] = cls
+        return cls
+
+    return _register
+
+
+class Potential(ABC):
+    """A flat-bottom restraint family: geometry and energy only.
+
+    Indices and bounds arrive prebuilt in a ``RestraintSet``; a potential
+    never touches RDKit or an AtomArray.
+
+    Attributes:
+        name: the snake_case registry key, set by ``@register``.
+        arity: how many atoms each restraint relates.
+    """
+
+    name: ClassVar[str]
+    arity: int
+
+    @abstractmethod
+    def compute_variable(self, positions: Tensor) -> tuple[Tensor, Tensor]:
+        """positions [M, R, arity, 3] -> (v [M, R], dv_dx [M, R, arity, 3])"""
+
+    def energy_and_gradient(
+        self, coords: Tensor, r: RestraintSet, weight: float
+    ) -> tuple[Tensor, Tensor]:
+        """Energy and dE/dx for one restraint family at one weight.
+
+        ``coords`` may be ``[N, 3]`` or carry any number of leading batch/
+        sample axes, e.g. ``[B, S, N, 3]``. The ``reshape(-1, n_atoms, 3)``
+        below is load-bearing: it is what makes the term correct regardless
+        of how many leading axes ``coords`` carries, including batch sizes
+        that happen to collide with ``arity``.
+        """
+        leading, n_atoms = coords.shape[:-2], coords.shape[-2]
+        flat = coords.reshape(-1, n_atoms, 3)  # [M, N, 3]
+
+        if r.atom_index.numel() == 0:
+            return coords.new_zeros(leading), torch.zeros_like(coords)
+
+        pos = flat[:, r.atom_index]  # [M, R, arity, 3]
+        v, dv_dx = self.compute_variable(pos)
+
+        below, above = r.lower - v, v - r.upper  # inf bounds never fire
+        energy = weight * (below.clamp(min=0) + above.clamp(min=0))
+        de_dv = weight * ((above > 0).to(v.dtype) - (below > 0).to(v.dtype))
+
+        contrib = de_dv[..., None, None] * dv_dx  # [M, R, arity, 3]
+        grad = torch.zeros_like(flat)
+        grad.index_add_(
+            1,
+            r.atom_index.reshape(-1),
+            contrib.reshape(flat.shape[0], -1, 3),
+        )
+        return energy.sum(-1).reshape(leading), grad.reshape(coords.shape)
+
+
+@register("distance_bounds_potential")
+class DistanceBoundsPotential(Potential):
+    """Flat-bottom restraint on interatomic distance, bounds from the RDKit
+    distance-geometry bounds matrix.
+
+    Derived from Boltz FlatBottomPotential + DistancePotential
+    (src/boltz/model/potentials/potentials.py). See THIRD_PARTY_NOTICES.md.
+    """
+
+    arity = 2
+
+    def compute_variable(self, positions: Tensor) -> tuple[Tensor, Tensor]:
+        diff = positions[..., 0, :] - positions[..., 1, :]  # [M, R, 3]
+        v = diff.norm(dim=-1).clamp_min(1e-6)  # [M, R]
+        u = diff / v[..., None]
+        return v, torch.stack((u, -u), dim=-2)  # [M, R, 2, 3]

--- a/openfold3/steering/schedules.py
+++ b/openfold3/steering/schedules.py
@@ -1,0 +1,92 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Time-varying scalar schedules for per-term weights.
+
+See THIRD_PARTY_NOTICES.md for provenance.
+
+A schedule maps normalized diffusion time ``t`` in [0, 1] to a float, where
+``t = 1`` is the noisiest step and ``t = 0`` the final (cleanest) step — the
+Boltz/Protenix convention adopted by ``StepState.steering_t``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+class Schedule:
+    """Base class: evaluate a weight at normalized time t."""
+
+    def at(self, t: float) -> float:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class Constant(Schedule):
+    value: float
+
+    def at(self, t: float) -> float:
+        return float(self.value)
+
+
+@dataclass(frozen=True)
+class ExponentialInterpolation(Schedule):
+    """Exponential interpolation from ``start`` (t=0) to ``end`` (t=1).
+
+    ``alpha == 0`` degenerates to linear interpolation. Negative ``alpha``
+    front-loads the change near t=0.
+    """
+
+    start: float
+    end: float
+    alpha: float = 0.0
+
+    def at(self, t: float) -> float:
+        if self.alpha == 0.0:
+            return float(self.start + (self.end - self.start) * t)
+        num = math.exp(self.alpha * t) - 1.0
+        den = math.exp(self.alpha) - 1.0
+        return float(self.start + (self.end - self.start) * (num / den))
+
+
+@dataclass(frozen=True)
+class PiecewiseStepFunction(Schedule):
+    """Piecewise-constant schedule.
+
+    ``values`` has exactly one more entry than ``thresholds``; the value used
+    is the one whose bin contains ``t``. This is how a late-only guidance
+    gate is expressed: under the adopted time convention
+    (``t = 1 - step/N``), "active only in the final 27.5% of denoising"
+    is ``PiecewiseStepFunction(thresholds=(0.275,), values=(weight, 0.0))``.
+    """
+
+    thresholds: tuple[float, ...]
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.values) != len(self.thresholds) + 1:
+            raise ValueError(
+                "values must have len(thresholds)+1 entries, got "
+                f"{len(self.values)} and {len(self.thresholds)}"
+            )
+
+    def at(self, t: float) -> float:
+        idx = 0
+        for thr in self.thresholds:
+            if t < thr:
+                break
+            idx += 1
+        return float(self.values[idx])

--- a/openfold3/steering/tests/__init__.py
+++ b/openfold3/steering/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/openfold3/steering/tests/_structures.py
+++ b/openfold3/steering/tests/_structures.py
@@ -1,0 +1,108 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared structure builders for the steering tests.
+
+Not named ``test_*`` so pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from openfold3.core.data.framework.data_module import openfold_batch_collator
+from openfold3.core.data.primitives.structure.labels import residue_view_iter
+from openfold3.core.data.primitives.structure.query import (
+    structure_with_ref_mols_from_query,
+)
+from openfold3.core.data.primitives.structure.tokenization import (
+    add_token_positions,
+    tokenize_atom_array,
+)
+from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+PROTEIN_A = {"molecule_type": "protein", "chain_ids": ["A"], "sequence": "GAGA"}
+PROTEIN_B = {"molecule_type": "protein", "chain_ids": ["B"], "sequence": "AAGG"}
+LIGAND_L = {"molecule_type": "ligand", "chain_ids": ["L"], "smiles": "C[C@H](O)C(=O)O"}
+LIGAND_M = {"molecule_type": "ligand", "chain_ids": ["M"], "smiles": "c1ccccc1"}
+
+# Layouts that renumber the global atom axis relative to a ligand-only query.
+LAYOUTS: dict[str, list[dict]] = {
+    "ligand_after_protein": [PROTEIN_A, LIGAND_L],
+    "ligand_before_protein": [LIGAND_L, PROTEIN_A],
+    "ligand_between_proteins": [PROTEIN_A, LIGAND_L, PROTEIN_B],
+    "two_ligands": [PROTEIN_A, LIGAND_L, LIGAND_M],
+    "repeated_protein_chains": [
+        {"molecule_type": "protein", "chain_ids": ["A", "B"], "sequence": "GAGA"},
+        LIGAND_L,
+    ],
+}
+
+
+def structure_for(chains: list[dict]):
+    """Build a tokenized structure with reference molecules from chain specs."""
+    structure = structure_with_ref_mols_from_query(
+        Query.model_validate({"chains": chains})
+    )
+    tokenize_atom_array(structure.atom_array)
+    add_token_positions(structure.atom_array)
+    return structure
+
+
+def ligand_atom_indices(structure) -> np.ndarray:
+    return np.flatnonzero(structure.atom_array.molecule_type_id == MoleculeType.LIGAND)
+
+
+def reference_coords_by_atom_name(structure) -> torch.Tensor:
+    """Place each ligand's reference conformer on the global atom axis.
+
+    Maps by atom name rather than by position, so this is independent of the
+    positional ``in_crop_mask`` zip that ``build_context`` uses -- which is
+    what makes it usable as an oracle for that mapping.
+    """
+    atom_array = structure.atom_array
+    coords = torch.zeros((len(atom_array), 3), dtype=torch.float32)
+    global_indices = np.arange(len(atom_array))
+    for residue, reference in zip(
+        residue_view_iter(atom_array), structure.processed_reference_mols, strict=True
+    ):
+        if not np.all(residue.molecule_type_id == MoleculeType.LIGAND):
+            continue
+        conformer = reference.mol.GetConformer()
+        local_by_name = {
+            atom.GetProp("annot_atom_name"): atom.GetIdx()
+            for atom in reference.mol.GetAtoms()
+        }
+        for global_index in global_indices[residue.indices]:
+            name = str(atom_array.atom_name[global_index])
+            position = conformer.GetAtomPosition(local_by_name[name])
+            coords[global_index] = torch.tensor(
+                [position.x, position.y, position.z], dtype=torch.float32
+            )
+    return coords
+
+
+def collate(features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Put features through the real collator, then the sample-axis unsqueeze.
+
+    Uses `openfold_batch_collator` itself rather than a stand-in, so these
+    tests cannot drift from what the dataloader actually does to a feature
+    dict. The `unsqueeze(1)` afterwards mirrors the `tensor_tree_map` in
+    projects/of3_all_atom/model.py, which is the other half of what a feature
+    experiences before the sampler sees it.
+    """
+    batch = openfold_batch_collator([dict(features)])
+    return {key: value.unsqueeze(1) for key, value in batch.items()}

--- a/openfold3/steering/tests/conftest.py
+++ b/openfold3/steering/tests/conftest.py
@@ -1,0 +1,55 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from openfold3.steering.potentials import CLASS_REGISTRY, Potential, register
+
+
+@pytest.fixture
+def isolated_registry():
+    """Let a test register throwaway potentials without leaking them.
+
+    CLASS_REGISTRY is module-global and is iterated by feature-key
+    derivation and by settings validation, so a test-only potential left
+    behind would change unrelated tests' behaviour.
+    """
+    original = dict(CLASS_REGISTRY)
+    try:
+        yield CLASS_REGISTRY
+    finally:
+        CLASS_REGISTRY.clear()
+        CLASS_REGISTRY.update(original)
+
+
+@pytest.fixture
+def register_throwaway(isolated_registry):
+    """Register a throwaway potential under a caller-chosen snake_case name.
+
+    Each test picks its own name so no two tests can collide through the
+    global registry, independently of the ordering pytest happens to choose.
+    """
+
+    def _register(name: str, arity: int = 2) -> type[Potential]:
+        class_name = "".join(part.title() for part in name.split("_"))
+        potential = type(
+            class_name,
+            (Potential,),
+            {"arity": arity, "compute_variable": lambda self, positions: None},
+        )
+        return register(name)(potential)
+
+    return _register

--- a/openfold3/steering/tests/test_batch_features.py
+++ b/openfold3/steering/tests/test_batch_features.py
@@ -1,0 +1,363 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The batch wire format: flatten, survive the collator, rebuild.
+
+The shape-mangling cases here are not hypothetical -- the collator applies
+`pad_sequence(...).squeeze(-1)` to every feature and the model then
+`unsqueeze(1)`s every leaf, so these are the shapes that actually reach the
+sampler.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from openfold3.steering.batch_features import (
+    STEERING_ENABLED_KEY,
+    STEERING_N_ATOMS_KEY,
+    STEERING_NUM_GD_STEPS_KEY,
+    context_to_features,
+    prepare_steering,
+    steering_enabled,
+    term_key,
+)
+from openfold3.steering.config import SteeringSettings
+from openfold3.steering.featurization import (
+    build_context,
+    maybe_create_steering_features,
+)
+from openfold3.steering.potentials import (
+    DistanceBoundsPotential,
+)
+from openfold3.steering.tests._structures import (
+    LAYOUTS,
+    collate,
+    reference_coords_by_atom_name,
+    structure_for,
+)
+from openfold3.steering.types import RestraintSet, SteeringContext
+
+_TERM = "distance_bounds_potential"
+
+
+def _context(n_restraints: int = 2, n_atoms: int = 5) -> SteeringContext:
+    atom_index = torch.tensor(
+        [[i, i + 1] for i in range(n_restraints)], dtype=torch.int64
+    ).reshape(n_restraints, 2)
+    return SteeringContext(
+        restraints={
+            _TERM: RestraintSet(
+                atom_index=atom_index,
+                lower=torch.full((n_restraints,), 1.0),
+                upper=torch.full((n_restraints,), 1.5),
+            )
+        },
+        n_atoms=n_atoms,
+    )
+
+
+def _enabled_settings(**kwargs) -> SteeringSettings:
+    return SteeringSettings.model_validate({"enabled": True, **kwargs})
+
+
+def test_feature_keys_are_derived_from_the_registry_key():
+    assert term_key(_TERM, "lower") == "steering_distance_bounds_potential_lower"
+
+
+def test_a_newly_registered_potential_gets_keys_with_no_bookkeeping(
+    register_throwaway, isolated_registry
+):
+    """Feature names are derived, not declared: registering a potential is
+    the only step: nothing in features.py has to be updated for its keys to
+    exist, so a new term cannot be silently left out of the wire format."""
+    register_throwaway("torsion_angle_potential", arity=4)
+
+    assert term_key("torsion_angle_potential", "count") == (
+        "steering_torsion_angle_potential_count"
+    )
+    assert "torsion_angle_potential" in isolated_registry
+
+
+def test_feature_keys_are_distinct_across_the_registry(
+    register_throwaway, isolated_registry
+):
+    """Two potentials whose derived names collided would silently share a
+    slot in the batch."""
+    register_throwaway("improper_dihedral_potential", arity=4)
+
+    keys = {term_key(name, "atom_index") for name in isolated_registry}
+    assert len(keys) == len(isolated_registry), "feature keys must be distinct"
+
+
+def test_context_to_features_emits_the_expected_key_set():
+    features = context_to_features(_context(), _enabled_settings())
+
+    assert set(features) == {
+        STEERING_ENABLED_KEY,
+        STEERING_NUM_GD_STEPS_KEY,
+        STEERING_N_ATOMS_KEY,
+        term_key(_TERM, "atom_index"),
+        term_key(_TERM, "lower"),
+        term_key(_TERM, "upper"),
+        term_key(_TERM, "count"),
+        term_key(_TERM, "weight"),
+        term_key(_TERM, "interval"),
+    }
+    assert features[term_key(_TERM, "count")].tolist() == [2]
+    assert features[term_key(_TERM, "atom_index")].dtype == torch.int64
+    assert features[term_key(_TERM, "lower")].dtype == torch.float32
+
+
+def test_context_to_features_is_empty_when_no_term_is_active():
+    """No keys at all is what makes disabled steering a structural no-op."""
+    settings = _enabled_settings(terms={_TERM: {"enabled": False}})
+    assert context_to_features(_context(), settings) == {}
+
+
+def test_context_to_features_is_empty_when_there_are_no_restraints():
+    empty = SteeringContext(
+        restraints={
+            _TERM: RestraintSet(
+                atom_index=torch.empty((0, 2), dtype=torch.int64),
+                lower=torch.empty((0,)),
+                upper=torch.empty((0,)),
+            )
+        },
+        n_atoms=5,
+    )
+    assert context_to_features(empty, _enabled_settings()) == {}
+
+
+def test_steering_enabled_is_false_without_features():
+    assert steering_enabled({}) is False
+    assert steering_enabled({STEERING_ENABLED_KEY: torch.tensor([False])}) is False
+    assert steering_enabled({STEERING_ENABLED_KEY: torch.tensor([True])}) is True
+
+
+def test_prepare_steering_round_trips_a_context():
+    ctx = _context()
+    settings = _enabled_settings(num_gd_steps=7)
+    features = context_to_features(ctx, settings)
+
+    prepared = prepare_steering(features, torch.ones(1, ctx.n_atoms))
+
+    assert prepared is not None
+    assert prepared.engine.num_gd_steps == 7
+    rebuilt = prepared.ctx.restraints[_TERM]
+    original = ctx.restraints[_TERM]
+    torch.testing.assert_close(rebuilt.atom_index, original.atom_index)
+    torch.testing.assert_close(rebuilt.lower, original.lower)
+    torch.testing.assert_close(rebuilt.upper, original.upper)
+    assert prepared.ctx.n_atoms == ctx.n_atoms
+
+    term = prepared.engine.terms[_TERM]
+    assert term.weight.at(0.5) == pytest.approx(settings.terms[_TERM].weight)
+    assert term.interval == settings.terms[_TERM].interval
+
+
+def test_prepare_steering_returns_none_without_features():
+    assert prepare_steering({}, torch.ones(1, 5)) is None
+
+
+@pytest.mark.parametrize("n_restraints", [1, 2, 5])
+def test_prepare_steering_survives_the_real_collation_path(n_restraints: int):
+    """n_restraints=1 is the interesting case: `[n]` bounds collapse to `[1]`
+    under squeeze(-1), so nothing may infer shape from the tensor itself."""
+    ctx = _context(n_restraints=n_restraints, n_atoms=n_restraints + 1)
+    features = collate(context_to_features(ctx, _enabled_settings()))
+
+    prepared = prepare_steering(features, torch.ones(1, ctx.n_atoms))
+
+    assert prepared is not None
+    rebuilt = prepared.ctx.restraints[_TERM]
+    assert rebuilt.atom_index.shape == (n_restraints, 2)
+    torch.testing.assert_close(rebuilt.atom_index, ctx.restraints[_TERM].atom_index)
+    torch.testing.assert_close(rebuilt.lower, ctx.restraints[_TERM].lower)
+
+
+def test_prepare_steering_rejects_multi_query_batches():
+    features = context_to_features(_context(), _enabled_settings())
+    with pytest.raises(ValueError, match="one query per model batch"):
+        prepare_steering(features, torch.ones(2, 5))
+
+
+def test_prepare_steering_rejects_an_atom_axis_mismatch():
+    features = context_to_features(_context(n_atoms=5), _enabled_settings())
+    with pytest.raises(ValueError, match="built for 5 atoms"):
+        prepare_steering(features, torch.ones(1, 9))
+
+
+def test_prepare_steering_rejects_a_missing_feature():
+    features = context_to_features(_context(), _enabled_settings())
+    del features[term_key(_TERM, "lower")]
+    with pytest.raises(ValueError, match="lower.* is missing"):
+        prepare_steering(features, torch.ones(1, 5))
+
+
+def test_prepare_steering_rejects_out_of_range_indices():
+    features = context_to_features(_context(n_atoms=5), _enabled_settings())
+    features[term_key(_TERM, "atom_index")] = torch.tensor(
+        [[0, 1], [2, 99]], dtype=torch.int64
+    )
+    with pytest.raises(ValueError, match="outside"):
+        prepare_steering(features, torch.ones(1, 5))
+
+
+def test_prepare_steering_rejects_a_count_mismatch():
+    features = context_to_features(_context(), _enabled_settings())
+    features[term_key(_TERM, "count")] = torch.tensor([3], dtype=torch.long)
+    with pytest.raises(ValueError, match="expected 6 for 3 restraint"):
+        prepare_steering(features, torch.ones(1, 5))
+
+
+def test_prepare_steering_rejects_a_float_index_tensor():
+    features = context_to_features(_context(), _enabled_settings())
+    features[term_key(_TERM, "atom_index")] = features[
+        term_key(_TERM, "atom_index")
+    ].float()
+    with pytest.raises(ValueError, match="must be an integer tensor"):
+        prepare_steering(features, torch.ones(1, 5))
+
+
+# ---------------------------------------------------------------------------
+# The featurization entry point: a real molecule all the way to batch tensors.
+# ---------------------------------------------------------------------------
+
+
+def _ligand_structure(smiles: str = "C[C@H](O)C(=O)O"):
+    return structure_for(
+        [{"molecule_type": "ligand", "chain_ids": ["L"], "smiles": smiles}]
+    )
+
+
+def _enabled() -> SteeringSettings:
+    return SteeringSettings(enabled=True)
+
+
+def test_features_are_empty_when_steering_is_disabled():
+    structure = _ligand_structure()
+    features = maybe_create_steering_features(
+        structure.atom_array, structure.processed_reference_mols, SteeringSettings()
+    )
+    assert features == {}
+
+
+def test_features_are_empty_when_settings_are_omitted():
+    """The default is off, so an unconfigured run emits nothing."""
+    structure = _ligand_structure()
+    assert (
+        maybe_create_steering_features(
+            structure.atom_array, structure.processed_reference_mols
+        )
+        == {}
+    )
+
+
+def test_features_are_empty_when_every_term_is_disabled():
+    structure = _ligand_structure()
+    settings = SteeringSettings.model_validate(
+        {"enabled": True, "terms": {_TERM: {"enabled": False}}}
+    )
+    assert (
+        maybe_create_steering_features(
+            structure.atom_array, structure.processed_reference_mols, settings
+        )
+        == {}
+    )
+
+
+def test_features_are_empty_for_a_query_with_no_ligand():
+    """A protein-only query yields no restraints, so steering no-ops on it
+    even in a steered run."""
+    structure = structure_for(
+        [{"molecule_type": "protein", "chain_ids": ["A"], "sequence": "GAGA"}]
+    )
+    features = maybe_create_steering_features(
+        structure.atom_array, structure.processed_reference_mols, _enabled()
+    )
+    assert features == {}
+
+
+def test_features_for_a_ligand_query_carry_restraints():
+    structure = _ligand_structure()
+    features = maybe_create_steering_features(
+        structure.atom_array, structure.processed_reference_mols, _enabled()
+    )
+
+    assert bool(features[STEERING_ENABLED_KEY].item()) is True
+    assert int(features[STEERING_N_ATOMS_KEY].item()) == len(structure.atom_array)
+    count = int(features[term_key(_TERM, "count")].item())
+    assert count > 0
+    assert features[term_key(_TERM, "atom_index")].shape == (count, 2)
+    assert features[term_key(_TERM, "lower")].shape == (count,)
+
+
+def test_featurization_round_trips_through_prepare_steering():
+    """What the sampler rebuilds must equal what extraction produced.
+
+    Narrow by design: this pins the flatten/rebuild step only. It cannot say
+    the restraints are *correct*, because the value it compares against comes
+    from the same build_context call maybe_create_steering_features makes
+    internally. The end-to-end check is the test below.
+    """
+    structure = _ligand_structure()
+    settings = _enabled()
+    features = maybe_create_steering_features(
+        structure.atom_array, structure.processed_reference_mols, settings
+    )
+
+    prepared = prepare_steering(features, torch.ones(1, len(structure.atom_array)))
+    assert prepared is not None
+
+    expected = build_context(
+        structure.atom_array,
+        structure.processed_reference_mols,
+        n_atoms=len(structure.atom_array),
+    ).restraints[_TERM]
+    rebuilt = prepared.ctx.restraints[_TERM]
+
+    torch.testing.assert_close(rebuilt.atom_index, expected.atom_index)
+    torch.testing.assert_close(rebuilt.lower, expected.lower)
+    torch.testing.assert_close(rebuilt.upper, expected.upper)
+    assert prepared.engine.num_gd_steps == settings.num_gd_steps
+
+
+@pytest.mark.parametrize("layout", sorted(LAYOUTS))
+def test_restraints_survive_the_whole_path_from_molecule_to_sampler(layout: str):
+    """Molecule -> features -> collator -> sampler-side constraints.
+
+    Every step the real pipeline takes, ending in an assertion that does not
+    reuse any of the machinery under test: the reference conformer each
+    molecule's bounds were derived from is placed by *atom name*, and must
+    satisfy the restraints the sampler ends up holding. A mangled shape, a
+    dropped term, or a mis-mapped atom index all show up as non-zero energy.
+    """
+    structure = structure_for(LAYOUTS[layout])
+    features = maybe_create_steering_features(
+        structure.atom_array, structure.processed_reference_mols, _enabled()
+    )
+    assert features, "a steered run with a ligand must emit features"
+
+    prepared = prepare_steering(
+        collate(features), torch.ones(1, len(structure.atom_array))
+    )
+    assert prepared is not None
+
+    coords = reference_coords_by_atom_name(structure)
+    energy, _ = DistanceBoundsPotential().energy_and_gradient(
+        coords, prepared.ctx.restraints[_TERM], 1.0
+    )
+    assert float(energy) == pytest.approx(0.0, abs=1e-6)

--- a/openfold3/steering/tests/test_config.py
+++ b/openfold3/steering/tests/test_config.py
@@ -1,0 +1,153 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation of the run-level steering settings."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from openfold3.steering import defaults
+from openfold3.steering.config import SteeringSettings, TermSettings
+
+
+def test_steering_is_off_by_default():
+    settings = SteeringSettings()
+    assert settings.enabled is False
+    assert settings.num_gd_steps == defaults.NUM_GD_STEPS
+    assert set(settings.terms) == {"distance_bounds_potential"}
+
+
+def test_terms_are_named_in_snake_case():
+    """A potential's registry key -- the name a user writes in the runner
+    yaml -- is snake_case, not the class name. Config keys, batch feature
+    prefixes and error messages all use the one string, so it has to be the
+    one that reads well in yaml."""
+    settings = SteeringSettings.model_validate(
+        {"terms": {"distance_bounds_potential": {"weight": 0.02}}}
+    )
+    assert settings.terms["distance_bounds_potential"].weight == 0.02
+
+
+def test_the_class_name_is_not_an_accepted_term_key():
+    """One name per term. Accepting the CamelCase class name as an alias too
+    would put two spellings of every term into circulation."""
+    with pytest.raises(ValidationError, match="unknown steering term"):
+        SteeringSettings.model_validate({"terms": {"DistanceBoundsPotential": {}}})
+
+
+def test_default_term_weight_comes_from_the_derived_defaults_table():
+    """The derived parameter table lives in defaults.py and nowhere else."""
+    assert TermSettings().weight == defaults.DISTANCE_WEIGHT
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        pytest.param({"num_gd_steps": 0}, "num_gd_steps", id="zero_gd_steps"),
+        pytest.param({"unknown_key": 1}, "extra_forbidden", id="unknown_setting"),
+        pytest.param(
+            {"terms": {"distance_bounds_potential": {"weight": -1.0}}},
+            "weight",
+            id="negative_weight",
+        ),
+        pytest.param(
+            {"terms": {"distance_bounds_potential": {"interval": 0}}},
+            "interval",
+            id="zero_interval",
+        ),
+        pytest.param(
+            {"terms": {"distance_bounds_potential": {"nope": 1}}},
+            "extra_forbidden",
+            id="unknown_term_setting",
+        ),
+        pytest.param(
+            {"terms": {"NotAPotential": {}}},
+            "unknown steering term",
+            id="unregistered_term",
+        ),
+        pytest.param(
+            {"terms": {"distance_bounds_potential": {"weight": float("inf")}}},
+            "finite_number",
+            id="infinite_weight",
+        ),
+        pytest.param(
+            {"terms": {"distance_bounds_potential": {"weight": float("nan")}}},
+            "finite_number",
+            id="nan_weight",
+        ),
+    ],
+)
+def test_settings_reject_invalid_values(payload: dict, match: str):
+    with pytest.raises(ValueError, match=match):
+        SteeringSettings.model_validate(payload)
+
+
+def test_settings_route_from_a_runner_config_to_the_inference_job(tmp_path):
+    """The path a runner yaml actually takes: dataset_config_kwargs.steering
+    -> InferenceExperimentConfig -> InferenceJobConfig -> the dataset."""
+    from openfold3.entry_points.experiment_runner import InferenceExperimentRunner
+    from openfold3.entry_points.validator import InferenceExperimentConfig
+    from openfold3.projects.of3_all_atom.config.inference_query_format import (
+        InferenceQuerySet,
+        Query,
+    )
+
+    checkpoint = tmp_path / "model.pt"
+    checkpoint.touch()
+    experiment = InferenceExperimentConfig(
+        inference_ckpt_path=checkpoint,
+        cache_path=tmp_path,
+        dataset_config_kwargs={
+            "steering": {"enabled": True, "num_gd_steps": 7},
+        },
+    )
+    assert experiment.dataset_config_kwargs.steering.num_gd_steps == 7
+
+    runner = InferenceExperimentRunner(experiment)
+    runner.inference_query_set = InferenceQuerySet(
+        queries={
+            "ligand": Query.model_validate(
+                {
+                    "chains": [
+                        {
+                            "molecule_type": "ligand",
+                            "chain_ids": ["L"],
+                            "smiles": "CCO",
+                        }
+                    ]
+                }
+            )
+        }
+    )
+    inference_job = runner.data_module_config.datasets[0].config
+
+    assert inference_job.steering == experiment.dataset_config_kwargs.steering
+    assert inference_job.steering.enabled is True
+
+
+def test_active_terms_skips_disabled_and_zero_weight_terms():
+    settings = SteeringSettings.model_validate(
+        {"terms": {"distance_bounds_potential": {"enabled": False}}}
+    )
+    assert settings.active_terms() == {}
+
+    settings = SteeringSettings.model_validate(
+        {"terms": {"distance_bounds_potential": {"weight": 0.0}}}
+    )
+    assert settings.active_terms() == {}
+
+    settings = SteeringSettings()
+    assert set(settings.active_terms()) == {"distance_bounds_potential"}

--- a/openfold3/steering/tests/test_engine.py
+++ b/openfold3/steering/tests/test_engine.py
@@ -1,0 +1,231 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for ChemicalSteering.on_denoised: the exact per-step
+displacement and monotone energy decrease on a violated restraint, and the
+structural no-op (`on_denoised(...) is None`) when nothing is usable.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from openfold3.steering.engine import ChemicalSteering, Term
+from openfold3.steering.potentials import DistanceBoundsPotential
+from openfold3.steering.schedules import Constant
+from openfold3.steering.types import RestraintSet, SteeringContext, StepState
+
+
+def _step_state(
+    ctx: SteeringContext,
+    *,
+    step_index: int = 0,
+    num_steps: int = 20,
+    n_samples: int = 2,
+) -> StepState:
+    """A StepState shaped the way SampleDiffusion builds one.
+
+    ChemicalSteering reads only `steering_t` and `ctx`, so the rest could be
+    anything -- but shaping it like the real call site keeps this from
+    quietly diverging from `_sample_rollout`, and means these tests fail
+    rather than silently pass if a term starts using a field. Sigmas descend
+    (`c_tau < t`) as the noise schedule does, and the coordinate tensors
+    carry the sampler's `[B, S, N, 3]` layout against a `[B, 1, N]` mask.
+    """
+    generator = torch.Generator().manual_seed(step_index)
+    shape = (1, n_samples, ctx.n_atoms, 3)
+    return StepState(
+        xl_noisy=torch.randn(shape, generator=generator),
+        noise=torch.randn(shape, generator=generator),
+        t=torch.tensor(1.5),
+        c_tau=torch.tensor(0.9),
+        step_index=step_index,
+        num_steps=num_steps,
+        start_step=0,
+        pass_name="primary",
+        atom_mask=torch.ones(1, 1, ctx.n_atoms),
+        ctx=ctx,
+    )
+
+
+def test_on_denoised_is_none_when_context_has_no_restraints():
+    ctx = SteeringContext(restraints={}, n_atoms=2)
+    steering = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(0.01)
+            )
+        },
+        num_gd_steps=20,
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]])
+    update = steering.on_denoised(x0, _step_state(ctx))
+    assert update is None
+
+
+def test_on_denoised_is_none_when_weight_is_zero():
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    ctx = SteeringContext(
+        restraints={"distance_bounds_potential": restraints}, n_atoms=2
+    )
+    steering = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(0.0)
+            )
+        },
+        num_gd_steps=20,
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]])
+    update = steering.on_denoised(x0, _step_state(ctx))
+    assert update is None
+
+
+def test_on_denoised_is_none_when_no_term_matches_the_context():
+    """A configured term whose restraint family is absent from the context
+    (e.g. it produced zero restraints for this query) is skipped, not an
+    error."""
+    ctx = SteeringContext(restraints={}, n_atoms=2)
+    steering = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(0.01)
+            )
+        },
+        num_gd_steps=5,
+    )
+    x0 = torch.randn(1, 1, 2, 3)
+    assert steering.on_denoised(x0, _step_state(ctx)) is None
+
+
+def test_energy_is_zero_on_a_valid_conformer():
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+    energy, _ = DistanceBoundsPotential().energy_and_gradient(x0, restraints, 0.01)
+    torch.testing.assert_close(energy, torch.zeros_like(energy))
+
+
+def test_on_denoised_reduces_bond_violation_by_the_exact_step_size():
+    weight = 0.01
+    num_gd_steps = 5
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    ctx = SteeringContext(
+        restraints={"distance_bounds_potential": restraints}, n_atoms=2
+    )
+    steering = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(weight)
+            )
+        },
+        num_gd_steps=num_gd_steps,
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]])
+    update = steering.on_denoised(x0, _step_state(ctx))
+    assert update is not None
+    assert update.n_active_terms == 1
+
+    guided = x0 + update.delta
+    initial_distance = torch.linalg.norm(x0[..., 0, :] - x0[..., 1, :])
+    guided_distance = torch.linalg.norm(guided[..., 0, :] - guided[..., 1, :])
+
+    # The subgradient is exactly +-1, so each of the 5 GD steps moves BOTH
+    # atoms by `weight` toward each other, closing the violation by
+    # `2 * weight` per step -- independent of the violation's magnitude.
+    expected_distance = initial_distance - 2 * num_gd_steps * weight
+    torch.testing.assert_close(guided_distance, expected_distance)
+    assert guided_distance < initial_distance
+
+
+def test_on_denoised_strictly_decreases_energy_over_20_steps():
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    ctx = SteeringContext(
+        restraints={"distance_bounds_potential": restraints}, n_atoms=2
+    )
+    steering = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(0.01)
+            )
+        },
+        num_gd_steps=20,
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]])
+    potential = DistanceBoundsPotential()
+
+    initial_energy, _ = potential.energy_and_gradient(x0, restraints, 1.0)
+    update = steering.on_denoised(x0, _step_state(ctx))
+    assert update is not None
+    guided = x0 + update.delta
+    final_energy, _ = potential.energy_and_gradient(guided, restraints, 1.0)
+
+    assert final_energy.item() < initial_energy.item()
+
+
+def test_on_denoised_respects_the_interval():
+    """A term evaluated only every Nth gradient-descent step contributes
+    proportionally less displacement."""
+    weight = 0.01
+    num_gd_steps = 10
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    ctx = SteeringContext(
+        restraints={"distance_bounds_potential": restraints}, n_atoms=2
+    )
+    x0 = torch.tensor([[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]])
+
+    every_step = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(weight), interval=1
+            )
+        },
+        num_gd_steps=num_gd_steps,
+    )
+    every_other_step = ChemicalSteering(
+        terms={
+            "distance_bounds_potential": Term(
+                potential=DistanceBoundsPotential(), weight=Constant(weight), interval=2
+            )
+        },
+        num_gd_steps=num_gd_steps,
+    )
+
+    dense_update = every_step.on_denoised(x0, _step_state(ctx))
+    sparse_update = every_other_step.on_denoised(x0, _step_state(ctx))
+    assert dense_update is not None
+    assert sparse_update is not None
+
+    dense_displacement = dense_update.delta.norm()
+    sparse_displacement = sparse_update.delta.norm()
+    torch.testing.assert_close(dense_displacement, 2 * sparse_displacement)

--- a/openfold3/steering/tests/test_featurization.py
+++ b/openfold3/steering/tests/test_featurization.py
@@ -1,0 +1,320 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden-value coverage of the buffer rules, single-atom and cropped-pair
+handling, unsupported-atomic-number rejection, and misaligned/missing
+reference-molecule errors.
+
+The posebusters aromatic-geometry test is distance-only by construction:
+benzene's aromatic ring bonds are RDKit BondType.AROMATIC rather than
+DOUBLE, so no planar-dihedral SMARTS would ever match them even if this
+package implemented that term (it does not yet).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+import torch
+from rdkit import Chem
+
+from openfold3.core.data.primitives.structure.labels import residue_view_iter
+from openfold3.core.data.primitives.structure.query import (
+    structure_with_ref_mols_from_query,
+)
+from openfold3.core.data.primitives.structure.tokenization import (
+    add_token_positions,
+    tokenize_atom_array,
+)
+from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+from openfold3.steering import defaults
+from openfold3.steering.featurization import (
+    MissingReferenceMoleculeError,
+    _compute_distance_constraints,
+    _DistanceConstraints,
+    _tensorize_distance_constraints,
+    build_context,
+)
+from openfold3.steering.potentials import DistanceBoundsPotential
+from openfold3.steering.tests._structures import (
+    LAYOUTS,
+    ligand_atom_indices,
+    reference_coords_by_atom_name,
+    structure_for,
+)
+from openfold3.steering.types import RestraintSet
+
+
+def _ligand_query(smiles: str) -> Query:
+    return Query.model_validate(
+        {"chains": [{"molecule_type": "ligand", "chain_ids": ["L"], "smiles": smiles}]}
+    )
+
+
+def _structure_for_smiles(smiles: str):
+    structure = structure_with_ref_mols_from_query(_ligand_query(smiles))
+    tokenize_atom_array(structure.atom_array)
+    add_token_positions(structure.atom_array)
+    return structure
+
+
+def test_tensorized_distance_bounds_match_pair_cutoff_rules():
+    constraints = _DistanceConstraints(
+        index=[(0, 1), (0, 2), (0, 3), (0, 4)],
+        lower=[1.0] * 4,
+        upper=[4.0] * 4,
+        bond_mask=[True, False, True, False],
+        angle_mask=[False, True, True, False],
+        pair_vdw_cutoffs=[2.0] * 4,
+    )
+
+    restraints = _tensorize_distance_constraints(
+        constraints,
+        bond_buffer=defaults.BOND_BUFFER,
+        angle_buffer=defaults.ANGLE_BUFFER,
+        clash_buffer=defaults.CLASH_BUFFER,
+    )
+
+    torch.testing.assert_close(
+        restraints.atom_index,
+        torch.tensor([[0, 1], [0, 2], [0, 3], [0, 4]], dtype=torch.int64),
+    )
+    torch.testing.assert_close(restraints.lower, torch.tensor([0.875, 2.0, 0.875, 2.0]))
+    torch.testing.assert_close(
+        restraints.upper, torch.tensor([2.0, 4.5, 2.0, float("inf")])
+    )
+
+
+def test_tensorize_empty_constraints_returns_empty_restraint_set():
+    restraints = _tensorize_distance_constraints(
+        _DistanceConstraints(),
+        bond_buffer=defaults.BOND_BUFFER,
+        angle_buffer=defaults.ANGLE_BUFFER,
+        clash_buffer=defaults.CLASH_BUFFER,
+    )
+    assert restraints.atom_index.shape == (0, 2)
+    assert restraints.lower.shape == (0,)
+    assert restraints.upper.shape == (0,)
+
+
+def test_geometry_constraints_handle_single_atom_and_cropped_pairs():
+    single_atom = Chem.MolFromSmiles("[Na+]")
+    empty = _compute_distance_constraints(
+        single_atom, {0: 4}, vdw_pair_cutoff_offset=defaults.VDW_PAIR_CUTOFF_OFFSET
+    )
+    assert empty == _DistanceConstraints()
+
+    mol = Chem.MolFromSmiles("CCO")
+    constraints = _compute_distance_constraints(
+        mol, {0: 10, 2: 12}, vdw_pair_cutoff_offset=defaults.VDW_PAIR_CUTOFF_OFFSET
+    )
+    assert constraints.index == [(10, 12)]
+    periodic_table = Chem.GetPeriodicTable()
+    expected_vdw_cutoff = (
+        defaults.VDW_PAIR_CUTOFF_OFFSET
+        + (periodic_table.GetRvdw(6) + periodic_table.GetRvdw(8)) / 2
+    )
+    assert constraints.pair_vdw_cutoffs == pytest.approx([expected_vdw_cutoff])
+
+
+def test_geometry_constraints_reject_unsupported_atomic_numbers():
+    mol = Chem.MolFromSmiles("*C")
+    with pytest.raises(ValueError, match="supported atomic numbers"):
+        _compute_distance_constraints(
+            mol, {0: 0, 1: 1}, vdw_pair_cutoff_offset=defaults.VDW_PAIR_CUTOFF_OFFSET
+        )
+
+
+def test_build_context_rejects_misaligned_reference_atoms():
+    structure = _structure_for_smiles("CCO")
+    reference = structure.processed_reference_mols[0]
+    malformed = replace(
+        reference, in_crop_mask=np.arange(reference.mol.GetNumAtoms()) != 0
+    )
+
+    with pytest.raises(ValueError, match="must match the OF3 residue"):
+        build_context(
+            structure.atom_array, [malformed], n_atoms=len(structure.atom_array)
+        )
+
+
+def test_build_context_raises_on_missing_reference_molecule():
+    """A missing reference molecule gets an explicit error naming both
+    counts, not the incidental `zip() argument N is shorter` message the
+    strict zip below would otherwise surface."""
+    structure = _structure_for_smiles("CCO")
+    with pytest.raises(
+        MissingReferenceMoleculeError,
+        match=r"one processed reference molecule per residue.*0 reference "
+        r"molecule\(s\) for 1 residue\(s\)",
+    ):
+        build_context(structure.atom_array, [], n_atoms=len(structure.atom_array))
+
+
+def test_build_context_raises_on_extra_reference_molecule():
+    structure = _structure_for_smiles("CCO")
+    extra = list(structure.processed_reference_mols) * 2
+
+    with pytest.raises(MissingReferenceMoleculeError, match=r"2 reference"):
+        build_context(structure.atom_array, extra, n_atoms=len(structure.atom_array))
+
+
+def test_build_context_emits_distance_restraints_for_a_simple_ligand():
+    structure = _structure_for_smiles("C[C@H](O)C(=O)O")
+    ctx = build_context(
+        structure.atom_array,
+        structure.processed_reference_mols,
+        n_atoms=len(structure.atom_array),
+    )
+
+    assert ctx.n_atoms == len(structure.atom_array)
+    restraints = ctx.restraints["distance_bounds_potential"]
+    assert restraints.atom_index.shape[0] > 0
+    assert restraints.atom_index.dtype == torch.int64
+    assert int(restraints.atom_index.max()) < ctx.n_atoms
+    assert torch.all(restraints.lower <= restraints.upper)
+
+
+def test_posebusters_bounds_penalize_out_of_plane_aromatic_geometry():
+    """Benzene: zero energy on the ideal planar hexagon, positive once one
+    atom is pushed out of plane. Distance-bounds-only: benzene's aromatic
+    ring bonds are RDKit BondType.AROMATIC (not DOUBLE), so this exercises
+    no planar-dihedral term -- there is none in this package yet."""
+    structure = _structure_for_smiles("c1ccccc1")
+    ctx = build_context(
+        structure.atom_array,
+        structure.processed_reference_mols,
+        n_atoms=len(structure.atom_array),
+    )
+    restraints = ctx.restraints["distance_bounds_potential"]
+    assert restraints.atom_index.shape[0] > 0
+
+    angles = torch.arange(6) * torch.pi / 3
+    planar = 1.4 * torch.stack(
+        (torch.cos(angles), torch.sin(angles), torch.zeros_like(angles)), dim=-1
+    )
+    planar = planar[None, None]
+    distorted = planar.clone()
+    distorted[..., 0, 2] = 1.0
+
+    potential = DistanceBoundsPotential()
+    planar_energy, _ = potential.energy_and_gradient(planar, restraints, 1.0)
+    distorted_energy, _ = potential.energy_and_gradient(distorted, restraints, 1.0)
+
+    torch.testing.assert_close(planar_energy, torch.zeros_like(planar_energy))
+    assert distorted_energy.item() > planar_energy.item()
+
+
+# ---------------------------------------------------------------------------
+# Protein-ligand complexes and atom renumbering
+#
+# build_context maps RDKit-local atom indices onto the global atom axis by
+# positionally zipping `in_crop_mask` against each ligand residue. In a
+# complex that axis is renumbered relative to a ligand-only query -- the
+# ligand no longer starts at 0, and where it starts depends on chain order,
+# chain count, and how many residues precede it. These tests pin that
+# restraints still land on the atoms they were computed for.
+#
+# The oracle is deliberately independent of the mapping under test: reference
+# conformer coordinates are placed by matching *atom names* between the
+# AtomArray and the RDKit molecule, not by the positional zip build_context
+# uses. If the two disagree, the reference conformer stops satisfying its own
+# restraints.
+# ---------------------------------------------------------------------------
+
+
+def _context_for(chains: list[dict]):
+    structure = structure_for(chains)
+    ctx = build_context(
+        structure.atom_array,
+        structure.processed_reference_mols,
+        n_atoms=len(structure.atom_array),
+    )
+    return structure, ctx.restraints["distance_bounds_potential"]
+
+
+@pytest.mark.parametrize("layout", sorted(LAYOUTS))
+def test_complex_restraints_reference_only_ligand_atoms(layout: str):
+    structure, restraints = _context_for(LAYOUTS[layout])
+    ligand_atoms = set(ligand_atom_indices(structure).tolist())
+
+    assert restraints.atom_index.shape[0] > 0
+    referenced = set(restraints.atom_index.flatten().tolist())
+    assert referenced <= ligand_atoms, (
+        f"{sorted(referenced - ligand_atoms)} are not ligand atoms"
+    )
+
+
+@pytest.mark.parametrize("layout", sorted(LAYOUTS))
+def test_complex_restraints_are_satisfied_by_the_reference_conformer(layout: str):
+    """The conformer the bounds were derived from must satisfy them exactly.
+
+    This is what catches a mis-mapped atom index: shift the ligand's global
+    offset and the restraints start relating the wrong pairs of atoms, so the
+    reference geometry violates its own bounds.
+    """
+    structure, restraints = _context_for(LAYOUTS[layout])
+    coords = reference_coords_by_atom_name(structure)
+
+    energy, _ = DistanceBoundsPotential().energy_and_gradient(coords, restraints, 1.0)
+
+    assert float(energy) == pytest.approx(0.0, abs=1e-6)
+
+    # Guard against the assertion above being vacuous: rotating every index by
+    # one atom is exactly the renumbering error this is meant to detect, and
+    # it must register.
+    rotated = RestraintSet(
+        atom_index=(restraints.atom_index + 1) % len(structure.atom_array),
+        lower=restraints.lower,
+        upper=restraints.upper,
+    )
+    rotated_energy, _ = DistanceBoundsPotential().energy_and_gradient(
+        coords, rotated, 1.0
+    )
+    assert float(rotated_energy) > 1.0
+
+
+def test_restraints_never_span_two_ligands() -> None:
+    """Distance bounds are intramolecular: every restraint must join two
+    atoms of the same ligand residue, never one atom from each."""
+    structure, restraints = _context_for(LAYOUTS["two_ligands"])
+
+    residue_of_atom: dict[int, int] = {}
+    global_indices = np.arange(len(structure.atom_array))
+    for residue_number, residue in enumerate(residue_view_iter(structure.atom_array)):
+        for global_index in global_indices[residue.indices]:
+            residue_of_atom[int(global_index)] = residue_number
+
+    for first, second in restraints.atom_index.tolist():
+        assert residue_of_atom[first] == residue_of_atom[second], (
+            f"restraint {(first, second)} spans two residues"
+        )
+
+
+def test_each_ligand_contributes_its_own_restraints():
+    """Both ligands in a two-ligand complex are steered, not just the first."""
+    structure, restraints = _context_for(LAYOUTS["two_ligands"])
+    referenced = set(restraints.atom_index.flatten().tolist())
+
+    ligand_residue_atoms = [
+        set(np.arange(len(structure.atom_array))[residue.indices].tolist())
+        for residue in residue_view_iter(structure.atom_array)
+        if np.all(residue.molecule_type_id == MoleculeType.LIGAND)
+    ]
+    assert len(ligand_residue_atoms) == 2
+    for atoms in ligand_residue_atoms:
+        assert referenced & atoms, "a ligand contributed no restraints"

--- a/openfold3/steering/tests/test_potentials.py
+++ b/openfold3/steering/tests/test_potentials.py
@@ -1,0 +1,219 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Analytic-gradient correctness against an independent autograd oracle,
+plus a broadcast-regression sweep across batch shapes -- including batch
+sizes that collide with the restraint arity, and a multi-sample (S > 1)
+rollout.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from openfold3.steering.potentials import (
+    DistanceBoundsPotential,
+    register,
+)
+from openfold3.steering.types import RestraintSet
+
+
+def _reference_flat_bottom(
+    value: torch.Tensor, lower: torch.Tensor, upper: torch.Tensor
+) -> torch.Tensor:
+    """Independent, differentiable oracle for the flat-bottom energy."""
+    return torch.relu(lower.expand_as(value) - value) + torch.relu(
+        value - upper.expand_as(value)
+    )
+
+
+def _autograd_distance_gradient(
+    coords: torch.Tensor, restraints: RestraintSet, weight: float
+) -> torch.Tensor:
+    """Independent autograd oracle: same restraints, built without reusing
+    DistanceBoundsPotential.compute_variable."""
+    coords = coords.clone().requires_grad_(True)
+    i, j = restraints.atom_index[:, 0], restraints.atom_index[:, 1]
+    diff = coords.index_select(-2, i) - coords.index_select(-2, j)
+    value = torch.linalg.norm(diff, dim=-1).clamp_min(1e-6)
+    energy = (
+        weight * _reference_flat_bottom(value, restraints.lower, restraints.upper)
+    ).sum()
+    (grad,) = torch.autograd.grad(energy, coords)
+    return grad
+
+
+def test_distance_gradient_matches_autograd():
+    coords = torch.tensor([[[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]]])
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0]),
+        upper=torch.tensor([1.0]),
+    )
+    weight = 0.01
+
+    potential = DistanceBoundsPotential()
+    _, analytic_grad = potential.energy_and_gradient(coords, restraints, weight)
+    autograd_grad = _autograd_distance_gradient(coords, restraints, weight)
+
+    torch.testing.assert_close(analytic_grad, autograd_grad)
+
+
+def test_distance_gradient_matches_autograd_with_upper_only_bound():
+    coords = torch.tensor([[[[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]]]])
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([float("-inf")]),
+        upper=torch.tensor([1.0]),
+    )
+    weight = 1.0
+
+    potential = DistanceBoundsPotential()
+    _, analytic_grad = potential.energy_and_gradient(coords, restraints, weight)
+    autograd_grad = _autograd_distance_gradient(coords, restraints, weight)
+
+    torch.testing.assert_close(analytic_grad, autograd_grad)
+    # The restraint is violated (distance 2.0 > upper 1.0), so it must be active.
+    assert not torch.equal(analytic_grad, torch.zeros_like(analytic_grad))
+
+
+def test_distance_energy_and_gradient_are_zero_inside_the_window():
+    coords = torch.tensor([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([0.5]),
+        upper=torch.tensor([1.5]),
+    )
+    potential = DistanceBoundsPotential()
+    energy, grad = potential.energy_and_gradient(coords, restraints, 1.0)
+
+    torch.testing.assert_close(energy, torch.zeros_like(energy))
+    torch.testing.assert_close(grad, torch.zeros_like(grad))
+
+
+def test_energy_and_gradient_is_a_noop_with_no_restraints():
+    torch.manual_seed(0)
+    coords = torch.randn(2, 3, 4, 3)
+    restraints = RestraintSet(
+        atom_index=torch.empty((0, 2), dtype=torch.int64),
+        lower=torch.empty((0,)),
+        upper=torch.empty((0,)),
+    )
+    potential = DistanceBoundsPotential()
+    energy, grad = potential.energy_and_gradient(coords, restraints, 0.01)
+
+    assert energy.shape == coords.shape[:-2]
+    torch.testing.assert_close(energy, torch.zeros_like(energy))
+    torch.testing.assert_close(grad, torch.zeros_like(coords))
+
+
+# ---------------------------------------------------------------------------
+# Broadcast-regression sweep: every leading-axis shape energy_and_gradient
+# must handle, including batch sizes that collide with the restraint arity.
+# ---------------------------------------------------------------------------
+
+_BATCH_SIZES = [1, 2, 3, 4, 5, 6, 7]
+
+
+@pytest.mark.parametrize("batch_size", _BATCH_SIZES)
+def test_broadcast_regression_unbatched_n3(batch_size: int):
+    """[N, 3] coords (no leading batch/sample axes) must work for every
+    restraint-family size, including sizes that collide with arity (2)."""
+    torch.manual_seed(batch_size)
+    n_atoms = max(batch_size, 2)
+    coords = torch.randn(n_atoms, 3, dtype=torch.float64)
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0], dtype=torch.float64),
+        upper=torch.tensor([1.0], dtype=torch.float64),
+    )
+    potential = DistanceBoundsPotential()
+    energy, grad = potential.energy_and_gradient(coords, restraints, 0.01)
+
+    assert energy.shape == ()
+    assert grad.shape == coords.shape
+    autograd_grad = _autograd_distance_gradient(coords, restraints, 0.01)
+    torch.testing.assert_close(grad, autograd_grad)
+
+
+@pytest.mark.parametrize("batch_size", _BATCH_SIZES)
+def test_broadcast_regression_batched_bsn3(batch_size: int):
+    """[B, S, N, 3] coords across a range of batch sizes, including sizes
+    that collide with arity (2)."""
+    torch.manual_seed(batch_size)
+    n_atoms = 5
+    n_samples = 3
+    coords = torch.randn(batch_size, n_samples, n_atoms, 3, dtype=torch.float64)
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1], [2, 3]], dtype=torch.int64),
+        lower=torch.tensor([1.0, 0.5], dtype=torch.float64),
+        upper=torch.tensor([1.0, 2.0], dtype=torch.float64),
+    )
+    potential = DistanceBoundsPotential()
+    energy, grad = potential.energy_and_gradient(coords, restraints, 0.02)
+
+    assert energy.shape == (batch_size, n_samples)
+    assert grad.shape == coords.shape
+    autograd_grad = _autograd_distance_gradient(coords, restraints, 0.02)
+    torch.testing.assert_close(grad, autograd_grad)
+
+
+def test_broadcast_regression_sample_axis_s_greater_than_one():
+    """S > 1 with B == 1: a dedicated multi-sample rollout, where each
+    sample must get its own, independently correct gradient."""
+    torch.manual_seed(42)
+    coords = torch.randn(1, 5, 4, 3, dtype=torch.float64)
+    restraints = RestraintSet(
+        atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+        lower=torch.tensor([1.0], dtype=torch.float64),
+        upper=torch.tensor([1.0], dtype=torch.float64),
+    )
+    potential = DistanceBoundsPotential()
+    energy, grad = potential.energy_and_gradient(coords, restraints, 0.01)
+
+    assert energy.shape == (1, 5)
+    # Each of the 5 samples must get its own, independently correct gradient.
+    autograd_grad = _autograd_distance_gradient(coords, restraints, 0.01)
+    torch.testing.assert_close(grad, autograd_grad)
+    for sample in range(5):
+        assert not torch.allclose(grad[0, sample], grad[0, (sample + 1) % 5])
+
+
+def test_registering_under_a_non_snake_case_name_is_rejected():
+    """The registry name is what a user types in the runner yaml, so the
+    snake_case convention is enforced at registration rather than left to
+    whoever adds the next potential."""
+    with pytest.raises(ValueError, match="must be snake_case"):
+        register("DistanceBoundsPotential")
+
+
+def test_registering_two_potentials_under_one_name_is_rejected(register_throwaway):
+    """The registry key is also the user-facing config key and the batch
+    feature prefix, so a silent overwrite would make one potential
+    unreachable and misroute the other's restraints."""
+    register_throwaway("colliding_potential")
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_throwaway("colliding_potential")
+
+
+def test_re_registering_the_same_class_is_allowed(
+    register_throwaway, isolated_registry
+):
+    """Idempotent, so a module re-import does not explode."""
+    potential = register_throwaway("reimported_potential")
+    register("reimported_potential")(potential)
+
+    assert isolated_registry["reimported_potential"] is potential

--- a/openfold3/steering/tests/test_schedules.py
+++ b/openfold3/steering/tests/test_schedules.py
@@ -1,0 +1,61 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from openfold3.steering.schedules import (
+    Constant,
+    ExponentialInterpolation,
+    PiecewiseStepFunction,
+)
+
+
+def test_constant_ignores_t():
+    schedule = Constant(0.5)
+    assert schedule.at(0.0) == pytest.approx(0.5)
+    assert schedule.at(1.0) == pytest.approx(0.5)
+
+
+def test_exponential_interpolation_alpha_zero_is_linear():
+    schedule = ExponentialInterpolation(start=0.0, end=1.0, alpha=0.0)
+    assert schedule.at(0.0) == pytest.approx(0.0)
+    assert schedule.at(1.0) == pytest.approx(1.0)
+    assert schedule.at(0.5) == pytest.approx(0.5)
+
+
+def test_exponential_interpolation_matches_closed_form():
+    schedule = ExponentialInterpolation(start=1.0, end=2.0, alpha=-3.0)
+    t = 0.4
+    expected = 1.0 + 1.0 * (math.exp(-3.0 * t) - 1.0) / (math.exp(-3.0) - 1.0)
+    assert schedule.at(t) == pytest.approx(expected)
+
+
+def test_piecewise_step_function_selects_the_containing_bin():
+    """A late-only guidance gate under this project's time convention
+    (t = 1 - step/N): active only for t <= 0.275, i.e. the final 27.5% of
+    denoising."""
+    schedule = PiecewiseStepFunction(thresholds=(0.275,), values=(0.01, 0.0))
+    assert schedule.at(0.0) == pytest.approx(0.01)
+    assert schedule.at(0.274) == pytest.approx(0.01)
+    assert schedule.at(0.275) == pytest.approx(0.0)
+    assert schedule.at(1.0) == pytest.approx(0.0)
+
+
+def test_piecewise_step_function_rejects_mismatched_lengths():
+    with pytest.raises(ValueError, match="values must have"):
+        PiecewiseStepFunction(thresholds=(0.5,), values=(1.0, 2.0, 3.0))

--- a/openfold3/steering/types.py
+++ b/openfold3/steering/types.py
@@ -1,0 +1,91 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core types for chemical steering.
+
+RestraintSet and SteeringContext are built once at featurization, on CPU, from
+RDKit. Everything downstream of that boundary — StepState, SteeringUpdate, and
+the engine in ``engine.py`` — sees only tensors and never imports RDKit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+
+@dataclass(frozen=True)
+class RestraintSet:
+    """One flat-bottom restraint family. Device-local, built at featurization."""
+
+    atom_index: Tensor  # int64   [n_restraints, arity]
+    lower: Tensor  # float32 [n_restraints]           may be -inf
+    upper: Tensor  # float32 [n_restraints]           may be +inf
+
+    def to(self, device: torch.device) -> RestraintSet:
+        return RestraintSet(
+            atom_index=self.atom_index.to(device),
+            lower=self.lower.to(device),
+            upper=self.upper.to(device),
+        )
+
+
+@dataclass(frozen=True)
+class SteeringContext:
+    """Everything steering needs at sampling time. No RDKit, no AtomArray."""
+
+    restraints: Mapping[str, RestraintSet]  # keyed by potential class name
+    n_atoms: int  # must match the model's atom axis
+
+    def to(self, device: torch.device) -> SteeringContext:
+        return SteeringContext(
+            restraints={name: r.to(device) for name, r in self.restraints.items()},
+            n_atoms=self.n_atoms,
+        )
+
+
+@dataclass(frozen=True)
+class StepState:
+    """What the sampler knows at the moment the hook fires."""
+
+    xl_noisy: Tensor  # [B, S, N, 3] denoiser input
+    noise: Tensor  # [B, S, N, 3] epsilon drawn this step (FK will need it)
+    t: Tensor  # sigma at this step
+    c_tau: Tensor  # sigma at the next step
+    step_index: int  # 0-based within THIS rollout pass
+    num_steps: int
+    start_step: int  # non-zero in the pocket-refinement pass
+    pass_name: str  # "primary" | "pocket_refine"
+    atom_mask: Tensor
+    ctx: SteeringContext
+
+    @property
+    def steering_t(self) -> float:
+        """Normalized time, Boltz/Protenix convention: 1.0 at the start -> 0."""
+        return 1.0 - self.step_index / max(1, self.num_steps)
+
+
+@dataclass(frozen=True)
+class SteeringUpdate:
+    """An ADDITIVE correction to x0.
+
+    Apply as:  x0_guided = x0 + update.delta
+    """
+
+    delta: Tensor  # [B, S, N, 3], same shape as x0, float32
+    n_active_terms: int = 0  # diagnostics; 0 means steering was inert
+    energy: Tensor | None = None  # per-sample; reserved for Feynman-Kac

--- a/openfold3/tests/inference/test_chemical_steering.py
+++ b/openfold3/tests/inference/test_chemical_steering.py
@@ -1,0 +1,287 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chemical-steering ligand-geometry test.
+
+``test_steering_repairs_ligand_internal_geometry`` runs one query twice, with
+``dataset_config_kwargs.steering.enabled`` on and off, and measures the internal
+geometry of the predicted ligand in each arm. Nothing else differs, so the
+difference is attributable to steering.
+
+The case is FKBP12 with rapamycin (PDB 1FKB), the ligand given by its CCD code
+``RAP`` rather than a SMILES string so the chemistry comes from the PDB
+component dictionary. Rapamycin is a 31-membered macrocycle with 65 heavy
+atoms: flexible enough that a single-sequence prediction strains it, which is
+what gives the test something to detect. The protein is 107 residues, so both
+arms together run in about two minutes.
+
+What is measured, and why
+-------------------------
+The metric is the worst violation of the ligand's RDKit distance-geometry
+bounds -- how far, in Angstrom, any restrained atom pair sits outside its
+permitted window. This is the same family of check PoseBusters applies for
+internal ligand validity (bond lengths, bond angles, internal steric clash),
+computed the same way, from ``GetMoleculeBoundsMatrix`` on the reference
+molecule.
+
+It is also, deliberately and openly, the quantity steering optimizes. That
+makes this an end-to-end demonstration that guidance reaches the sampler and
+changes the output chemistry, not independent evidence that the chemistry is
+*right*. The independent check is the ring geometry asserted alongside it, and
+foldsteer's PoseBusters benchmark (66.0% -> 89.3% valid) is the external
+evidence.
+
+Two facts worth recording, both measured on this case:
+
+* The violations are entirely nonbonded 1-4 and 1-5 pairs -- torsional strain,
+  atoms folded closer than any reachable torsion allows (e.g. C6-O4 at 3.42 A
+  against a 4.28 A bound). Bond lengths and bond angles were already correct in
+  both arms, so this term is not fixing those here.
+* The *unbuffered* bounds matrix is not a usable yardstick: RDKit's own
+  generated conformer for this molecule violates it by up to 2.12 A over 15
+  pairs, worse than the predictions do. The buffered bounds the package
+  actually restrains against are satisfied exactly by that conformer, which is
+  what makes "zero violation" a meaningful target rather than an unreachable
+  one (``openfold3/steering/tests/test_featurization.py`` pins that).
+
+The metrics themselves live in ``openfold3.core.metrics.ligand_geometry`` and
+are unit-tested in ``openfold3/tests/test_ligand_geometry.py``, which needs
+neither an accelerator nor weights.
+
+Requires an accelerator (CUDA, ROCm or MPS) and downloaded model weights; skips
+otherwise.
+
+Run with:
+    pytest openfold3/tests/inference/test_chemical_steering.py
+"""
+
+import logging
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from openfold3.core.data.primitives.structure.query import (
+    StructureWithReferenceMolecules,
+    structure_with_ref_mols_from_query,
+)
+from openfold3.core.data.primitives.structure.tokenization import (
+    add_token_positions,
+    tokenize_atom_array,
+)
+from openfold3.core.metrics.alignment import Structure
+from openfold3.core.metrics.ligand_geometry import (
+    mean_ring_torsion,
+    saturated_ring_atom_names,
+    worst_bounds_violation,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
+    Query,
+)
+from openfold3.steering.featurization import build_context
+from openfold3.steering.potentials import DistanceBoundsPotential
+from openfold3.tests.inference.helpers import (
+    SampleScores,
+    measure_samples,
+    predicted_structure_cifs,
+    run_inference,
+)
+from openfold3.tests.utils.compare_utils import skip_unless_accelerator_available
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.slow]
+
+QUERY_NAME = "fkbp12_rapamycin"
+PROTEIN_CHAIN_ID = "A"
+LIGAND_CHAIN_ID = "B"
+
+#: Human FKBP12 (UniProt P62942) with rapamycin — the 1FKB complex.
+CHAINS = [
+    {
+        "molecule_type": "protein",
+        "chain_ids": [PROTEIN_CHAIN_ID],
+        "sequence": (
+            "MGVQVETISPGDGRTFPKRGQTCVVHYTGMLEDGKKFDSSRDRNKPFKFMLGKQEVIRGWEEGVAQM"
+            "SVGQRAKLTISPDYAYGATGHPGIIPPHATLVFDVELLKLE"
+        ),
+    },
+    {
+        "molecule_type": "ligand",
+        "chain_ids": [LIGAND_CHAIN_ID],
+        "ccd_codes": ["RAP"],
+    },
+]
+
+#: Run single-sequence.
+USE_MSA_SERVER = False
+USE_TEMPLATES = False
+
+#: Fewer samples than SCORED_DIFFUSION_SAMPLES: this asserts on a within-sample
+#: geometric property, not on accuracy against an experimental structure, and
+#: the separation between the arms is two orders of magnitude wide.
+NUM_DIFFUSION_SAMPLES = 5
+
+# Calibrated on one run of 5 samples per arm, of3-ob-2025-06-30-174k on a
+# CUDA GB10:
+#   steering off  worst violation 0.74, 0.86, 0.88, 1.00, 1.15 Å (mean 0.93),
+#                 10-13 violated pairs per sample
+#   steering on   worst violation 0.000 x4, 0.003 Å (mean 0.001),
+#                 0-1 violated pairs per sample
+# The thresholds sit an order of magnitude inside that gap on both sides, so
+# they tolerate hardware and precision variance but still fail if guidance
+# stops reaching the sampler (then on collapses onto off).
+STEERING_ON_VIOLATION_MAX_ANGSTROM = 0.10
+STEERING_OFF_VIOLATION_MIN_ANGSTROM = 0.30
+
+#: A saturated all-carbon six-ring sits in a chair, ~55° of torsion at every
+#: bond. Guidance must not flatten it toward 0° — the failure mode Tom
+#: Goddard's badchem survey documents for predicted ligands, where cyclohexane
+#: came back planar:
+#: https://www.rbvi.ucsf.edu/chimerax/data/ligchem-feb2026/badchem.html
+#: Measured ~53-55° in both arms here; the floor is well below that.
+SATURATED_RING_TORSION_MIN_DEGREES = 45.0
+
+
+def _query_structure() -> StructureWithReferenceMolecules:
+    """The tokenized query structure and its reference molecules."""
+    structure = structure_with_ref_mols_from_query(
+        Query.model_validate({"chains": CHAINS})
+    )
+    tokenize_atom_array(structure.atom_array)
+    add_token_positions(structure.atom_array)
+    return structure
+
+
+def _ligand_coords_by_name(prediction: Structure) -> dict[str, np.ndarray]:
+    """Predicted ligand coordinates keyed by atom name, as the ring metrics
+    want them."""
+    ligand = prediction.heavy_atoms(LIGAND_CHAIN_ID)
+    return {
+        str(name): np.asarray(coord, dtype=float)
+        for name, coord in zip(ligand.atom_name, ligand.coord, strict=True)
+    }
+
+
+def _ligand_coordinates(
+    prediction: Structure, structure: StructureWithReferenceMolecules
+) -> torch.Tensor:
+    """Predicted ligand coordinates, laid out on the query's global atom axis.
+
+    Mapped by atom name rather than by position, so this does not depend on the
+    predicted cif listing atoms in the query's order. Non-ligand atoms stay at
+    the origin and are never read: the restraints are intramolecular, so every
+    index they carry is a ligand atom.
+    """
+    ligand = prediction.heavy_atoms(LIGAND_CHAIN_ID)
+    coords_by_name = {
+        str(name): np.asarray(coord, dtype=np.float32)
+        for name, coord in zip(ligand.atom_name, ligand.coord, strict=True)
+    }
+    atom_array = structure.atom_array
+    coords = torch.zeros((len(atom_array), 3), dtype=torch.float32)
+    for index, (name, chain) in enumerate(
+        zip(atom_array.atom_name, atom_array.chain_id, strict=True)
+    ):
+        if str(chain) == LIGAND_CHAIN_ID:
+            coords[index] = torch.from_numpy(coords_by_name[str(name)])
+    return coords
+
+
+def _run(*, steering_enabled: bool, out_dir: Path) -> list[Path]:
+    """Run one condition and return its predicted sample cifs, in sample order."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_inference(
+        InferenceQuerySet.model_validate({"queries": {QUERY_NAME: {"chains": CHAINS}}}),
+        out_dir,
+        use_msa_server=USE_MSA_SERVER,
+        use_templates=USE_TEMPLATES,
+        num_diffusion_samples=NUM_DIFFUSION_SAMPLES,
+        extra_yaml=textwrap.dedent(f"""\
+            dataset_config_kwargs:
+              steering:
+                enabled: {str(steering_enabled).lower()}
+            """),
+    )
+    return predicted_structure_cifs(out_dir, QUERY_NAME)
+
+
+@skip_unless_accelerator_available()
+@pytest.mark.inference_verification
+def test_steering_repairs_ligand_internal_geometry(tmp_path: Path) -> None:
+    """Steering must clear the predicted ligand's distance-bounds violations."""
+    structure = _query_structure()
+    restraints = build_context(
+        structure.atom_array,
+        structure.processed_reference_mols,
+        n_atoms=len(structure.atom_array),
+    ).restraints[DistanceBoundsPotential.name]
+    rings = saturated_ring_atom_names(structure.processed_reference_mols[-1].mol)
+
+    def _measure(sample_cifs: list[Path]) -> tuple[SampleScores, SampleScores]:
+        measurements = measure_samples(
+            sample_cifs,
+            lambda prediction: (
+                worst_bounds_violation(
+                    _ligand_coordinates(prediction, structure), restraints
+                ),
+                mean_ring_torsion(_ligand_coords_by_name(prediction), rings),
+            ),
+            expected_samples=NUM_DIFFUSION_SAMPLES,
+        )
+        return (
+            SampleScores.of(measurements, lambda pair: pair[0]),
+            SampleScores.of(measurements, lambda pair: pair[1]),
+        )
+
+    on_violation, on_torsion = _measure(
+        _run(steering_enabled=True, out_dir=tmp_path / "on")
+    )
+    off_violation, off_torsion = _measure(
+        _run(steering_enabled=False, out_dir=tmp_path / "off")
+    )
+    logger.info(
+        "%s worst distance-bounds violation (Å) | steering on %s | off %s",
+        QUERY_NAME,
+        on_violation,
+        off_violation,
+    )
+    logger.info(
+        "%s mean saturated-ring |torsion| (°) | steering on %s | off %s",
+        QUERY_NAME,
+        on_torsion,
+        off_torsion,
+    )
+
+    assert on_violation.mean < STEERING_ON_VIOLATION_MAX_ANGSTROM, (
+        f"{QUERY_NAME}: steering left the ligand strained — mean worst violation "
+        f"{on_violation.mean:.3f} Å over {NUM_DIFFUSION_SAMPLES} samples exceeds "
+        f"the {STEERING_ON_VIOLATION_MAX_ANGSTROM} Å ceiling"
+    )
+    assert off_violation.mean > STEERING_OFF_VIOLATION_MIN_ANGSTROM, (
+        f"{QUERY_NAME}: the unsteered ligand was already clean — mean worst "
+        f"violation {off_violation.mean:.3f} Å is below the "
+        f"{STEERING_OFF_VIOLATION_MIN_ANGSTROM} Å floor, so this case no longer "
+        "demonstrates anything about steering"
+    )
+    assert on_torsion.mean > SATURATED_RING_TORSION_MIN_DEGREES, (
+        f"{QUERY_NAME}: steering flattened the saturated ring — mean |torsion| "
+        f"{on_torsion.mean:.1f}° is below the "
+        f"{SATURATED_RING_TORSION_MIN_DEGREES}° floor a chair conformation sits "
+        "well above"
+    )

--- a/openfold3/tests/test_ligand_geometry.py
+++ b/openfold3/tests/test_ligand_geometry.py
@@ -1,0 +1,268 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ligand internal-geometry metrics.
+
+These back the end-to-end steering test
+(``openfold3/tests/inference/test_chemical_steering.py``), which needs an
+accelerator and weights and so cannot be run on demand. The metrics themselves
+are pure geometry, so they are pinned here instead, against constructed
+coordinates whose answers are known analytically.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from rdkit import Chem
+
+from openfold3.core.metrics.ligand_geometry import (
+    mean_ring_torsion,
+    saturated_ring_atom_names,
+    torsion_degrees,
+    worst_bounds_violation,
+)
+from openfold3.steering.types import RestraintSet
+
+
+def _restraints(
+    pairs: list[list[int]], lower: list[float], upper: list[float]
+) -> RestraintSet:
+    return RestraintSet(
+        atom_index=torch.tensor(pairs, dtype=torch.int64),
+        lower=torch.tensor(lower, dtype=torch.float32),
+        upper=torch.tensor(upper, dtype=torch.float32),
+    )
+
+
+# ---------------------------------------------------------------------------
+# torsion_degrees
+# ---------------------------------------------------------------------------
+
+
+def _butane_like(dihedral_degrees: float) -> np.ndarray:
+    """Four points whose dihedral is exactly ``dihedral_degrees``.
+
+    Atoms 1 and 2 sit on the x axis; 0 and 3 hang off them in the yz plane,
+    rotated apart by the requested angle. Rotating the fourth point is the
+    whole construction, so the expected answer is known by build rather than
+    by a second implementation of the same formula.
+    """
+    angle = np.radians(dihedral_degrees)
+    return np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.5, 0.0, 0.0],
+            [1.5, np.cos(angle), np.sin(angle)],
+        ]
+    )
+
+
+@pytest.mark.parametrize("expected", [0.0, 60.0, 90.0, 120.0, 179.0, -60.0, -120.0])
+def test_torsion_degrees_recovers_the_angle_it_was_built_with(expected: float) -> None:
+    assert torsion_degrees(_butane_like(expected)) == pytest.approx(expected, abs=1e-4)
+
+
+def test_torsion_degrees_is_sign_flipped_by_mirroring() -> None:
+    """A dihedral is signed: reflecting the four points must negate it. This is
+    what distinguishes it from a plain angle, and what makes |torsion| the
+    right thing to average over a ring."""
+    points = _butane_like(70.0)
+    mirrored = points * np.array([1.0, 1.0, -1.0])
+
+    assert torsion_degrees(points) == pytest.approx(70.0, abs=1e-4)
+    assert torsion_degrees(mirrored) == pytest.approx(-70.0, abs=1e-4)
+
+
+def test_torsion_degrees_ignores_rigid_motion() -> None:
+    """Translating and rotating the whole system cannot change an internal
+    coordinate."""
+    points = _butane_like(55.0)
+    rotation = np.linalg.qr(np.random.default_rng(0).normal(size=(3, 3)))[0]
+    if np.linalg.det(rotation) < 0:  # keep it a rotation, not a reflection
+        rotation[:, 0] *= -1
+    moved = points @ rotation.T + np.array([3.0, -7.0, 11.0])
+
+    assert torsion_degrees(moved) == pytest.approx(torsion_degrees(points), abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# worst_bounds_violation
+# ---------------------------------------------------------------------------
+
+
+def test_no_violation_when_every_pair_sits_inside_its_window() -> None:
+    coords = torch.tensor([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    restraints = _restraints([[0, 1]], [1.0], [3.0])
+
+    assert worst_bounds_violation(coords, restraints) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("separation", "expected"),
+    [
+        pytest.param(0.5, 0.5, id="below_lower_bound"),
+        pytest.param(1.0, 0.0, id="exactly_on_lower_bound"),
+        pytest.param(3.0, 0.0, id="exactly_on_upper_bound"),
+        pytest.param(4.25, 1.25, id="above_upper_bound"),
+    ],
+)
+def test_violation_is_the_distance_outside_the_window(
+    separation: float, expected: float
+) -> None:
+    coords = torch.tensor([[0.0, 0.0, 0.0], [separation, 0.0, 0.0]])
+    restraints = _restraints([[0, 1]], [1.0], [3.0])
+
+    assert worst_bounds_violation(coords, restraints) == pytest.approx(expected)
+
+
+def test_violation_reports_the_worst_pair_not_the_first_or_the_sum() -> None:
+    coords = torch.tensor([[0.0, 0.0, 0.0], [0.9, 0.0, 0.0], [0.0, 0.2, 0.0]])
+    restraints = _restraints([[0, 1], [0, 2]], [1.0, 1.0], [3.0, 3.0])
+
+    # pair (0,1) is 0.1 short, pair (0,2) is 0.8 short.
+    assert worst_bounds_violation(coords, restraints) == pytest.approx(0.8)
+
+
+def test_infinite_upper_bounds_never_count_as_violated() -> None:
+    """Nonbonded pairs carry an infinite upper bound -- they may be arbitrarily
+    far apart, and must never register as violated however far apart they
+    are."""
+    coords = torch.tensor([[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]])
+    restraints = _restraints([[0, 1]], [1.0], [float("inf")])
+
+    assert worst_bounds_violation(coords, restraints) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# saturated_ring_atom_names / mean_ring_torsion
+# ---------------------------------------------------------------------------
+
+
+def _named(smiles: str) -> Chem.Mol:
+    """Parse SMILES and give every atom the annotation the pipeline uses."""
+    mol = Chem.MolFromSmiles(smiles)
+    for atom in mol.GetAtoms():
+        atom.SetProp("annot_atom_name", f"{atom.GetSymbol()}{atom.GetIdx()}")
+    return mol
+
+
+@pytest.mark.parametrize(
+    ("smiles", "expected_rings"),
+    [
+        pytest.param("C1CCCCC1", 1, id="cyclohexane"),
+        pytest.param("c1ccccc1", 0, id="benzene_is_aromatic"),
+        pytest.param("C1=CCCCC1", 0, id="cyclohexene_has_a_double_bond"),
+        pytest.param("C1CCCC1", 0, id="cyclopentane_is_five_membered"),
+        pytest.param("C1CCNCC1", 0, id="piperidine_is_not_all_carbon"),
+        pytest.param("C1CCCCC1C1CCCCC1", 2, id="bicyclohexyl"),
+        pytest.param("C1CCc2ccccc2C1", 0, id="tetralin_ring_is_fused_to_an_arene"),
+    ],
+)
+def test_saturated_ring_detection_accepts_only_saturated_carbocycles(
+    smiles: str, expected_rings: int
+) -> None:
+    """The metric is calibrated on a chair, so anything that is not a saturated
+    all-carbon six-ring has to be excluded -- an aromatic ring is flat by
+    right, and a five-ring puckers to a different amplitude."""
+    assert len(saturated_ring_atom_names(_named(smiles))) == expected_rings
+
+
+def test_saturated_ring_names_are_the_ring_atoms_in_ring_order() -> None:
+    mol = _named("C1CCCCC1")
+    (ring,) = saturated_ring_atom_names(mol)
+
+    assert len(ring) == 6
+    assert set(ring) == {f"C{index}" for index in range(6)}
+    # Consecutive entries must be bonded, or the torsions walk the wrong path.
+    name_to_index = {f"C{atom.GetIdx()}": atom.GetIdx() for atom in mol.GetAtoms()}
+    for position, name in enumerate(ring):
+        neighbour = ring[(position + 1) % 6]
+        assert mol.GetBondBetweenAtoms(name_to_index[name], name_to_index[neighbour]), (
+            f"{name} and {neighbour} are adjacent in the ring but not bonded"
+        )
+
+
+RING_NAMES = tuple(f"C{index}" for index in range(6))
+
+
+def _hexagon(pucker_angstrom: float) -> dict[str, np.ndarray]:
+    """Six carbons on a 1.46 A hexagon, alternating +-``pucker`` in z.
+
+    One builder for both ring fixtures, so a chair and a flat ring differ in
+    exactly one number and nothing else.
+    """
+    coords = {}
+    for index, name in enumerate(RING_NAMES):
+        angle = index * np.pi / 3
+        coords[name] = np.array(
+            [
+                1.46 * np.cos(angle),
+                1.46 * np.sin(angle),
+                pucker_angstrom * (-1) ** index,
+            ]
+        )
+    return coords
+
+
+@pytest.fixture
+def chair() -> dict[str, np.ndarray]:
+    """An ideal cyclohexane chair: +-0.25 A of alternating pucker."""
+    return _hexagon(0.25)
+
+
+@pytest.fixture
+def flat_ring() -> dict[str, np.ndarray]:
+    """The same hexagon built with no pucker at all, so every z is 0.
+
+    The badchem failure mode, where a predictor returns a saturated ring
+    planar: https://www.rbvi.ucsf.edu/chimerax/data/ligchem-feb2026/badchem.html
+    """
+    return _hexagon(0.0)
+
+
+def test_mean_ring_torsion_reports_a_chair_near_55_degrees(
+    chair: dict[str, np.ndarray],
+) -> None:
+    """The number the steering test's floor is set against."""
+    assert mean_ring_torsion(chair, [RING_NAMES]) == pytest.approx(55.0, abs=5.0)
+
+
+def test_mean_ring_torsion_is_zero_for_a_flat_ring(
+    flat_ring: dict[str, np.ndarray],
+) -> None:
+    """A ring returned planar reads as 0 degrees, so the floor in the steering
+    test separates the two cases by its whole range."""
+    assert mean_ring_torsion(flat_ring, [RING_NAMES]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_mean_ring_torsion_averages_over_every_ring_and_bond(
+    chair: dict[str, np.ndarray], flat_ring: dict[str, np.ndarray]
+) -> None:
+    """Two rings, one puckered and one flat, must average rather than report
+    either alone -- otherwise a single flattened ring could hide."""
+    puckered_group = {f"a_{name}": xyz for name, xyz in chair.items()}
+    flat_group = {f"b_{name}": xyz for name, xyz in flat_ring.items()}
+    coords = puckered_group | flat_group
+    rings = [
+        tuple(f"a_{name}" for name in RING_NAMES),
+        tuple(f"b_{name}" for name in RING_NAMES),
+    ]
+
+    both = mean_ring_torsion(coords, rings)
+    puckered_only = mean_ring_torsion(coords, rings[:1])
+
+    assert both == pytest.approx(puckered_only / 2, rel=1e-6)

--- a/openfold3/tests/test_steering_dataset.py
+++ b/openfold3/tests/test_steering_dataset.py
@@ -1,0 +1,186 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Steering features as the inference dataset actually emits them.
+
+The package's own tests exercise `maybe_create_steering_features` directly; these
+go through `InferenceDataset.create_all_features`, which is the only thing
+that proves a run reaches the sampler with restraints. Without them, deleting
+the call in `create_all_features` leaves every other steering test green while
+steering silently never happens.
+
+Ethanol is the molecule under test because its restraint set is small enough
+to write out by hand: two bonds and the one 1-3 pair they share.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openfold3.core.data.framework.single_datasets.inference import InferenceDataset
+from openfold3.core.data.pipelines.preprocessing.template import (
+    TemplatePreprocessorSettings,
+)
+from openfold3.core.data.resources.residues import MoleculeType
+from openfold3.projects.of3_all_atom.config.dataset_configs import InferenceJobConfig
+from openfold3.projects.of3_all_atom.config.inference_query_format import (
+    InferenceQuerySet,
+)
+from openfold3.steering.batch_features import (
+    STEERING_ENABLED_KEY,
+    STEERING_N_ATOMS_KEY,
+    STEERING_NUM_GD_STEPS_KEY,
+    term_key,
+)
+from openfold3.steering.config import SteeringSettings
+
+_TERM = "distance_bounds_potential"
+
+# A protein chain precedes the ligand so the ligand does not start at atom 0:
+# restraints are built against RDKit-local indices, and the global offset is
+# exactly what a wiring mistake would get wrong.
+_PROTEIN = {"molecule_type": "protein", "chain_ids": ["A"], "sequence": "GAGA"}
+_ETHANOL = {"molecule_type": "ligand", "chain_ids": ["L"], "smiles": "CCO"}
+
+# Ethanol, heavy atoms only: both bonds plus the 1-3 pair across them.
+_EXPECTED_PAIRS = {("C1", "C2"), ("C2", "O1"), ("C1", "O1")}
+
+
+def _dataset(chains: list[dict], settings: SteeringSettings) -> InferenceDataset:
+    query_set = InferenceQuerySet.model_validate(
+        {"queries": {"query": {"chains": chains}}}
+    )
+    return InferenceDataset(
+        dataset_config=InferenceJobConfig(
+            query_set=query_set,
+            template_preprocessor_settings=TemplatePreprocessorSettings(),
+            steering=settings,
+        )
+    )
+
+
+def _features(chains: list[dict], settings: SteeringSettings) -> dict:
+    dataset = _dataset(chains, settings)
+    return dataset.create_all_features(dataset.query_cache["query"])
+
+
+@pytest.fixture
+def ethanol_features() -> dict:
+    return _features([_PROTEIN, _ETHANOL], SteeringSettings(enabled=True))
+
+
+def test_enabled_steering_emits_exactly_the_expected_feature_keys(ethanol_features):
+    """The key set is the contract with `prepare_steering`; a missing key
+    raises there rather than degrading, and an extra one would be dropped
+    silently."""
+    emitted = {key for key in ethanol_features if key.startswith("steering_")}
+
+    assert emitted == {
+        STEERING_ENABLED_KEY,
+        STEERING_NUM_GD_STEPS_KEY,
+        STEERING_N_ATOMS_KEY,
+        term_key(_TERM, "atom_index"),
+        term_key(_TERM, "lower"),
+        term_key(_TERM, "upper"),
+        term_key(_TERM, "count"),
+        term_key(_TERM, "weight"),
+        term_key(_TERM, "interval"),
+    }
+
+
+def test_emitted_features_agree_with_the_structure_they_describe(ethanol_features):
+    settings = SteeringSettings(enabled=True)
+    atom_array = ethanol_features["atom_array"]
+    count = int(ethanol_features[term_key(_TERM, "count")].item())
+    atom_index = ethanol_features[term_key(_TERM, "atom_index")]
+
+    assert bool(ethanol_features[STEERING_ENABLED_KEY].item())
+    assert int(ethanol_features[STEERING_N_ATOMS_KEY].item()) == len(atom_array)
+    assert (
+        int(ethanol_features[STEERING_NUM_GD_STEPS_KEY].item()) == settings.num_gd_steps
+    )
+    assert float(ethanol_features[term_key(_TERM, "weight")].item()) == pytest.approx(
+        settings.terms[_TERM].weight
+    )
+    # `count` is the shape authority downstream -- the collator reshapes these
+    # tensors, so orientation is never inferred from `atom_index.shape`.
+    assert atom_index.numel() == count * 2
+    assert ethanol_features[term_key(_TERM, "lower")].numel() == count
+    assert ethanol_features[term_key(_TERM, "upper")].numel() == count
+
+
+def test_ethanol_generates_its_three_distance_constraints(ethanol_features):
+    """Ethanol's heavy-atom restraints, enumerated: C1-C2, C2-O1, and the
+    1-3 pair C1...O1. Identified by atom name, so this pins that the global
+    offset of the ligand -- 18, not 0, behind a four-residue protein chain --
+    is applied to every index."""
+    atom_array = ethanol_features["atom_array"]
+    atom_index = ethanol_features[term_key(_TERM, "atom_index")]
+
+    ligand_atoms = np.flatnonzero(atom_array.molecule_type_id == MoleculeType.LIGAND)
+    assert ligand_atoms.min() > 0, "ligand must not start at atom 0 for this test"
+
+    named = {
+        frozenset((str(atom_array.atom_name[i]), str(atom_array.atom_name[j])))
+        for i, j in atom_index.tolist()
+    }
+    assert named == {frozenset(pair) for pair in _EXPECTED_PAIRS}
+
+    referenced = set(atom_index.flatten().tolist())
+    assert referenced <= set(ligand_atoms.tolist())
+
+
+def test_ethanol_bounds_bracket_the_real_bond_lengths(ethanol_features):
+    """Bounds are physical, not placeholders: each bond's window contains its
+    textbook length, and the 1-3 pair's window sits above both."""
+    atom_array = ethanol_features["atom_array"]
+    atom_index = ethanol_features[term_key(_TERM, "atom_index")]
+    lower = ethanol_features[term_key(_TERM, "lower")]
+    upper = ethanol_features[term_key(_TERM, "upper")]
+
+    windows = {
+        frozenset((str(atom_array.atom_name[i]), str(atom_array.atom_name[j]))): (
+            float(lower[k]),
+            float(upper[k]),
+        )
+        for k, (i, j) in enumerate(atom_index.tolist())
+    }
+
+    for pair, expected in (
+        (("C1", "C2"), 1.52),  # C-C single bond
+        (("C2", "O1"), 1.43),  # C-O single bond
+        (("C1", "O1"), 2.37),  # 1-3 separation across the C-C-O angle
+    ):
+        low, high = windows[frozenset(pair)]
+        assert low < expected < high, (
+            f"{pair} window [{low}, {high}] excludes {expected}"
+        )
+
+
+def test_steering_features_are_absent_when_steering_is_disabled():
+    """Off by default, and "off" means no keys at all: the sampler probes for
+    the enable key with `.get`, so an absent key is what makes a disabled run
+    bit-identical to one without steering."""
+    features = _features([_PROTEIN, _ETHANOL], SteeringSettings())
+
+    assert not [key for key in features if key.startswith("steering_")]
+
+
+def test_a_ligandless_query_emits_no_steering_features():
+    """Enabled but nothing to steer: a protein-only query must take the same
+    no-key path rather than emitting an empty restraint set."""
+    features = _features([_PROTEIN], SteeringSettings(enabled=True))
+
+    assert not [key for key in features if key.startswith("steering_")]

--- a/openfold3/tests/test_steering_sampler.py
+++ b/openfold3/tests/test_steering_sampler.py
@@ -1,0 +1,390 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The chemical-steering hook inside SampleDiffusion.
+
+Follows the idioms in test_pocket_constraints.py: an identity denoiser and a
+directly constructed SampleDiffusion with the stochastic terms zeroed
+(`noise_scale=0`, `gamma_0=0`), so a seed is enough to make a rollout
+reproducible. The one thing a seed cannot give is what the
+`no_random_augmentation` fixture below provides -- see its docstring.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from openfold3.core.model.structure import diffusion_module
+from openfold3.core.model.structure.diffusion_module import (
+    DiffusionModule,
+    SampleDiffusion,
+)
+from openfold3.steering.batch_features import (
+    STEERING_ENABLED_KEY,
+    context_to_features,
+    term_key,
+)
+from openfold3.steering.config import SteeringSettings
+from openfold3.steering.engine import ChemicalSteering
+from openfold3.steering.types import RestraintSet, SteeringContext
+
+_TERM = "distance_bounds_potential"
+_N_ATOMS = 4
+_SEED = 11
+
+# Three sigmas -> two denoising steps, the smallest schedule that still shows
+# steering_t advancing between steps.
+_NOISE_SCHEDULE = torch.tensor([1.0, 0.5, 0.1])
+_NUM_DENOISING_STEPS = len(_NOISE_SCHEDULE) - 1
+
+
+class _IdentityDenoiser(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+        self.input_dtypes: list[torch.dtype] = []
+
+    def forward(self, *, xl_noisy, **_kwargs):
+        self.calls += 1
+        self.input_dtypes.append(xl_noisy.dtype)
+        return xl_noisy
+
+
+def _sampler(denoiser: torch.nn.Module | None = None) -> SampleDiffusion:
+    return SampleDiffusion(
+        gamma_0=0.0,
+        gamma_min=0.0,
+        noise_scale=0.0,
+        step_scale=1.0,
+        # The stand-in denoisers here satisfy the call contract but not the
+        # declared DiffusionModule type.
+        diffusion_module=cast(
+            DiffusionModule, denoiser if denoiser is not None else _IdentityDenoiser()
+        ),
+    )
+
+
+def _base_batch(
+    batch_dim: int = 1, dtype: torch.dtype = torch.float32
+) -> dict[str, torch.Tensor]:
+    # The rollout takes its coordinate dtype from atom_mask.
+    return {
+        "atom_mask": torch.ones(batch_dim, _N_ATOMS, dtype=dtype),
+        "token_mask": torch.ones(batch_dim, 1),
+    }
+
+
+def _steering_features(
+    *, weight: float = 0.25, num_gd_steps: int = 2
+) -> dict[str, torch.Tensor]:
+    """One badly violated restraint, so guidance visibly moves atoms.
+
+    The window is one-sided (`[0, 1]`, "no longer than 1 Angstrom") on
+    purpose. A zero-width window plus a step size large enough to see would
+    overshoot the bound and be pushed back the next gradient step, so a pair
+    could land back where it started and the correction would cancel -- which
+    is exactly what an earlier version of this file did, leaving the "pulls a
+    violated restraint together" assertion to pass on float32 rounding noise
+    for one of the two samples.
+    """
+    ctx = SteeringContext(
+        restraints={
+            _TERM: RestraintSet(
+                atom_index=torch.tensor([[0, 1]], dtype=torch.int64),
+                lower=torch.tensor([0.0]),
+                upper=torch.tensor([1.0]),
+            )
+        },
+        n_atoms=_N_ATOMS,
+    )
+    settings = SteeringSettings.model_validate(
+        {
+            "enabled": True,
+            "num_gd_steps": num_gd_steps,
+            "terms": {_TERM: {"weight": weight}},
+        }
+    )
+    return context_to_features(ctx, settings)
+
+
+@pytest.fixture
+def no_random_augmentation():
+    """Hold the coordinate frame fixed across denoising steps.
+
+    Seeding already makes a rollout reproducible: `_sampler` zeroes the
+    stochastic terms, and steering draws no randomness of its own (see
+    `test_enabled_steering_consumes_no_extra_randomness`), so a steered and
+    an unsteered run walk the same RNG stream. What a seed cannot do is keep
+    the two comparable atom by atom -- `centre_random_augmentation` recentres
+    on the structure's centroid, so moving the two restrained atoms displaces
+    every other atom as well, and "only the restrained atoms moved" stops
+    being a meaningful assertion.
+    """
+    with patch.object(
+        diffusion_module,
+        "centre_random_augmentation",
+        new=lambda *, xl, atom_mask: xl,
+    ):
+        yield
+
+
+def _recording_step_state(sink: list) -> type:
+    """A StepState subclass that appends each instance the rollout builds."""
+
+    class _RecordingStepState(diffusion_module.StepState):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            sink.append(self)
+
+    return _RecordingStepState
+
+
+def _run(sampler: SampleDiffusion, batch: dict, batch_dim: int = 1) -> torch.Tensor:
+    with torch.no_grad():
+        return sampler(
+            batch=batch,
+            si_input=torch.zeros(batch_dim, 1, 1),
+            si_trunk=torch.zeros(batch_dim, 1, 1),
+            zij_trunk=torch.zeros(batch_dim, 1, 1, 1),
+            noise_schedule=_NOISE_SCHEDULE,
+            no_rollout_samples=2,
+        )
+
+
+def _separation(coords: torch.Tensor) -> torch.Tensor:
+    """Distance between the two restrained atoms, per sample."""
+    return torch.linalg.norm(coords[:, :, 0] - coords[:, :, 1], dim=-1)
+
+
+def test_disabled_steering_is_bit_identical():
+    """The property the whole design hangs on: a batch carrying no steering
+    features must produce byte-identical output and consume identical RNG.
+
+    Deliberately leaves augmentation in place -- this is the one test that
+    has to exercise the real path end to end.
+    """
+    torch.manual_seed(_SEED)
+    unmodified = _run(_sampler(), _base_batch())
+    rng_after_unmodified = torch.random.get_rng_state()
+
+    disabled_batch = _base_batch() | {STEERING_ENABLED_KEY: torch.tensor([False])}
+    torch.manual_seed(_SEED)
+    disabled = _run(_sampler(), disabled_batch)
+    rng_after_disabled = torch.random.get_rng_state()
+
+    torch.testing.assert_close(disabled, unmodified, rtol=0.0, atol=0.0)
+    assert torch.equal(rng_after_disabled, rng_after_unmodified)
+
+
+def test_enabled_steering_consumes_no_extra_randomness():
+    """Steering must not draw from the RNG stream: if it did, an enabled run
+    would desynchronize every subsequent draw rather than merely adding a
+    correction -- and every seeded comparison in this file would be comparing
+    two different noise trajectories."""
+    torch.manual_seed(_SEED)
+    _run(_sampler(), _base_batch())
+    rng_after_unsteered = torch.random.get_rng_state()
+
+    torch.manual_seed(_SEED)
+    _run(_sampler(), _base_batch() | _steering_features())
+    rng_after_steered = torch.random.get_rng_state()
+
+    assert torch.equal(rng_after_steered, rng_after_unsteered)
+
+
+def test_enabled_steering_changes_the_output(no_random_augmentation):
+    torch.manual_seed(_SEED)
+    unsteered = _run(_sampler(), _base_batch())
+
+    torch.manual_seed(_SEED)
+    steered = _run(_sampler(), _base_batch() | _steering_features())
+
+    assert not torch.allclose(steered, unsteered)
+    # Only the restrained atoms move; the rest of the structure is untouched.
+    torch.testing.assert_close(steered[:, :, 2:], unsteered[:, :, 2:])
+
+
+def test_steering_pulls_a_violated_restraint_together(no_random_augmentation):
+    """Guidance should shorten an over-long restrained distance."""
+    torch.manual_seed(_SEED)
+    unsteered = _run(_sampler(), _base_batch())
+    torch.manual_seed(_SEED)
+    steered = _run(_sampler(), _base_batch() | _steering_features())
+
+    # Precondition: the restraint (upper bound 1.0) is violated to begin
+    # with, so there is something for guidance to correct.
+    assert torch.all(_separation(unsteered) > 1.0)
+    assert torch.all(_separation(steered) < _separation(unsteered))
+
+
+def test_steering_hook_runs_every_denoising_step() -> None:
+    """One call per denoising step, with steering_t following Boltz's and
+    Protenix's `1 - step_index / num_steps` convention rather than an
+    off-by-one variant of it.
+
+    Written out for this schedule: two steps, so steering_t starts at 1.0
+    (`1 - 0/2`) and reaches 0.5 (`1 - 1/2`) on the last one. Note it never
+    reaches 0 -- the convention counts steps taken, not sigmas visited, which
+    is the off-by-one this pins down.
+    """
+    states: list = []
+    denoiser = _IdentityDenoiser()
+
+    with patch.object(diffusion_module, "StepState", new=_recording_step_state(states)):
+        _run(_sampler(denoiser), _base_batch() | _steering_features())
+
+    expected_steering_t = [
+        1.0 - step / _NUM_DENOISING_STEPS for step in range(_NUM_DENOISING_STEPS)
+    ]
+    assert denoiser.calls == _NUM_DENOISING_STEPS
+    assert expected_steering_t == [1.0, 0.5]  # guards the formula above
+    assert [state.steering_t for state in states] == expected_steering_t
+
+
+def test_steering_does_not_run_in_the_pocket_refinement_pass(
+    no_random_augmentation,
+) -> None:
+    """The refinement rollout is deliberately unsteered, so the hook fires
+    only for the primary pass's steps."""
+    states: list = []
+    batch = _base_batch() | _steering_features()
+    batch.update(
+        {
+            "pocket_sampling_enabled": torch.tensor([True]),
+            "pocket_sampling_ligand_atom_mask": torch.tensor([[0, 0, 1, 1]]),
+            "pocket_sampling_start_frac": torch.tensor([0.5]),
+            "pocket_sampling_ligand_jitter": torch.tensor([0.0]),
+        }
+    )
+    denoiser = _IdentityDenoiser()
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                diffusion_module, "StepState", new=_recording_step_state(states)
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                diffusion_module,
+                "_build_pocket_sampling_seeds",
+                new=lambda **_kwargs: torch.zeros(1, 2, _N_ATOMS, 3),
+            )
+        )
+        _run(_sampler(denoiser), batch)
+
+    # Three denoiser calls (2 primary + 1 refinement) but only the two
+    # primary steps are steered.
+    assert denoiser.calls == 3
+    assert [state.step_index for state in states] == [0, 1]
+
+
+def test_steering_runs_in_float32_under_a_bfloat16_rollout(
+    no_random_augmentation,
+) -> None:
+    """The `.float()` on the way into the engine is load-bearing.
+
+    Potentials accumulate `num_gd_steps` corrections and compare distances
+    against bounds; bf16's ~3 decimal digits would quantize both. The engine
+    therefore sees float32 no matter what precision the rollout runs at.
+    """
+    seen: list[torch.dtype] = []
+    original = ChemicalSteering.on_denoised
+
+    def _record(self, coords, state):
+        seen.append(coords.dtype)
+        return original(self, coords, state)
+
+    torch.manual_seed(_SEED)
+    with patch.object(ChemicalSteering, "on_denoised", new=_record):
+        _run(_sampler(), _base_batch(dtype=torch.bfloat16) | _steering_features())
+
+    assert seen == [torch.float32, torch.float32]
+
+
+def test_bfloat16_rollout_is_steered_without_changing_any_dtype(no_random_augmentation):
+    """Guidance is cast back to the denoised tensor's dtype, so a bf16 rollout
+    stays bf16 throughout: same denoiser input dtypes, same output dtype,
+    different coordinates."""
+    unsteered_denoiser = _IdentityDenoiser()
+    torch.manual_seed(_SEED)
+    unsteered = _run(_sampler(unsteered_denoiser), _base_batch(dtype=torch.bfloat16))
+
+    steered_denoiser = _IdentityDenoiser()
+    torch.manual_seed(_SEED)
+    steered = _run(
+        _sampler(steered_denoiser),
+        _base_batch(dtype=torch.bfloat16) | _steering_features(),
+    )
+
+    assert steered.dtype == unsteered.dtype == torch.bfloat16
+    assert steered_denoiser.input_dtypes == unsteered_denoiser.input_dtypes
+    assert not torch.allclose(steered.float(), unsteered.float())
+    assert torch.all(_separation(steered) < _separation(unsteered))
+
+
+def test_malformed_steering_features_raise_before_the_denoiser_runs():
+    denoiser = _IdentityDenoiser()
+    batch = _base_batch() | _steering_features()
+    del batch[term_key(_TERM, "lower")]
+
+    with pytest.raises(ValueError, match="lower.* is missing"):
+        _run(_sampler(denoiser), batch)
+
+    assert denoiser.calls == 0
+
+
+def test_steering_rejects_multi_query_batches():
+    batch = _base_batch(batch_dim=2) | _steering_features()
+    with pytest.raises(ValueError, match="one query per model batch"):
+        _run(_sampler(), batch, batch_dim=2)
+
+
+def test_an_unsteered_multi_query_batch_never_reaches_the_steering_guard():
+    """The batch-size restriction belongs to steering, not to the sampler.
+
+    `prepare_steering` returns early for a batch with no steering features,
+    before its batch_dim check -- so an ordinary multi-query rollout is
+    unaffected. That early return is load-bearing and this pins it.
+    """
+    denoiser = _IdentityDenoiser()
+
+    _run(_sampler(denoiser), _base_batch(batch_dim=2), batch_dim=2)
+
+    assert denoiser.calls == 2
+
+
+def test_use_steering_without_a_prepared_object_is_rejected():
+    """The two rollout arguments must agree: `use_steering=True` with nothing
+    prepared would otherwise run an unsteered rollout under a name that says
+    the opposite."""
+    with pytest.raises(ValueError, match="requires a prepared steering object"):
+        _sampler()._sample_rollout(
+            batch=_base_batch(),
+            xl=torch.zeros(1, 2, _N_ATOMS, 3),
+            atom_mask=torch.ones(1, _N_ATOMS),
+            si_input=torch.zeros(1, 1, 1),
+            si_trunk=torch.zeros(1, 1, 1),
+            zij_trunk=torch.zeros(1, 1, 1, 1),
+            noise_schedule=torch.tensor([1.0, 0.5]),
+            start_step=0,
+            use_conditioning=True,
+            use_steering=True,
+            steering=None,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ log_cli = true
 log_cli_level = "WARNING"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
-testpaths = ["openfold3/tests"]
+testpaths = ["openfold3/tests", "openfold3/steering/tests"]
 python_files = ["test_*.py"]
 markers = [
     "inference_verification: Tests to verify installation on inference example",


### PR DESCRIPTION
**Summary**

This PR adds stereochemistry steering to OpenFold3. In this PR the foundation is laid for adding more potentials, and also more test cases, in particular by introducing  a new top level `steering` directory. 

**Provenance**
The work here is based on @peter-s-obi #385  and @etowahadams [Foldsteer repo](https://github.com/etowahadams/foldsteer). Both of these works in turn borrowed formulations and code from Boltz and Protenix

**Changes**

- Type classes to represent Potentials and Schedules
- Functions to create features which represent bounds defined by the ligand stereochemistry
- DistanceBoundsPotential as a first example potential
- Hooks to call steering in the data pipeline (in the `InferenceDataset`) and in the diffusion module
- Steering configurations settings: `SteeringSettings`
- Documentation to include steering descriptors 
- THIRD_PARTY_NOTICES.md to record provenances in the `openfold3/steering` directory 

**Testing**

- Unit tests for all new steering pieces
- An integration test with PDB:1FKB which contains rapamycin and explicitly tests for saturated six-ring torsion (h/t [Tom Goddard's BadChem](https://www.rbvi.ucsf.edu/chimerax/data/ligchem-feb2026/badchem.html)) 
- Full unit tests / integration tests (running)
- mypy linting

**Other Notes**

The individual commits are organized by themes. It might be easiest to review this PR commit by commit.