### PR TITLE
In CI / CD tests: Fix OPENFOLD_CACHE env variable leakage between tests

### DIFF
--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -1011,6 +1011,29 @@ class TestSetupOpenFold:
         with patch.dict(os.environ, {}, clear=False):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _stub_ccd_freshness_check(self):
+        """Keep these tests off the network and away from the installed CCD.
+
+        ``setup_openfold.main`` calls ``setup_biotite_ccd`` with
+        ``biotite.setup_ccd.OUTPUT_CCD``, resolved at import time -- so it is the
+        real ~63 MB file in the environment, not anything under tmp_path, whatever
+        HOME is patched to. Its staleness check does an unmocked ``head_object``
+        against s3://openfold3-data, which makes these tests depend on that bucket
+        being reachable and slow on a poor connection.
+
+        Worse, ``download_s3_file`` is mocked here with a stub that only touches
+        the path: were the check ever to report the CCD stale, the "download"
+        would truncate the installed file to zero bytes and break every later test
+        that needs it.
+
+        Reporting the CCD as current skips the download entirely. No test in this
+        class asserts on CCD behaviour; ``test_setup_openfold.py`` covers it
+        directly against a tmp_path copy.
+        """
+        with patch("openfold3.setup_openfold.s3_file_matches_local", return_value=True):
+            yield
+
     def test_non_interactive(self, tmp_path):
         env_patch = patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=False)
         s3_patch = patch(

--- a/openfold3/tests/test_entry_points.py
+++ b/openfold3/tests/test_entry_points.py
@@ -995,6 +995,22 @@ class TestUserDefaultRunnerYaml:
 
 
 class TestSetupOpenFold:
+    @pytest.fixture(autouse=True)
+    def _isolate_environment(self):
+        """Restore os.environ after each test in this class.
+
+        ``setup_openfold.main`` sets ``OPENFOLD_CACHE`` on the process so the rest
+        of the run resolves parameters from the chosen cache. That is fine for a
+        CLI, but in a test session it outlives the test: later tests then resolve
+        ``get_default_checkpoint_dir()`` to this test's tmp_path, find the dummy
+        checkpoint seeded there, and fail in ``torch.load`` with
+        "pickle data was truncated" rather than skipping. Under ``pytest -n auto``
+        only the worker that happened to run this class is affected, which made it
+        look intermittent and environment-specific.
+        """
+        with patch.dict(os.environ, {}, clear=False):
+            yield
+
     def test_non_interactive(self, tmp_path):
         env_patch = patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=False)
         s3_patch = patch(

--- a/openfold3/tests/test_model_checkpoint.py
+++ b/openfold3/tests/test_model_checkpoint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import textwrap
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -48,6 +49,15 @@ def default_ckpt_path():
     )
     if not default_ckpt_path.exists():
         pytest.skip("Default checkpoint not found; skipping test.")
+    # Existence is not enough: another test can leave OPENFOLD_CACHE pointing at a
+    # directory holding a placeholder of the same name. Real checkpoints are zip
+    # archives, so anything else is not one -- skip rather than failing later in
+    # torch.load with an unrelated-looking unpickling error.
+    if not zipfile.is_zipfile(default_ckpt_path):
+        pytest.skip(
+            f"{default_ckpt_path} is not a checkpoint archive "
+            f"({default_ckpt_path.stat().st_size} bytes); skipping test."
+        )
     return default_ckpt_path
 
 


### PR DESCRIPTION
**Summary**
A leakage of os.environ("OPENFOLD_CACHE") was being set to a dummy file by some tests. This caused downstream tests that read the Openfold3 parameters from the OPENFOLD_CACHE directory to fail with an unrelated `_pickle.UnpicklingError: pickle data was truncated`. error, e.g. https://github.com/aqlaboratory/openfold-3/actions/runs/34333869915/job/102409722611

This error only triggers upon certain orders of execution of the tests, which is randomized upon running `pytest -n auto`

**Changes**
- Properly isolate the environment variables so that they do not leak into other tests.
- Also isolate the CCD check to ensure that a stale CCD file does not get replaced with a dummy empty CCD file.

**Testing**
Reproduced before the fix by running `test_existing_parameter_installation` followed by `test_model_checkpoint.py` in one process. 
Before the fix: 5 failed, 2 passed
After the fix: 7 passed

