### PR TITLE
Inference memory: fused input relpos and pair SwiGLU

### DIFF
--- a/docs/source/configuration_reference.md
+++ b/docs/source/configuration_reference.md
@@ -188,6 +188,7 @@ Controls template structure processing.
   - `min_bin` *(float)*: Minimum distance bin (default: `3.25`)
   - `max_bin` *(float)*: Maximum distance bin (default: `50.75`)
   - `n_bins` *(int)*: Number of bins (default: `39`)
+- `use_coordinate_pair_features` *(bool)*: Build template pair features online from compact O(N) coordinates instead of materializing N² distogram / unit-vector tensors (default: `false`). Supported for both inference and training. Requires the default distogram bins (`3.25` / `50.75` / `39`). See {doc}`kernels` for the Triton projection path and `OPENFOLD3_FUSED_TEMPLATE_COORD`.
 
 **Example**:
 ```yaml
@@ -195,7 +196,10 @@ dataset_config_kwargs:
   template:
     n_templates: 4
     take_top_k: true
+    use_coordinate_pair_features: true
 ```
+
+For training, set the same flag under each dataset’s `config.template` block in `dataset_configs`.
 
 ---
 

--- a/docs/source/debugging_how_to.md
+++ b/docs/source/debugging_how_to.md
@@ -23,6 +23,7 @@ Put this snippet at the very top of your launch script
 
 ```python
 import debugpy
+
 debugpy.listen(("0.0.0.0", 5678))
 print("Waiting for debugger to attach...")
 debugpy.wait_for_client()

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -198,6 +198,7 @@ We provide several example runner files in our [examples directory](https://gith
 - Customizing output formats
 - Enabling cuEquivariance kernels
 - Enabling AMD ROCm Triton kernels
+- Enabling online template coordinate pair features (`template.use_coordinate_pair_features`)
 - Saving MSA and Template processing outputs
 - And more
 

--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -61,3 +61,49 @@ OPENFOLD3_FUSED_TEMPLATE_COORD=0
 ```
 
 TF32 for the Triton backward GEMM follows `torch.backends.cuda.matmul.allow_tf32`. Distogram settings must remain the defaults (`min_bin=3.25`, `max_bin=50.75`, `n_bins=39`).
+
+# Fused input relative-position embedding
+
+The input embedder can add relative-position pair features from compact index tables instead of materializing an N² one-hot `relpos_complex` tensor and running `linear_relpos` over it. When `linear_relpos` is bias-free (the default all-atom preset), OpenFold3 uses this weight-table path automatically for both inference and training.
+
+Under inference / no-grad, the gather-add may update the pair tensor in place, and bias-free token-bonds are folded in with `addmm_` so a pair-sized linear output is not allocated. Under training, an autograd wrapper keeps a length-generic Triton split-K weight backward (deterministic per-split accumulate, fp32 reduction) and falls back to a differentiable eager gather-add when Triton is ineligible (for example CPU or non-contiguous inputs).
+
+## Triton kernel
+
+On CUDA with contiguous pair / weight tensors and activation dtype `float32` or `bfloat16`, the fused gather-add uses a length-generic Triton kernel (sequence length is only the launch grid, so one compile serves all N). Sequence-length specialization is intentionally avoided.
+
+IEEE fp32 and TF32 share the same gather-add: there is no `tl.dot`, so `torch.backends.cuda.matmul.allow_tf32` does not change the math. bf16-mixed keeps fp32 Parameter masters; weight tiles are upcast on load, the add and `dW` accumulate in fp32, and pair activations stay bf16. Matching bf16 weights remain eligible. The eager fallback downcasts the table when the pair and weight dtypes do not match.
+
+```bash
+# Default: use Triton when eligible
+OPENFOLD3_FUSED_RELPOS=1
+
+# Force the eager weight-table path
+OPENFOLD3_FUSED_RELPOS=0
+```
+
+If `linear_relpos` has a bias, the classic `relpos_complex` + `Linear` path is retained.
+
+# Fused pair SwiGLU transition
+
+Pair `SwiGLUTransition` (LN → SwiGLU → Linear, optional mask and residual) can run as one length-generic Triton kernel instead of the module primitives. The dispatcher is `SwiGLUTransition`; ineligible shapes keep the eager path.
+
+Under inference / no-grad, the kernel may write `residual + transition(x)` in place when `residual` is `x`. Under training, an autograd wrapper saves `x_hat` / `mean` / `rstd` and rematerializes the SwiGLU hidden activations; `dW` uses exclusive split-M tiles (deterministic, no atomics) and accumulates in fp32.
+
+## Triton kernel
+
+On CUDA with a contiguous activation, `float32` or `bfloat16` activations, fp32 Parameter masters, `c_in ≤ 256`, hidden width `≤ 512`, and at least 4096 rows, the fused path uses one `GEMM_MODE` for every `tl.dot`:
+
+- `ieee` — fp32 activations and `torch.backends.cuda.matmul.allow_tf32` off
+- `tf32` — fp32 activations and `allow_tf32` on
+- `bf16` — bf16 activations with fp32 masters (tiles downcast for the GEMM, accumulate in fp32)
+
+bf16 weights are ineligible and fall back to `SwiGLUTransition`. Sequence length is not a specialize key.
+
+```bash
+# Default: use Triton when eligible
+OPENFOLD3_FUSED_SWIGLU_TRANSITION=1
+
+# Force the SwiGLUTransition primitives
+OPENFOLD3_FUSED_SWIGLU_TRANSITION=0
+```

--- a/docs/source/kernels.md
+++ b/docs/source/kernels.md
@@ -34,4 +34,30 @@ model_update:
           use_deepspeed_evo_attention: true  # set this to False to use cueq only
 ```
 
-This runner.yml is specifically for inference, but similar settings can be used for training. 
+This runner.yml is specifically for inference, but similar settings can be used for training.
+
+# Online template coordinate projection
+
+OpenFold3 can replace resident N² template distogram / unit-vector features with compact O(N) coordinates and project pair features online in the template embedder. Enable it from dataset template settings:
+
+```yaml
+# Inference (`dataset_config_kwargs`) or training (`dataset_configs.*.*.config`)
+template:
+  use_coordinate_pair_features: true
+```
+
+When the batch contains `template_pseudo_beta_coords` / `template_frame_atom_coords`, the model uses the coordinate embedder automatically and streams templates on GPU (no template offload).
+
+## Triton kernel
+
+On CUDA with eligible shapes (`B=1`, output channels `64`, activation dtype `float32` or `bfloat16`), projection uses a length-generic Triton kernel (N and strides are not specialized). Training uses an autograd wrapper with a Triton split-K backward; inference may update the pair tensor in place. Geometry inputs stay fp32; under bf16 autocast, pair activations remain bf16 while the kernel accumulates in fp32.
+
+```bash
+# Default: use Triton when eligible
+OPENFOLD3_FUSED_TEMPLATE_COORD=1
+
+# Force the chunked eager reference path
+OPENFOLD3_FUSED_TEMPLATE_COORD=0
+```
+
+TF32 for the Triton backward GEMM follows `torch.backends.cuda.matmul.allow_tf32`. Distogram settings must remain the defaults (`min_bin=3.25`, `max_bin=50.75`, `n_bins=39`).

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -75,6 +75,8 @@ dataset_configs:
         template:
           n_templates: 4
           take_top_k: false
+          # Optional: O(N) coords + online pair projection (see kernels.md)
+          # use_coordinate_pair_features: true
         crop:
           token_crop:
             enabled: true
@@ -96,6 +98,7 @@ dataset_configs:
         template:
           n_templates: 4
           take_top_k: true
+          # use_coordinate_pair_features: true
         crop:
           token_crop:
             enabled: false

--- a/openfold3/core/data/framework/single_datasets/base_of3.py
+++ b/openfold3/core/data/framework/single_datasets/base_of3.py
@@ -173,11 +173,6 @@ class BaseOF3Dataset(SingleDataset, ABC):
         self.crop = dataset_config.crop.model_dump()
         self.loss = dataset_config.loss.model_dump()
         self.template = dataset_config.template
-        if self.template.use_coordinate_pair_features:
-            raise NotImplementedError(
-                "Coordinate-derived template features are inference-only; "
-                "training support requires a differentiable projection path."
-            )
 
         # Misc
         self.single_moltype = None
@@ -311,6 +306,7 @@ class BaseOF3Dataset(SingleDataset, ABC):
             min_bin=self.template.distogram.min_bin,
             max_bin=self.template.distogram.max_bin,
             n_bins=self.template.distogram.n_bins,
+            use_coordinate_pair_features=self.template.use_coordinate_pair_features,
         )
 
         return template_features

--- a/openfold3/core/data/framework/single_datasets/base_of3.py
+++ b/openfold3/core/data/framework/single_datasets/base_of3.py
@@ -173,6 +173,11 @@ class BaseOF3Dataset(SingleDataset, ABC):
         self.crop = dataset_config.crop.model_dump()
         self.loss = dataset_config.loss.model_dump()
         self.template = dataset_config.template
+        if self.template.use_coordinate_pair_features:
+            raise NotImplementedError(
+                "Coordinate-derived template features are inference-only; "
+                "training support requires a differentiable projection path."
+            )
 
         # Misc
         self.single_moltype = None

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -294,6 +294,9 @@ class InferenceDataset(Dataset):
             min_bin=self.template_settings.distogram.min_bin,
             max_bin=self.template_settings.distogram.max_bin,
             n_bins=self.template_settings.distogram.n_bins,
+            use_coordinate_pair_features=(
+                self.template_settings.use_coordinate_pair_features
+            ),
         )
 
         return template_features

--- a/openfold3/core/data/framework/single_datasets/inference.py
+++ b/openfold3/core/data/framework/single_datasets/inference.py
@@ -18,8 +18,11 @@ Inference class template for first inference pipeline prototype.
 
 import itertools
 import logging
+import random
 import traceback
+from contextlib import contextmanager
 
+import numpy as np
 import pandas as pd
 import torch
 from biotite.structure import AtomArray
@@ -70,6 +73,22 @@ from openfold3.projects.of3_all_atom.config.inference_query_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _seeded_feature_creation(seed: int):
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
 
 
 @register_dataset
@@ -331,7 +350,8 @@ class InferenceDataset(Dataset):
         is_repeated_sample = bool(datapoint["repeated_sample"])
 
         try:
-            features = self.create_all_features(query)
+            with _seeded_feature_creation(int(seed)):
+                features = self.create_all_features(query)
             features["query_id"] = query_id
             features["seed"] = torch.tensor([seed])
             features["repeated_sample"] = torch.tensor(

--- a/openfold3/core/data/pipelines/featurization/template.py
+++ b/openfold3/core/data/pipelines/featurization/template.py
@@ -54,6 +54,7 @@ def featurize_template_structures_of3(
     min_bin: float,
     max_bin: float,
     n_bins: int,
+    use_coordinate_pair_features: bool = False,
 ) -> dict[str, torch.Tensor]:
     """Featurizes template data for AF3.
 
@@ -70,6 +71,9 @@ def featurize_template_structures_of3(
             Distogram constructed from pseudo beta atoms distances.
         - template_unit_vector:
             Unit vector constructed from backbone frames.
+        - template_pseudo_beta_coords / template_frame_atom_coords:
+            Compact alternative to the two pair features when
+            ``use_coordinate_pair_features`` is enabled.
 
     Args:
         template_slice_collection (TemplateSliceCollection):
@@ -84,6 +88,8 @@ def featurize_template_structures_of3(
             The maximum distance for the distogram bins.
         n_bins (int):
             The number of bins in the distogram.
+        use_coordinate_pair_features (bool):
+            Return compact coordinates instead of materialized pair features.
 
     Returns:
         dict[str, torch.Tensor]:
@@ -95,19 +101,6 @@ def featurize_template_structures_of3(
         n_tokens,
     )
 
-    # Create asym ID to mask inter-chain features and mask
-    token_starts_with_stop, _ = extract_starts_entities(atom_array)
-    token_starts = token_starts_with_stop[:-1]
-    chain_ids_token = atom_array.chain_id[token_starts]
-    _, renum_ids = np.unique(chain_ids_token, return_inverse=True)
-    asym_id = pad_token_dim(
-        {"asym_id": torch.tensor(renum_ids + 1, dtype=torch.int32)}, n_tokens
-    )["asym_id"]
-    multichain_pair_mask = (asym_id[..., None] == asym_id[..., None, :])[
-        ..., None, :, :, None
-    ]
-
-    # Create features
     features = {}
     features["template_pseudo_beta_mask"] = torch.tensor(
         ~np.isnan(template_feature_precursor.pseudo_beta_atom_coords).any(axis=-1),
@@ -121,6 +114,33 @@ def featurize_template_structures_of3(
         template_feature_precursor.res_names,
         features["template_pseudo_beta_mask"],
     )
+    if use_coordinate_pair_features:
+        features["template_pseudo_beta_coords"] = torch.nan_to_num(
+            torch.as_tensor(
+                template_feature_precursor.pseudo_beta_atom_coords,
+                dtype=torch.float32,
+            )
+        )
+        features["template_frame_atom_coords"] = torch.nan_to_num(
+            torch.as_tensor(
+                template_feature_precursor.frame_atom_coords,
+                dtype=torch.float32,
+            )
+        )
+        return features
+
+    # The legacy representation masks pair features during featurization.
+    token_starts_with_stop, _ = extract_starts_entities(atom_array)
+    token_starts = token_starts_with_stop[:-1]
+    chain_ids_token = atom_array.chain_id[token_starts]
+    _, renum_ids = np.unique(chain_ids_token, return_inverse=True)
+    asym_id = pad_token_dim(
+        {"asym_id": torch.tensor(renum_ids + 1, dtype=torch.int32)}, n_tokens
+    )["asym_id"]
+    multichain_pair_mask = (asym_id[..., None] == asym_id[..., None, :])[
+        ..., None, :, :, None
+    ]
+
     features["template_distogram"] = create_template_distogram(
         template_feature_precursor.pseudo_beta_atom_coords,
         features["template_pseudo_beta_mask"],

--- a/openfold3/core/data/primitives/quality_control/asserts.py
+++ b/openfold3/core/data/primitives/quality_control/asserts.py
@@ -222,7 +222,10 @@ def assert_gt_crop_slice(features):
 
 def assert_shape(features, token_budget, n_templates):
     """Asserts the shape of the features."""
+    _assert_template_feature_representation(features)
     for k, v in FULL_TOKEN_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == token_budget, (
                 f"Token shape mismatch for key '{k}'."
@@ -231,11 +234,15 @@ def assert_shape(features, token_budget, n_templates):
         for i in v:
             assert features[k].shape[i] <= 16384, f"MSA shape '{k}' larger than 16384."
     for k, v in FULL_TEMPLATE_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == n_templates, (
                 f"Template shape '{k}' shape mismatch."
             )
     for k, v in FULL_OTHER_DIM_INDEX_MAP.items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         for i in v:
             assert features[k].shape[i] == FULL_OTHER_DIM_SIZE_MAP[k][i], (
                 f"Other shape '{k}' shape mismatch."
@@ -244,7 +251,10 @@ def assert_shape(features, token_budget, n_templates):
 
 def assert_dtype(features):
     """Asserts the dtype of the features."""
+    _assert_template_feature_representation(features)
     for k, v in (FEATURE_CORE_DTYPES | FEATURE_OTHER_DTYPES).items():
+        if k in TEMPLATE_ALTERNATIVE_FEATURES and k not in features:
+            continue
         assert features[k].dtype == v, f"Cropped feature '{k}' dtype mismatch."
     for k, v in (FEATURE_CORE_DTYPES | FEATURE_GT_DTYPES).items():
         assert features["ground_truth"][k].dtype == v, (
@@ -254,6 +264,20 @@ def assert_dtype(features):
         assert features["loss_weights"][k].dtype == v, (
             f"Loss feature '{k}' dtype mismatch."
         )
+
+
+def _assert_template_feature_representation(features: dict) -> None:
+    legacy_count = sum(k in features for k in TEMPLATE_LEGACY_PAIR_FEATURES)
+    coordinate_count = sum(k in features for k in TEMPLATE_COORDINATE_FEATURES)
+    assert legacy_count in (0, len(TEMPLATE_LEGACY_PAIR_FEATURES)), (
+        "Template legacy pair features are incomplete."
+    )
+    assert coordinate_count in (0, len(TEMPLATE_COORDINATE_FEATURES)), (
+        "Template coordinate features are incomplete."
+    )
+    assert (legacy_count > 0) != (coordinate_count > 0), (
+        "Exactly one template pair-feature representation is required."
+    )
 
 
 def assert_resid_same_in_tokenid(features):
@@ -322,6 +346,18 @@ ENSEMBLED_ASSERTS = [
     assert_profile_sum,
 ]
 
+TEMPLATE_LEGACY_PAIR_FEATURES = (
+    "template_distogram",
+    "template_unit_vector",
+)
+TEMPLATE_COORDINATE_FEATURES = (
+    "template_pseudo_beta_coords",
+    "template_frame_atom_coords",
+)
+TEMPLATE_ALTERNATIVE_FEATURES = frozenset(
+    TEMPLATE_LEGACY_PAIR_FEATURES + TEMPLATE_COORDINATE_FEATURES
+)
+
 FULL_TOKEN_DIM_INDEX_MAP = {
     "residue_index": [-1],
     "token_index": [-1],
@@ -347,6 +383,8 @@ FULL_TOKEN_DIM_INDEX_MAP = {
     "template_backbone_frame_mask": [-1],
     "template_distogram": [-2, -3],
     "template_unit_vector": [-2, -3],
+    "template_pseudo_beta_coords": [-2],
+    "template_frame_atom_coords": [-3],
 }
 FULL_MSA_DIM_INDEX_MAP = {
     "msa": [-3],
@@ -359,6 +397,8 @@ FULL_TEMPLATE_DIM_INDEX_MAP = {
     "template_backbone_frame_mask": [-2],
     "template_distogram": [-4],
     "template_unit_vector": [-4],
+    "template_pseudo_beta_coords": [-3],
+    "template_frame_atom_coords": [-4],
 }
 FULL_OTHER_DIM_INDEX_MAP = {
     "restype": [-1],
@@ -369,6 +409,8 @@ FULL_OTHER_DIM_INDEX_MAP = {
     "template_restype": [-1],
     "template_distogram": [-1],
     "template_unit_vector": [-1],
+    "template_pseudo_beta_coords": [-1],
+    "template_frame_atom_coords": [-1, -2],
 }
 FULL_OTHER_DIM_SIZE_MAP = {
     "restype": [32],
@@ -379,6 +421,8 @@ FULL_OTHER_DIM_SIZE_MAP = {
     "template_restype": [32],
     "template_distogram": [39],
     "template_unit_vector": [3],
+    "template_pseudo_beta_coords": [3],
+    "template_frame_atom_coords": [3, 3],
 }
 
 FEATURE_CORE_DTYPES = {
@@ -419,6 +463,8 @@ FEATURE_OTHER_DTYPES = {
     "template_backbone_frame_mask": torch.float32,
     "template_distogram": torch.float32,
     "template_unit_vector": torch.float32,
+    "template_pseudo_beta_coords": torch.float32,
+    "template_frame_atom_coords": torch.float32,
     "msa_mask": torch.float32,
     "num_paired_seqs": torch.int32,
 }

--- a/openfold3/core/kernels/triton/fused_relpos_embed.py
+++ b/openfold3/core/kernels/triton/fused_relpos_embed.py
@@ -15,11 +15,10 @@
 # by Liang Hong <lhong22@cse.cuhk.edu.hk>: fused Triton gather-add for the
 # relative-position embedding tables used by the input embedder.
 
-"""Fused relpos gather-add for the input embedder (inference path).
+"""Fused relpos gather-add (forward + split-K weight backward).
 
-In-place / out-of-place forward and a thin input-embedder wrapper. Sequence
-length is only the launch grid, so one compile serves all N. Training falls
-back to a differentiable eager gather-add until a Triton backward lands.
+In-place forward, out-of-place forward for training, and a thin input-embedder
+wrapper. Sequence length is only the launch grid, so one compile serves all N.
 """
 
 from __future__ import annotations
@@ -27,6 +26,7 @@ from __future__ import annotations
 import os
 
 import torch
+from torch.autograd.function import once_differentiable
 
 try:
     import triton
@@ -37,6 +37,9 @@ except ImportError:  # pragma: no cover
     triton = None
     tl = None
     _TRITON_AVAILABLE = False
+
+# Exclusive pair chunks (no atomics). Fixed so compiles reuse across lengths.
+_BWD_SPLIT_K = 256
 
 
 def is_fused_relpos_embed_enabled() -> bool:
@@ -106,9 +109,73 @@ if _TRITON_AVAILABLE:
         ).to(tl.float32)
         tl.store(OUT_ptr + off, z_vals.to(OUT_ptr.dtype.element_ty), mask=mask)
 
+    @triton.jit(
+        do_not_specialize=["M"],
+        do_not_specialize_on_alignment=[
+            "GRAD_ptr",
+            "IDX1_ptr",
+            "IDX2_ptr",
+            "IDX3_ptr",
+            "SAME_ENTITY_ptr",
+            "PARTIAL_ptr",
+        ],
+    )
+    def _fused_relpos_weight_grad_kernel(
+        GRAD_ptr,
+        IDX1_ptr,
+        IDX2_ptr,
+        IDX3_ptr,
+        SAME_ENTITY_ptr,
+        PARTIAL_ptr,
+        M,
+        C: tl.constexpr,
+        VOCAB: tl.constexpr,
+        SAME_ENTITY_OFFSET: tl.constexpr,
+        SPLIT_K: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        """Deterministic per-split accumulate (no atomics).
+
+        One program owns ``partial[split]`` and walks its pairs in order.
+        Threads only parallelize the channel axis, so load/add/store is race-free.
+        """
+        split = tl.program_id(0)
+        pairs_per_split = (M + SPLIT_K - 1) // SPLIT_K
+        split_start = split * pairs_per_split
+        split_end = tl.minimum(split_start + pairs_per_split, M)
+
+        c = tl.arange(0, BLOCK_C)
+        c_mask = c < C
+        base = PARTIAL_ptr + split * VOCAB * C
+
+        for pair in range(split_start, split_end):
+            idx1 = tl.load(IDX1_ptr + pair)
+            idx2 = tl.load(IDX2_ptr + pair)
+            idx3 = tl.load(IDX3_ptr + pair)
+            same_ent = tl.load(SAME_ENTITY_ptr + pair).to(tl.float32)
+            g = tl.load(
+                GRAD_ptr + pair * C + c, mask=c_mask, other=0.0
+            ).to(tl.float32)
+
+            p1 = base + idx1 * C + c
+            tl.store(p1, tl.load(p1, mask=c_mask, other=0.0) + g, mask=c_mask)
+            p2 = base + idx2 * C + c
+            tl.store(p2, tl.load(p2, mask=c_mask, other=0.0) + g, mask=c_mask)
+            p3 = base + idx3 * C + c
+            tl.store(p3, tl.load(p3, mask=c_mask, other=0.0) + g, mask=c_mask)
+            pe = base + SAME_ENTITY_OFFSET * C + c
+            tl.store(
+                pe,
+                tl.load(pe, mask=c_mask, other=0.0) + g * same_ent,
+                mask=c_mask,
+            )
+
 else:  # pragma: no cover
 
     def _fused_relpos_embed_kernel(*_a, **_k):
+        raise RuntimeError("Triton is required for fused_relpos_embed")
+
+    def _fused_relpos_weight_grad_kernel(*_a, **_k):
         raise RuntimeError("Triton is required for fused_relpos_embed")
 
 
@@ -165,7 +232,7 @@ def fused_relpos_embed(
     same_entity: torch.Tensor,
     same_entity_offset: int,
 ) -> torch.Tensor:
-    """Out-of-place fused gather-add."""
+    """Out-of-place fused gather-add (for training)."""
     assert z.is_contiguous(), "z must be contiguous"
     out = torch.empty_like(z)
     return _launch_forward(
@@ -187,6 +254,87 @@ def eager_relpos_embed_add_(
     z.add_(w[rel_token_idx])
     z.add_(w[rel_chain_idx])
     z.add_(same_entity[..., None].to(dtype=z.dtype) * w[same_entity_offset])
+
+
+def eager_relpos_weight_grad(
+    grad_z: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+    vocab: int,
+) -> torch.Tensor:
+    """fp32 weight-table ``dW`` baseline (same math as gather-add forward)."""
+    C = grad_z.shape[-1]
+    g = grad_z.reshape(-1, C).float()
+    grad_w = torch.zeros(vocab, C, device=grad_z.device, dtype=torch.float32)
+    grad_w.index_add_(0, rel_pos_idx.reshape(-1), g)
+    grad_w.index_add_(0, rel_token_idx.reshape(-1), g)
+    grad_w.index_add_(0, rel_chain_idx.reshape(-1), g)
+    se = same_entity.reshape(-1).to(dtype=g.dtype)
+    grad_w[same_entity_offset] += (g * se[:, None]).sum(dim=0)
+    return grad_w
+
+
+def fused_relpos_weight_grad(
+    grad_z: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+    vocab: int,
+) -> torch.Tensor:
+    """Split-K Triton ``[vocab, C]`` weight gradient (fp32 accumulate)."""
+    grad_z = grad_z.contiguous()
+    C = grad_z.shape[-1]
+    M = grad_z.numel() // C
+    partial = torch.zeros(
+        _BWD_SPLIT_K, vocab, C, device=grad_z.device, dtype=torch.float32
+    )
+    _fused_relpos_weight_grad_kernel[(_BWD_SPLIT_K,)](
+        grad_z.view(-1, C),
+        rel_pos_idx.reshape(-1).contiguous(),
+        rel_token_idx.reshape(-1).contiguous(),
+        rel_chain_idx.reshape(-1).contiguous(),
+        same_entity.reshape(-1).contiguous(),
+        partial,
+        M,
+        C=C,
+        VOCAB=vocab,
+        SAME_ENTITY_OFFSET=same_entity_offset,
+        SPLIT_K=_BWD_SPLIT_K,
+        BLOCK_C=triton.next_power_of_2(C),
+    )
+    return partial.sum(dim=0)
+
+
+class _FusedRelposEmbedFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, z, weight, idx1, idx2, idx3, same_entity, offset):
+        w = weight.to(dtype=z.dtype).t().contiguous()
+        out = fused_relpos_embed(
+            z, w, idx1, idx2, idx3, same_entity, int(offset.item())
+        )
+        ctx.save_for_backward(idx1, idx2, idx3, same_entity)
+        ctx.offset = int(offset.item())
+        ctx.vocab = weight.shape[1]
+        ctx.weight_dtype = weight.dtype
+        return out
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_out):
+        idx1, idx2, idx3, same_entity = ctx.saved_tensors
+        grad_z = grad_out if ctx.needs_input_grad[0] else None
+        grad_weight = None
+        if ctx.needs_input_grad[1]:
+            grad_w = fused_relpos_weight_grad(
+                grad_out, idx1, idx2, idx3, same_entity, ctx.offset, ctx.vocab
+            )
+            grad_weight = grad_w.t().to(dtype=ctx.weight_dtype).contiguous()
+        return grad_z, grad_weight, None, None, None, None, None
 
 
 def _build_indices(batch, max_relative_idx, max_relative_chain):
@@ -226,7 +374,7 @@ def add_relpos_pair_embedding(
     max_relative_chain: int,
     inplace_safe: bool = False,
 ) -> torch.Tensor:
-    """Input-embedder wrapper: classic path, fused inference, or eager training."""
+    """Input-embedder wrapper: classic path, fused inference, or fused training."""
     if linear_relpos.bias is not None:
         from openfold3.core.utils.relpos import relpos_complex
         from openfold3.core.utils.tensor_utils import add
@@ -248,7 +396,17 @@ def add_relpos_pair_embedding(
     )
 
     if use_grad:
-        # Differentiable eager fallback until Triton weight backward lands.
+        if _can_use_triton(z, w):
+            return _FusedRelposEmbedFn.apply(
+                z,
+                weight,
+                idx1,
+                idx2,
+                idx3,
+                same_entity,
+                torch.tensor(offset, dtype=torch.int64),
+            )
+        # Eager differentiable fallback (e.g. CPU).
         wt = weight.to(dtype=z.dtype).t()
         return (
             z

--- a/openfold3/core/kernels/triton/fused_relpos_embed.py
+++ b/openfold3/core/kernels/triton/fused_relpos_embed.py
@@ -1,0 +1,272 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# by Liang Hong <lhong22@cse.cuhk.edu.hk>: fused Triton gather-add for the
+# relative-position embedding tables used by the input embedder.
+
+"""Fused relpos gather-add for the input embedder (inference path).
+
+In-place / out-of-place forward and a thin input-embedder wrapper. Sequence
+length is only the launch grid, so one compile serves all N. Training falls
+back to a differentiable eager gather-add until a Triton backward lands.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    _TRITON_AVAILABLE = False
+
+
+def is_fused_relpos_embed_enabled() -> bool:
+    if not _TRITON_AVAILABLE:
+        return False
+    return os.environ.get("OPENFOLD3_FUSED_RELPOS", "1").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _can_use_triton(z: torch.Tensor, w: torch.Tensor) -> bool:
+    return (
+        is_fused_relpos_embed_enabled()
+        and z.is_cuda
+        and w.is_cuda
+        and z.is_contiguous()
+        and w.is_contiguous()
+        and z.dtype in (torch.float32, torch.bfloat16)
+        and w.dtype == z.dtype
+        and z.shape[-1] == w.shape[-1]
+    )
+
+
+if _TRITON_AVAILABLE:
+
+    @triton.jit(
+        do_not_specialize_on_alignment=[
+            "Z_ptr",
+            "OUT_ptr",
+            "W_ptr",
+            "IDX1_ptr",
+            "IDX2_ptr",
+            "IDX3_ptr",
+            "SAME_ENTITY_ptr",
+        ],
+    )
+    def _fused_relpos_embed_kernel(
+        Z_ptr,
+        OUT_ptr,
+        W_ptr,
+        IDX1_ptr,
+        IDX2_ptr,
+        IDX3_ptr,
+        SAME_ENTITY_ptr,
+        C: tl.constexpr,
+        SAME_ENTITY_OFFSET: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        ij = tl.program_id(0).to(tl.int64)
+        idx1 = tl.load(IDX1_ptr + ij)
+        idx2 = tl.load(IDX2_ptr + ij)
+        idx3 = tl.load(IDX3_ptr + ij)
+        same_ent = tl.load(SAME_ENTITY_ptr + ij).to(tl.float32)
+
+        c = tl.arange(0, BLOCK_C)
+        mask = c < C
+        off = ij * C + c
+        z_vals = tl.load(Z_ptr + off, mask=mask).to(tl.float32)
+        z_vals += tl.load(W_ptr + idx1 * C + c, mask=mask).to(tl.float32)
+        z_vals += tl.load(W_ptr + idx2 * C + c, mask=mask).to(tl.float32)
+        z_vals += tl.load(W_ptr + idx3 * C + c, mask=mask).to(tl.float32)
+        z_vals += same_ent * tl.load(
+            W_ptr + SAME_ENTITY_OFFSET * C + c, mask=mask
+        ).to(tl.float32)
+        tl.store(OUT_ptr + off, z_vals.to(OUT_ptr.dtype.element_ty), mask=mask)
+
+else:  # pragma: no cover
+
+    def _fused_relpos_embed_kernel(*_a, **_k):
+        raise RuntimeError("Triton is required for fused_relpos_embed")
+
+
+def _launch_forward(
+    z: torch.Tensor,
+    w: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    C = z.shape[-1]
+    M = z.numel() // C
+    _fused_relpos_embed_kernel[(M,)](
+        z.view(-1, C),
+        out.view(-1, C),
+        w,
+        rel_pos_idx.reshape(-1),
+        rel_token_idx.reshape(-1),
+        rel_chain_idx.reshape(-1),
+        same_entity.reshape(-1),
+        C=C,
+        SAME_ENTITY_OFFSET=same_entity_offset,
+        BLOCK_C=triton.next_power_of_2(C),
+    )
+    return out
+
+
+def fused_relpos_embed_add_(
+    z: torch.Tensor,
+    w: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+) -> None:
+    """In-place fused gather-add into ``z``."""
+    assert z.is_contiguous(), "z must be contiguous"
+    _launch_forward(
+        z, w, rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity,
+        same_entity_offset, out=z,
+    )
+
+
+def fused_relpos_embed(
+    z: torch.Tensor,
+    w: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+) -> torch.Tensor:
+    """Out-of-place fused gather-add."""
+    assert z.is_contiguous(), "z must be contiguous"
+    out = torch.empty_like(z)
+    return _launch_forward(
+        z, w, rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity,
+        same_entity_offset, out=out,
+    )
+
+
+def eager_relpos_embed_add_(
+    z: torch.Tensor,
+    w: torch.Tensor,
+    rel_pos_idx: torch.Tensor,
+    rel_token_idx: torch.Tensor,
+    rel_chain_idx: torch.Tensor,
+    same_entity: torch.Tensor,
+    same_entity_offset: int,
+) -> None:
+    z.add_(w[rel_pos_idx])
+    z.add_(w[rel_token_idx])
+    z.add_(w[rel_chain_idx])
+    z.add_(same_entity[..., None].to(dtype=z.dtype) * w[same_entity_offset])
+
+
+def _build_indices(batch, max_relative_idx, max_relative_chain):
+    res_idx = batch["residue_index"]
+    asym_id = batch["asym_id"]
+    entity_id = batch["entity_id"]
+    same_chain = asym_id[..., None] == asym_id[..., None, :]
+    same_res = res_idx[..., None] == res_idx[..., None, :]
+    same_entity = entity_id[..., None] == entity_id[..., None, :]
+
+    def relpos_idx(pos, condition, clip):
+        offset = pos[..., None] - pos[..., None, :]
+        clipped = torch.clamp(offset + clip, min=0, max=2 * clip)
+        return torch.where(
+            condition,
+            clipped,
+            (2 * clip + 1) * torch.ones_like(clipped),
+        ).long()
+
+    rel_pos_bins = 2 * max_relative_idx + 2
+    same_entity_offset = 2 * rel_pos_bins
+    rel_pos_idx = relpos_idx(res_idx, same_chain, max_relative_idx)
+    rel_token_idx = relpos_idx(
+        batch["token_index"], same_chain & same_res, max_relative_idx
+    ) + rel_pos_bins
+    rel_chain_idx = relpos_idx(
+        batch["sym_id"], same_entity, max_relative_chain
+    ) + (same_entity_offset + 1)
+    return rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity, same_entity_offset
+
+
+def add_relpos_pair_embedding(
+    z: torch.Tensor,
+    linear_relpos: torch.nn.Linear,
+    batch: dict,
+    max_relative_idx: int,
+    max_relative_chain: int,
+    inplace_safe: bool = False,
+) -> torch.Tensor:
+    """Input-embedder wrapper: classic path, fused inference, or eager training."""
+    if linear_relpos.bias is not None:
+        from openfold3.core.utils.relpos import relpos_complex
+        from openfold3.core.utils.tensor_utils import add
+
+        feats = relpos_complex(
+            batch=batch,
+            max_relative_idx=max_relative_idx,
+            max_relative_chain=max_relative_chain,
+        ).to(dtype=z.dtype)
+        return add(z, linear_relpos(feats), inplace=inplace_safe)
+
+    idx1, idx2, idx3, same_entity, offset = _build_indices(
+        batch, max_relative_idx, max_relative_chain
+    )
+    weight = linear_relpos.weight
+    w = weight.to(dtype=z.dtype).t().contiguous()
+    use_grad = torch.is_grad_enabled() and (
+        z.requires_grad or weight.requires_grad
+    )
+
+    if use_grad:
+        # Differentiable eager fallback until Triton weight backward lands.
+        wt = weight.to(dtype=z.dtype).t()
+        return (
+            z
+            + wt[idx1]
+            + wt[idx2]
+            + wt[idx3]
+            + same_entity[..., None].to(dtype=z.dtype) * wt[offset]
+        )
+
+    if _can_use_triton(z, w):
+        if inplace_safe:
+            fused_relpos_embed_add_(z, w, idx1, idx2, idx3, same_entity, offset)
+            return z
+        return fused_relpos_embed(z, w, idx1, idx2, idx3, same_entity, offset)
+
+    if inplace_safe:
+        eager_relpos_embed_add_(z, w, idx1, idx2, idx3, same_entity, offset)
+        return z
+    out = z.clone()
+    eager_relpos_embed_add_(out, w, idx1, idx2, idx3, same_entity, offset)
+    return out

--- a/openfold3/core/kernels/triton/fused_relpos_embed.py
+++ b/openfold3/core/kernels/triton/fused_relpos_embed.py
@@ -19,6 +19,11 @@
 
 In-place forward, out-of-place forward for training, and a thin input-embedder
 wrapper. Sequence length is only the launch grid, so one compile serves all N.
+
+Precision: IEEE fp32 and TF32 use fp32 activations (gather-add has no
+``tl.dot``, so TF32 does not change the math). bf16-mixed uses bf16
+activations with fp32 Parameter masters; weight tiles are upcast on load
+and ``dW`` accumulates in fp32.
 """
 
 from __future__ import annotations
@@ -54,6 +59,7 @@ def is_fused_relpos_embed_enabled() -> bool:
 
 
 def _can_use_triton(z: torch.Tensor, w: torch.Tensor) -> bool:
+    # fp32 masters + bf16 activations (mixed), or matching fp32 / bf16.
     return (
         is_fused_relpos_embed_enabled()
         and z.is_cuda
@@ -61,7 +67,7 @@ def _can_use_triton(z: torch.Tensor, w: torch.Tensor) -> bool:
         and z.is_contiguous()
         and w.is_contiguous()
         and z.dtype in (torch.float32, torch.bfloat16)
-        and w.dtype == z.dtype
+        and w.dtype in (torch.float32, z.dtype)
         and z.shape[-1] == w.shape[-1]
     )
 
@@ -104,9 +110,9 @@ if _TRITON_AVAILABLE:
         z_vals += tl.load(W_ptr + idx1 * C + c, mask=mask).to(tl.float32)
         z_vals += tl.load(W_ptr + idx2 * C + c, mask=mask).to(tl.float32)
         z_vals += tl.load(W_ptr + idx3 * C + c, mask=mask).to(tl.float32)
-        z_vals += same_ent * tl.load(
-            W_ptr + SAME_ENTITY_OFFSET * C + c, mask=mask
-        ).to(tl.float32)
+        z_vals += same_ent * tl.load(W_ptr + SAME_ENTITY_OFFSET * C + c, mask=mask).to(
+            tl.float32
+        )
         tl.store(OUT_ptr + off, z_vals.to(OUT_ptr.dtype.element_ty), mask=mask)
 
     @triton.jit(
@@ -153,9 +159,7 @@ if _TRITON_AVAILABLE:
             idx2 = tl.load(IDX2_ptr + pair)
             idx3 = tl.load(IDX3_ptr + pair)
             same_ent = tl.load(SAME_ENTITY_ptr + pair).to(tl.float32)
-            g = tl.load(
-                GRAD_ptr + pair * C + c, mask=c_mask, other=0.0
-            ).to(tl.float32)
+            g = tl.load(GRAD_ptr + pair * C + c, mask=c_mask, other=0.0).to(tl.float32)
 
             p1 = base + idx1 * C + c
             tl.store(p1, tl.load(p1, mask=c_mask, other=0.0) + g, mask=c_mask)
@@ -218,8 +222,14 @@ def fused_relpos_embed_add_(
     """In-place fused gather-add into ``z``."""
     assert z.is_contiguous(), "z must be contiguous"
     _launch_forward(
-        z, w, rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity,
-        same_entity_offset, out=z,
+        z,
+        w,
+        rel_pos_idx,
+        rel_token_idx,
+        rel_chain_idx,
+        same_entity,
+        same_entity_offset,
+        out=z,
     )
 
 
@@ -236,8 +246,14 @@ def fused_relpos_embed(
     assert z.is_contiguous(), "z must be contiguous"
     out = torch.empty_like(z)
     return _launch_forward(
-        z, w, rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity,
-        same_entity_offset, out=out,
+        z,
+        w,
+        rel_pos_idx,
+        rel_token_idx,
+        rel_chain_idx,
+        same_entity,
+        same_entity_offset,
+        out=out,
     )
 
 
@@ -313,7 +329,7 @@ def fused_relpos_weight_grad(
 class _FusedRelposEmbedFn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, z, weight, idx1, idx2, idx3, same_entity, offset):
-        w = weight.to(dtype=z.dtype).t().contiguous()
+        w = weight.t().contiguous()
         out = fused_relpos_embed(
             z, w, idx1, idx2, idx3, same_entity, int(offset.item())
         )
@@ -357,12 +373,13 @@ def _build_indices(batch, max_relative_idx, max_relative_chain):
     rel_pos_bins = 2 * max_relative_idx + 2
     same_entity_offset = 2 * rel_pos_bins
     rel_pos_idx = relpos_idx(res_idx, same_chain, max_relative_idx)
-    rel_token_idx = relpos_idx(
-        batch["token_index"], same_chain & same_res, max_relative_idx
-    ) + rel_pos_bins
-    rel_chain_idx = relpos_idx(
-        batch["sym_id"], same_entity, max_relative_chain
-    ) + (same_entity_offset + 1)
+    rel_token_idx = (
+        relpos_idx(batch["token_index"], same_chain & same_res, max_relative_idx)
+        + rel_pos_bins
+    )
+    rel_chain_idx = relpos_idx(batch["sym_id"], same_entity, max_relative_chain) + (
+        same_entity_offset + 1
+    )
     return rel_pos_idx, rel_token_idx, rel_chain_idx, same_entity, same_entity_offset
 
 
@@ -390,10 +407,9 @@ def add_relpos_pair_embedding(
         batch, max_relative_idx, max_relative_chain
     )
     weight = linear_relpos.weight
-    w = weight.to(dtype=z.dtype).t().contiguous()
-    use_grad = torch.is_grad_enabled() and (
-        z.requires_grad or weight.requires_grad
-    )
+    z = z.contiguous()
+    w = weight.t().contiguous()
+    use_grad = torch.is_grad_enabled() and (z.requires_grad or weight.requires_grad)
 
     if use_grad:
         if _can_use_triton(z, w):
@@ -422,6 +438,9 @@ def add_relpos_pair_embedding(
             return z
         return fused_relpos_embed(z, w, idx1, idx2, idx3, same_entity, offset)
 
+    # Eager gather requires matching dtypes; mixed training downcasts here.
+    if w.dtype != z.dtype:
+        w = w.to(dtype=z.dtype)
     if inplace_safe:
         eager_relpos_embed_add_(z, w, idx1, idx2, idx3, same_entity, offset)
         return z

--- a/openfold3/core/kernels/triton/fused_swiglu_transition.py
+++ b/openfold3/core/kernels/triton/fused_swiglu_transition.py
@@ -22,23 +22,25 @@ Fuses
     x -> LayerNorm -> SwiGLU(SiLU(linear_a(x)) * linear_b(x)) -> linear_out
       -> * mask  [-> + residual]
 
-GEMMs honor ``torch.backends.cuda.matmul.allow_tf32`` for fp32 activations:
+One ``GEMM_MODE`` selects the ``tl.dot`` policy for launch, autotune, and
+the kernel:
 
-- TF32 on: ``input_precision="tf32"`` with round-nearest ``f32->tf32``
+- ``bf16``: bf16 activations, fp32 accumulate. Weight tiles are downcast
+  inside the GEMM only.
+- ``tf32``: fp32 activations with round-nearest ``f32->tf32``
   (``cvt.rna.tf32.f32``), matching cuBLAS TF32. Triton's default TF32
   *truncates*, which was the source of the extra ~2e-2 abs error.
-- TF32 off: ``input_precision="ieee"`` (true FP32).
+- ``ieee``: true FP32 when ``torch.backends.cuda.matmul.allow_tf32`` is off.
 
 Triton requires fp32 Parameter masters (same as fused template
-projection). Activations may be fp32 or bf16. bf16 activations use
-``tl.dot`` in bf16 with fp32 accumulate; weight tiles are downcast
-inside the GEMM only. Pure bf16 weights are ineligible.
+projection). Pure bf16 weights are ineligible.
 
 Inference (in-place) never materializes the ``[M, hidden]`` expansion.
-Training (out-of-place) writes ``x_hat``, ``a``, and ``b`` so backward can
-skip LayerNorm and the up-projections. Weight grads use exclusive split-M
-tiles (no atomics). Sequence length ``M`` is not an autotune / specialize
-key. Ineligible shapes use ``SwiGLUTransition`` primitives.
+Training (out-of-place) writes ``x_hat``, ``a``, ``b``, ``mean``, and
+``rstd`` so backward can skip LayerNorm and the up-projections. Weight
+grads use exclusive split-M tiles (no atomics). Sequence length ``M`` is
+not an autotune / specialize key. Ineligible shapes use
+``SwiGLUTransition`` primitives.
 """
 
 from __future__ import annotations
@@ -152,30 +154,26 @@ if _TRITON_AVAILABLE:
     def _dw_autotune_configs():
         # dW keeps three weight accumulators live; keep tiles inside SMEM.
         configs = []
-        for block_m, block_h, num_warps in (
-            (16, 32, 4),
-            (16, 64, 4),
-            (32, 32, 4),
-            (32, 64, 4),
-            (64, 32, 4),
-            (64, 32, 8),
+        for block_m, block_h, num_warps, num_stages in (
+            (16, 32, 4, 1),
+            (16, 64, 4, 2),
+            (32, 32, 4, 2),
+            (32, 64, 4, 2),
+            (64, 32, 4, 2),
+            (64, 32, 8, 2),
+            (64, 64, 8, 2),
         ):
             configs.append(
                 triton.Config(
                     {"BLOCK_M": block_m, "BLOCK_H": block_h},
                     num_warps=num_warps,
-                    num_stages=1,
+                    num_stages=num_stages,
                 )
             )
         return configs
 
     def _prune_by_precision(configs, named_args, **kwargs):
-        precision = kwargs.get("INPUT_PRECISION", named_args.get("INPUT_PRECISION"))
-        act = named_args.get("X_ptr")
-        if act is None:
-            act = named_args.get("A_ptr")
-        if act is None:
-            act = named_args.get("XHAT_ptr")
+        mode = kwargs.get("GEMM_MODE", named_args.get("GEMM_MODE"))
         H = kwargs.get("H", named_args.get("H"))
         kept = []
         for cfg in configs:
@@ -183,11 +181,7 @@ if _TRITON_AVAILABLE:
             block_h = cfg.kwargs["BLOCK_H"]
             if H is not None and block_h > int(H):
                 continue
-            if (
-                precision == "ieee"
-                and getattr(act, "dtype", None) != torch.bfloat16
-                and block_m >= 64
-            ):
+            if mode == "ieee" and block_m >= 64:
                 continue
             kept.append(cfg)
         return kept if kept else configs[:1]
@@ -204,26 +198,27 @@ if _TRITON_AVAILABLE:
         )
 
     @triton.jit
-    def _dot_f32(a, b, INPUT_PRECISION: tl.constexpr, ROUND_TF32: tl.constexpr, act_ptr):
-        # act_ptr is the activation allocation (X / a / x_hat). Its storage
-        # dtype is the input; tl.dot input_precision is only ieee/tf32.
-        if act_ptr.dtype.element_ty == tl.bfloat16:
+    def _dot_f32(a, b, GEMM_MODE: tl.constexpr):
+        if GEMM_MODE == "bf16":
             return tl.dot(
                 a.to(tl.bfloat16),
                 b.to(tl.bfloat16),
                 input_precision="ieee",
                 out_dtype=tl.float32,
             )
-        if ROUND_TF32:
+        a = a.to(tl.float32)
+        b = b.to(tl.float32)
+        if GEMM_MODE == "tf32":
             a = _round_to_tf32(a)
             b = _round_to_tf32(b)
-        return tl.dot(a, b, input_precision=INPUT_PRECISION, out_dtype=tl.float32)
+            return tl.dot(a, b, input_precision="tf32", out_dtype=tl.float32)
+        return tl.dot(a, b, input_precision="ieee", out_dtype=tl.float32)
 
     @triton.autotune(
         configs=_fwd_autotune_configs(),
-        key=["INPUT_PRECISION", "K", "H", "C_OUT", "SAVE_ACTS"],
+        key=["GEMM_MODE", "K", "H", "C_OUT"],
         prune_configs_by={"early_config_prune": _prune_by_precision},
-        restore_value=["Y_ptr", "A_ptr", "B_ptr"],
+        restore_value=["Y_ptr", "A_ptr", "B_ptr", "Mean_ptr", "Rstd_ptr"],
     )
     @triton.jit(
         do_not_specialize=[
@@ -256,8 +251,11 @@ if _TRITON_AVAILABLE:
             "Mask_ptr",
             "Res_ptr",
             "Y_ptr",
+            "XHAT_ptr",
             "A_ptr",
             "B_ptr",
+            "Mean_ptr",
+            "Rstd_ptr",
         ],
     )
     def _fused_swiglu_transition_fwd_kernel(
@@ -273,6 +271,8 @@ if _TRITON_AVAILABLE:
         XHAT_ptr,
         A_ptr,
         B_ptr,
+        Mean_ptr,
+        Rstd_ptr,
         stride_x_m,
         stride_x_k,
         stride_wa_h,
@@ -298,8 +298,7 @@ if _TRITON_AVAILABLE:
         HAS_MASK: tl.constexpr,
         HAS_RESIDUAL: tl.constexpr,
         SAVE_ACTS: tl.constexpr,
-        INPUT_PRECISION: tl.constexpr,
-        ROUND_TF32: tl.constexpr,
+        GEMM_MODE: tl.constexpr,
         BLOCK_M: tl.constexpr,
         BLOCK_H: tl.constexpr,
         BLOCK_K: tl.constexpr,
@@ -339,6 +338,8 @@ if _TRITON_AVAILABLE:
                 x_hat.to(XHAT_ptr.dtype.element_ty),
                 mask=m_mask[:, None] & k_mask[None, :],
             )
+            tl.store(Mean_ptr + offs_m, mean, mask=m_mask)
+            tl.store(Rstd_ptr + offs_m, rstd, mask=m_mask)
 
         acc_out = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
         for h0 in range(0, H, BLOCK_H):
@@ -351,7 +352,7 @@ if _TRITON_AVAILABLE:
             wa = tl.load(wa_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
                 tl.float32
             )
-            acc_a = _dot_f32(x_hat, tl.trans(wa), INPUT_PRECISION, ROUND_TF32, X_ptr)
+            acc_a = _dot_f32(x_hat, tl.trans(wa), GEMM_MODE)
 
             wb_ptrs = (
                 WB_ptr + offs_h[:, None] * stride_wb_h + offs_k[None, :] * stride_wb_k
@@ -359,7 +360,7 @@ if _TRITON_AVAILABLE:
             wb = tl.load(wb_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
                 tl.float32
             )
-            acc_b = _dot_f32(x_hat, tl.trans(wb), INPUT_PRECISION, ROUND_TF32, X_ptr)
+            acc_b = _dot_f32(x_hat, tl.trans(wb), GEMM_MODE)
 
             if SAVE_ACTS:
                 a_ptrs = A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :]
@@ -382,7 +383,7 @@ if _TRITON_AVAILABLE:
             wo = tl.load(wo_ptrs, mask=n_mask[:, None] & h_mask[None, :], other=0.0).to(
                 tl.float32
             )
-            acc_out += _dot_f32(silu, tl.trans(wo), INPUT_PRECISION, ROUND_TF32, X_ptr)
+            acc_out += _dot_f32(silu, tl.trans(wo), GEMM_MODE)
 
         if HAS_MASK:
             mask_val = tl.load(
@@ -410,7 +411,7 @@ if _TRITON_AVAILABLE:
 
     @triton.autotune(
         configs=_dx_autotune_configs(),
-        key=["INPUT_PRECISION", "K", "H", "C_OUT"],
+        key=["GEMM_MODE", "K", "H", "C_OUT"],
         prune_configs_by={"early_config_prune": _prune_by_precision},
         restore_value=["GX_ptr"],
     )
@@ -453,8 +454,7 @@ if _TRITON_AVAILABLE:
         H: tl.constexpr,
         C_OUT: tl.constexpr,
         HAS_MASK: tl.constexpr,
-        INPUT_PRECISION: tl.constexpr,
-        ROUND_TF32: tl.constexpr,
+        GEMM_MODE: tl.constexpr,
         BLOCK_M: tl.constexpr,
         BLOCK_H: tl.constexpr,
         BLOCK_K: tl.constexpr,
@@ -471,14 +471,12 @@ if _TRITON_AVAILABLE:
         n_mask = offs_n < C_OUT
 
         go_ptrs = GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :]
-        go = tl.load(go_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0).to(
-            tl.float32
-        )
+        go = tl.load(go_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0)
         if HAS_MASK:
             mask_val = tl.load(
                 Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
             ).to(tl.float32)
-            go = go * mask_val[:, None]
+            go = go.to(tl.float32) * mask_val[:, None]
 
         grad_x_hat = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
         for h0 in range(0, H, BLOCK_H):
@@ -498,25 +496,25 @@ if _TRITON_AVAILABLE:
                 WA_ptr + offs_h[:, None] * K + offs_k[None, :],
                 mask=h_mask[:, None] & k_mask[None, :],
                 other=0.0,
-            ).to(tl.float32)
+            )
             wb = tl.load(
                 WB_ptr + offs_h[:, None] * K + offs_k[None, :],
                 mask=h_mask[:, None] & k_mask[None, :],
                 other=0.0,
-            ).to(tl.float32)
+            )
             wo = tl.load(
                 WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
                 mask=n_mask[:, None] & h_mask[None, :],
                 other=0.0,
-            ).to(tl.float32)
+            )
 
-            grad_h = _dot_f32(go, wo, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            grad_h = _dot_f32(go, wo, GEMM_MODE)
             sig = tl.sigmoid(a)
             silu_a = a * sig
             grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
             grad_b = grad_h * silu_a
-            grad_x_hat += _dot_f32(grad_a, wa, INPUT_PRECISION, ROUND_TF32, A_ptr)
-            grad_x_hat += _dot_f32(grad_b, wb, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            grad_x_hat += _dot_f32(grad_a, wa, GEMM_MODE)
+            grad_x_hat += _dot_f32(grad_b, wb, GEMM_MODE)
 
         gx_ptrs = GX_ptr + offs_m_64[:, None] * stride_gx_m + offs_k[None, :]
         tl.store(
@@ -527,7 +525,7 @@ if _TRITON_AVAILABLE:
 
     @triton.autotune(
         configs=_dw_autotune_configs(),
-        key=["INPUT_PRECISION", "K", "H", "C_OUT"],
+        key=["GEMM_MODE", "K", "H", "C_OUT"],
         prune_configs_by={"early_config_prune": _prune_by_precision},
         restore_value=["PWA_ptr", "PWB_ptr", "PWO_ptr"],
     )
@@ -572,8 +570,7 @@ if _TRITON_AVAILABLE:
         H: tl.constexpr,
         C_OUT: tl.constexpr,
         HAS_MASK: tl.constexpr,
-        INPUT_PRECISION: tl.constexpr,
-        ROUND_TF32: tl.constexpr,
+        GEMM_MODE: tl.constexpr,
         SPLIT_M: tl.constexpr,
         BLOCK_M: tl.constexpr,
         BLOCK_H: tl.constexpr,
@@ -598,7 +595,7 @@ if _TRITON_AVAILABLE:
             WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
             mask=n_mask[:, None] & h_mask[None, :],
             other=0.0,
-        ).to(tl.float32)
+        )
 
         acc_dwa = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
         acc_dwb = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
@@ -609,21 +606,22 @@ if _TRITON_AVAILABLE:
             offs_m_64 = offs_m.to(tl.int64)
             m_mask = offs_m < split_end
 
+            # x_hat / go only feed MMA; keep storage dtype on the bf16 path.
             x_hat = tl.load(
                 XHAT_ptr + offs_m_64[:, None] * stride_xhat_m + offs_k[None, :],
                 mask=m_mask[:, None] & k_mask[None, :],
                 other=0.0,
-            ).to(tl.float32)
+            )
             go = tl.load(
                 GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :],
                 mask=m_mask[:, None] & n_mask[None, :],
                 other=0.0,
-            ).to(tl.float32)
+            )
             if HAS_MASK:
                 mask_val = tl.load(
                     Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
                 ).to(tl.float32)
-                go = go * mask_val[:, None]
+                go = go.to(tl.float32) * mask_val[:, None]
             a = tl.load(
                 A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :],
                 mask=m_mask[:, None] & h_mask[None, :],
@@ -638,12 +636,12 @@ if _TRITON_AVAILABLE:
             sig = tl.sigmoid(a)
             silu_a = a * sig
             h = silu_a * b
-            grad_h = _dot_f32(go, wo, INPUT_PRECISION, ROUND_TF32, A_ptr)
-            acc_dwo += _dot_f32(tl.trans(go), h, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            grad_h = _dot_f32(go, wo, GEMM_MODE)
+            acc_dwo += _dot_f32(tl.trans(go), h, GEMM_MODE)
             grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
             grad_b = grad_h * silu_a
-            acc_dwa += _dot_f32(tl.trans(grad_a), x_hat, INPUT_PRECISION, ROUND_TF32, A_ptr)
-            acc_dwb += _dot_f32(tl.trans(grad_b), x_hat, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            acc_dwa += _dot_f32(tl.trans(grad_a), x_hat, GEMM_MODE)
+            acc_dwb += _dot_f32(tl.trans(grad_b), x_hat, GEMM_MODE)
 
         pwa_ptrs = PWA_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
         pwb_ptrs = PWB_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
@@ -664,11 +662,13 @@ else:  # pragma: no cover
         raise RuntimeError("Triton is required for fused_swiglu_transition")
 
 
-def _matmul_precision_args(act: torch.Tensor) -> tuple[str, bool]:
-    """``tl.dot`` input_precision from the TF32 context. bf16 inputs ignore it."""
-    if act.dtype == torch.bfloat16 or not torch.backends.cuda.matmul.allow_tf32:
-        return "ieee", False
-    return "tf32", True
+def _gemm_mode(act: torch.Tensor) -> str:
+    """One GEMM policy for launch, autotune, and ``tl.dot``."""
+    if act.dtype == torch.bfloat16:
+        return "bf16"
+    if torch.backends.cuda.matmul.allow_tf32:
+        return "tf32"
+    return "ieee"
 
 
 def _next_power_of_two(n: int) -> int:
@@ -693,7 +693,7 @@ def _launch_fused_swiglu_transition(
 
     Inference (``save_acts=False``) may write in place when ``residual`` aliases
     ``x``. Training (``save_acts=True``) writes a fresh ``y`` plus ``x_hat``,
-    ``a``, ``b`` for the backward kernels.
+    ``a``, ``b``, ``mean``, and ``rstd`` for the backward kernels.
     """
     M, K = x_2d.shape
     H = w_a.shape[0]
@@ -708,12 +708,15 @@ def _launch_fused_swiglu_transition(
         x_hat = torch.empty((M, K), dtype=x_2d.dtype, device=x_2d.device)
         a = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
         b = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
+        mean = torch.empty((M,), dtype=torch.float32, device=x_2d.device)
+        rstd = torch.empty((M,), dtype=torch.float32, device=x_2d.device)
     else:
         x_hat = a = b = y
+        mean = rstd = y
 
     BLOCK_K = max(_next_power_of_two(K), 16)
     BLOCK_N = max(_next_power_of_two(C_OUT), 16)
-    input_precision, round_tf32 = _matmul_precision_args(x_2d)
+    gemm_mode = _gemm_mode(x_2d)
 
     beta_ptr = beta if beta is not None else x_2d
     mask_ptr = mask_1d if mask_1d is not None else x_2d
@@ -736,6 +739,8 @@ def _launch_fused_swiglu_transition(
         x_hat,
         a,
         b,
+        mean,
+        rstd,
         x_2d.stride(0),
         x_2d.stride(1),
         w_a.stride(0),
@@ -761,13 +766,12 @@ def _launch_fused_swiglu_transition(
         HAS_MASK=mask_1d is not None,
         HAS_RESIDUAL=residual_2d is not None,
         SAVE_ACTS=save_acts,
-        INPUT_PRECISION=input_precision,
-        ROUND_TF32=round_tf32,
+        GEMM_MODE=gemm_mode,
         BLOCK_K=BLOCK_K,
         BLOCK_N=BLOCK_N,
     )
     if save_acts:
-        return y, x_hat, a, b
+        return y, x_hat, a, b, mean, rstd
     return y
 
 
@@ -791,7 +795,7 @@ def fused_swiglu_transition_weight_grad(
     M, K = x_hat.shape
     H = a.shape[1]
     C_OUT = w_out.shape[0]
-    input_precision, round_tf32 = _matmul_precision_args(a)
+    gemm_mode = _gemm_mode(a)
     BLOCK_K = max(_next_power_of_two(K), 16)
     BLOCK_N = max(_next_power_of_two(C_OUT), 16)
 
@@ -806,13 +810,13 @@ def fused_swiglu_transition_weight_grad(
     grad_wa = grad_wb = grad_wo = None
     if compute_dw:
         x_hat_c = x_hat.contiguous()
-        partial_wa = torch.zeros(
+        partial_wa = torch.empty(
             _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
         )
-        partial_wb = torch.zeros(
+        partial_wb = torch.empty(
             _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
         )
-        partial_wo = torch.zeros(
+        partial_wo = torch.empty(
             _BWD_SPLIT_M, C_OUT, H, device=x_hat.device, dtype=torch.float32
         )
 
@@ -839,8 +843,7 @@ def fused_swiglu_transition_weight_grad(
             H,
             C_OUT,
             HAS_MASK=has_mask,
-            INPUT_PRECISION=input_precision,
-            ROUND_TF32=round_tf32,
+            GEMM_MODE=gemm_mode,
             SPLIT_M=_BWD_SPLIT_M,
             BLOCK_K=BLOCK_K,
             BLOCK_N=BLOCK_N,
@@ -848,11 +851,9 @@ def fused_swiglu_transition_weight_grad(
         grad_wa = partial_wa.sum(dim=0)
         grad_wb = partial_wb.sum(dim=0)
         grad_wo = partial_wo.sum(dim=0)
-        del partial_wa, partial_wb, partial_wo
 
     grad_x_hat = None
     if compute_dx:
-        # fp32 x_hat is dead after dW; reuse it for d(x_hat) instead of +1U.
         if x_hat.dtype == torch.float32:
             grad_x_hat = x_hat
         else:
@@ -882,8 +883,7 @@ def fused_swiglu_transition_weight_grad(
             H,
             C_OUT,
             HAS_MASK=has_mask,
-            INPUT_PRECISION=input_precision,
-            ROUND_TF32=round_tf32,
+            GEMM_MODE=gemm_mode,
             BLOCK_K=BLOCK_K,
             BLOCK_N=BLOCK_N,
         )
@@ -902,7 +902,7 @@ class _FusedSwiGLUTransitionFn(torch.autograd.Function):
         c_in = gamma.shape[0]
         x_2d = x.contiguous().view(-1, c_in)
         mask_1d = mask.reshape(-1).contiguous() if has_mask else None
-        y_2d, x_hat, a, b = _launch_fused_swiglu_transition(
+        y_2d, x_hat, a, b, mean, rstd = _launch_fused_swiglu_transition(
             x_2d,
             gamma,
             beta if has_beta else None,
@@ -916,8 +916,9 @@ class _FusedSwiGLUTransitionFn(torch.autograd.Function):
         )
         y = y_2d.view_as(x)
 
-        ctx.save_for_backward(x, x_hat, a, b, gamma, beta_t, w_a, w_b, w_out, mask_t)
-        ctx.eps = float(eps)
+        ctx.save_for_backward(
+            x, x_hat, a, b, mean, rstd, gamma, beta_t, w_a, w_b, w_out, mask_t
+        )
         ctx.has_beta = has_beta
         ctx.has_mask = has_mask
         ctx.x_shape = x.shape
@@ -926,10 +927,11 @@ class _FusedSwiGLUTransitionFn(torch.autograd.Function):
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_out):
-        x, x_hat, a, b, gamma, beta_t, w_a, w_b, w_out, mask_t = ctx.saved_tensors
+        x, x_hat, a, b, mean, rstd, gamma, beta_t, w_a, w_b, w_out, mask_t = (
+            ctx.saved_tensors
+        )
         beta = beta_t if ctx.has_beta else None
         mask = mask_t if ctx.has_mask else None
-        eps = ctx.eps
         c_in = gamma.shape[0]
 
         go_2d = grad_out.contiguous().view(-1, grad_out.shape[-1])
@@ -953,10 +955,7 @@ class _FusedSwiGLUTransitionFn(torch.autograd.Function):
         grad_x = grad_gamma = grad_beta = None
         if need_dx:
             x_2d = x.contiguous().view(-1, c_in)
-            x_f = x_2d.float()
-            mean = x_f.mean(dim=-1)
-            var = x_f.var(dim=-1, unbiased=False)
-            rstd = torch.rsqrt(var + eps)
+            x_f = x_2d.float() if x_2d.dtype != torch.float32 else x_2d
             ln_weight = gamma.float()
             ln_bias = beta.float() if beta is not None else None
             grad_input, grad_gamma, grad_beta = torch.ops.aten.native_layer_norm_backward(
@@ -1012,8 +1011,8 @@ def fused_swiglu_transition(
     Triton only. The model uses ``SwiGLUTransition`` primitives when this
     launch is ineligible. Inference may write in place when ``residual is
     x``. Training is always out-of-place and saves activations for the
-    Triton backward. Triton keeps fp32 masters; bf16 activations use bf16
-    GEMMs.
+    Triton backward. ``GEMM_MODE`` is ``bf16``, ``tf32``, or ``ieee``;
+    masters stay fp32.
     """
     if not is_fused_swiglu_transition_eligible(x, gamma, beta, w_a, w_b, w_out):
         raise RuntimeError(

--- a/openfold3/core/kernels/triton/fused_swiglu_transition.py
+++ b/openfold3/core/kernels/triton/fused_swiglu_transition.py
@@ -15,32 +15,12 @@
 # by Liang Hong <lhong22@cse.cuhk.edu.hk>: fused pair SwiGLU transition
 # (Triton) with training backward.
 
-"""Fused SwiGLU pair transition via a length-generic Triton kernel.
+"""Fused pair SwiGLU transition (Triton).
 
-Fuses
-
-    x -> LayerNorm -> SwiGLU(SiLU(linear_a(x)) * linear_b(x)) -> linear_out
-      -> * mask  [-> + residual]
-
-One ``GEMM_MODE`` selects the ``tl.dot`` policy for launch, autotune, and
-the kernel:
-
-- ``bf16``: bf16 activations, fp32 accumulate. Weight tiles are downcast
-  inside the GEMM only.
-- ``tf32``: fp32 activations with round-nearest ``f32->tf32``
-  (``cvt.rna.tf32.f32``), matching cuBLAS TF32. Triton's default TF32
-  *truncates*, which was the source of the extra ~2e-2 abs error.
-- ``ieee``: true FP32 when ``torch.backends.cuda.matmul.allow_tf32`` is off.
-
-Triton requires fp32 Parameter masters (same as fused template
-projection). Pure bf16 weights are ineligible.
-
-Inference (in-place) never materializes the ``[M, hidden]`` expansion.
-Training (out-of-place) writes ``x_hat``, ``a``, ``b``, ``mean``, and
-``rstd`` so backward can skip LayerNorm and the up-projections. Weight
-grads use exclusive split-M tiles (no atomics). Sequence length ``M`` is
-not an autotune / specialize key. Ineligible shapes use
-``SwiGLUTransition`` primitives.
+LN -> SwiGLU -> Linear -> (*mask) [+ residual]. ``M`` is not an autotune or
+specialize key. Training saves ``x_hat`` / ``mean`` / ``rstd`` and rematerializes
+``a`` / ``b``; ``dW`` uses exclusive split-M tiles. Ineligible shapes use
+``SwiGLUTransition``.
 """
 
 from __future__ import annotations
@@ -63,23 +43,15 @@ except ImportError:  # pragma: no cover
 # Pair transition (c_z=128, n=4 -> H=512) with headroom; wider sites fall back.
 _MAX_C_IN = 256
 _MAX_HIDDEN = 512
-# Below this row count, fused launch / tiling overhead is not worthwhile.
 _MIN_M = 4096
-# Exclusive row splits for deterministic Triton weight grads (no atomics).
 _BWD_SPLIT_M = 16
-
-
-def is_triton_available() -> bool:
-    return _TRITON_AVAILABLE
+_TRUE = {"1", "true", "yes", "on"}
 
 
 def is_fused_swiglu_transition_enabled() -> bool:
-    return os.environ.get("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    return os.environ.get("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1").strip().lower() in (
+        _TRUE
+    )
 
 
 def is_fused_swiglu_transition_eligible(
@@ -91,7 +63,6 @@ def is_fused_swiglu_transition_eligible(
     w_out: torch.Tensor,
 ) -> bool:
     c_in = gamma.shape[0]
-    hidden = w_a.shape[0]
     masters = (gamma, w_a, w_b, w_out) + ((beta,) if beta is not None else ())
     return (
         is_fused_swiglu_transition_enabled()
@@ -101,94 +72,67 @@ def is_fused_swiglu_transition_eligible(
         and x.dtype in (torch.float32, torch.bfloat16)
         and all(w.dtype == torch.float32 for w in masters)
         and c_in <= _MAX_C_IN
-        and hidden <= _MAX_HIDDEN
+        and w_a.shape[0] <= _MAX_HIDDEN
         and (x.numel() // c_in) >= _MIN_M
     )
 
 
 if _TRITON_AVAILABLE:
 
-    def _fwd_autotune_configs():
-        configs = []
-        for block_m, block_h, num_warps, num_stages in (
-            (16, 32, 4, 1),
-            (16, 32, 4, 2),
-            (16, 64, 4, 1),
-            (32, 32, 4, 1),
-            (32, 32, 4, 2),
-            (32, 64, 4, 1),
-            (64, 64, 4, 1),
-            (128, 64, 8, 1),
-            (128, 64, 8, 2),
-        ):
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
-                    num_warps=num_warps,
-                    num_stages=num_stages,
-                )
+    def _configs(tiles):
+        return [
+            triton.Config(
+                {"BLOCK_M": block_m, "BLOCK_H": block_h},
+                num_warps=num_warps,
+                num_stages=num_stages,
             )
-        return configs
+            for block_m, block_h, num_warps, num_stages in tiles
+        ]
 
-    def _dx_autotune_configs():
-        configs = []
-        for block_m, block_h, num_warps, num_stages in (
-            (16, 32, 4, 1),
-            (16, 32, 4, 2),
-            (16, 64, 4, 1),
-            (32, 32, 4, 1),
-            (32, 32, 4, 2),
-            (32, 64, 4, 1),
-            (64, 64, 4, 1),
-            (128, 64, 8, 1),
-        ):
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
-                    num_warps=num_warps,
-                    num_stages=num_stages,
-                )
-            )
-        return configs
-
-    def _dw_autotune_configs():
-        # dW keeps three weight accumulators live; keep tiles inside SMEM.
-        configs = []
-        for block_m, block_h, num_warps, num_stages in (
-            (16, 32, 4, 1),
-            (16, 64, 4, 2),
-            (32, 32, 4, 2),
-            (32, 64, 4, 2),
-            (64, 32, 4, 2),
-            (64, 32, 8, 2),
-            (64, 64, 8, 2),
-        ):
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
-                    num_warps=num_warps,
-                    num_stages=num_stages,
-                )
-            )
-        return configs
+    # Shared by forward / dX. dW keeps smaller tiles (3 live weight accums).
+    _GEMM_TILES = (
+        (16, 32, 4, 1),
+        (16, 32, 4, 2),
+        (16, 64, 4, 1),
+        (32, 32, 4, 1),
+        (32, 32, 4, 2),
+        (32, 64, 4, 1),
+        (64, 64, 4, 1),
+        (128, 64, 8, 1),
+    )
+    _DW_TILES = (
+        (16, 32, 4, 1),
+        (16, 32, 4, 2),
+        (32, 32, 4, 1),
+        (32, 32, 4, 2),
+    )
 
     def _prune_by_precision(configs, named_args, **kwargs):
         mode = kwargs.get("GEMM_MODE", named_args.get("GEMM_MODE"))
         H = kwargs.get("H", named_args.get("H"))
-        kept = []
-        for cfg in configs:
-            block_m = cfg.kwargs["BLOCK_M"]
-            block_h = cfg.kwargs["BLOCK_H"]
-            if H is not None and block_h > int(H):
-                continue
-            if mode == "ieee" and block_m >= 64:
-                continue
-            kept.append(cfg)
-        return kept if kept else configs[:1]
+        kept = [
+            cfg
+            for cfg in configs
+            if (H is None or cfg.kwargs["BLOCK_H"] <= int(H))
+            and not (mode == "ieee" and cfg.kwargs["BLOCK_M"] >= 64)
+        ]
+        return kept or configs[:1]
 
-    @triton.jit
-    def _silu_fp32(x):
-        return x * tl.sigmoid(x)
+    def _autotuned(tiles, key, restore, strides, ptrs):
+        def decorator(fn):
+            return triton.autotune(
+                configs=_configs(tiles),
+                key=key,
+                prune_configs_by={"early_config_prune": _prune_by_precision},
+                restore_value=restore,
+            )(
+                triton.jit(
+                    do_not_specialize=list(strides),
+                    do_not_specialize_on_alignment=list(ptrs),
+                )(fn)
+            )
+
+        return decorator
 
     @triton.jit
     def _round_to_tf32(x):
@@ -209,39 +153,66 @@ if _TRITON_AVAILABLE:
         a = a.to(tl.float32)
         b = b.to(tl.float32)
         if GEMM_MODE == "tf32":
-            a = _round_to_tf32(a)
-            b = _round_to_tf32(b)
-            return tl.dot(a, b, input_precision="tf32", out_dtype=tl.float32)
+            return tl.dot(
+                _round_to_tf32(a),
+                _round_to_tf32(b),
+                input_precision="tf32",
+                out_dtype=tl.float32,
+            )
         return tl.dot(a, b, input_precision="ieee", out_dtype=tl.float32)
 
-    @triton.autotune(
-        configs=_fwd_autotune_configs(),
-        key=["GEMM_MODE", "K", "H", "C_OUT"],
-        prune_configs_by={"early_config_prune": _prune_by_precision},
-        restore_value=["Y_ptr", "A_ptr", "B_ptr", "Mean_ptr", "Rstd_ptr"],
-    )
-    @triton.jit(
-        do_not_specialize=[
+    @triton.jit
+    def _load2d(ptr, offs_m, offs_n, stride_m, m_mask, n_mask):
+        return tl.load(
+            ptr + offs_m[:, None] * stride_m + offs_n[None, :],
+            mask=m_mask[:, None] & n_mask[None, :],
+            other=0.0,
+        )
+
+    @triton.jit
+    def _store2d(ptr, val, offs_m, offs_n, stride_m, m_mask, n_mask):
+        tl.store(
+            ptr + offs_m[:, None] * stride_m + offs_n[None, :],
+            val.to(ptr.dtype.element_ty),
+            mask=m_mask[:, None] & n_mask[None, :],
+        )
+
+    @triton.jit
+    def _load_w(ptr, offs_r, offs_c, row_stride, r_mask, c_mask):
+        return tl.load(
+            ptr + offs_r[:, None] * row_stride + offs_c[None, :],
+            mask=r_mask[:, None] & c_mask[None, :],
+            other=0.0,
+        )
+
+    @triton.jit
+    def _mask_rows(go, Mask_ptr, offs_m, stride_mask_m, m_mask, HAS_MASK: tl.constexpr):
+        if not HAS_MASK:
+            return go
+        mask_val = tl.load(Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0)
+        return go.to(tl.float32) * mask_val[:, None].to(tl.float32)
+
+    @triton.jit
+    def _swiglu_grads(a, b, grad_h):
+        sig = tl.sigmoid(a)
+        silu_a = a * sig
+        grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
+        return silu_a * b, grad_a, grad_h * silu_a
+
+    @_autotuned(
+        _GEMM_TILES + ((128, 64, 8, 2),),
+        ["GEMM_MODE", "K", "H", "C_OUT", "SAVE_ACTS"],
+        ["Y_ptr", "XHAT_ptr", "Mean_ptr", "Rstd_ptr"],
+        (
             "stride_x_m",
-            "stride_x_k",
-            "stride_wa_h",
-            "stride_wa_k",
-            "stride_wb_h",
-            "stride_wb_k",
-            "stride_wo_n",
-            "stride_wo_h",
             "stride_res_m",
-            "stride_res_n",
             "stride_y_m",
-            "stride_y_n",
             "stride_mask_m",
             "stride_xhat_m",
-            "stride_a_m",
-            "stride_b_m",
             "M",
             "eps",
-        ],
-        do_not_specialize_on_alignment=[
+        ),
+        (
             "X_ptr",
             "WA_ptr",
             "WB_ptr",
@@ -252,11 +223,9 @@ if _TRITON_AVAILABLE:
             "Res_ptr",
             "Y_ptr",
             "XHAT_ptr",
-            "A_ptr",
-            "B_ptr",
             "Mean_ptr",
             "Rstd_ptr",
-        ],
+        ),
     )
     def _fused_swiglu_transition_fwd_kernel(
         X_ptr,
@@ -269,26 +238,13 @@ if _TRITON_AVAILABLE:
         Res_ptr,
         Y_ptr,
         XHAT_ptr,
-        A_ptr,
-        B_ptr,
         Mean_ptr,
         Rstd_ptr,
         stride_x_m,
-        stride_x_k,
-        stride_wa_h,
-        stride_wa_k,
-        stride_wb_h,
-        stride_wb_k,
-        stride_wo_n,
-        stride_wo_h,
         stride_res_m,
-        stride_res_n,
         stride_y_m,
-        stride_y_n,
         stride_mask_m,
         stride_xhat_m,
-        stride_a_m,
-        stride_b_m,
         M,
         K: tl.constexpr,
         H: tl.constexpr,
@@ -304,40 +260,25 @@ if _TRITON_AVAILABLE:
         BLOCK_K: tl.constexpr,
         BLOCK_N: tl.constexpr,
     ):
-        pid_m = tl.program_id(0)
-        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_m_64 = offs_m.to(tl.int64)
+        offs_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m64 = offs_m.to(tl.int64)
         offs_k = tl.arange(0, BLOCK_K)
         offs_n = tl.arange(0, BLOCK_N)
         m_mask = offs_m < M
         k_mask = offs_k < K
         n_mask = offs_n < C_OUT
 
-        x_ptrs = X_ptr + offs_m_64[:, None] * stride_x_m + offs_k[None, :] * stride_x_k
-        x = tl.load(x_ptrs, mask=m_mask[:, None] & k_mask[None, :], other=0.0).to(
-            tl.float32
-        )
+        x = _load2d(X_ptr, offs_m64, offs_k, stride_x_m, m_mask, k_mask).to(tl.float32)
         mean = tl.sum(x, axis=1) / K
         x_centered = tl.where(k_mask[None, :], x - mean[:, None], 0.0)
-        var = tl.sum(x_centered * x_centered, axis=1) / K
-        rstd = 1.0 / tl.sqrt(var + eps)
+        rstd = 1.0 / tl.sqrt(tl.sum(x_centered * x_centered, axis=1) / K + eps)
         gamma = tl.load(Gamma_ptr + offs_k, mask=k_mask, other=0.0).to(tl.float32)
         x_hat = x_centered * rstd[:, None] * gamma[None, :]
         if HAS_LN_BIAS:
             beta = tl.load(Beta_ptr + offs_k, mask=k_mask, other=0.0).to(tl.float32)
             x_hat = x_hat + tl.where(k_mask[None, :], beta[None, :], 0.0)
-
         if SAVE_ACTS:
-            xhat_ptrs = (
-                XHAT_ptr
-                + offs_m_64[:, None] * stride_xhat_m
-                + offs_k[None, :]
-            )
-            tl.store(
-                xhat_ptrs,
-                x_hat.to(XHAT_ptr.dtype.element_ty),
-                mask=m_mask[:, None] & k_mask[None, :],
-            )
+            _store2d(XHAT_ptr, x_hat, offs_m64, offs_k, stride_xhat_m, m_mask, k_mask)
             tl.store(Mean_ptr + offs_m, mean, mask=m_mask)
             tl.store(Rstd_ptr + offs_m, rstd, mask=m_mask)
 
@@ -345,107 +286,37 @@ if _TRITON_AVAILABLE:
         for h0 in range(0, H, BLOCK_H):
             offs_h = h0 + tl.arange(0, BLOCK_H)
             h_mask = offs_h < H
-
-            wa_ptrs = (
-                WA_ptr + offs_h[:, None] * stride_wa_h + offs_k[None, :] * stride_wa_k
-            )
-            wa = tl.load(wa_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
-                tl.float32
-            )
-            acc_a = _dot_f32(x_hat, tl.trans(wa), GEMM_MODE)
-
-            wb_ptrs = (
-                WB_ptr + offs_h[:, None] * stride_wb_h + offs_k[None, :] * stride_wb_k
-            )
-            wb = tl.load(wb_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
-                tl.float32
-            )
-            acc_b = _dot_f32(x_hat, tl.trans(wb), GEMM_MODE)
-
-            if SAVE_ACTS:
-                a_ptrs = A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :]
-                b_ptrs = B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :]
-                tl.store(
-                    a_ptrs,
-                    acc_a.to(A_ptr.dtype.element_ty),
-                    mask=m_mask[:, None] & h_mask[None, :],
-                )
-                tl.store(
-                    b_ptrs,
-                    acc_b.to(B_ptr.dtype.element_ty),
-                    mask=m_mask[:, None] & h_mask[None, :],
-                )
-
-            silu = _silu_fp32(acc_a) * acc_b
-            wo_ptrs = (
-                WOUT_ptr + offs_n[:, None] * stride_wo_n + offs_h[None, :] * stride_wo_h
-            )
-            wo = tl.load(wo_ptrs, mask=n_mask[:, None] & h_mask[None, :], other=0.0).to(
-                tl.float32
-            )
+            wa = _load_w(WA_ptr, offs_h, offs_k, K, h_mask, k_mask)
+            wb = _load_w(WB_ptr, offs_h, offs_k, K, h_mask, k_mask)
+            wo = _load_w(WOUT_ptr, offs_n, offs_h, H, n_mask, h_mask)
+            a = _dot_f32(x_hat, tl.trans(wa), GEMM_MODE)
+            b = _dot_f32(x_hat, tl.trans(wb), GEMM_MODE)
+            silu = (a * tl.sigmoid(a)) * b
             acc_out += _dot_f32(silu, tl.trans(wo), GEMM_MODE)
 
-        if HAS_MASK:
-            mask_val = tl.load(
-                Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
-            )
-            acc_out = acc_out * mask_val[:, None].to(tl.float32)
-
+        acc_out = _mask_rows(acc_out, Mask_ptr, offs_m, stride_mask_m, m_mask, HAS_MASK)
         if HAS_RESIDUAL:
-            res_ptrs = (
-                Res_ptr
-                + offs_m_64[:, None] * stride_res_m
-                + offs_n[None, :] * stride_res_n
-            )
-            res = tl.load(
-                res_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0
+            acc_out = acc_out + _load2d(
+                Res_ptr, offs_m64, offs_n, stride_res_m, m_mask, n_mask
             ).to(tl.float32)
-            acc_out = acc_out + res
+        _store2d(Y_ptr, acc_out, offs_m64, offs_n, stride_y_m, m_mask, n_mask)
 
-        y_ptrs = Y_ptr + offs_m_64[:, None] * stride_y_m + offs_n[None, :] * stride_y_n
-        tl.store(
-            y_ptrs,
-            acc_out.to(Y_ptr.dtype.element_ty),
-            mask=m_mask[:, None] & n_mask[None, :],
-        )
-
-    @triton.autotune(
-        configs=_dx_autotune_configs(),
-        key=["GEMM_MODE", "K", "H", "C_OUT"],
-        prune_configs_by={"early_config_prune": _prune_by_precision},
-        restore_value=["GX_ptr"],
-    )
-    @triton.jit(
-        do_not_specialize=[
-            "stride_a_m",
-            "stride_b_m",
-            "stride_go_m",
-            "stride_gx_m",
-            "stride_mask_m",
-            "M",
-        ],
-        do_not_specialize_on_alignment=[
-            "A_ptr",
-            "B_ptr",
-            "WA_ptr",
-            "WB_ptr",
-            "WOUT_ptr",
-            "Mask_ptr",
-            "GO_ptr",
-            "GX_ptr",
-        ],
+    @_autotuned(
+        _GEMM_TILES,
+        ["GEMM_MODE", "K", "H", "C_OUT"],
+        ["GX_ptr"],
+        ("stride_xhat_m", "stride_go_m", "stride_gx_m", "stride_mask_m", "M"),
+        ("XHAT_ptr", "WA_ptr", "WB_ptr", "WOUT_ptr", "Mask_ptr", "GO_ptr", "GX_ptr"),
     )
     def _fused_swiglu_transition_bwd_dx_kernel(
-        A_ptr,
-        B_ptr,
+        XHAT_ptr,
         WA_ptr,
         WB_ptr,
         WOUT_ptr,
         Mask_ptr,
         GO_ptr,
         GX_ptr,
-        stride_a_m,
-        stride_b_m,
+        stride_xhat_m,
         stride_go_m,
         stride_gx_m,
         stride_mask_m,
@@ -460,100 +331,58 @@ if _TRITON_AVAILABLE:
         BLOCK_K: tl.constexpr,
         BLOCK_N: tl.constexpr,
     ):
-        """d(x_hat) from saved up-projection activations; grid over rows."""
-        pid_m = tl.program_id(0)
-        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_m_64 = offs_m.to(tl.int64)
+        offs_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m64 = offs_m.to(tl.int64)
         offs_k = tl.arange(0, BLOCK_K)
         offs_n = tl.arange(0, BLOCK_N)
         m_mask = offs_m < M
         k_mask = offs_k < K
         n_mask = offs_n < C_OUT
 
-        go_ptrs = GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :]
-        go = tl.load(go_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0)
-        if HAS_MASK:
-            mask_val = tl.load(
-                Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
-            ).to(tl.float32)
-            go = go.to(tl.float32) * mask_val[:, None]
-
+        go = _mask_rows(
+            _load2d(GO_ptr, offs_m64, offs_n, stride_go_m, m_mask, n_mask),
+            Mask_ptr,
+            offs_m,
+            stride_mask_m,
+            m_mask,
+            HAS_MASK,
+        )
+        x_hat = _load2d(XHAT_ptr, offs_m64, offs_k, stride_xhat_m, m_mask, k_mask)
         grad_x_hat = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
         for h0 in range(0, H, BLOCK_H):
             offs_h = h0 + tl.arange(0, BLOCK_H)
             h_mask = offs_h < H
-            a = tl.load(
-                A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :],
-                mask=m_mask[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            b = tl.load(
-                B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :],
-                mask=m_mask[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            wa = tl.load(
-                WA_ptr + offs_h[:, None] * K + offs_k[None, :],
-                mask=h_mask[:, None] & k_mask[None, :],
-                other=0.0,
-            )
-            wb = tl.load(
-                WB_ptr + offs_h[:, None] * K + offs_k[None, :],
-                mask=h_mask[:, None] & k_mask[None, :],
-                other=0.0,
-            )
-            wo = tl.load(
-                WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
-                mask=n_mask[:, None] & h_mask[None, :],
-                other=0.0,
-            )
-
-            grad_h = _dot_f32(go, wo, GEMM_MODE)
-            sig = tl.sigmoid(a)
-            silu_a = a * sig
-            grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
-            grad_b = grad_h * silu_a
+            wa = _load_w(WA_ptr, offs_h, offs_k, K, h_mask, k_mask)
+            wb = _load_w(WB_ptr, offs_h, offs_k, K, h_mask, k_mask)
+            wo = _load_w(WOUT_ptr, offs_n, offs_h, H, n_mask, h_mask)
+            a = _dot_f32(x_hat, tl.trans(wa), GEMM_MODE)
+            b = _dot_f32(x_hat, tl.trans(wb), GEMM_MODE)
+            _h, grad_a, grad_b = _swiglu_grads(a, b, _dot_f32(go, wo, GEMM_MODE))
             grad_x_hat += _dot_f32(grad_a, wa, GEMM_MODE)
             grad_x_hat += _dot_f32(grad_b, wb, GEMM_MODE)
+        _store2d(GX_ptr, grad_x_hat, offs_m64, offs_k, stride_gx_m, m_mask, k_mask)
 
-        gx_ptrs = GX_ptr + offs_m_64[:, None] * stride_gx_m + offs_k[None, :]
-        tl.store(
-            gx_ptrs,
-            grad_x_hat.to(GX_ptr.dtype.element_ty),
-            mask=m_mask[:, None] & k_mask[None, :],
-        )
-
-    @triton.autotune(
-        configs=_dw_autotune_configs(),
-        key=["GEMM_MODE", "K", "H", "C_OUT"],
-        prune_configs_by={"early_config_prune": _prune_by_precision},
-        restore_value=["PWA_ptr", "PWB_ptr", "PWO_ptr"],
-    )
-    @triton.jit(
-        do_not_specialize=[
-            "stride_xhat_m",
-            "stride_a_m",
-            "stride_b_m",
-            "stride_go_m",
-            "stride_mask_m",
-            "M",
-        ],
-        do_not_specialize_on_alignment=[
+    @_autotuned(
+        _DW_TILES,
+        ["GEMM_MODE", "K", "H", "C_OUT"],
+        ["PWA_ptr", "PWB_ptr", "PWO_ptr"],
+        ("stride_xhat_m", "stride_go_m", "stride_mask_m", "M"),
+        (
             "XHAT_ptr",
-            "A_ptr",
-            "B_ptr",
+            "WA_ptr",
+            "WB_ptr",
             "WOUT_ptr",
             "Mask_ptr",
             "GO_ptr",
             "PWA_ptr",
             "PWB_ptr",
             "PWO_ptr",
-        ],
+        ),
     )
     def _fused_swiglu_transition_bwd_dw_kernel(
         XHAT_ptr,
-        A_ptr,
-        B_ptr,
+        WA_ptr,
+        WB_ptr,
         WOUT_ptr,
         Mask_ptr,
         GO_ptr,
@@ -561,8 +390,6 @@ if _TRITON_AVAILABLE:
         PWB_ptr,
         PWO_ptr,
         stride_xhat_m,
-        stride_a_m,
-        stride_b_m,
         stride_go_m,
         stride_mask_m,
         M,
@@ -577,93 +404,132 @@ if _TRITON_AVAILABLE:
         BLOCK_K: tl.constexpr,
         BLOCK_N: tl.constexpr,
     ):
-        """One program: one row-split x one H-tile; dW accumulated in registers."""
         split = tl.program_id(0)
-        h_tile = tl.program_id(1)
         rows_per_split = (M + SPLIT_M - 1) // SPLIT_M
         split_start = split * rows_per_split
         split_end = tl.minimum(split_start + rows_per_split, M)
-
         offs_k = tl.arange(0, BLOCK_K)
         offs_n = tl.arange(0, BLOCK_N)
-        offs_h = h_tile * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_h = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
         k_mask = offs_k < K
         n_mask = offs_n < C_OUT
         h_mask = offs_h < H
 
-        wo = tl.load(
-            WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
-            mask=n_mask[:, None] & h_mask[None, :],
-            other=0.0,
-        )
-
+        wo = _load_w(WOUT_ptr, offs_n, offs_h, H, n_mask, h_mask)
+        wa = _load_w(WA_ptr, offs_h, offs_k, K, h_mask, k_mask)
+        wb = _load_w(WB_ptr, offs_h, offs_k, K, h_mask, k_mask)
         acc_dwa = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
         acc_dwb = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
         acc_dwo = tl.zeros((BLOCK_N, BLOCK_H), dtype=tl.float32)
 
         for m0 in range(split_start, split_end, BLOCK_M):
             offs_m = m0 + tl.arange(0, BLOCK_M)
-            offs_m_64 = offs_m.to(tl.int64)
+            offs_m64 = offs_m.to(tl.int64)
             m_mask = offs_m < split_end
-
-            # x_hat / go only feed MMA; keep storage dtype on the bf16 path.
-            x_hat = tl.load(
-                XHAT_ptr + offs_m_64[:, None] * stride_xhat_m + offs_k[None, :],
-                mask=m_mask[:, None] & k_mask[None, :],
-                other=0.0,
+            x_hat = _load2d(XHAT_ptr, offs_m64, offs_k, stride_xhat_m, m_mask, k_mask)
+            go = _mask_rows(
+                _load2d(GO_ptr, offs_m64, offs_n, stride_go_m, m_mask, n_mask),
+                Mask_ptr,
+                offs_m,
+                stride_mask_m,
+                m_mask,
+                HAS_MASK,
             )
-            go = tl.load(
-                GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :],
-                mask=m_mask[:, None] & n_mask[None, :],
-                other=0.0,
-            )
-            if HAS_MASK:
-                mask_val = tl.load(
-                    Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
-                ).to(tl.float32)
-                go = go.to(tl.float32) * mask_val[:, None]
-            a = tl.load(
-                A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :],
-                mask=m_mask[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            b = tl.load(
-                B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :],
-                mask=m_mask[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-
-            sig = tl.sigmoid(a)
-            silu_a = a * sig
-            h = silu_a * b
-            grad_h = _dot_f32(go, wo, GEMM_MODE)
+            a = _dot_f32(x_hat, tl.trans(wa), GEMM_MODE)
+            b = _dot_f32(x_hat, tl.trans(wb), GEMM_MODE)
+            h, grad_a, grad_b = _swiglu_grads(a, b, _dot_f32(go, wo, GEMM_MODE))
             acc_dwo += _dot_f32(tl.trans(go), h, GEMM_MODE)
-            grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
-            grad_b = grad_h * silu_a
             acc_dwa += _dot_f32(tl.trans(grad_a), x_hat, GEMM_MODE)
             acc_dwb += _dot_f32(tl.trans(grad_b), x_hat, GEMM_MODE)
 
-        pwa_ptrs = PWA_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
-        pwb_ptrs = PWB_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
-        pwo_ptrs = PWO_ptr + split * C_OUT * H + offs_n[:, None] * H + offs_h[None, :]
-        tl.store(pwa_ptrs, acc_dwa, mask=h_mask[:, None] & k_mask[None, :])
-        tl.store(pwb_ptrs, acc_dwb, mask=h_mask[:, None] & k_mask[None, :])
-        tl.store(pwo_ptrs, acc_dwo, mask=n_mask[:, None] & h_mask[None, :])
+        tl.store(
+            PWA_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :],
+            acc_dwa,
+            mask=h_mask[:, None] & k_mask[None, :],
+        )
+        tl.store(
+            PWB_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :],
+            acc_dwb,
+            mask=h_mask[:, None] & k_mask[None, :],
+        )
+        tl.store(
+            PWO_ptr + split * C_OUT * H + offs_n[:, None] * H + offs_h[None, :],
+            acc_dwo,
+            mask=n_mask[:, None] & h_mask[None, :],
+        )
+
+    @triton.jit(
+        do_not_specialize=["stride_gy_m", "stride_x_m", "stride_gx_m", "M"],
+        do_not_specialize_on_alignment=[
+            "GY_ptr",
+            "X_ptr",
+            "Mean_ptr",
+            "Rstd_ptr",
+            "Gamma_ptr",
+            "GX_ptr",
+            "PGamma_ptr",
+            "PBeta_ptr",
+        ],
+    )
+    def _fused_swiglu_transition_ln_bwd_kernel(
+        GY_ptr,
+        X_ptr,
+        Mean_ptr,
+        Rstd_ptr,
+        Gamma_ptr,
+        GX_ptr,
+        PGamma_ptr,
+        PBeta_ptr,
+        stride_gy_m,
+        stride_x_m,
+        stride_gx_m,
+        M,
+        K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        offs_m = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m64 = offs_m.to(tl.int64)
+        offs_k = tl.arange(0, BLOCK_K)
+        m_mask = offs_m < M
+        k_mask = offs_k < K
+        gy = _load2d(GY_ptr, offs_m64, offs_k, stride_gy_m, m_mask, k_mask).to(
+            tl.float32
+        )
+        x = _load2d(X_ptr, offs_m64, offs_k, stride_x_m, m_mask, k_mask).to(tl.float32)
+        mean = tl.load(Mean_ptr + offs_m, mask=m_mask, other=0.0)
+        rstd = tl.load(Rstd_ptr + offs_m, mask=m_mask, other=0.0)
+        gamma = tl.load(Gamma_ptr + offs_k, mask=k_mask, other=0.0).to(tl.float32)
+        x_norm = tl.where(
+            m_mask[:, None] & k_mask[None, :],
+            (x - mean[:, None]) * rstd[:, None],
+            0.0,
+        )
+        grad_norm = gy * gamma[None, :]
+        grad_mean = tl.sum(grad_norm, axis=1) / K
+        grad_proj = tl.sum(grad_norm * x_norm, axis=1) / K
+        gx = rstd[:, None] * (
+            grad_norm - grad_mean[:, None] - x_norm * grad_proj[:, None]
+        )
+        _store2d(GX_ptr, gx, offs_m64, offs_k, stride_gx_m, m_mask, k_mask)
+        tl.store(
+            PGamma_ptr + pid * K + offs_k, tl.sum(gy * x_norm, axis=0), mask=k_mask
+        )
+        tl.store(PBeta_ptr + pid * K + offs_k, tl.sum(gy, axis=0), mask=k_mask)
 
 else:  # pragma: no cover
 
-    def _fused_swiglu_transition_fwd_kernel(*_a, **_k):
+    def _unavailable(*_a, **_k):
         raise RuntimeError("Triton is required for fused_swiglu_transition")
 
-    def _fused_swiglu_transition_bwd_dx_kernel(*_a, **_k):
-        raise RuntimeError("Triton is required for fused_swiglu_transition")
-
-    def _fused_swiglu_transition_bwd_dw_kernel(*_a, **_k):
-        raise RuntimeError("Triton is required for fused_swiglu_transition")
+    _fused_swiglu_transition_fwd_kernel = _unavailable
+    _fused_swiglu_transition_bwd_dx_kernel = _unavailable
+    _fused_swiglu_transition_bwd_dw_kernel = _unavailable
+    _fused_swiglu_transition_ln_bwd_kernel = _unavailable
 
 
 def _gemm_mode(act: torch.Tensor) -> str:
-    """One GEMM policy for launch, autotune, and ``tl.dot``."""
     if act.dtype == torch.bfloat16:
         return "bf16"
     if torch.backends.cuda.matmul.allow_tf32:
@@ -672,9 +538,11 @@ def _gemm_mode(act: torch.Tensor) -> str:
 
 
 def _next_power_of_two(n: int) -> int:
-    if n <= 1:
-        return 1
-    return 1 << (n - 1).bit_length()
+    return 1 if n <= 1 else 1 << (n - 1).bit_length()
+
+
+def _block_kn(k: int, c_out: int) -> tuple[int, int]:
+    return max(_next_power_of_two(k), 16), max(_next_power_of_two(c_out), 16)
 
 
 def _launch_fused_swiglu_transition(
@@ -689,74 +557,49 @@ def _launch_fused_swiglu_transition(
     eps: float,
     save_acts: bool = False,
 ):
-    """Launch fused forward.
-
-    Inference (``save_acts=False``) may write in place when ``residual`` aliases
-    ``x``. Training (``save_acts=True``) writes a fresh ``y`` plus ``x_hat``,
-    ``a``, ``b``, ``mean``, and ``rstd`` for the backward kernels.
-    """
     M, K = x_2d.shape
-    H = w_a.shape[0]
-    C_OUT = w_out.shape[0]
+    H, C_OUT = w_a.shape[0], w_out.shape[0]
+    w_a, w_b, w_out, gamma = (t.contiguous() for t in (w_a, w_b, w_out, gamma))
+    if beta is not None:
+        beta = beta.contiguous()
 
     in_place = residual_2d is not None and residual_2d.data_ptr() == x_2d.data_ptr()
     if save_acts and in_place:
         raise RuntimeError("fused SwiGLU training forward cannot write in place")
-    y = x_2d if in_place else torch.empty((M, C_OUT), dtype=x_2d.dtype, device=x_2d.device)
-
+    y = (
+        x_2d
+        if in_place
+        else torch.empty((M, C_OUT), dtype=x_2d.dtype, device=x_2d.device)
+    )
     if save_acts:
         x_hat = torch.empty((M, K), dtype=x_2d.dtype, device=x_2d.device)
-        a = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
-        b = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
         mean = torch.empty((M,), dtype=torch.float32, device=x_2d.device)
         rstd = torch.empty((M,), dtype=torch.float32, device=x_2d.device)
     else:
-        x_hat = a = b = y
-        mean = rstd = y
+        x_hat = mean = rstd = x_2d
 
-    BLOCK_K = max(_next_power_of_two(K), 16)
-    BLOCK_N = max(_next_power_of_two(C_OUT), 16)
-    gemm_mode = _gemm_mode(x_2d)
-
-    beta_ptr = beta if beta is not None else x_2d
-    mask_ptr = mask_1d if mask_1d is not None else x_2d
-    stride_mask_m = mask_1d.stride(0) if mask_1d is not None else 0
-    res = residual_2d if residual_2d is not None else x_2d
-
-    def _grid(meta):
-        return (triton.cdiv(M, meta["BLOCK_M"]),)
-
-    _fused_swiglu_transition_fwd_kernel[_grid](
+    dummy = x_2d
+    block_k, block_n = _block_kn(K, C_OUT)
+    _fused_swiglu_transition_fwd_kernel[
+        (lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),))
+    ](
         x_2d,
         w_a,
         w_b,
         w_out,
         gamma,
-        beta_ptr,
-        mask_ptr,
-        res,
+        beta if beta is not None else dummy,
+        mask_1d if mask_1d is not None else dummy,
+        residual_2d if residual_2d is not None else dummy,
         y,
         x_hat,
-        a,
-        b,
         mean,
         rstd,
         x_2d.stride(0),
-        x_2d.stride(1),
-        w_a.stride(0),
-        w_a.stride(1),
-        w_b.stride(0),
-        w_b.stride(1),
-        w_out.stride(0),
-        w_out.stride(1),
-        res.stride(0),
-        res.stride(1),
+        (residual_2d if residual_2d is not None else dummy).stride(0),
         y.stride(0),
-        y.stride(1),
-        stride_mask_m,
+        mask_1d.stride(0) if mask_1d is not None else 0,
         x_hat.stride(0),
-        a.stride(0),
-        b.stride(0),
         M,
         K,
         H,
@@ -766,19 +609,15 @@ def _launch_fused_swiglu_transition(
         HAS_MASK=mask_1d is not None,
         HAS_RESIDUAL=residual_2d is not None,
         SAVE_ACTS=save_acts,
-        GEMM_MODE=gemm_mode,
-        BLOCK_K=BLOCK_K,
-        BLOCK_N=BLOCK_N,
+        GEMM_MODE=_gemm_mode(x_2d),
+        BLOCK_K=block_k,
+        BLOCK_N=block_n,
     )
-    if save_acts:
-        return y, x_hat, a, b, mean, rstd
-    return y
+    return (y, x_hat, mean, rstd) if save_acts else y
 
 
-def fused_swiglu_transition_weight_grad(
+def _fused_swiglu_transition_weight_grad(
     x_hat: torch.Tensor,
-    a: torch.Tensor,
-    b: torch.Tensor,
     grad_out_2d: torch.Tensor,
     w_a: torch.Tensor,
     w_b: torch.Tensor,
@@ -786,47 +625,34 @@ def fused_swiglu_transition_weight_grad(
     mask_1d: torch.Tensor | None,
     compute_dx: bool = True,
     compute_dw: bool = True,
-) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-    """Triton backward from saved ``x_hat``, ``a``, ``b``.
-
-    Returns ``d(x_hat), dWa, dWb, dWo``. Split-M ``dW`` runs first so the
-    ``x_hat`` buffer can be reused for ``d(x_hat)`` when it is fp32.
-    """
+) -> tuple[
+    torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
+]:
     M, K = x_hat.shape
-    H = a.shape[1]
-    C_OUT = w_out.shape[0]
-    gemm_mode = _gemm_mode(a)
-    BLOCK_K = max(_next_power_of_two(K), 16)
-    BLOCK_N = max(_next_power_of_two(C_OUT), 16)
-
-    a_c = a.contiguous()
-    b_c = b.contiguous()
-    go_c = grad_out_2d.contiguous()
-    wo_c = w_out.contiguous()
-    mask_ptr = mask_1d if mask_1d is not None else a_c
-    stride_mask_m = mask_1d.stride(0) if mask_1d is not None else 0
+    H, C_OUT = w_a.shape[0], w_out.shape[0]
+    x_hat_c, go_c = x_hat.contiguous(), grad_out_2d.contiguous()
+    wa_c, wb_c, wo_c = w_a.contiguous(), w_b.contiguous(), w_out.contiguous()
+    mask_ptr = mask_1d if mask_1d is not None else x_hat_c
+    stride_mask = mask_1d.stride(0) if mask_1d is not None else 0
+    block_k, block_n = _block_kn(K, C_OUT)
+    gemm_mode = _gemm_mode(x_hat)
     has_mask = mask_1d is not None
 
     grad_wa = grad_wb = grad_wo = None
     if compute_dw:
-        x_hat_c = x_hat.contiguous()
         partial_wa = torch.empty(
             _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
         )
-        partial_wb = torch.empty(
-            _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
-        )
+        partial_wb = torch.empty_like(partial_wa)
         partial_wo = torch.empty(
             _BWD_SPLIT_M, C_OUT, H, device=x_hat.device, dtype=torch.float32
         )
-
-        def _grid_dw(meta):
-            return (_BWD_SPLIT_M, triton.cdiv(H, meta["BLOCK_H"]))
-
-        _fused_swiglu_transition_bwd_dw_kernel[_grid_dw](
+        _fused_swiglu_transition_bwd_dw_kernel[
+            lambda meta: (_BWD_SPLIT_M, triton.cdiv(H, meta["BLOCK_H"]))
+        ](
             x_hat_c,
-            a_c,
-            b_c,
+            wa_c,
+            wb_c,
             wo_c,
             mask_ptr,
             go_c,
@@ -834,10 +660,8 @@ def fused_swiglu_transition_weight_grad(
             partial_wb,
             partial_wo,
             x_hat_c.stride(0),
-            a_c.stride(0),
-            b_c.stride(0),
             go_c.stride(0),
-            stride_mask_m,
+            stride_mask,
             M,
             K,
             H,
@@ -845,67 +669,92 @@ def fused_swiglu_transition_weight_grad(
             HAS_MASK=has_mask,
             GEMM_MODE=gemm_mode,
             SPLIT_M=_BWD_SPLIT_M,
-            BLOCK_K=BLOCK_K,
-            BLOCK_N=BLOCK_N,
+            BLOCK_K=block_k,
+            BLOCK_N=block_n,
         )
-        grad_wa = partial_wa.sum(dim=0)
-        grad_wb = partial_wb.sum(dim=0)
-        grad_wo = partial_wo.sum(dim=0)
+        grad_wa, grad_wb, grad_wo = (
+            partial_wa.sum(0),
+            partial_wb.sum(0),
+            partial_wo.sum(0),
+        )
 
     grad_x_hat = None
     if compute_dx:
-        if x_hat.dtype == torch.float32:
-            grad_x_hat = x_hat
-        else:
-            grad_x_hat = torch.empty((M, K), dtype=torch.float32, device=x_hat.device)
-        wa_c = w_a.contiguous()
-        wb_c = w_b.contiguous()
-
-        def _grid_dx(meta):
-            return (triton.cdiv(M, meta["BLOCK_M"]),)
-
-        _fused_swiglu_transition_bwd_dx_kernel[_grid_dx](
-            a_c,
-            b_c,
+        grad_x_hat = (
+            x_hat
+            if x_hat.dtype == torch.float32
+            else torch.empty((M, K), dtype=torch.float32, device=x_hat.device)
+        )
+        _fused_swiglu_transition_bwd_dx_kernel[
+            lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+        ](
+            x_hat_c,
             wa_c,
             wb_c,
             wo_c,
             mask_ptr,
             go_c,
             grad_x_hat,
-            a_c.stride(0),
-            b_c.stride(0),
+            x_hat_c.stride(0),
             go_c.stride(0),
             grad_x_hat.stride(0),
-            stride_mask_m,
+            stride_mask,
             M,
             K,
             H,
             C_OUT,
             HAS_MASK=has_mask,
             GEMM_MODE=gemm_mode,
-            BLOCK_K=BLOCK_K,
-            BLOCK_N=BLOCK_N,
+            BLOCK_K=block_k,
+            BLOCK_N=block_n,
         )
-
     return grad_x_hat, grad_wa, grad_wb, grad_wo
+
+
+def _fused_swiglu_transition_layer_norm_backward(
+    grad_y: torch.Tensor,
+    x: torch.Tensor,
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+    gamma: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    M, K = x.shape
+    block_m, block_k = 16, max(_next_power_of_two(K), 16)
+    n_blocks = triton.cdiv(M, block_m)
+    grad_x = torch.empty_like(x)
+    partial_gamma = torch.empty((n_blocks, K), dtype=torch.float32, device=x.device)
+    partial_beta = torch.empty_like(partial_gamma)
+    _fused_swiglu_transition_ln_bwd_kernel[(n_blocks,)](
+        grad_y,
+        x,
+        mean,
+        rstd,
+        gamma,
+        grad_x,
+        partial_gamma,
+        partial_beta,
+        grad_y.stride(0),
+        x.stride(0),
+        grad_x.stride(0),
+        M,
+        K,
+        BLOCK_M=block_m,
+        BLOCK_K=block_k,
+        num_warps=4,
+    )
+    return grad_x, partial_gamma.sum(0), partial_beta.sum(0)
 
 
 class _FusedSwiGLUTransitionFn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, gamma, beta, w_a, w_b, w_out, mask, eps):
-        has_beta = beta is not None
-        has_mask = mask is not None
-        beta_t = beta if has_beta else x.new_empty(0)
-        mask_t = mask if has_mask else x.new_empty(0)
-
-        c_in = gamma.shape[0]
-        x_2d = x.contiguous().view(-1, c_in)
+        has_beta, has_mask = beta is not None, mask is not None
+        x_2d = x.contiguous().view(-1, gamma.shape[0])
         mask_1d = mask.reshape(-1).contiguous() if has_mask else None
-        y_2d, x_hat, a, b, mean, rstd = _launch_fused_swiglu_transition(
+        y_2d, x_hat, mean, rstd = _launch_fused_swiglu_transition(
             x_2d,
             gamma,
-            beta if has_beta else None,
+            beta,
             w_a,
             w_b,
             w_out,
@@ -914,85 +763,61 @@ class _FusedSwiGLUTransitionFn(torch.autograd.Function):
             float(eps),
             save_acts=True,
         )
-        y = y_2d.view_as(x)
-
         ctx.save_for_backward(
-            x, x_hat, a, b, mean, rstd, gamma, beta_t, w_a, w_b, w_out, mask_t
+            x,
+            x_hat,
+            mean,
+            rstd,
+            gamma,
+            beta if has_beta else x.new_empty(0),
+            w_a,
+            w_b,
+            w_out,
+            mask if has_mask else x.new_empty(0),
         )
         ctx.has_beta = has_beta
         ctx.has_mask = has_mask
         ctx.x_shape = x.shape
-        return y
+        return y_2d.view_as(x)
 
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_out):
-        x, x_hat, a, b, mean, rstd, gamma, beta_t, w_a, w_b, w_out, mask_t = (
-            ctx.saved_tensors
-        )
-        beta = beta_t if ctx.has_beta else None
-        mask = mask_t if ctx.has_mask else None
-        c_in = gamma.shape[0]
-
-        go_2d = grad_out.contiguous().view(-1, grad_out.shape[-1])
-        mask_1d = mask.reshape(-1).contiguous() if mask is not None else None
-
-        need_dx = any(ctx.needs_input_grad[:3])
-        need_dw = any(ctx.needs_input_grad[3:6])
-        grad_x_hat, grad_wa, grad_wb, grad_wo = fused_swiglu_transition_weight_grad(
+        x, x_hat, mean, rstd, gamma, beta_t, w_a, w_b, w_out, mask_t = ctx.saved_tensors
+        need = ctx.needs_input_grad
+        mask_1d = mask_t.reshape(-1).contiguous() if ctx.has_mask else None
+        gxhat, gwa, gwb, gwo = _fused_swiglu_transition_weight_grad(
             x_hat,
-            a,
-            b,
-            go_2d,
+            grad_out.contiguous().view(-1, grad_out.shape[-1]),
             w_a,
             w_b,
             w_out,
             mask_1d,
-            compute_dx=need_dx,
-            compute_dw=need_dw,
+            compute_dx=any(need[:3]),
+            compute_dw=any(need[3:6]),
         )
-
-        grad_x = grad_gamma = grad_beta = None
-        if need_dx:
-            x_2d = x.contiguous().view(-1, c_in)
-            x_f = x_2d.float() if x_2d.dtype != torch.float32 else x_2d
-            ln_weight = gamma.float()
-            ln_bias = beta.float() if beta is not None else None
-            grad_input, grad_gamma, grad_beta = torch.ops.aten.native_layer_norm_backward(
-                grad_x_hat,
-                x_f,
-                (c_in,),
+        gx = ggamma = gbeta = None
+        if any(need[:3]):
+            gin, ggamma, gbeta = _fused_swiglu_transition_layer_norm_backward(
+                gxhat,
+                x.contiguous().view(-1, gamma.shape[0]),
                 mean,
                 rstd,
-                ln_weight,
-                ln_bias,
-                (
-                    ctx.needs_input_grad[0],
-                    ctx.needs_input_grad[1],
-                    ctx.needs_input_grad[2],
-                ),
+                gamma,
             )
-            if grad_input is not None:
-                grad_x = grad_input.view(ctx.x_shape).to(dtype=x.dtype)
-            if grad_gamma is not None:
-                grad_gamma = grad_gamma.to(dtype=gamma.dtype)
-            if grad_beta is not None:
-                grad_beta = grad_beta.to(dtype=beta.dtype)
-
-        if not ctx.needs_input_grad[3]:
-            grad_wa = None
-        else:
-            grad_wa = grad_wa.to(dtype=w_a.dtype)
-        if not ctx.needs_input_grad[4]:
-            grad_wb = None
-        else:
-            grad_wb = grad_wb.to(dtype=w_b.dtype)
-        if not ctx.needs_input_grad[5]:
-            grad_wo = None
-        else:
-            grad_wo = grad_wo.to(dtype=w_out.dtype)
-
-        return grad_x, grad_gamma, grad_beta, grad_wa, grad_wb, grad_wo, None, None
+            gx = gin.view(ctx.x_shape) if need[0] else None
+            ggamma = ggamma.to(dtype=gamma.dtype) if need[1] else None
+            gbeta = gbeta.to(dtype=beta_t.dtype) if need[2] and ctx.has_beta else None
+        return (
+            gx,
+            ggamma,
+            gbeta,
+            gwa.to(dtype=w_a.dtype) if need[3] else None,
+            gwb.to(dtype=w_b.dtype) if need[4] else None,
+            gwo.to(dtype=w_out.dtype) if need[5] else None,
+            None,
+            None,
+        )
 
 
 def fused_swiglu_transition(
@@ -1006,43 +831,36 @@ def fused_swiglu_transition(
     eps: float = 1e-5,
     residual: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Fused LN -> SwiGLU -> Linear -> (*mask) [-> +residual].
-
-    Triton only. The model uses ``SwiGLUTransition`` primitives when this
-    launch is ineligible. Inference may write in place when ``residual is
-    x``. Training is always out-of-place and saves activations for the
-    Triton backward. ``GEMM_MODE`` is ``bf16``, ``tf32``, or ``ieee``;
-    masters stay fp32.
-    """
+    """Fused LN -> SwiGLU -> Linear -> (*mask) [-> +residual]."""
     if not is_fused_swiglu_transition_eligible(x, gamma, beta, w_a, w_b, w_out):
         raise RuntimeError(
             "fused_swiglu_transition requires an eligible Triton launch; "
             "use SwiGLUTransition for the eager path"
         )
 
-    c_in = gamma.shape[0]
-    use_grad = torch.is_grad_enabled() and (
-        x.requires_grad
-        or gamma.requires_grad
-        or (beta is not None and beta.requires_grad)
-        or w_a.requires_grad
-        or w_b.requires_grad
-        or w_out.requires_grad
+    use_grad = torch.is_grad_enabled() and any(
+        t is not None and t.requires_grad for t in (x, gamma, beta, w_a, w_b, w_out)
     )
     if use_grad:
         if residual is not None:
-            update = fused_swiglu_transition(
-                x, gamma, beta, w_a, w_b, w_out, mask=mask, eps=eps, residual=None
+            return residual + fused_swiglu_transition(
+                x, gamma, beta, w_a, w_b, w_out, mask=mask, eps=eps
             )
-            return residual + update
         return _FusedSwiGLUTransitionFn.apply(
             x, gamma, beta, w_a, w_b, w_out, mask, eps
         )
 
-    x_2d = x.contiguous().view(-1, c_in)
-    mask_1d = mask.reshape(-1) if mask is not None else None
-    res_2d = residual.view(-1, c_in) if residual is not None else None
+    c_in = gamma.shape[0]
     y_2d = _launch_fused_swiglu_transition(
-        x_2d, gamma, beta, w_a, w_b, w_out, mask_1d, res_2d, eps, save_acts=False
+        x.contiguous().view(-1, c_in),
+        gamma,
+        beta,
+        w_a,
+        w_b,
+        w_out,
+        mask.reshape(-1).contiguous() if mask is not None else None,
+        residual.contiguous().view(-1, c_in) if residual is not None else None,
+        eps,
+        save_acts=False,
     )
     return y_2d.view_as(x if residual is None else residual)

--- a/openfold3/core/kernels/triton/fused_swiglu_transition.py
+++ b/openfold3/core/kernels/triton/fused_swiglu_transition.py
@@ -1,0 +1,1049 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# by Liang Hong <lhong22@cse.cuhk.edu.hk>: fused pair SwiGLU transition
+# (Triton) with training backward.
+
+"""Fused SwiGLU pair transition via a length-generic Triton kernel.
+
+Fuses
+
+    x -> LayerNorm -> SwiGLU(SiLU(linear_a(x)) * linear_b(x)) -> linear_out
+      -> * mask  [-> + residual]
+
+GEMMs honor ``torch.backends.cuda.matmul.allow_tf32`` for fp32 activations:
+
+- TF32 on: ``input_precision="tf32"`` with round-nearest ``f32->tf32``
+  (``cvt.rna.tf32.f32``), matching cuBLAS TF32. Triton's default TF32
+  *truncates*, which was the source of the extra ~2e-2 abs error.
+- TF32 off: ``input_precision="ieee"`` (true FP32).
+
+Triton requires fp32 Parameter masters (same as fused template
+projection). Activations may be fp32 or bf16. bf16 activations use
+``tl.dot`` in bf16 with fp32 accumulate; weight tiles are downcast
+inside the GEMM only. Pure bf16 weights are ineligible.
+
+Inference (in-place) never materializes the ``[M, hidden]`` expansion.
+Training (out-of-place) writes ``x_hat``, ``a``, and ``b`` so backward can
+skip LayerNorm and the up-projections. Weight grads use exclusive split-M
+tiles (no atomics). Sequence length ``M`` is not an autotune / specialize
+key. Ineligible shapes use ``SwiGLUTransition`` primitives.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from torch.autograd.function import once_differentiable
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    _TRITON_AVAILABLE = False
+
+# Pair transition (c_z=128, n=4 -> H=512) with headroom; wider sites fall back.
+_MAX_C_IN = 256
+_MAX_HIDDEN = 512
+# Below this row count, fused launch / tiling overhead is not worthwhile.
+_MIN_M = 4096
+# Exclusive row splits for deterministic Triton weight grads (no atomics).
+_BWD_SPLIT_M = 16
+
+
+def is_triton_available() -> bool:
+    return _TRITON_AVAILABLE
+
+
+def is_fused_swiglu_transition_enabled() -> bool:
+    return os.environ.get("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def is_fused_swiglu_transition_eligible(
+    x: torch.Tensor,
+    gamma: torch.Tensor,
+    beta: torch.Tensor | None,
+    w_a: torch.Tensor,
+    w_b: torch.Tensor,
+    w_out: torch.Tensor,
+) -> bool:
+    c_in = gamma.shape[0]
+    hidden = w_a.shape[0]
+    masters = (gamma, w_a, w_b, w_out) + ((beta,) if beta is not None else ())
+    return (
+        is_fused_swiglu_transition_enabled()
+        and _TRITON_AVAILABLE
+        and x.is_cuda
+        and x.is_contiguous()
+        and x.dtype in (torch.float32, torch.bfloat16)
+        and all(w.dtype == torch.float32 for w in masters)
+        and c_in <= _MAX_C_IN
+        and hidden <= _MAX_HIDDEN
+        and (x.numel() // c_in) >= _MIN_M
+    )
+
+
+if _TRITON_AVAILABLE:
+
+    def _fwd_autotune_configs():
+        configs = []
+        for block_m, block_h, num_warps, num_stages in (
+            (16, 32, 4, 1),
+            (16, 32, 4, 2),
+            (16, 64, 4, 1),
+            (32, 32, 4, 1),
+            (32, 32, 4, 2),
+            (32, 64, 4, 1),
+            (64, 64, 4, 1),
+            (128, 64, 8, 1),
+            (128, 64, 8, 2),
+        ):
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                )
+            )
+        return configs
+
+    def _dx_autotune_configs():
+        configs = []
+        for block_m, block_h, num_warps, num_stages in (
+            (16, 32, 4, 1),
+            (16, 32, 4, 2),
+            (16, 64, 4, 1),
+            (32, 32, 4, 1),
+            (32, 32, 4, 2),
+            (32, 64, 4, 1),
+            (64, 64, 4, 1),
+            (128, 64, 8, 1),
+        ):
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                )
+            )
+        return configs
+
+    def _dw_autotune_configs():
+        # dW keeps three weight accumulators live; keep tiles inside SMEM.
+        configs = []
+        for block_m, block_h, num_warps in (
+            (16, 32, 4),
+            (16, 64, 4),
+            (32, 32, 4),
+            (32, 64, 4),
+            (64, 32, 4),
+            (64, 32, 8),
+        ):
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_H": block_h},
+                    num_warps=num_warps,
+                    num_stages=1,
+                )
+            )
+        return configs
+
+    def _prune_by_precision(configs, named_args, **kwargs):
+        precision = kwargs.get("INPUT_PRECISION", named_args.get("INPUT_PRECISION"))
+        act = named_args.get("X_ptr")
+        if act is None:
+            act = named_args.get("A_ptr")
+        if act is None:
+            act = named_args.get("XHAT_ptr")
+        H = kwargs.get("H", named_args.get("H"))
+        kept = []
+        for cfg in configs:
+            block_m = cfg.kwargs["BLOCK_M"]
+            block_h = cfg.kwargs["BLOCK_H"]
+            if H is not None and block_h > int(H):
+                continue
+            if (
+                precision == "ieee"
+                and getattr(act, "dtype", None) != torch.bfloat16
+                and block_m >= 64
+            ):
+                continue
+            kept.append(cfg)
+        return kept if kept else configs[:1]
+
+    @triton.jit
+    def _silu_fp32(x):
+        return x * tl.sigmoid(x)
+
+    @triton.jit
+    def _round_to_tf32(x):
+        ASM: tl.constexpr = "cvt.rna.tf32.f32 $0, $1;"
+        return tl.inline_asm_elementwise(
+            ASM, "=r, r", [x], dtype=tl.float32, is_pure=True, pack=1
+        )
+
+    @triton.jit
+    def _dot_f32(a, b, INPUT_PRECISION: tl.constexpr, ROUND_TF32: tl.constexpr, act_ptr):
+        # act_ptr is the activation allocation (X / a / x_hat). Its storage
+        # dtype is the input; tl.dot input_precision is only ieee/tf32.
+        if act_ptr.dtype.element_ty == tl.bfloat16:
+            return tl.dot(
+                a.to(tl.bfloat16),
+                b.to(tl.bfloat16),
+                input_precision="ieee",
+                out_dtype=tl.float32,
+            )
+        if ROUND_TF32:
+            a = _round_to_tf32(a)
+            b = _round_to_tf32(b)
+        return tl.dot(a, b, input_precision=INPUT_PRECISION, out_dtype=tl.float32)
+
+    @triton.autotune(
+        configs=_fwd_autotune_configs(),
+        key=["INPUT_PRECISION", "K", "H", "C_OUT", "SAVE_ACTS"],
+        prune_configs_by={"early_config_prune": _prune_by_precision},
+        restore_value=["Y_ptr", "A_ptr", "B_ptr"],
+    )
+    @triton.jit(
+        do_not_specialize=[
+            "stride_x_m",
+            "stride_x_k",
+            "stride_wa_h",
+            "stride_wa_k",
+            "stride_wb_h",
+            "stride_wb_k",
+            "stride_wo_n",
+            "stride_wo_h",
+            "stride_res_m",
+            "stride_res_n",
+            "stride_y_m",
+            "stride_y_n",
+            "stride_mask_m",
+            "stride_xhat_m",
+            "stride_a_m",
+            "stride_b_m",
+            "M",
+            "eps",
+        ],
+        do_not_specialize_on_alignment=[
+            "X_ptr",
+            "WA_ptr",
+            "WB_ptr",
+            "WOUT_ptr",
+            "Gamma_ptr",
+            "Beta_ptr",
+            "Mask_ptr",
+            "Res_ptr",
+            "Y_ptr",
+            "A_ptr",
+            "B_ptr",
+        ],
+    )
+    def _fused_swiglu_transition_fwd_kernel(
+        X_ptr,
+        WA_ptr,
+        WB_ptr,
+        WOUT_ptr,
+        Gamma_ptr,
+        Beta_ptr,
+        Mask_ptr,
+        Res_ptr,
+        Y_ptr,
+        XHAT_ptr,
+        A_ptr,
+        B_ptr,
+        stride_x_m,
+        stride_x_k,
+        stride_wa_h,
+        stride_wa_k,
+        stride_wb_h,
+        stride_wb_k,
+        stride_wo_n,
+        stride_wo_h,
+        stride_res_m,
+        stride_res_n,
+        stride_y_m,
+        stride_y_n,
+        stride_mask_m,
+        stride_xhat_m,
+        stride_a_m,
+        stride_b_m,
+        M,
+        K: tl.constexpr,
+        H: tl.constexpr,
+        C_OUT: tl.constexpr,
+        eps,
+        HAS_LN_BIAS: tl.constexpr,
+        HAS_MASK: tl.constexpr,
+        HAS_RESIDUAL: tl.constexpr,
+        SAVE_ACTS: tl.constexpr,
+        INPUT_PRECISION: tl.constexpr,
+        ROUND_TF32: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m_64 = offs_m.to(tl.int64)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs_n = tl.arange(0, BLOCK_N)
+        m_mask = offs_m < M
+        k_mask = offs_k < K
+        n_mask = offs_n < C_OUT
+
+        x_ptrs = X_ptr + offs_m_64[:, None] * stride_x_m + offs_k[None, :] * stride_x_k
+        x = tl.load(x_ptrs, mask=m_mask[:, None] & k_mask[None, :], other=0.0).to(
+            tl.float32
+        )
+        mean = tl.sum(x, axis=1) / K
+        x_centered = tl.where(k_mask[None, :], x - mean[:, None], 0.0)
+        var = tl.sum(x_centered * x_centered, axis=1) / K
+        rstd = 1.0 / tl.sqrt(var + eps)
+        gamma = tl.load(Gamma_ptr + offs_k, mask=k_mask, other=0.0).to(tl.float32)
+        x_hat = x_centered * rstd[:, None] * gamma[None, :]
+        if HAS_LN_BIAS:
+            beta = tl.load(Beta_ptr + offs_k, mask=k_mask, other=0.0).to(tl.float32)
+            x_hat = x_hat + tl.where(k_mask[None, :], beta[None, :], 0.0)
+
+        if SAVE_ACTS:
+            xhat_ptrs = (
+                XHAT_ptr
+                + offs_m_64[:, None] * stride_xhat_m
+                + offs_k[None, :]
+            )
+            tl.store(
+                xhat_ptrs,
+                x_hat.to(XHAT_ptr.dtype.element_ty),
+                mask=m_mask[:, None] & k_mask[None, :],
+            )
+
+        acc_out = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for h0 in range(0, H, BLOCK_H):
+            offs_h = h0 + tl.arange(0, BLOCK_H)
+            h_mask = offs_h < H
+
+            wa_ptrs = (
+                WA_ptr + offs_h[:, None] * stride_wa_h + offs_k[None, :] * stride_wa_k
+            )
+            wa = tl.load(wa_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
+                tl.float32
+            )
+            acc_a = _dot_f32(x_hat, tl.trans(wa), INPUT_PRECISION, ROUND_TF32, X_ptr)
+
+            wb_ptrs = (
+                WB_ptr + offs_h[:, None] * stride_wb_h + offs_k[None, :] * stride_wb_k
+            )
+            wb = tl.load(wb_ptrs, mask=h_mask[:, None] & k_mask[None, :], other=0.0).to(
+                tl.float32
+            )
+            acc_b = _dot_f32(x_hat, tl.trans(wb), INPUT_PRECISION, ROUND_TF32, X_ptr)
+
+            if SAVE_ACTS:
+                a_ptrs = A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :]
+                b_ptrs = B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :]
+                tl.store(
+                    a_ptrs,
+                    acc_a.to(A_ptr.dtype.element_ty),
+                    mask=m_mask[:, None] & h_mask[None, :],
+                )
+                tl.store(
+                    b_ptrs,
+                    acc_b.to(B_ptr.dtype.element_ty),
+                    mask=m_mask[:, None] & h_mask[None, :],
+                )
+
+            silu = _silu_fp32(acc_a) * acc_b
+            wo_ptrs = (
+                WOUT_ptr + offs_n[:, None] * stride_wo_n + offs_h[None, :] * stride_wo_h
+            )
+            wo = tl.load(wo_ptrs, mask=n_mask[:, None] & h_mask[None, :], other=0.0).to(
+                tl.float32
+            )
+            acc_out += _dot_f32(silu, tl.trans(wo), INPUT_PRECISION, ROUND_TF32, X_ptr)
+
+        if HAS_MASK:
+            mask_val = tl.load(
+                Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
+            )
+            acc_out = acc_out * mask_val[:, None].to(tl.float32)
+
+        if HAS_RESIDUAL:
+            res_ptrs = (
+                Res_ptr
+                + offs_m_64[:, None] * stride_res_m
+                + offs_n[None, :] * stride_res_n
+            )
+            res = tl.load(
+                res_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0
+            ).to(tl.float32)
+            acc_out = acc_out + res
+
+        y_ptrs = Y_ptr + offs_m_64[:, None] * stride_y_m + offs_n[None, :] * stride_y_n
+        tl.store(
+            y_ptrs,
+            acc_out.to(Y_ptr.dtype.element_ty),
+            mask=m_mask[:, None] & n_mask[None, :],
+        )
+
+    @triton.autotune(
+        configs=_dx_autotune_configs(),
+        key=["INPUT_PRECISION", "K", "H", "C_OUT"],
+        prune_configs_by={"early_config_prune": _prune_by_precision},
+        restore_value=["GX_ptr"],
+    )
+    @triton.jit(
+        do_not_specialize=[
+            "stride_a_m",
+            "stride_b_m",
+            "stride_go_m",
+            "stride_gx_m",
+            "stride_mask_m",
+            "M",
+        ],
+        do_not_specialize_on_alignment=[
+            "A_ptr",
+            "B_ptr",
+            "WA_ptr",
+            "WB_ptr",
+            "WOUT_ptr",
+            "Mask_ptr",
+            "GO_ptr",
+            "GX_ptr",
+        ],
+    )
+    def _fused_swiglu_transition_bwd_dx_kernel(
+        A_ptr,
+        B_ptr,
+        WA_ptr,
+        WB_ptr,
+        WOUT_ptr,
+        Mask_ptr,
+        GO_ptr,
+        GX_ptr,
+        stride_a_m,
+        stride_b_m,
+        stride_go_m,
+        stride_gx_m,
+        stride_mask_m,
+        M,
+        K: tl.constexpr,
+        H: tl.constexpr,
+        C_OUT: tl.constexpr,
+        HAS_MASK: tl.constexpr,
+        INPUT_PRECISION: tl.constexpr,
+        ROUND_TF32: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        """d(x_hat) from saved up-projection activations; grid over rows."""
+        pid_m = tl.program_id(0)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_m_64 = offs_m.to(tl.int64)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs_n = tl.arange(0, BLOCK_N)
+        m_mask = offs_m < M
+        k_mask = offs_k < K
+        n_mask = offs_n < C_OUT
+
+        go_ptrs = GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :]
+        go = tl.load(go_ptrs, mask=m_mask[:, None] & n_mask[None, :], other=0.0).to(
+            tl.float32
+        )
+        if HAS_MASK:
+            mask_val = tl.load(
+                Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
+            ).to(tl.float32)
+            go = go * mask_val[:, None]
+
+        grad_x_hat = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+        for h0 in range(0, H, BLOCK_H):
+            offs_h = h0 + tl.arange(0, BLOCK_H)
+            h_mask = offs_h < H
+            a = tl.load(
+                A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :],
+                mask=m_mask[:, None] & h_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            b = tl.load(
+                B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :],
+                mask=m_mask[:, None] & h_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            wa = tl.load(
+                WA_ptr + offs_h[:, None] * K + offs_k[None, :],
+                mask=h_mask[:, None] & k_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            wb = tl.load(
+                WB_ptr + offs_h[:, None] * K + offs_k[None, :],
+                mask=h_mask[:, None] & k_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            wo = tl.load(
+                WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
+                mask=n_mask[:, None] & h_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+
+            grad_h = _dot_f32(go, wo, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            sig = tl.sigmoid(a)
+            silu_a = a * sig
+            grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
+            grad_b = grad_h * silu_a
+            grad_x_hat += _dot_f32(grad_a, wa, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            grad_x_hat += _dot_f32(grad_b, wb, INPUT_PRECISION, ROUND_TF32, A_ptr)
+
+        gx_ptrs = GX_ptr + offs_m_64[:, None] * stride_gx_m + offs_k[None, :]
+        tl.store(
+            gx_ptrs,
+            grad_x_hat.to(GX_ptr.dtype.element_ty),
+            mask=m_mask[:, None] & k_mask[None, :],
+        )
+
+    @triton.autotune(
+        configs=_dw_autotune_configs(),
+        key=["INPUT_PRECISION", "K", "H", "C_OUT"],
+        prune_configs_by={"early_config_prune": _prune_by_precision},
+        restore_value=["PWA_ptr", "PWB_ptr", "PWO_ptr"],
+    )
+    @triton.jit(
+        do_not_specialize=[
+            "stride_xhat_m",
+            "stride_a_m",
+            "stride_b_m",
+            "stride_go_m",
+            "stride_mask_m",
+            "M",
+        ],
+        do_not_specialize_on_alignment=[
+            "XHAT_ptr",
+            "A_ptr",
+            "B_ptr",
+            "WOUT_ptr",
+            "Mask_ptr",
+            "GO_ptr",
+            "PWA_ptr",
+            "PWB_ptr",
+            "PWO_ptr",
+        ],
+    )
+    def _fused_swiglu_transition_bwd_dw_kernel(
+        XHAT_ptr,
+        A_ptr,
+        B_ptr,
+        WOUT_ptr,
+        Mask_ptr,
+        GO_ptr,
+        PWA_ptr,
+        PWB_ptr,
+        PWO_ptr,
+        stride_xhat_m,
+        stride_a_m,
+        stride_b_m,
+        stride_go_m,
+        stride_mask_m,
+        M,
+        K: tl.constexpr,
+        H: tl.constexpr,
+        C_OUT: tl.constexpr,
+        HAS_MASK: tl.constexpr,
+        INPUT_PRECISION: tl.constexpr,
+        ROUND_TF32: tl.constexpr,
+        SPLIT_M: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        """One program: one row-split x one H-tile; dW accumulated in registers."""
+        split = tl.program_id(0)
+        h_tile = tl.program_id(1)
+        rows_per_split = (M + SPLIT_M - 1) // SPLIT_M
+        split_start = split * rows_per_split
+        split_end = tl.minimum(split_start + rows_per_split, M)
+
+        offs_k = tl.arange(0, BLOCK_K)
+        offs_n = tl.arange(0, BLOCK_N)
+        offs_h = h_tile * BLOCK_H + tl.arange(0, BLOCK_H)
+        k_mask = offs_k < K
+        n_mask = offs_n < C_OUT
+        h_mask = offs_h < H
+
+        wo = tl.load(
+            WOUT_ptr + offs_n[:, None] * H + offs_h[None, :],
+            mask=n_mask[:, None] & h_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        acc_dwa = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
+        acc_dwb = tl.zeros((BLOCK_H, BLOCK_K), dtype=tl.float32)
+        acc_dwo = tl.zeros((BLOCK_N, BLOCK_H), dtype=tl.float32)
+
+        for m0 in range(split_start, split_end, BLOCK_M):
+            offs_m = m0 + tl.arange(0, BLOCK_M)
+            offs_m_64 = offs_m.to(tl.int64)
+            m_mask = offs_m < split_end
+
+            x_hat = tl.load(
+                XHAT_ptr + offs_m_64[:, None] * stride_xhat_m + offs_k[None, :],
+                mask=m_mask[:, None] & k_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            go = tl.load(
+                GO_ptr + offs_m_64[:, None] * stride_go_m + offs_n[None, :],
+                mask=m_mask[:, None] & n_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            if HAS_MASK:
+                mask_val = tl.load(
+                    Mask_ptr + offs_m * stride_mask_m, mask=m_mask, other=0.0
+                ).to(tl.float32)
+                go = go * mask_val[:, None]
+            a = tl.load(
+                A_ptr + offs_m_64[:, None] * stride_a_m + offs_h[None, :],
+                mask=m_mask[:, None] & h_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            b = tl.load(
+                B_ptr + offs_m_64[:, None] * stride_b_m + offs_h[None, :],
+                mask=m_mask[:, None] & h_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+
+            sig = tl.sigmoid(a)
+            silu_a = a * sig
+            h = silu_a * b
+            grad_h = _dot_f32(go, wo, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            acc_dwo += _dot_f32(tl.trans(go), h, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            grad_a = grad_h * b * (sig + silu_a * (1.0 - sig))
+            grad_b = grad_h * silu_a
+            acc_dwa += _dot_f32(tl.trans(grad_a), x_hat, INPUT_PRECISION, ROUND_TF32, A_ptr)
+            acc_dwb += _dot_f32(tl.trans(grad_b), x_hat, INPUT_PRECISION, ROUND_TF32, A_ptr)
+
+        pwa_ptrs = PWA_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
+        pwb_ptrs = PWB_ptr + split * H * K + offs_h[:, None] * K + offs_k[None, :]
+        pwo_ptrs = PWO_ptr + split * C_OUT * H + offs_n[:, None] * H + offs_h[None, :]
+        tl.store(pwa_ptrs, acc_dwa, mask=h_mask[:, None] & k_mask[None, :])
+        tl.store(pwb_ptrs, acc_dwb, mask=h_mask[:, None] & k_mask[None, :])
+        tl.store(pwo_ptrs, acc_dwo, mask=n_mask[:, None] & h_mask[None, :])
+
+else:  # pragma: no cover
+
+    def _fused_swiglu_transition_fwd_kernel(*_a, **_k):
+        raise RuntimeError("Triton is required for fused_swiglu_transition")
+
+    def _fused_swiglu_transition_bwd_dx_kernel(*_a, **_k):
+        raise RuntimeError("Triton is required for fused_swiglu_transition")
+
+    def _fused_swiglu_transition_bwd_dw_kernel(*_a, **_k):
+        raise RuntimeError("Triton is required for fused_swiglu_transition")
+
+
+def _matmul_precision_args(act: torch.Tensor) -> tuple[str, bool]:
+    """``tl.dot`` input_precision from the TF32 context. bf16 inputs ignore it."""
+    if act.dtype == torch.bfloat16 or not torch.backends.cuda.matmul.allow_tf32:
+        return "ieee", False
+    return "tf32", True
+
+
+def _next_power_of_two(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def _launch_fused_swiglu_transition(
+    x_2d: torch.Tensor,
+    gamma: torch.Tensor,
+    beta: torch.Tensor | None,
+    w_a: torch.Tensor,
+    w_b: torch.Tensor,
+    w_out: torch.Tensor,
+    mask_1d: torch.Tensor | None,
+    residual_2d: torch.Tensor | None,
+    eps: float,
+    save_acts: bool = False,
+):
+    """Launch fused forward.
+
+    Inference (``save_acts=False``) may write in place when ``residual`` aliases
+    ``x``. Training (``save_acts=True``) writes a fresh ``y`` plus ``x_hat``,
+    ``a``, ``b`` for the backward kernels.
+    """
+    M, K = x_2d.shape
+    H = w_a.shape[0]
+    C_OUT = w_out.shape[0]
+
+    in_place = residual_2d is not None and residual_2d.data_ptr() == x_2d.data_ptr()
+    if save_acts and in_place:
+        raise RuntimeError("fused SwiGLU training forward cannot write in place")
+    y = x_2d if in_place else torch.empty((M, C_OUT), dtype=x_2d.dtype, device=x_2d.device)
+
+    if save_acts:
+        x_hat = torch.empty((M, K), dtype=x_2d.dtype, device=x_2d.device)
+        a = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
+        b = torch.empty((M, H), dtype=x_2d.dtype, device=x_2d.device)
+    else:
+        x_hat = a = b = y
+
+    BLOCK_K = max(_next_power_of_two(K), 16)
+    BLOCK_N = max(_next_power_of_two(C_OUT), 16)
+    input_precision, round_tf32 = _matmul_precision_args(x_2d)
+
+    beta_ptr = beta if beta is not None else x_2d
+    mask_ptr = mask_1d if mask_1d is not None else x_2d
+    stride_mask_m = mask_1d.stride(0) if mask_1d is not None else 0
+    res = residual_2d if residual_2d is not None else x_2d
+
+    def _grid(meta):
+        return (triton.cdiv(M, meta["BLOCK_M"]),)
+
+    _fused_swiglu_transition_fwd_kernel[_grid](
+        x_2d,
+        w_a,
+        w_b,
+        w_out,
+        gamma,
+        beta_ptr,
+        mask_ptr,
+        res,
+        y,
+        x_hat,
+        a,
+        b,
+        x_2d.stride(0),
+        x_2d.stride(1),
+        w_a.stride(0),
+        w_a.stride(1),
+        w_b.stride(0),
+        w_b.stride(1),
+        w_out.stride(0),
+        w_out.stride(1),
+        res.stride(0),
+        res.stride(1),
+        y.stride(0),
+        y.stride(1),
+        stride_mask_m,
+        x_hat.stride(0),
+        a.stride(0),
+        b.stride(0),
+        M,
+        K,
+        H,
+        C_OUT,
+        eps,
+        HAS_LN_BIAS=beta is not None,
+        HAS_MASK=mask_1d is not None,
+        HAS_RESIDUAL=residual_2d is not None,
+        SAVE_ACTS=save_acts,
+        INPUT_PRECISION=input_precision,
+        ROUND_TF32=round_tf32,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+    )
+    if save_acts:
+        return y, x_hat, a, b
+    return y
+
+
+def fused_swiglu_transition_weight_grad(
+    x_hat: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    grad_out_2d: torch.Tensor,
+    w_a: torch.Tensor,
+    w_b: torch.Tensor,
+    w_out: torch.Tensor,
+    mask_1d: torch.Tensor | None,
+    compute_dx: bool = True,
+    compute_dw: bool = True,
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    """Triton backward from saved ``x_hat``, ``a``, ``b``.
+
+    Returns ``d(x_hat), dWa, dWb, dWo``. Split-M ``dW`` runs first so the
+    ``x_hat`` buffer can be reused for ``d(x_hat)`` when it is fp32.
+    """
+    M, K = x_hat.shape
+    H = a.shape[1]
+    C_OUT = w_out.shape[0]
+    input_precision, round_tf32 = _matmul_precision_args(a)
+    BLOCK_K = max(_next_power_of_two(K), 16)
+    BLOCK_N = max(_next_power_of_two(C_OUT), 16)
+
+    a_c = a.contiguous()
+    b_c = b.contiguous()
+    go_c = grad_out_2d.contiguous()
+    wo_c = w_out.contiguous()
+    mask_ptr = mask_1d if mask_1d is not None else a_c
+    stride_mask_m = mask_1d.stride(0) if mask_1d is not None else 0
+    has_mask = mask_1d is not None
+
+    grad_wa = grad_wb = grad_wo = None
+    if compute_dw:
+        x_hat_c = x_hat.contiguous()
+        partial_wa = torch.zeros(
+            _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
+        )
+        partial_wb = torch.zeros(
+            _BWD_SPLIT_M, H, K, device=x_hat.device, dtype=torch.float32
+        )
+        partial_wo = torch.zeros(
+            _BWD_SPLIT_M, C_OUT, H, device=x_hat.device, dtype=torch.float32
+        )
+
+        def _grid_dw(meta):
+            return (_BWD_SPLIT_M, triton.cdiv(H, meta["BLOCK_H"]))
+
+        _fused_swiglu_transition_bwd_dw_kernel[_grid_dw](
+            x_hat_c,
+            a_c,
+            b_c,
+            wo_c,
+            mask_ptr,
+            go_c,
+            partial_wa,
+            partial_wb,
+            partial_wo,
+            x_hat_c.stride(0),
+            a_c.stride(0),
+            b_c.stride(0),
+            go_c.stride(0),
+            stride_mask_m,
+            M,
+            K,
+            H,
+            C_OUT,
+            HAS_MASK=has_mask,
+            INPUT_PRECISION=input_precision,
+            ROUND_TF32=round_tf32,
+            SPLIT_M=_BWD_SPLIT_M,
+            BLOCK_K=BLOCK_K,
+            BLOCK_N=BLOCK_N,
+        )
+        grad_wa = partial_wa.sum(dim=0)
+        grad_wb = partial_wb.sum(dim=0)
+        grad_wo = partial_wo.sum(dim=0)
+        del partial_wa, partial_wb, partial_wo
+
+    grad_x_hat = None
+    if compute_dx:
+        # fp32 x_hat is dead after dW; reuse it for d(x_hat) instead of +1U.
+        if x_hat.dtype == torch.float32:
+            grad_x_hat = x_hat
+        else:
+            grad_x_hat = torch.empty((M, K), dtype=torch.float32, device=x_hat.device)
+        wa_c = w_a.contiguous()
+        wb_c = w_b.contiguous()
+
+        def _grid_dx(meta):
+            return (triton.cdiv(M, meta["BLOCK_M"]),)
+
+        _fused_swiglu_transition_bwd_dx_kernel[_grid_dx](
+            a_c,
+            b_c,
+            wa_c,
+            wb_c,
+            wo_c,
+            mask_ptr,
+            go_c,
+            grad_x_hat,
+            a_c.stride(0),
+            b_c.stride(0),
+            go_c.stride(0),
+            grad_x_hat.stride(0),
+            stride_mask_m,
+            M,
+            K,
+            H,
+            C_OUT,
+            HAS_MASK=has_mask,
+            INPUT_PRECISION=input_precision,
+            ROUND_TF32=round_tf32,
+            BLOCK_K=BLOCK_K,
+            BLOCK_N=BLOCK_N,
+        )
+
+    return grad_x_hat, grad_wa, grad_wb, grad_wo
+
+
+class _FusedSwiGLUTransitionFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, gamma, beta, w_a, w_b, w_out, mask, eps):
+        has_beta = beta is not None
+        has_mask = mask is not None
+        beta_t = beta if has_beta else x.new_empty(0)
+        mask_t = mask if has_mask else x.new_empty(0)
+
+        c_in = gamma.shape[0]
+        x_2d = x.contiguous().view(-1, c_in)
+        mask_1d = mask.reshape(-1).contiguous() if has_mask else None
+        y_2d, x_hat, a, b = _launch_fused_swiglu_transition(
+            x_2d,
+            gamma,
+            beta if has_beta else None,
+            w_a,
+            w_b,
+            w_out,
+            mask_1d,
+            None,
+            float(eps),
+            save_acts=True,
+        )
+        y = y_2d.view_as(x)
+
+        ctx.save_for_backward(x, x_hat, a, b, gamma, beta_t, w_a, w_b, w_out, mask_t)
+        ctx.eps = float(eps)
+        ctx.has_beta = has_beta
+        ctx.has_mask = has_mask
+        ctx.x_shape = x.shape
+        return y
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_out):
+        x, x_hat, a, b, gamma, beta_t, w_a, w_b, w_out, mask_t = ctx.saved_tensors
+        beta = beta_t if ctx.has_beta else None
+        mask = mask_t if ctx.has_mask else None
+        eps = ctx.eps
+        c_in = gamma.shape[0]
+
+        go_2d = grad_out.contiguous().view(-1, grad_out.shape[-1])
+        mask_1d = mask.reshape(-1).contiguous() if mask is not None else None
+
+        need_dx = any(ctx.needs_input_grad[:3])
+        need_dw = any(ctx.needs_input_grad[3:6])
+        grad_x_hat, grad_wa, grad_wb, grad_wo = fused_swiglu_transition_weight_grad(
+            x_hat,
+            a,
+            b,
+            go_2d,
+            w_a,
+            w_b,
+            w_out,
+            mask_1d,
+            compute_dx=need_dx,
+            compute_dw=need_dw,
+        )
+
+        grad_x = grad_gamma = grad_beta = None
+        if need_dx:
+            x_2d = x.contiguous().view(-1, c_in)
+            x_f = x_2d.float()
+            mean = x_f.mean(dim=-1)
+            var = x_f.var(dim=-1, unbiased=False)
+            rstd = torch.rsqrt(var + eps)
+            ln_weight = gamma.float()
+            ln_bias = beta.float() if beta is not None else None
+            grad_input, grad_gamma, grad_beta = torch.ops.aten.native_layer_norm_backward(
+                grad_x_hat,
+                x_f,
+                (c_in,),
+                mean,
+                rstd,
+                ln_weight,
+                ln_bias,
+                (
+                    ctx.needs_input_grad[0],
+                    ctx.needs_input_grad[1],
+                    ctx.needs_input_grad[2],
+                ),
+            )
+            if grad_input is not None:
+                grad_x = grad_input.view(ctx.x_shape).to(dtype=x.dtype)
+            if grad_gamma is not None:
+                grad_gamma = grad_gamma.to(dtype=gamma.dtype)
+            if grad_beta is not None:
+                grad_beta = grad_beta.to(dtype=beta.dtype)
+
+        if not ctx.needs_input_grad[3]:
+            grad_wa = None
+        else:
+            grad_wa = grad_wa.to(dtype=w_a.dtype)
+        if not ctx.needs_input_grad[4]:
+            grad_wb = None
+        else:
+            grad_wb = grad_wb.to(dtype=w_b.dtype)
+        if not ctx.needs_input_grad[5]:
+            grad_wo = None
+        else:
+            grad_wo = grad_wo.to(dtype=w_out.dtype)
+
+        return grad_x, grad_gamma, grad_beta, grad_wa, grad_wb, grad_wo, None, None
+
+
+def fused_swiglu_transition(
+    x: torch.Tensor,
+    gamma: torch.Tensor,
+    beta: torch.Tensor | None,
+    w_a: torch.Tensor,
+    w_b: torch.Tensor,
+    w_out: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    eps: float = 1e-5,
+    residual: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused LN -> SwiGLU -> Linear -> (*mask) [-> +residual].
+
+    Triton only. The model uses ``SwiGLUTransition`` primitives when this
+    launch is ineligible. Inference may write in place when ``residual is
+    x``. Training is always out-of-place and saves activations for the
+    Triton backward. Triton keeps fp32 masters; bf16 activations use bf16
+    GEMMs.
+    """
+    if not is_fused_swiglu_transition_eligible(x, gamma, beta, w_a, w_b, w_out):
+        raise RuntimeError(
+            "fused_swiglu_transition requires an eligible Triton launch; "
+            "use SwiGLUTransition for the eager path"
+        )
+
+    c_in = gamma.shape[0]
+    use_grad = torch.is_grad_enabled() and (
+        x.requires_grad
+        or gamma.requires_grad
+        or (beta is not None and beta.requires_grad)
+        or w_a.requires_grad
+        or w_b.requires_grad
+        or w_out.requires_grad
+    )
+    if use_grad:
+        if residual is not None:
+            update = fused_swiglu_transition(
+                x, gamma, beta, w_a, w_b, w_out, mask=mask, eps=eps, residual=None
+            )
+            return residual + update
+        return _FusedSwiGLUTransitionFn.apply(
+            x, gamma, beta, w_a, w_b, w_out, mask, eps
+        )
+
+    x_2d = x.contiguous().view(-1, c_in)
+    mask_1d = mask.reshape(-1) if mask is not None else None
+    res_2d = residual.view(-1, c_in) if residual is not None else None
+    y_2d = _launch_fused_swiglu_transition(
+        x_2d, gamma, beta, w_a, w_b, w_out, mask_1d, res_2d, eps, save_acts=False
+    )
+    return y_2d.view_as(x if residual is None else residual)

--- a/openfold3/core/kernels/triton/fused_template_coordinate.py
+++ b/openfold3/core/kernels/triton/fused_template_coordinate.py
@@ -134,15 +134,15 @@ if _TRITON_AVAILABLE:
 
         frame_i_base = frame_coords_ptr + i * stride_frame_i
         n_x = tl.load(frame_i_base, mask=pair_mask, other=0.0).to(tl.float32)
-        n_y = tl.load(
-            frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0
-        ).to(tl.float32)
+        n_y = tl.load(frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
         n_z = tl.load(
             frame_i_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
-        ca_x = tl.load(
-            frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0
-        ).to(tl.float32)
+        ca_x = tl.load(frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
         ca_y = tl.load(
             frame_i_base + stride_frame_atom + stride_frame_xyz,
             mask=pair_mask,
@@ -168,9 +168,9 @@ if _TRITON_AVAILABLE:
         ).to(tl.float32)
         frame_j_base = frame_coords_ptr + j * stride_frame_i + stride_frame_atom
         j_ca_x = tl.load(frame_j_base, mask=pair_mask, other=0.0).to(tl.float32)
-        j_ca_y = tl.load(
-            frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0
-        ).to(tl.float32)
+        j_ca_y = tl.load(frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
         j_ca_z = tl.load(
             frame_j_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
@@ -456,13 +456,13 @@ if _TRITON_AVAILABLE:
         if not COMPUTE_SCALAR:
             feature_mask &= feature < 39
 
-        accumulator = tl.zeros(
-            (BLOCK_CHANNELS, BLOCK_FEATURES), dtype=tl.float32
-        )
+        accumulator = tl.zeros((BLOCK_CHANNELS, BLOCK_FEATURES), dtype=tl.float32)
         pair_count = N * N
         pairs_per_split = (
-            pair_count + SPLIT_K * BLOCK_PAIRS - 1
-        ) // (SPLIT_K * BLOCK_PAIRS) * BLOCK_PAIRS
+            (pair_count + SPLIT_K * BLOCK_PAIRS - 1)
+            // (SPLIT_K * BLOCK_PAIRS)
+            * BLOCK_PAIRS
+        )
         pair_start = split * pairs_per_split
         pair_stop = tl.minimum(pair_start + pairs_per_split, pair_count)
         while pair_start < pair_stop:
@@ -508,14 +508,11 @@ if _TRITON_AVAILABLE:
 
             dgram_scale = pb_pair_mask * in_bin.to(tl.float32)
             features = tl.where(
-                (feature[None, :] < 39)
-                & (feature[None, :] == bin_index[:, None]),
+                (feature[None, :] < 39) & (feature[None, :] == bin_index[:, None]),
                 dgram_scale[:, None],
                 0.0,
             )
-            features += tl.where(
-                feature[None, :] == 39, pb_pair_mask[:, None], 0.0
-            )
+            features += tl.where(feature[None, :] == 39, pb_pair_mask[:, None], 0.0)
             features += tl.where(
                 feature[None, :] == 40,
                 (bb_pair_mask * local_x)[:, None],
@@ -531,9 +528,7 @@ if _TRITON_AVAILABLE:
                 (bb_pair_mask * local_z)[:, None],
                 0.0,
             )
-            features += tl.where(
-                feature[None, :] == 43, bb_pair_mask[:, None], 0.0
-            )
+            features += tl.where(feature[None, :] == 43, bb_pair_mask[:, None], 0.0)
             features = tl.where(
                 pair_mask[:, None] & feature_mask[None, :], features, 0.0
             )
@@ -616,9 +611,7 @@ if _TRITON_AVAILABLE:
         if COMPUTE_DGRAM:
             dgram_mask = output_mask & (feature < 39)
             tl.store(
-                grad_dgram_ptr
-                + channel * stride_dgram_c
-                + feature * stride_dgram_f,
+                grad_dgram_ptr + channel * stride_dgram_c + feature * stride_dgram_f,
                 accumulator,
                 mask=dgram_mask,
             )
@@ -664,9 +657,7 @@ def template_coordinate_projection(
         dgram_weight,
         scalar_weight,
     )
-    if torch.is_grad_enabled() and any(
-        x.requires_grad for x in (source, out, *inputs)
-    ):
+    if torch.is_grad_enabled() and any(x.requires_grad for x in (source, out, *inputs)):
         raise RuntimeError(
             "Raw template coordinate Triton launches are not autograd-aware; "
             "use the model dispatcher"

--- a/openfold3/core/kernels/triton/fused_template_coordinate.py
+++ b/openfold3/core/kernels/triton/fused_template_coordinate.py
@@ -21,6 +21,7 @@ The fixed-shape projection (39 distogram inputs and five scalar inputs into
 64 output channels) is fused with coordinate-to-pair feature construction.
 No pairwise feature tensor is written to HBM. Sequence length and all tensor
 strides remain runtime values so one compiled kernel serves every length.
+Supports fp32/bf16 pair activations with fp32 accumulate.
 """
 
 from __future__ import annotations
@@ -39,50 +40,21 @@ except ImportError:  # pragma: no cover
 if _TRITON_AVAILABLE:
     _BLOCK_PAIRS = 16
     _BLOCK_CHANNELS = 64
+    _BWD_BLOCK_PAIRS = 32
+    _BWD_BLOCK_CHANNELS = 64
+    _BWD_BLOCK_FEATURES = 16
+    _BWD_SPLIT_K = 64
+    _BWD_FEATURES = 44
 
-    @triton.jit(
-        do_not_specialize=[
-            "N",
-            "stride_out_i",
-            "stride_out_j",
-            "stride_out_c",
-            "stride_pb_i",
-            "stride_pb_xyz",
-            "stride_frame_i",
-            "stride_frame_atom",
-            "stride_frame_xyz",
-            "stride_pb_mask_i",
-            "stride_bb_mask_i",
-            "stride_asym_i",
-            "stride_w_dgram_c",
-            "stride_w_dgram_bin",
-            "stride_w_scalar_c",
-            "stride_w_scalar_feat",
-        ],
-        do_not_specialize_on_alignment=[
-            "out_ptr",
-            "pb_coords_ptr",
-            "frame_coords_ptr",
-            "pb_mask_ptr",
-            "bb_mask_ptr",
-            "asym_id_ptr",
-            "w_dgram_ptr",
-            "w_scalar_ptr",
-        ],
-    )
-    def _template_coordinate_projection_kernel(
-        out_ptr,
+    @triton.jit
+    def _template_coordinate_pair_features(
+        pair,
         pb_coords_ptr,
         frame_coords_ptr,
         pb_mask_ptr,
         bb_mask_ptr,
         asym_id_ptr,
-        w_dgram_ptr,
-        w_scalar_ptr,
         N,
-        stride_out_i,
-        stride_out_j,
-        stride_out_c,
         stride_pb_i,
         stride_pb_xyz,
         stride_frame_i,
@@ -91,17 +63,8 @@ if _TRITON_AVAILABLE:
         stride_pb_mask_i,
         stride_bb_mask_i,
         stride_asym_i,
-        stride_w_dgram_c,
-        stride_w_dgram_bin,
-        stride_w_scalar_c,
-        stride_w_scalar_feat,
-        BLOCK_PAIRS: tl.constexpr,
-        BLOCK_CHANNELS: tl.constexpr,
     ):
-        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
-        channel = tl.arange(0, BLOCK_CHANNELS)
         pair_mask = pair < N * N
-
         i = pair // N
         j = pair - i * N
 
@@ -140,8 +103,6 @@ if _TRITON_AVAILABLE:
         pb_dz = pb_iz - pb_jz
         dist2 = pb_dx * pb_dx + pb_dy * pb_dy + pb_dz * pb_dz
 
-        # Current template distogram uses 39 strict open intervals with
-        # linearly spaced (unsquared) edges from 3.25 to 50.75 Angstrom.
         min_bin = 3.25
         bin_step = 1.25
         distance = tl.sqrt(dist2)
@@ -173,15 +134,15 @@ if _TRITON_AVAILABLE:
 
         frame_i_base = frame_coords_ptr + i * stride_frame_i
         n_x = tl.load(frame_i_base, mask=pair_mask, other=0.0).to(tl.float32)
-        n_y = tl.load(frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        n_y = tl.load(
+            frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         n_z = tl.load(
             frame_i_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
-        ca_x = tl.load(frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        ca_x = tl.load(
+            frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         ca_y = tl.load(
             frame_i_base + stride_frame_atom + stride_frame_xyz,
             mask=pair_mask,
@@ -207,9 +168,9 @@ if _TRITON_AVAILABLE:
         ).to(tl.float32)
         frame_j_base = frame_coords_ptr + j * stride_frame_i + stride_frame_atom
         j_ca_x = tl.load(frame_j_base, mask=pair_mask, other=0.0).to(tl.float32)
-        j_ca_y = tl.load(frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
-            tl.float32
-        )
+        j_ca_y = tl.load(
+            frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
         j_ca_z = tl.load(
             frame_j_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
         ).to(tl.float32)
@@ -263,13 +224,130 @@ if _TRITON_AVAILABLE:
         local_x *= inv_delta_norm
         local_y *= inv_delta_norm
         local_z *= inv_delta_norm
+        return (
+            i,
+            j,
+            pair_mask,
+            bin_index,
+            in_bin,
+            pb_pair_mask,
+            bb_pair_mask,
+            local_x,
+            local_y,
+            local_z,
+        )
 
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_source_i",
+            "stride_source_j",
+            "stride_source_c",
+            "stride_out_i",
+            "stride_out_j",
+            "stride_out_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_w_dgram_c",
+            "stride_w_dgram_bin",
+            "stride_w_scalar_c",
+            "stride_w_scalar_feat",
+        ],
+        do_not_specialize_on_alignment=[
+            "source_ptr",
+            "out_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "w_dgram_ptr",
+            "w_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_kernel(
+        source_ptr,
+        out_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        w_dgram_ptr,
+        w_scalar_ptr,
+        N,
+        stride_source_i,
+        stride_source_j,
+        stride_source_c,
+        stride_out_i,
+        stride_out_j,
+        stride_out_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_w_dgram_c,
+        stride_w_dgram_bin,
+        stride_w_scalar_c,
+        stride_w_scalar_feat,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+    ):
+        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
+        channel = tl.arange(0, BLOCK_CHANNELS)
+
+        (
+            i,
+            j,
+            pair_mask,
+            bin_index,
+            in_bin,
+            pb_pair_mask,
+            bb_pair_mask,
+            local_x,
+            local_y,
+            local_z,
+        ) = _template_coordinate_pair_features(
+            pair,
+            pb_coords_ptr,
+            frame_coords_ptr,
+            pb_mask_ptr,
+            bb_mask_ptr,
+            asym_id_ptr,
+            N,
+            stride_pb_i,
+            stride_pb_xyz,
+            stride_frame_i,
+            stride_frame_atom,
+            stride_frame_xyz,
+            stride_pb_mask_i,
+            stride_bb_mask_i,
+            stride_asym_i,
+        )
+
+        source_offsets = (
+            i[:, None] * stride_source_i
+            + j[:, None] * stride_source_j
+            + channel[None, :] * stride_source_c
+        )
         out_offsets = (
             i[:, None] * stride_out_i
             + j[:, None] * stride_out_j
             + channel[None, :] * stride_out_c
         )
-        out = tl.load(out_ptr + out_offsets, mask=pair_mask[:, None]).to(tl.float32)
+        out = tl.load(source_ptr + source_offsets, mask=pair_mask[:, None]).to(
+            tl.float32
+        )
 
         w_dgram = tl.load(
             w_dgram_ptr
@@ -303,11 +381,260 @@ if _TRITON_AVAILABLE:
             + w_bb[None, :]
         )
 
-        tl.store(out_ptr + out_offsets, out, mask=pair_mask[:, None])
+        tl.store(
+            out_ptr + out_offsets,
+            out.to(out_ptr.dtype.element_ty),
+            mask=pair_mask[:, None],
+        )
+
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_grad_i",
+            "stride_grad_j",
+            "stride_grad_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_partial_split",
+            "stride_partial_c",
+            "stride_partial_f",
+        ],
+        do_not_specialize_on_alignment=[
+            "grad_output_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "partial_ptr",
+        ],
+    )
+    def _template_coordinate_projection_bwd_partial_kernel(
+        grad_output_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        partial_ptr,
+        N,
+        stride_grad_i,
+        stride_grad_j,
+        stride_grad_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_partial_split,
+        stride_partial_c,
+        stride_partial_f,
+        COMPUTE_DGRAM: tl.constexpr,
+        COMPUTE_SCALAR: tl.constexpr,
+        ALLOW_TF32: tl.constexpr,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+        BLOCK_FEATURES: tl.constexpr,
+        SPLIT_K: tl.constexpr,
+    ):
+        channel = tl.program_id(0) * BLOCK_CHANNELS + tl.arange(0, BLOCK_CHANNELS)
+        feature = tl.program_id(1) * BLOCK_FEATURES + tl.arange(0, BLOCK_FEATURES)
+        split = tl.program_id(2)
+        channel_mask = channel < 64
+        feature_mask = feature < 44
+        if not COMPUTE_DGRAM:
+            feature_mask &= feature >= 39
+        if not COMPUTE_SCALAR:
+            feature_mask &= feature < 39
+
+        accumulator = tl.zeros(
+            (BLOCK_CHANNELS, BLOCK_FEATURES), dtype=tl.float32
+        )
+        pair_count = N * N
+        pairs_per_split = (
+            pair_count + SPLIT_K * BLOCK_PAIRS - 1
+        ) // (SPLIT_K * BLOCK_PAIRS) * BLOCK_PAIRS
+        pair_start = split * pairs_per_split
+        pair_stop = tl.minimum(pair_start + pairs_per_split, pair_count)
+        while pair_start < pair_stop:
+            pair = pair_start + tl.arange(0, BLOCK_PAIRS)
+            (
+                i,
+                j,
+                pair_mask,
+                bin_index,
+                in_bin,
+                pb_pair_mask,
+                bb_pair_mask,
+                local_x,
+                local_y,
+                local_z,
+            ) = _template_coordinate_pair_features(
+                pair,
+                pb_coords_ptr,
+                frame_coords_ptr,
+                pb_mask_ptr,
+                bb_mask_ptr,
+                asym_id_ptr,
+                N,
+                stride_pb_i,
+                stride_pb_xyz,
+                stride_frame_i,
+                stride_frame_atom,
+                stride_frame_xyz,
+                stride_pb_mask_i,
+                stride_bb_mask_i,
+                stride_asym_i,
+            )
+            grad_offsets = (
+                i[:, None] * stride_grad_i
+                + j[:, None] * stride_grad_j
+                + channel[None, :] * stride_grad_c
+            )
+            grad = tl.load(
+                grad_output_ptr + grad_offsets,
+                mask=pair_mask[:, None] & channel_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+
+            dgram_scale = pb_pair_mask * in_bin.to(tl.float32)
+            features = tl.where(
+                (feature[None, :] < 39)
+                & (feature[None, :] == bin_index[:, None]),
+                dgram_scale[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 39, pb_pair_mask[:, None], 0.0
+            )
+            features += tl.where(
+                feature[None, :] == 40,
+                (bb_pair_mask * local_x)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 41,
+                (bb_pair_mask * local_y)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 42,
+                (bb_pair_mask * local_z)[:, None],
+                0.0,
+            )
+            features += tl.where(
+                feature[None, :] == 43, bb_pair_mask[:, None], 0.0
+            )
+            features = tl.where(
+                pair_mask[:, None] & feature_mask[None, :], features, 0.0
+            )
+            if ALLOW_TF32:
+                accumulator = tl.dot(
+                    tl.trans(grad),
+                    features,
+                    accumulator,
+                    input_precision="tf32",
+                    out_dtype=tl.float32,
+                )
+            else:
+                accumulator = tl.dot(
+                    tl.trans(grad),
+                    features,
+                    accumulator,
+                    input_precision="ieee",
+                    out_dtype=tl.float32,
+                )
+            pair_start += BLOCK_PAIRS
+
+        partial_offsets = (
+            split * stride_partial_split
+            + channel[:, None] * stride_partial_c
+            + feature[None, :] * stride_partial_f
+        )
+        tl.store(
+            partial_ptr + partial_offsets,
+            accumulator,
+            mask=channel_mask[:, None] & feature_mask[None, :],
+        )
+
+    @triton.jit(
+        do_not_specialize=[
+            "stride_partial_split",
+            "stride_partial_c",
+            "stride_partial_f",
+            "stride_dgram_c",
+            "stride_dgram_f",
+            "stride_scalar_c",
+            "stride_scalar_f",
+        ],
+        do_not_specialize_on_alignment=[
+            "partial_ptr",
+            "grad_dgram_ptr",
+            "grad_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_bwd_reduce_kernel(
+        partial_ptr,
+        grad_dgram_ptr,
+        grad_scalar_ptr,
+        stride_partial_split,
+        stride_partial_c,
+        stride_partial_f,
+        stride_dgram_c,
+        stride_dgram_f,
+        stride_scalar_c,
+        stride_scalar_f,
+        COMPUTE_DGRAM: tl.constexpr,
+        COMPUTE_SCALAR: tl.constexpr,
+        SPLIT_K: tl.constexpr,
+        BLOCK_OUTPUTS: tl.constexpr,
+    ):
+        output = tl.program_id(0) * BLOCK_OUTPUTS + tl.arange(0, BLOCK_OUTPUTS)
+        output_mask = output < 64 * 44
+        channel = output // 44
+        feature = output - channel * 44
+        accumulator = tl.zeros((BLOCK_OUTPUTS,), dtype=tl.float32)
+        for split in range(SPLIT_K):
+            accumulator += tl.load(
+                partial_ptr
+                + split * stride_partial_split
+                + channel * stride_partial_c
+                + feature * stride_partial_f,
+                mask=output_mask,
+                other=0.0,
+            ).to(tl.float32)
+
+        if COMPUTE_DGRAM:
+            dgram_mask = output_mask & (feature < 39)
+            tl.store(
+                grad_dgram_ptr
+                + channel * stride_dgram_c
+                + feature * stride_dgram_f,
+                accumulator,
+                mask=dgram_mask,
+            )
+        if COMPUTE_SCALAR:
+            scalar_mask = output_mask & (feature >= 39)
+            tl.store(
+                grad_scalar_ptr
+                + channel * stride_scalar_c
+                + (feature - 39) * stride_scalar_f,
+                accumulator,
+                mask=scalar_mask,
+            )
 
 
-def template_coordinate_projection_add_(
-    out: torch.Tensor,
+def template_coordinate_projection(
+    source: torch.Tensor,
     pseudo_beta_coords: torch.Tensor,
     frame_atom_coords: torch.Tensor,
     pseudo_beta_mask: torch.Tensor,
@@ -315,27 +642,75 @@ def template_coordinate_projection_add_(
     asym_id: torch.Tensor,
     dgram_weight: torch.Tensor,
     scalar_weight: torch.Tensor,
-) -> None:
-    """Add coordinate-derived template projections to ``out`` in place.
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Add coordinate-derived projections to ``source`` and write ``out``.
 
-    This launcher intentionally supports only the production inference shape:
-    B=1, fp32, 39 distogram inputs, five scalar inputs, and 64 output channels.
+    ``source`` and ``out`` may be the same tensor for guarded inference use.
+    Training callers pass a fresh ``out`` through an autograd wrapper. This
+    launcher intentionally supports only the production B=1, fp32/bf16, 39+5
+    to 64 shape.
     """
     if not _TRITON_AVAILABLE:
         raise RuntimeError("Triton is required for coordinate template projection")
+    if out is None:
+        out = torch.empty_like(source)
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+    )
+    if torch.is_grad_enabled() and any(
+        x.requires_grad for x in (source, out, *inputs)
+    ):
+        raise RuntimeError(
+            "Raw template coordinate Triton launches are not autograd-aware; "
+            "use the model dispatcher"
+        )
     if not (
-        out.is_cuda
-        and out.dtype == torch.float32
-        and out.shape[0] == 1
-        and out.shape[-1] == 64
+        source.is_cuda
+        and out.is_cuda
+        and source.device == out.device
+        and source.dtype in (torch.float32, torch.bfloat16)
+        and out.dtype == source.dtype
+        and source.dim() == 4
+        and source.shape[0] == 1
+        and source.shape[-1] == 64
+        and all(x.is_cuda and x.device == source.device for x in inputs)
+        and dgram_weight.dtype == torch.float32
+        and scalar_weight.dtype == torch.float32
         and dgram_weight.shape == (64, 39)
         and scalar_weight.shape == (64, 5)
     ):
         raise ValueError("Unsupported coordinate template projection configuration")
 
-    n_token = out.shape[1]
-    if out.shape != (1, n_token, n_token, 64):
-        raise ValueError(f"Expected out [1,N,N,64], got {tuple(out.shape)}")
+    n_token = source.shape[1]
+    expected_shape = (1, n_token, n_token, 64)
+    if source.shape != expected_shape or out.shape != expected_shape:
+        raise ValueError(
+            "Expected source and out [1,N,N,64], got "
+            f"{tuple(source.shape)} and {tuple(out.shape)}"
+        )
+    input_shapes = (
+        pseudo_beta_coords.shape == (1, n_token, 3)
+        and frame_atom_coords.shape == (1, n_token, 3, 3)
+        and pseudo_beta_mask.shape == (1, n_token)
+        and backbone_frame_mask.shape == (1, n_token)
+        and asym_id.shape == (1, n_token)
+    )
+    if not input_shapes:
+        raise ValueError("Coordinate inputs do not match source token dimensions")
+    if torch._debug_has_internal_overlap(out) != 0:
+        raise ValueError("Template coordinate output must not overlap internally")
+    if (
+        source.untyped_storage().data_ptr() == out.untyped_storage().data_ptr()
+        and source is not out
+    ):
+        raise ValueError("source and out may only alias when they are the same tensor")
 
     pb = pseudo_beta_coords[0]
     frame = frame_atom_coords[0]
@@ -344,6 +719,7 @@ def template_coordinate_projection_add_(
     asym = asym_id[0]
     grid = (triton.cdiv(n_token * n_token, _BLOCK_PAIRS),)
     _template_coordinate_projection_kernel[grid](
+        source,
         out,
         pb,
         frame,
@@ -353,6 +729,9 @@ def template_coordinate_projection_add_(
         dgram_weight,
         scalar_weight,
         n_token,
+        source.stride(1),
+        source.stride(2),
+        source.stride(3),
         out.stride(1),
         out.stride(2),
         out.stride(3),
@@ -372,4 +751,158 @@ def template_coordinate_projection_add_(
         BLOCK_CHANNELS=_BLOCK_CHANNELS,
         num_warps=4,
         num_stages=1,
+    )
+    return out
+
+
+def template_coordinate_projection_backward(
+    grad_output: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    *,
+    compute_dgram: bool = True,
+    compute_scalar: bool = True,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Compute coordinate-projection weight gradients with deterministic split-K."""
+    if not _TRITON_AVAILABLE:
+        raise RuntimeError("Triton is required for coordinate template projection")
+    if not compute_dgram and not compute_scalar:
+        return None, None
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+    )
+    if not (
+        grad_output.is_cuda
+        and grad_output.dtype in (torch.float32, torch.bfloat16)
+        and grad_output.dim() == 4
+        and grad_output.shape[0] == 1
+        and grad_output.shape[-1] == 64
+        and all(x.is_cuda and x.device == grad_output.device for x in inputs)
+    ):
+        raise ValueError(
+            "Unsupported coordinate template projection backward configuration"
+        )
+
+    n_token = grad_output.shape[1]
+    if grad_output.shape != (1, n_token, n_token, 64):
+        raise ValueError("Expected grad_output [1,N,N,64]")
+    if not (
+        pseudo_beta_coords.shape == (1, n_token, 3)
+        and frame_atom_coords.shape == (1, n_token, 3, 3)
+        and pseudo_beta_mask.shape == (1, n_token)
+        and backbone_frame_mask.shape == (1, n_token)
+        and asym_id.shape == (1, n_token)
+    ):
+        raise ValueError("Coordinate inputs do not match grad_output token dimensions")
+
+    grad = grad_output[0]
+    pb = pseudo_beta_coords[0]
+    frame = frame_atom_coords[0]
+    pb_mask = pseudo_beta_mask[0]
+    bb_mask = backbone_frame_mask[0]
+    asym = asym_id[0]
+    partial = torch.empty(
+        (_BWD_SPLIT_K, 64, _BWD_FEATURES),
+        dtype=torch.float32,
+        device=grad_output.device,
+    )
+    grad_dgram = torch.empty((64, 39), dtype=torch.float32, device=grad_output.device)
+    grad_scalar = torch.empty((64, 5), dtype=torch.float32, device=grad_output.device)
+
+    partial_grid = (
+        triton.cdiv(64, _BWD_BLOCK_CHANNELS),
+        triton.cdiv(_BWD_FEATURES, _BWD_BLOCK_FEATURES),
+        _BWD_SPLIT_K,
+    )
+    _template_coordinate_projection_bwd_partial_kernel[partial_grid](
+        grad,
+        pb,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        partial,
+        n_token,
+        grad.stride(0),
+        grad.stride(1),
+        grad.stride(2),
+        pb.stride(0),
+        pb.stride(1),
+        frame.stride(0),
+        frame.stride(1),
+        frame.stride(2),
+        pb_mask.stride(0),
+        bb_mask.stride(0),
+        asym.stride(0),
+        partial.stride(0),
+        partial.stride(1),
+        partial.stride(2),
+        COMPUTE_DGRAM=compute_dgram,
+        COMPUTE_SCALAR=compute_scalar,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_PAIRS=_BWD_BLOCK_PAIRS,
+        BLOCK_CHANNELS=_BWD_BLOCK_CHANNELS,
+        BLOCK_FEATURES=_BWD_BLOCK_FEATURES,
+        SPLIT_K=_BWD_SPLIT_K,
+        num_warps=4,
+        num_stages=1,
+    )
+    reduce_block = 256
+    reduce_grid = (triton.cdiv(64 * _BWD_FEATURES, reduce_block),)
+    _template_coordinate_projection_bwd_reduce_kernel[reduce_grid](
+        partial,
+        grad_dgram,
+        grad_scalar,
+        partial.stride(0),
+        partial.stride(1),
+        partial.stride(2),
+        grad_dgram.stride(0),
+        grad_dgram.stride(1),
+        grad_scalar.stride(0),
+        grad_scalar.stride(1),
+        COMPUTE_DGRAM=compute_dgram,
+        COMPUTE_SCALAR=compute_scalar,
+        SPLIT_K=_BWD_SPLIT_K,
+        BLOCK_OUTPUTS=reduce_block,
+        num_warps=8,
+        num_stages=1,
+    )
+    return (
+        grad_dgram if compute_dgram else None,
+        grad_scalar if compute_scalar else None,
+    )
+
+
+def template_coordinate_projection_add_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> None:
+    """Inference-only in-place compatibility wrapper."""
+    if torch.is_grad_enabled():
+        raise RuntimeError(
+            "In-place template coordinate projection requires disabled grad mode"
+        )
+    template_coordinate_projection(
+        out,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        out=out,
     )

--- a/openfold3/core/kernels/triton/fused_template_coordinate.py
+++ b/openfold3/core/kernels/triton/fused_template_coordinate.py
@@ -1,0 +1,375 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# by Liang Hong <lhong22@cse.cuhk.edu.hk>: length-generic Triton template
+# coordinate feature construction and fused pair projection.
+
+"""Coordinate-derived template pair projection.
+
+The fixed-shape projection (39 distogram inputs and five scalar inputs into
+64 output channels) is fused with coordinate-to-pair feature construction.
+No pairwise feature tensor is written to HBM. Sequence length and all tensor
+strides remain runtime values so one compiled kernel serves every length.
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TRITON_AVAILABLE = False
+
+
+if _TRITON_AVAILABLE:
+    _BLOCK_PAIRS = 16
+    _BLOCK_CHANNELS = 64
+
+    @triton.jit(
+        do_not_specialize=[
+            "N",
+            "stride_out_i",
+            "stride_out_j",
+            "stride_out_c",
+            "stride_pb_i",
+            "stride_pb_xyz",
+            "stride_frame_i",
+            "stride_frame_atom",
+            "stride_frame_xyz",
+            "stride_pb_mask_i",
+            "stride_bb_mask_i",
+            "stride_asym_i",
+            "stride_w_dgram_c",
+            "stride_w_dgram_bin",
+            "stride_w_scalar_c",
+            "stride_w_scalar_feat",
+        ],
+        do_not_specialize_on_alignment=[
+            "out_ptr",
+            "pb_coords_ptr",
+            "frame_coords_ptr",
+            "pb_mask_ptr",
+            "bb_mask_ptr",
+            "asym_id_ptr",
+            "w_dgram_ptr",
+            "w_scalar_ptr",
+        ],
+    )
+    def _template_coordinate_projection_kernel(
+        out_ptr,
+        pb_coords_ptr,
+        frame_coords_ptr,
+        pb_mask_ptr,
+        bb_mask_ptr,
+        asym_id_ptr,
+        w_dgram_ptr,
+        w_scalar_ptr,
+        N,
+        stride_out_i,
+        stride_out_j,
+        stride_out_c,
+        stride_pb_i,
+        stride_pb_xyz,
+        stride_frame_i,
+        stride_frame_atom,
+        stride_frame_xyz,
+        stride_pb_mask_i,
+        stride_bb_mask_i,
+        stride_asym_i,
+        stride_w_dgram_c,
+        stride_w_dgram_bin,
+        stride_w_scalar_c,
+        stride_w_scalar_feat,
+        BLOCK_PAIRS: tl.constexpr,
+        BLOCK_CHANNELS: tl.constexpr,
+    ):
+        pair = tl.program_id(0) * BLOCK_PAIRS + tl.arange(0, BLOCK_PAIRS)
+        channel = tl.arange(0, BLOCK_CHANNELS)
+        pair_mask = pair < N * N
+
+        i = pair // N
+        j = pair - i * N
+
+        pb_ix = tl.load(
+            pb_coords_ptr + i * stride_pb_i,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_iy = tl.load(
+            pb_coords_ptr + i * stride_pb_i + stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_iz = tl.load(
+            pb_coords_ptr + i * stride_pb_i + 2 * stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jx = tl.load(
+            pb_coords_ptr + j * stride_pb_i,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jy = tl.load(
+            pb_coords_ptr + j * stride_pb_i + stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_jz = tl.load(
+            pb_coords_ptr + j * stride_pb_i + 2 * stride_pb_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        pb_dx = pb_ix - pb_jx
+        pb_dy = pb_iy - pb_jy
+        pb_dz = pb_iz - pb_jz
+        dist2 = pb_dx * pb_dx + pb_dy * pb_dy + pb_dz * pb_dz
+
+        # Current template distogram uses 39 strict open intervals with
+        # linearly spaced (unsquared) edges from 3.25 to 50.75 Angstrom.
+        min_bin = 3.25
+        bin_step = 1.25
+        distance = tl.sqrt(dist2)
+        bin_index = tl.floor((distance - min_bin) / bin_step).to(tl.int32)
+        bin_index = tl.maximum(0, tl.minimum(38, bin_index))
+        lower = min_bin + bin_index.to(tl.float32) * bin_step
+        lower2 = lower * lower
+        upper = lower + bin_step
+        upper2 = tl.where(bin_index == 38, 1.0e8, upper * upper)
+        in_bin = (dist2 > lower2) & (dist2 < upper2)
+
+        pb_mask_i = tl.load(
+            pb_mask_ptr + i * stride_pb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        pb_mask_j = tl.load(
+            pb_mask_ptr + j * stride_pb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        bb_mask_i = tl.load(
+            bb_mask_ptr + i * stride_bb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        bb_mask_j = tl.load(
+            bb_mask_ptr + j * stride_bb_mask_i, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        asym_i = tl.load(asym_id_ptr + i * stride_asym_i, mask=pair_mask, other=0)
+        asym_j = tl.load(asym_id_ptr + j * stride_asym_i, mask=pair_mask, other=1)
+        same_chain = (asym_i == asym_j).to(tl.float32)
+        pb_pair_mask = pb_mask_i * pb_mask_j * same_chain
+        bb_pair_mask = bb_mask_i * bb_mask_j * same_chain
+
+        frame_i_base = frame_coords_ptr + i * stride_frame_i
+        n_x = tl.load(frame_i_base, mask=pair_mask, other=0.0).to(tl.float32)
+        n_y = tl.load(frame_i_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        n_z = tl.load(
+            frame_i_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        ca_x = tl.load(frame_i_base + stride_frame_atom, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        ca_y = tl.load(
+            frame_i_base + stride_frame_atom + stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        ca_z = tl.load(
+            frame_i_base + stride_frame_atom + 2 * stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        c_x = tl.load(
+            frame_i_base + 2 * stride_frame_atom, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+        c_y = tl.load(
+            frame_i_base + 2 * stride_frame_atom + stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        c_z = tl.load(
+            frame_i_base + 2 * stride_frame_atom + 2 * stride_frame_xyz,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        frame_j_base = frame_coords_ptr + j * stride_frame_i + stride_frame_atom
+        j_ca_x = tl.load(frame_j_base, mask=pair_mask, other=0.0).to(tl.float32)
+        j_ca_y = tl.load(frame_j_base + stride_frame_xyz, mask=pair_mask, other=0.0).to(
+            tl.float32
+        )
+        j_ca_z = tl.load(
+            frame_j_base + 2 * stride_frame_xyz, mask=pair_mask, other=0.0
+        ).to(tl.float32)
+
+        axis_x_x = c_x - ca_x
+        axis_x_y = c_y - ca_y
+        axis_x_z = c_z - ca_z
+        inv_x_norm = tl.rsqrt(
+            tl.maximum(
+                axis_x_x * axis_x_x + axis_x_y * axis_x_y + axis_x_z * axis_x_z,
+                1.0e-12,
+            )
+        )
+        axis_x_x *= inv_x_norm
+        axis_x_y *= inv_x_norm
+        axis_x_z *= inv_x_norm
+
+        axis_y_x = n_x - ca_x
+        axis_y_y = n_y - ca_y
+        axis_y_z = n_z - ca_z
+        projection = axis_y_x * axis_x_x + axis_y_y * axis_x_y + axis_y_z * axis_x_z
+        axis_y_x -= projection * axis_x_x
+        axis_y_y -= projection * axis_x_y
+        axis_y_z -= projection * axis_x_z
+        inv_y_norm = tl.rsqrt(
+            tl.maximum(
+                axis_y_x * axis_y_x + axis_y_y * axis_y_y + axis_y_z * axis_y_z,
+                1.0e-12,
+            )
+        )
+        axis_y_x *= inv_y_norm
+        axis_y_y *= inv_y_norm
+        axis_y_z *= inv_y_norm
+
+        axis_z_x = axis_x_y * axis_y_z - axis_x_z * axis_y_y
+        axis_z_y = axis_x_z * axis_y_x - axis_x_x * axis_y_z
+        axis_z_z = axis_x_x * axis_y_y - axis_x_y * axis_y_x
+
+        delta_x = j_ca_x - ca_x
+        delta_y = j_ca_y - ca_y
+        delta_z = j_ca_z - ca_z
+        local_x = delta_x * axis_x_x + delta_y * axis_x_y + delta_z * axis_x_z
+        local_y = delta_x * axis_y_x + delta_y * axis_y_y + delta_z * axis_y_z
+        local_z = delta_x * axis_z_x + delta_y * axis_z_y + delta_z * axis_z_z
+        inv_delta_norm = tl.rsqrt(
+            tl.maximum(
+                local_x * local_x + local_y * local_y + local_z * local_z,
+                1.0e-12,
+            )
+        )
+        local_x *= inv_delta_norm
+        local_y *= inv_delta_norm
+        local_z *= inv_delta_norm
+
+        out_offsets = (
+            i[:, None] * stride_out_i
+            + j[:, None] * stride_out_j
+            + channel[None, :] * stride_out_c
+        )
+        out = tl.load(out_ptr + out_offsets, mask=pair_mask[:, None]).to(tl.float32)
+
+        w_dgram = tl.load(
+            w_dgram_ptr
+            + channel[None, :] * stride_w_dgram_c
+            + bin_index[:, None] * stride_w_dgram_bin,
+            mask=pair_mask[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        out += w_dgram * (pb_pair_mask * in_bin.to(tl.float32))[:, None]
+
+        w_pb = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 0 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_x = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 1 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_y = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 2 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_z = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 3 * stride_w_scalar_feat
+        ).to(tl.float32)
+        w_bb = tl.load(
+            w_scalar_ptr + channel * stride_w_scalar_c + 4 * stride_w_scalar_feat
+        ).to(tl.float32)
+        out += pb_pair_mask[:, None] * w_pb[None, :]
+        out += bb_pair_mask[:, None] * (
+            local_x[:, None] * w_x[None, :]
+            + local_y[:, None] * w_y[None, :]
+            + local_z[:, None] * w_z[None, :]
+            + w_bb[None, :]
+        )
+
+        tl.store(out_ptr + out_offsets, out, mask=pair_mask[:, None])
+
+
+def template_coordinate_projection_add_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> None:
+    """Add coordinate-derived template projections to ``out`` in place.
+
+    This launcher intentionally supports only the production inference shape:
+    B=1, fp32, 39 distogram inputs, five scalar inputs, and 64 output channels.
+    """
+    if not _TRITON_AVAILABLE:
+        raise RuntimeError("Triton is required for coordinate template projection")
+    if not (
+        out.is_cuda
+        and out.dtype == torch.float32
+        and out.shape[0] == 1
+        and out.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+    ):
+        raise ValueError("Unsupported coordinate template projection configuration")
+
+    n_token = out.shape[1]
+    if out.shape != (1, n_token, n_token, 64):
+        raise ValueError(f"Expected out [1,N,N,64], got {tuple(out.shape)}")
+
+    pb = pseudo_beta_coords[0]
+    frame = frame_atom_coords[0]
+    pb_mask = pseudo_beta_mask[0]
+    bb_mask = backbone_frame_mask[0]
+    asym = asym_id[0]
+    grid = (triton.cdiv(n_token * n_token, _BLOCK_PAIRS),)
+    _template_coordinate_projection_kernel[grid](
+        out,
+        pb,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        n_token,
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        pb.stride(0),
+        pb.stride(1),
+        frame.stride(0),
+        frame.stride(1),
+        frame.stride(2),
+        pb_mask.stride(0),
+        bb_mask.stride(0),
+        asym.stride(0),
+        dgram_weight.stride(0),
+        dgram_weight.stride(1),
+        scalar_weight.stride(0),
+        scalar_weight.stride(1),
+        BLOCK_PAIRS=_BLOCK_PAIRS,
+        BLOCK_CHANNELS=_BLOCK_CHANNELS,
+        num_warps=4,
+        num_stages=1,
+    )

--- a/openfold3/core/model/feature_embedders/input_embedders.py
+++ b/openfold3/core/model/feature_embedders/input_embedders.py
@@ -29,7 +29,6 @@ from openfold3.core.model.layers.sequence_local_atom_attention import (
     AtomAttentionEncoder,
 )
 from openfold3.core.model.primitives import Linear
-from openfold3.core.utils.relpos import relpos_complex
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -146,26 +145,53 @@ class InputEmbedderAllAtom(nn.Module):
         # [*, N_token, C_s]
         s = self.linear_s(s_input)
 
+        z = self.embed_z(
+            batch=batch, s_input=s_input, dtype=s.dtype, inplace_safe=inplace_safe
+        )
+
+        return s_input, s, z
+
+    def embed_z(
+        self,
+        batch: dict,
+        s_input: torch.Tensor,
+        dtype: torch.dtype,
+        inplace_safe: bool = False,
+    ) -> torch.Tensor:
+        """Build the input pair representation from cached single input features."""
         s_input_emb_i = self.linear_z_i(s_input)
         s_input_emb_j = self.linear_z_j(s_input)
-        token_bonds_emb = self.linear_token_bonds(
-            batch["token_bonds"].unsqueeze(-1).to(dtype=s.dtype)
-        )
 
         # [*, N_token, N_token, C_z]
         z = s_input_emb_i[..., None, :] + s_input_emb_j[..., None, :, :]
+        del s_input_emb_i, s_input_emb_j
 
-        relpos_feats = relpos_complex(
-            batch=batch,
-            max_relative_idx=self.max_relative_idx,
-            max_relative_chain=self.max_relative_chain,
-        ).to(dtype=z.dtype)
-        relpos_emb = self.linear_relpos(relpos_feats)
-        z = add(z, relpos_emb, inplace=inplace_safe)
+        # Inference: bias-free 1->C token-bonds is x * W[0], so fold in with
+        # addmm_ and avoid a pair-sized linear output.
+        token_bonds = batch["token_bonds"].to(dtype=dtype)
+        if not torch.is_grad_enabled() and self.linear_token_bonds.bias is None:
+            z.view(-1, z.shape[-1]).addmm_(
+                token_bonds.reshape(-1, 1),
+                self.linear_token_bonds.weight[:, 0].unsqueeze(0),
+            )
+        else:
+            token_bonds_emb = self.linear_token_bonds(token_bonds.unsqueeze(-1))
+            z = add(z, token_bonds_emb, inplace=inplace_safe)
+            del token_bonds_emb
+        del token_bonds
 
-        z = add(z, token_bonds_emb, inplace=inplace_safe)
+        from openfold3.core.kernels.triton.fused_relpos_embed import (
+            add_relpos_pair_embedding,
+        )
 
-        return s_input, s, z
+        return add_relpos_pair_embedding(
+            z,
+            self.linear_relpos,
+            batch,
+            self.max_relative_idx,
+            self.max_relative_chain,
+            inplace_safe=inplace_safe,
+        )
 
 
 class MSAModuleEmbedder(nn.Module):

--- a/openfold3/core/model/heads/head_modules.py
+++ b/openfold3/core/model/heads/head_modules.py
@@ -173,6 +173,7 @@ class AuxiliaryHeadsAllAtom(nn.Module):
         si_input = si_input.detach().clone()
         si = si.detach().clone()
         zij = zij.detach().clone()
+        del output["zij_trunk"]
         atom_positions_predicted = atom_positions_predicted.detach().clone()
 
         token_mask = batch["token_mask"]

--- a/openfold3/core/model/latent/base_blocks.py
+++ b/openfold3/core/model/latent/base_blocks.py
@@ -481,7 +481,41 @@ class PairBlock(nn.Module):
             inplace_safe=inplace_safe,
         )
 
-        z = add(
+        z = self._apply_pair_transition(
+            z=z,
+            pair_trans_mask=pair_trans_mask,
+            chunk_size=chunk_size,
+            inplace_safe=inplace_safe,
+        )
+
+        return z
+
+    def _apply_pair_transition(
+        self,
+        z: torch.Tensor,
+        pair_trans_mask: torch.Tensor | None,
+        chunk_size: int | None,
+        inplace_safe: bool,
+    ) -> torch.Tensor:
+        """Residual pair transition; fused in-place when eligible under inference."""
+        from openfold3.core.kernels.triton.fused_swiglu_transition import (
+            is_fused_swiglu_transition_enabled,
+        )
+
+        if (
+            is_fused_swiglu_transition_enabled()
+            and inplace_safe
+            and not torch.is_grad_enabled()
+            and isinstance(self.pair_transition, SwiGLUTransition)
+        ):
+            trans_mask = (
+                pair_trans_mask.unsqueeze(-1) if pair_trans_mask is not None else None
+            )
+            return self.pair_transition._transition_inplace(
+                x=z, mask=trans_mask, residual=z
+            )
+
+        return add(
             z,
             self.pair_transition(
                 z,
@@ -490,5 +524,3 @@ class PairBlock(nn.Module):
             ),
             inplace=inplace_safe,
         )
-
-        return z

--- a/openfold3/core/model/latent/base_blocks.py
+++ b/openfold3/core/model/latent/base_blocks.py
@@ -40,6 +40,7 @@ from openfold3.core.model.layers.triangular_multiplicative_update import (
 )
 from openfold3.core.model.primitives import DropoutRowwise
 from openfold3.core.model.utils import assert_sole_holder
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -315,20 +316,25 @@ class PairBlock(nn.Module):
         use_triton_triangle_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the outgoing and incoming triangular multiplicative updates."""
-        inplace_safe = inplace_safe and (not use_cueq_triangle_kernels)
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        use_cueq_trimul = use_cueq_triangle_kernels and not chunked_trimul
+        # cuEq supersedes inplace_safe unless a trimul chunk cap forces eager.
+        inplace_safe = inplace_safe and (not use_cueq_trimul)
         ## VS: having both inplace_safe and use_cueq_triangle_kernels set to
         ## true causes `z = z + self.ps_dropout_row_layer(tmu_update)` below
         ## to be skipped, as this is the expected output of tri_mult w/ inplace
         ## safe, creating an error. So disable inplace_safe if
         ## use_cueq_triangle_kernels is true. Ideally could be refactored to use
         ## _add_with_inplace=False, then wrap with add as done elsewhere
+        inplace_chunk_size = trimul_chunk_cap() if chunked_trimul else 256
         tmu_update = self.tri_mul_out(
             z,
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)
@@ -345,8 +351,9 @@ class PairBlock(nn.Module):
             mask=pair_mask,
             inplace_safe=inplace_safe,
             _add_with_inplace=True,
-            use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+            use_cueq_triangle_kernels=use_cueq_trimul,
             use_triton_triangle_kernels=use_triton_triangle_kernels,
+            _inplace_chunk_size=inplace_chunk_size,
         )
         if not inplace_safe:
             z = z + self.ps_dropout_row_layer(tmu_update)

--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -133,21 +133,14 @@ class MSAStack(nn.Module, ABC):
             )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
-                # Tensors cloned to avoid getting written to in-place
-                # A corollary is that chunk size tuning should be disabled for
-                # large N, when z gets really big
-                args=(
-                    m.clone(),
-                    z.clone(),
-                ),
+                # Probe must not write in-place; tuner clones on a cache miss.
+                args=(m, z),
                 max_chunk_size=chunk_size,
             )
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
-            attn_chunk = apply_triangle_attn_chunk_cap(
-                attn_chunk, n_tokens=z.shape[-3]
-            )
+            attn_chunk = apply_triangle_attn_chunk_cap(attn_chunk, n_tokens=z.shape[-3])
             tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(

--- a/openfold3/core/model/latent/base_stacks.py
+++ b/openfold3/core/model/latent/base_stacks.py
@@ -28,7 +28,11 @@ import torch
 from torch import nn
 
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 
 
 # TODO: Rename to CheckpointStack and generalize any kind of block (i.e. remove
@@ -141,6 +145,10 @@ class MSAStack(nn.Module, ABC):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -378,19 +378,14 @@ class PairFormerStack(nn.Module):
             )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
-                # We don't want to write in-place during chunk tuning runs
-                args=(
-                    s.clone(),
-                    z.clone(),
-                ),
+                # Probe must not write in-place; tuner clones on a cache miss.
+                args=(s, z),
                 max_chunk_size=chunk_size,
             )
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
-            attn_chunk = apply_triangle_attn_chunk_cap(
-                attn_chunk, n_tokens=z.shape[-3]
-            )
+            attn_chunk = apply_triangle_attn_chunk_cap(attn_chunk, n_tokens=z.shape[-3])
             tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(

--- a/openfold3/core/model/latent/pairformer.py
+++ b/openfold3/core/model/latent/pairformer.py
@@ -28,7 +28,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.layers.attention_pair_bias import AttentionPairBias
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.utils.checkpointing import checkpoint_blocks
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -384,6 +388,10 @@ class PairFormerStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=z.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -43,7 +43,6 @@ from openfold3.core.utils.chunk_utils import (
     apply_transition_chunk_cap,
     apply_triangle_attn_chunk_cap,
 )
-from openfold3.core.utils.tensor_utils import add
 
 _TEMPLATE_DIM_BY_KEY = {
     "template_restype": -3,
@@ -412,15 +411,14 @@ class TemplatePairStack(nn.Module):
             )
             tuned_chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=blocks[0],
-                args=(t.clone(),),
+                # Probe must not write in-place; tuner clones on a cache miss.
+                args=(t,),
                 max_chunk_size=chunk_size,
             )
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
-            attn_chunk = apply_triangle_attn_chunk_cap(
-                attn_chunk, n_tokens=t.shape[-3]
-            )
+            attn_chunk = apply_triangle_attn_chunk_cap(attn_chunk, n_tokens=t.shape[-3])
             tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -183,14 +183,11 @@ class TemplatePairBlock(PairBlock):
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
             )
 
-        t = add(
-            t,
-            self.pair_transition(
-                t,
-                mask=mask if _mask_trans else None,
-                chunk_size=chunk_size,
-            ),
-            inplace_safe,
+        t = self._apply_pair_transition(
+            z=t,
+            pair_trans_mask=mask if _mask_trans else None,
+            chunk_size=chunk_size,
+            inplace_safe=inplace_safe,
         )
 
         return t

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -34,7 +34,7 @@ from openfold3.core.model.feature_embedders.template_embedders import (
 from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.primitives.fused_template_coordinate import (
-    fused_template_coordinate_pair_embedder_inference,
+    fused_template_coordinate_pair_embedder,
 )
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
@@ -633,7 +633,7 @@ class TemplateEmbedderAllAtom(nn.Module):
 
         for i in range(n_templ):
             if use_coordinate_features:
-                t = fused_template_coordinate_pair_embedder_inference(
+                t = fused_template_coordinate_pair_embedder(
                     module=self.template_pair_embedder,
                     batch=batch,
                     z=z,
@@ -667,8 +667,10 @@ class TemplateEmbedderAllAtom(nn.Module):
             t = t.squeeze(-4)
             if t_sum is None:
                 t_sum = t
-            else:
+            elif inplace_safe:
                 t_sum.add_(t)
+            else:
+                t_sum = t_sum + t
             del t
 
         assert t_sum is not None

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -42,6 +42,25 @@ from openfold3.core.utils.chunk_utils import (
 )
 from openfold3.core.utils.tensor_utils import add
 
+_TEMPLATE_DIM_BY_KEY = {
+    "template_restype": -3,
+    "template_pseudo_beta_mask": -2,
+    "template_backbone_frame_mask": -2,
+    "template_distogram": -4,
+    "template_unit_vector": -4,
+}
+
+
+def _slice_template_feature(k: str, x: torch.Tensor, idx: int) -> torch.Tensor:
+    """Return one template while preserving the singleton template dimension."""
+    template_dim = _TEMPLATE_DIM_BY_KEY.get(k)
+    if template_dim is None:
+        return x
+
+    slices = [slice(None)] * x.dim()
+    slices[template_dim] = slice(idx, idx + 1)
+    return x[tuple(slices)]
+
 
 # TODO: Make arguments match PairBlock
 class TemplatePairBlock(PairBlock):
@@ -590,6 +609,60 @@ class TemplateEmbedderAllAtom(nn.Module):
 
         return t_out.to(device=out_device)
 
+    def _forward_streaming(
+        self,
+        batch: dict,
+        z: torch.Tensor,
+        pair_mask: torch.Tensor,
+        chunk_size: int | None = None,
+        _mask_trans: bool = True,
+        use_deepspeed_evo_attention: bool = False,
+        use_cueq_triangle_kernels: bool = False,
+        use_triton_triangle_kernels: bool = False,
+        use_lma: bool = False,
+        inplace_safe: bool = False,
+    ) -> torch.Tensor:
+        """Process templates one-at-a-time and accumulate their stack outputs."""
+        n_templ = batch["template_restype"].shape[-3]
+        pair_mask = pair_mask[..., None, :, :].to(dtype=z.dtype)
+        t_sum = None
+
+        for i in range(n_templ):
+            batch_templ = {
+                k: (
+                    _slice_template_feature(k, v, i)
+                    if isinstance(v, torch.Tensor) and k.startswith("template_")
+                    else v
+                )
+                for k, v in batch.items()
+            }
+
+            t = self.template_pair_embedder(batch=batch_templ, z=z)
+            batch_templ.pop("template_distogram", None)
+            batch_templ.pop("template_unit_vector", None)
+
+            t = self.template_pair_stack(
+                t,
+                pair_mask,
+                chunk_size=chunk_size,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+                _mask_trans=_mask_trans,
+            )
+
+            t = t.squeeze(-4)
+            if t_sum is None:
+                t_sum = t
+            else:
+                t_sum.add_(t)
+            del t
+
+        assert t_sum is not None
+        return t_sum / n_templ
+
     def _forward(
         self,
         batch: dict,
@@ -668,8 +741,30 @@ class TemplateEmbedderAllAtom(nn.Module):
                 [*, N_token, N_token, C_z] Template embedding
         """
         n_templ = batch["template_restype"].shape[-3]
+        template_sum_done = False
+        can_stream = (
+            inplace_safe
+            and not self.training
+            and not torch.is_grad_enabled()
+            and not offload_inference
+            and n_templ > 1
+        )
 
-        if offload_inference:
+        if can_stream:
+            t = self._forward_streaming(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=chunk_size,
+                _mask_trans=True,
+                use_deepspeed_evo_attention=use_deepspeed_evo_attention,
+                use_cueq_triangle_kernels=use_cueq_triangle_kernels,
+                use_triton_triangle_kernels=use_triton_triangle_kernels,
+                use_lma=use_lma,
+                inplace_safe=inplace_safe,
+            )
+            template_sum_done = True
+        elif offload_inference:
             t = self._forward_offload(
                 batch=batch,
                 z=z,
@@ -696,8 +791,10 @@ class TemplateEmbedderAllAtom(nn.Module):
                 inplace_safe=inplace_safe,
             )
 
+        if not template_sum_done:
+            t = torch.sum(t, dim=-4) / n_templ
+
         # [*, N_token, N_token, C_z]
-        t = torch.sum(t, dim=-4) / n_templ
         t = torch.nn.functional.relu(t)
         t = self.linear_t(t)
 

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -33,6 +33,9 @@ from openfold3.core.model.feature_embedders.template_embedders import (
 )
 from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
+from openfold3.core.model.primitives.fused_template_coordinate import (
+    fused_template_coordinate_pair_embedder_inference,
+)
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
 from openfold3.core.utils.chunk_utils import (
@@ -621,6 +624,7 @@ class TemplateEmbedderAllAtom(nn.Module):
         use_triton_triangle_kernels: bool = False,
         use_lma: bool = False,
         inplace_safe: bool = False,
+        use_coordinate_features: bool = False,
     ) -> torch.Tensor:
         """Process templates one-at-a-time and accumulate their stack outputs."""
         n_templ = batch["template_restype"].shape[-3]
@@ -628,18 +632,25 @@ class TemplateEmbedderAllAtom(nn.Module):
         t_sum = None
 
         for i in range(n_templ):
-            batch_templ = {
-                k: (
-                    _slice_template_feature(k, v, i)
-                    if isinstance(v, torch.Tensor) and k.startswith("template_")
-                    else v
+            if use_coordinate_features:
+                t = fused_template_coordinate_pair_embedder_inference(
+                    module=self.template_pair_embedder,
+                    batch=batch,
+                    z=z,
+                    template_index=i,
                 )
-                for k, v in batch.items()
-            }
-
-            t = self.template_pair_embedder(batch=batch_templ, z=z)
-            batch_templ.pop("template_distogram", None)
-            batch_templ.pop("template_unit_vector", None)
+            else:
+                batch_templ = {
+                    k: (
+                        _slice_template_feature(k, v, i)
+                        if isinstance(v, torch.Tensor) and k.startswith("template_")
+                        else v
+                    )
+                    for k, v in batch.items()
+                }
+                t = self.template_pair_embedder(batch=batch_templ, z=z)
+                batch_templ.pop("template_distogram", None)
+                batch_templ.pop("template_unit_vector", None)
 
             t = self.template_pair_stack(
                 t,
@@ -742,7 +753,9 @@ class TemplateEmbedderAllAtom(nn.Module):
         """
         n_templ = batch["template_restype"].shape[-3]
         template_sum_done = False
-        can_stream = (
+        use_coordinate_features = "template_pseudo_beta_coords" in batch
+        # Coordinate inputs are O(N); always stream on GPU and ignore offload.
+        can_stream = use_coordinate_features or (
             inplace_safe
             and not self.training
             and not torch.is_grad_enabled()
@@ -762,6 +775,7 @@ class TemplateEmbedderAllAtom(nn.Module):
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
                 use_lma=use_lma,
                 inplace_safe=inplace_safe,
+                use_coordinate_features=use_coordinate_features,
             )
             template_sum_done = True
         elif offload_inference:

--- a/openfold3/core/model/latent/template_module.py
+++ b/openfold3/core/model/latent/template_module.py
@@ -35,7 +35,11 @@ from openfold3.core.model.latent.base_blocks import PairBlock
 from openfold3.core.model.primitives import LayerNorm, Linear
 from openfold3.core.model.utils import assert_sole_holder
 from openfold3.core.utils.checkpointing import checkpoint_blocks, checkpoint_section
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+)
 from openfold3.core.utils.tensor_utils import add
 
 
@@ -395,6 +399,10 @@ class TemplatePairStack(nn.Module):
             attn_chunk = (
                 tuned_chunk_size if use_flash_kernels else max(1, tuned_chunk_size // 4)
             )
+            attn_chunk = apply_triangle_attn_chunk_cap(
+                attn_chunk, n_tokens=t.shape[-3]
+            )
+            tuned_chunk_size = apply_transition_chunk_cap(tuned_chunk_size)
             blocks = [
                 partial(
                     b,

--- a/openfold3/core/model/layers/diffusion_conditioning.py
+++ b/openfold3/core/model/layers/diffusion_conditioning.py
@@ -213,9 +213,22 @@ class DiffusionConditioning(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         pair_token_mask = token_mask.unsqueeze(-1) * token_mask.unsqueeze(-2)
 
-        # Pair conditioning
+        # Pair conditioning. Inference fused path writes zij += update in
+        # place (same kernel as PairBlock). Training keeps the out-of-place add.
+        # Do not in-place into zij_trunk: _embed_zij returns a new tensor.
+        from openfold3.core.kernels.triton.fused_swiglu_transition import (
+            is_fused_swiglu_transition_enabled,
+        )
+
         for l in self.transition_z:
-            zij = zij + l(zij, mask=pair_token_mask, chunk_size=chunk_size)
+            if (
+                is_fused_swiglu_transition_enabled()
+                and not torch.is_grad_enabled()
+                and isinstance(l, SwiGLUTransition)
+            ):
+                zij = l._transition_inplace(x=zij, mask=pair_token_mask, residual=zij)
+            else:
+                zij = zij + l(zij, mask=pair_token_mask, chunk_size=chunk_size)
 
         # Single conditioning
         for l in self.transition_s:
@@ -235,12 +248,8 @@ class DiffusionConditioning(nn.Module):
         if self.chunk_size_tuner is not None:
             chunk_size = self.chunk_size_tuner.tune_chunk_size(
                 representative_fn=self._forward,
-                # We don't want to write in-place during chunk tuning runs
-                args=(
-                    si.clone(),
-                    zij.clone(),
-                    token_mask,
-                ),
+                # Probe must not write in-place; tuner clones on a cache miss.
+                args=(si, zij, token_mask),
                 max_chunk_size=chunk_size,
             )
 

--- a/openfold3/core/model/layers/diffusion_conditioning.py
+++ b/openfold3/core/model/layers/diffusion_conditioning.py
@@ -21,7 +21,10 @@ from openfold3.core.model.feature_embedders.input_embedders import FourierEmbedd
 from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.model.primitives.linear import Linear
 from openfold3.core.model.primitives.normalization import LayerNorm
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    apply_transition_chunk_cap,
+)
 from openfold3.core.utils.relpos import relpos_complex
 
 
@@ -29,6 +32,8 @@ class DiffusionConditioning(nn.Module):
     """
     Implements AF3 Algorithm 21.
     """
+
+    _EMBED_ZIJ_CHUNK_ROWS: int = 128
 
     def __init__(
         self,
@@ -130,6 +135,53 @@ class DiffusionConditioning(nn.Module):
         if tune_chunk_size:
             self.chunk_size_tuner = ChunkSizeTuner()
 
+    def _embed_zij(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        if not torch.is_grad_enabled():
+            return self._embed_zij_chunked(batch, zij_trunk)
+
+        relpos_zij = relpos_complex(
+            batch=batch,
+            max_relative_idx=self.max_relative_idx,
+            max_relative_chain=self.max_relative_chain,
+        ).to(dtype=zij_trunk.dtype)
+
+        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
+        return self.linear_z(self.layer_norm_z(zij))
+
+    def _embed_zij_chunked(
+        self,
+        batch: dict,
+        zij_trunk: torch.Tensor,
+    ) -> torch.Tensor:
+        """Row-chunked LN/linear over trunk pair + relpos (channel-wise LN)."""
+        n_token = zij_trunk.shape[-3]
+        chunk = self._EMBED_ZIJ_CHUNK_ROWS
+        out = torch.empty(
+            *zij_trunk.shape[:-1],
+            self.c_z,
+            dtype=zij_trunk.dtype,
+            device=zij_trunk.device,
+        )
+        for i in range(0, n_token, chunk):
+            row_slice = slice(i, min(i + chunk, n_token))
+            relpos_chunk = relpos_complex(
+                batch=batch,
+                max_relative_idx=self.max_relative_idx,
+                max_relative_chain=self.max_relative_chain,
+                row_slice=row_slice,
+            ).to(dtype=zij_trunk.dtype)
+            cat_chunk = torch.cat(
+                [zij_trunk[..., row_slice, :, :], relpos_chunk], dim=-1
+            )
+            del relpos_chunk
+            out[..., row_slice, :, :] = self.linear_z(self.layer_norm_z(cat_chunk))
+            del cat_chunk
+        return out
+
     def _embed_trunk_inputs(
         self,
         batch: dict,
@@ -139,14 +191,7 @@ class DiffusionConditioning(nn.Module):
         zij_trunk: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Pair conditioning
-        relpos_zij = relpos_complex(
-            batch=batch,
-            max_relative_idx=self.max_relative_idx,
-            max_relative_chain=self.max_relative_chain,
-        ).to(dtype=zij_trunk.dtype)
-
-        zij = torch.cat([zij_trunk, relpos_zij], dim=-1)
-        zij = self.linear_z(self.layer_norm_z(zij))
+        zij = self._embed_zij(batch=batch, zij_trunk=zij_trunk)
 
         # Single conditioning
         si = torch.cat([si_trunk, si_input], dim=-1)
@@ -198,6 +243,8 @@ class DiffusionConditioning(nn.Module):
                 ),
                 max_chunk_size=chunk_size,
             )
+
+        chunk_size = apply_transition_chunk_cap(chunk_size)
 
         si, zij = self._forward(
             si=si, zij=zij, token_mask=token_mask, chunk_size=chunk_size

--- a/openfold3/core/model/layers/sequence_local_atom_attention.py
+++ b/openfold3/core/model/layers/sequence_local_atom_attention.py
@@ -30,7 +30,9 @@ from openfold3.core.utils.atom_attention_block_utils import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
 )
 from openfold3.core.utils.checkpointing import checkpoint_section
 
@@ -542,16 +544,25 @@ class AtomAttentionEncoder(nn.Module):
 
         ql = ql * atom_mask.unsqueeze(-1)
 
-        agg_args = (
-            batch["token_mask"],
-            batch["atom_to_token_index"],
-            atom_mask,
-            self.linear_q(ql),
-            -2,
-            "mean",
-        )
+        if not self.training and not torch.is_grad_enabled():
+            aggregate_fn = aggregate_atom_feat_to_tokens_segmented
+            agg_args = (
+                batch["num_atoms_per_token"],
+                atom_mask,
+                self.linear_q(ql),
+            )
+        else:
+            aggregate_fn = aggregate_atom_feat_to_tokens
+            agg_args = (
+                batch["token_mask"],
+                batch["atom_to_token_index"],
+                atom_mask,
+                self.linear_q(ql),
+                -2,
+                "mean",
+            )
         ai = checkpoint_section(
-            fn=aggregate_atom_feat_to_tokens,
+            fn=aggregate_fn,
             args=agg_args,
             apply_ckpt=self.ckpt_intermediate_steps,
             use_reentrant=self.use_reentrant,
@@ -674,11 +685,11 @@ class AtomAttentionDecoder(nn.Module):
         """
         # Broadcast per-token activations to atoms
         # [*, N_atom, c_atom]
-        ql = ql + broadcast_token_feat_to_atoms(
+        ql = ql + broadcast_token_feat_to_atoms_by_index(
             token_mask=batch["token_mask"],
-            num_atoms_per_token=batch["num_atoms_per_token"],
+            atom_to_token_index=batch["atom_to_token_index"],
+            atom_mask=batch["atom_mask"],
             token_feat=self.linear_q_in(ai),
-            token_dim=-2,
         )
 
         # Atom transformer

--- a/openfold3/core/model/layers/transition.py
+++ b/openfold3/core/model/layers/transition.py
@@ -264,18 +264,51 @@ class SwiGLUTransition(Transition):
             self.n * self.c_in, c_in, **linear_init_params.linear_out
         )
 
-    def _transition(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-        # [*, N, C_in]
+    def _eager_transition(
+        self, x: torch.Tensor, mask: torch.Tensor | None
+    ) -> torch.Tensor:
         x = self.layer_norm(x)
-
-        # [*, N, C_hidden]
         x = self.swiglu(x)
-
-        # [*, N, C_in]
         x = self.linear_out(x)
-        x = x * mask
+        return x if mask is None else x * mask
 
-        return x
+    def _fused_weight_args(self):
+        return (
+            self.layer_norm.weight,
+            self.layer_norm.bias,
+            self.swiglu.linear_a.weight,
+            self.swiglu.linear_b.weight,
+            self.linear_out.weight,
+        )
+
+    def _transition(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        from openfold3.core.kernels.triton.fused_swiglu_transition import (
+            fused_swiglu_transition,
+            is_fused_swiglu_transition_eligible,
+        )
+
+        weights = self._fused_weight_args()
+        if is_fused_swiglu_transition_eligible(x, *weights):
+            return fused_swiglu_transition(
+                x, *weights, mask=mask, eps=self.layer_norm.eps
+            )
+        return self._eager_transition(x, mask)
+
+    def _transition_inplace(
+        self, x: torch.Tensor, mask: torch.Tensor, residual: torch.Tensor
+    ) -> torch.Tensor:
+        """Fused ``residual + transition(x)``; may write in place when residual is x."""
+        from openfold3.core.kernels.triton.fused_swiglu_transition import (
+            fused_swiglu_transition,
+            is_fused_swiglu_transition_eligible,
+        )
+
+        weights = self._fused_weight_args()
+        if is_fused_swiglu_transition_eligible(x, *weights):
+            return fused_swiglu_transition(
+                x, *weights, mask=mask, eps=self.layer_norm.eps, residual=residual
+            )
+        return residual + self._eager_transition(x, mask)
 
 
 class ConditionedTransitionBlock(nn.Module):

--- a/openfold3/core/model/layers/triangular_multiplicative_update.py
+++ b/openfold3/core/model/layers/triangular_multiplicative_update.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 import openfold3.core.config.default_linear_init_config as lin_init
 from openfold3.core.kernels.cueq_utils import is_cuequivariance_available
 from openfold3.core.model.primitives import LayerNorm, Linear
+from openfold3.core.utils.chunk_utils import trimul_chunk_cap, use_chunked_trimul
 from openfold3.core.utils.tensor_utils import permute_final_dims
 
 if is_cuequivariance_available():
@@ -1117,8 +1118,9 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
         ## NOTE: valid for inplace safe and use_cueq_triangle_kernels to be enabled
         ## inplace safe is used across the codebase and so should not
         ## be disabled. So if use_cueq_triangle_kernels is True, it will always
-        ## supersede inplace_safe
-        if use_cueq_triangle_kernels:
+        ## supersede inplace_safe unless a trimul chunk cap forces eager.
+        chunked_trimul = use_chunked_trimul(inplace_safe)
+        if use_cueq_triangle_kernels and not chunked_trimul:
             ## VS: The cuequivariance kernel is based on the boltz implementation
             ## of triangle multiplicative update, which fuses the linear_*_p
             ## projections into a single layer (similarly for linear_*_g).
@@ -1149,10 +1151,11 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             return x
 
         if inplace_safe:
+            chunk_size = trimul_chunk_cap() if chunked_trimul else _inplace_chunk_size
             x = self._inference_forward(
                 z,
                 mask,
-                inplace_chunk_size=_inplace_chunk_size,
+                inplace_chunk_size=chunk_size,
                 with_add=_add_with_inplace,
                 use_triton_triangle_kernels=use_triton_triangle_kernels,
             )

--- a/openfold3/core/model/primitives/fused_template_coordinate.py
+++ b/openfold3/core/model/primitives/fused_template_coordinate.py
@@ -1,0 +1,281 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference dispatcher for online template coordinate pair features.
+
+Builds one template's pair embedding from compact O(N) coordinates. On CUDA
+fp32 with Triton available, projection uses the length-generic kernel in
+``fused_template_coordinate`` (N and strides are runtime values). Otherwise
+falls back to a chunked eager reference with the same math.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    _TRITON_KERNEL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TRITON_KERNEL_AVAILABLE = False
+
+
+def _env_flag(name: str, default: str = "1") -> bool:
+    val = os.environ.get(name, default).strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def is_fused_template_coordinate_enabled() -> bool:
+    """Runtime gate for the Triton coordinate projection kernel."""
+    if not _TRITON_KERNEL_AVAILABLE:
+        return False
+    return _env_flag("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+
+
+_LN_CHUNK_ROWS = 64
+
+
+def _chunked_ln_linear_z(
+    z: torch.Tensor,
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Compute ``LN(z) @ W_z.T + B_z`` writing directly into a fresh output."""
+    B, N, _, c_z = z.shape
+    c_out = module.linear_z.weight.shape[0]
+    out = torch.empty(B, N, N, c_out, dtype=dtype, device=z.device)
+
+    ln_w = module.layer_norm_z.weight
+    ln_b = module.layer_norm_z.bias
+    lin_w = module.linear_z.weight
+    lin_b = module.linear_z.bias
+    if ln_w.dtype != dtype:
+        ln_w = ln_w.to(dtype)
+    if ln_b is not None and ln_b.dtype != dtype:
+        ln_b = ln_b.to(dtype)
+    if lin_w.dtype != dtype:
+        lin_w = lin_w.to(dtype)
+    if lin_b is not None and lin_b.dtype != dtype:
+        lin_b = lin_b.to(dtype)
+
+    chunk_rows = min(_LN_CHUNK_ROWS, max(16, N // 10))
+    for start in range(0, N, chunk_rows):
+        end = min(N, start + chunk_rows)
+        z_chunk = z[:, start:end].contiguous()
+        z_norm = F.layer_norm(
+            z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps
+        )
+        out[:, start:end] = F.linear(z_norm, lin_w, lin_b)
+        del z_chunk, z_norm
+    return out
+
+
+def _build_scalar_weight(module: nn.Module, dtype: torch.dtype) -> torch.Tensor:
+    """Concat scalar-feature Linear weights into ``[c_out, 5]``."""
+    return torch.cat(
+        (
+            module.pseudo_beta_mask_linear.weight,
+            module.x_linear.weight,
+            module.y_linear.weight,
+            module.z_linear.weight,
+            module.backbone_mask_linear.weight,
+        ),
+        dim=-1,
+    ).to(dtype=dtype)
+
+
+def _add_restype_projections_(
+    a: torch.Tensor,
+    restype: torch.Tensor,
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    """Project O(N) restype inputs and broadcast-add without pair expansion."""
+    for linear, dim in (
+        (module.aatype_linear_1, -2),
+        (module.aatype_linear_2, -3),
+    ):
+        weight = linear.weight.to(dtype=dtype)
+        a.add_(F.linear(restype, weight, None).unsqueeze(dim))
+
+
+def _fetch_coordinate_template_slice(
+    batch: dict,
+    template_index: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fetch compact coordinates, masks, and restype for one template."""
+    values = (
+        batch["template_pseudo_beta_coords"][..., template_index, :, :],
+        batch["template_frame_atom_coords"][..., template_index, :, :, :],
+        batch["template_pseudo_beta_mask"][..., template_index, :],
+        batch["template_backbone_frame_mask"][..., template_index, :],
+        batch["template_restype"][..., template_index, :, :],
+    )
+    return tuple(
+        value.to(device=device, dtype=dtype, non_blocking=True).contiguous()
+        for value in values
+    )
+
+
+def template_coordinate_projection_add_reference_(
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int = 32,
+) -> None:
+    """Chunked reference for coordinate construction and direct projection."""
+    n_token = out.shape[-2]
+    lower = torch.linspace(
+        3.25, 50.75, 39, device=out.device, dtype=torch.float32
+    ).square()
+    dgram_lookup = dgram_weight.to(dtype=out.dtype).transpose(0, 1)
+    scalar_weight = scalar_weight.to(dtype=out.dtype)
+
+    n_coords = frame_atom_coords[..., 0, :]
+    ca_coords = frame_atom_coords[..., 1, :]
+    c_coords = frame_atom_coords[..., 2, :]
+
+    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
+    axis_y = n_coords - ca_coords
+    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
+    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
+    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
+
+    for start in range(0, n_token, chunk_rows):
+        stop = min(start + chunk_rows, n_token)
+        pb_delta = (
+            pseudo_beta_coords[:, start:stop, None, :]
+            - pseudo_beta_coords[:, None, :, :]
+        )
+        dist2 = pb_delta.square().sum(dim=-1)
+        bin_index = torch.searchsorted(lower, dist2, right=False) - 1
+        safe_bin = bin_index.clamp(min=0, max=38)
+        bin_lower = lower[safe_bin]
+        bin_upper = torch.where(
+            safe_bin == 38,
+            torch.full_like(bin_lower, 1.0e8),
+            lower[(safe_bin + 1).clamp(max=38)],
+        )
+        in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+
+        same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(out.dtype)
+        pb_pair_mask = (
+            pseudo_beta_mask[:, start:stop, None]
+            * pseudo_beta_mask[:, None, :]
+            * same_chain
+        )
+        bb_pair_mask = (
+            backbone_frame_mask[:, start:stop, None]
+            * backbone_frame_mask[:, None, :]
+            * same_chain
+        )
+
+        dgram_projection = F.embedding(safe_bin, dgram_lookup)
+        dgram_projection.mul_((in_bin.to(out.dtype) * pb_pair_mask)[..., None])
+        out[:, start:stop].add_(dgram_projection)
+
+        delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
+        local = torch.stack(
+            (
+                (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
+                (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
+                (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
+            ),
+            dim=-1,
+        )
+        local = F.normalize(local, dim=-1, eps=1e-6)
+        local.mul_(bb_pair_mask[..., None])
+        scalar_features = torch.cat(
+            (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
+        )
+        out[:, start:stop].add_(
+            F.linear(scalar_features.to(out.dtype), scalar_weight, None)
+        )
+
+
+def fused_template_coordinate_pair_embedder_inference(
+    module: nn.Module,
+    batch: dict,
+    z: torch.Tensor,
+    template_index: int,
+) -> torch.Tensor:
+    """Embed one compact-coordinate template without raw pairwise features."""
+    if module.training or torch.is_grad_enabled():
+        raise RuntimeError(
+            "fused_template_coordinate_pair_embedder_inference is inference-only"
+        )
+    if z.dim() != 4 or z.shape[0] != 1 or z.shape[-3] != z.shape[-2]:
+        raise ValueError("Coordinate template embedding requires z [1,N,N,C]")
+
+    dtype = z.dtype
+    a = _chunked_ln_linear_z(z, module, dtype)
+    (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        restype,
+    ) = _fetch_coordinate_template_slice(
+        batch, template_index, dtype=dtype, device=z.device
+    )
+    _add_restype_projections_(a, restype, module, dtype)
+
+    dgram_weight = module.dgram_linear.weight
+    scalar_weight = _build_scalar_weight(module, dtype)
+    asym_id = batch["asym_id"].to(device=z.device, non_blocking=True).contiguous()
+    use_triton = (
+        is_fused_template_coordinate_enabled()
+        and z.is_cuda
+        and dtype == torch.float32
+        and a.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+    )
+    if use_triton:
+        template_coordinate_projection_add_(
+            a,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight.contiguous(),
+            scalar_weight.contiguous(),
+        )
+    else:
+        template_coordinate_projection_add_reference_(
+            a,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight,
+            scalar_weight,
+        )
+    return a.unsqueeze(-4)

--- a/openfold3/core/model/primitives/fused_template_coordinate.py
+++ b/openfold3/core/model/primitives/fused_template_coordinate.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inference dispatcher for online template coordinate pair features.
+"""Online template coordinate pair features with guarded training support.
 
 Builds one template's pair embedding from compact O(N) coordinates. On CUDA
-fp32 with Triton available, projection uses the length-generic kernel in
-``fused_template_coordinate`` (N and strides are runtime values). Otherwise
-falls back to a chunked eager reference with the same math.
+fp32/bf16 with Triton available, projection uses the length-generic kernel in
+``fused_template_coordinate`` (N and strides are runtime values; accumulate in
+fp32). Otherwise falls back to a chunked eager reference with the same math.
+Training computes model-parameter gradients without retaining pairwise
+coordinate features.
 """
 
 from __future__ import annotations
@@ -27,10 +29,13 @@ import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.autograd.function import once_differentiable
 
 try:
     from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
         template_coordinate_projection_add_,
+        template_coordinate_projection_backward,
     )
 
     _TRITON_KERNEL_AVAILABLE = True
@@ -80,9 +85,7 @@ def _chunked_ln_linear_z(
     for start in range(0, N, chunk_rows):
         end = min(N, start + chunk_rows)
         z_chunk = z[:, start:end].contiguous()
-        z_norm = F.layer_norm(
-            z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps
-        )
+        z_norm = F.layer_norm(z_chunk, (c_z,), ln_w, ln_b, module.layer_norm_z.eps)
         out[:, start:end] = F.linear(z_norm, lin_w, lin_b)
         del z_chunk, z_norm
     return out
@@ -102,19 +105,25 @@ def _build_scalar_weight(module: nn.Module, dtype: torch.dtype) -> torch.Tensor:
     ).to(dtype=dtype)
 
 
-def _add_restype_projections_(
+def _add_restype_projections(
     a: torch.Tensor,
     restype: torch.Tensor,
     module: nn.Module,
     dtype: torch.dtype,
-) -> None:
+    inplace: bool,
+) -> torch.Tensor:
     """Project O(N) restype inputs and broadcast-add without pair expansion."""
     for linear, dim in (
         (module.aatype_linear_1, -2),
         (module.aatype_linear_2, -3),
     ):
         weight = linear.weight.to(dtype=dtype)
-        a.add_(F.linear(restype, weight, None).unsqueeze(dim))
+        update = F.linear(restype, weight, None).unsqueeze(dim)
+        if inplace:
+            a.add_(update)
+        else:
+            a = a + update
+    return a
 
 
 def _fetch_coordinate_template_slice(
@@ -123,17 +132,175 @@ def _fetch_coordinate_template_slice(
     dtype: torch.dtype,
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Fetch compact coordinates, masks, and restype for one template."""
-    values = (
-        batch["template_pseudo_beta_coords"][..., template_index, :, :],
-        batch["template_frame_atom_coords"][..., template_index, :, :, :],
-        batch["template_pseudo_beta_mask"][..., template_index, :],
-        batch["template_backbone_frame_mask"][..., template_index, :],
-        batch["template_restype"][..., template_index, :, :],
+    """Fetch fp32 geometry/masks and activation-dtype restype for one template."""
+    return (
+        batch["template_pseudo_beta_coords"][..., template_index, :, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_frame_atom_coords"][..., template_index, :, :, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_pseudo_beta_mask"][..., template_index, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_backbone_frame_mask"][..., template_index, :]
+        .to(device=device, dtype=torch.float32, non_blocking=True)
+        .contiguous(),
+        batch["template_restype"][..., template_index, :, :]
+        .to(device=device, dtype=dtype, non_blocking=True)
+        .contiguous(),
     )
-    return tuple(
-        value.to(device=device, dtype=dtype, non_blocking=True).contiguous()
-        for value in values
+
+
+def _coordinate_frame_axes(
+    frame_atom_coords: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    frame_atom_coords = frame_atom_coords.to(torch.float32)
+    n_coords = frame_atom_coords[..., 0, :]
+    ca_coords = frame_atom_coords[..., 1, :]
+    c_coords = frame_atom_coords[..., 2, :]
+    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
+    axis_y = n_coords - ca_coords
+    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
+    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
+    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
+    return ca_coords, axis_x, axis_y, axis_z
+
+
+def _coordinate_feature_chunk(
+    pseudo_beta_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    ca_coords: torch.Tensor,
+    axis_x: torch.Tensor,
+    axis_y: torch.Tensor,
+    axis_z: torch.Tensor,
+    lower: torch.Tensor,
+    start: int,
+    stop: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    pb_coords = pseudo_beta_coords.to(torch.float32)
+    pb_delta = pb_coords[:, start:stop, None, :] - pb_coords[:, None, :, :]
+    dist2 = pb_delta.square().sum(dim=-1)
+    bin_index = torch.searchsorted(lower, dist2, right=False) - 1
+    safe_bin = bin_index.clamp(min=0, max=38)
+    bin_lower = lower[safe_bin]
+    bin_upper = torch.where(
+        safe_bin == 38,
+        torch.full_like(bin_lower, 1.0e8),
+        lower[(safe_bin + 1).clamp(max=38)],
+    )
+    in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+
+    same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(dtype)
+    pb_pair_mask = (
+        pseudo_beta_mask[:, start:stop, None]
+        * pseudo_beta_mask[:, None, :]
+        * same_chain
+    )
+    bb_pair_mask = (
+        backbone_frame_mask[:, start:stop, None]
+        * backbone_frame_mask[:, None, :]
+        * same_chain
+    )
+
+    delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
+    local = torch.stack(
+        (
+            (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
+            (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
+            (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
+        ),
+        dim=-1,
+    )
+    local = F.normalize(local, dim=-1, eps=1e-6)
+    local = local * bb_pair_mask[..., None]
+    scalar_features = torch.cat(
+        (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
+    )
+    dgram_scale = in_bin.to(dtype) * pb_pair_mask
+    return safe_bin, dgram_scale, scalar_features
+
+
+def _coordinate_projection_reference_loop(
+    source: torch.Tensor,
+    out: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int,
+    *,
+    inplace: bool,
+) -> torch.Tensor:
+    """Row-chunked eager projection into ``out`` (in-place add or fresh write)."""
+    n_token = source.shape[-2]
+    lower = torch.linspace(
+        3.25, 50.75, 39, device=source.device, dtype=torch.float32
+    ).square()
+    dgram_lookup = dgram_weight.to(dtype=source.dtype).transpose(0, 1)
+    scalar_weight = scalar_weight.to(dtype=source.dtype)
+    ca_coords, axis_x, axis_y, axis_z = _coordinate_frame_axes(frame_atom_coords)
+    for start in range(0, n_token, chunk_rows):
+        stop = min(start + chunk_rows, n_token)
+        safe_bin, dgram_scale, scalar_features = _coordinate_feature_chunk(
+            pseudo_beta_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            ca_coords,
+            axis_x,
+            axis_y,
+            axis_z,
+            lower,
+            start,
+            stop,
+            source.dtype,
+        )
+        dgram_projection = F.embedding(safe_bin, dgram_lookup)
+        dgram_projection = dgram_projection * dgram_scale[..., None]
+        scalar_projection = F.linear(
+            scalar_features.to(source.dtype), scalar_weight, None
+        )
+        if inplace:
+            out[:, start:stop].add_(dgram_projection)
+            out[:, start:stop].add_(scalar_projection)
+        else:
+            out[:, start:stop] = (
+                source[:, start:stop] + dgram_projection + scalar_projection
+            )
+    return out
+
+
+def template_coordinate_projection_reference(
+    source: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+    chunk_rows: int = 32,
+) -> torch.Tensor:
+    """Differentiable row-chunked coordinate projection with a fresh output."""
+    return _coordinate_projection_reference_loop(
+        source,
+        torch.empty_like(source),
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows,
+        inplace=False,
     )
 
 
@@ -148,92 +315,166 @@ def template_coordinate_projection_add_reference_(
     scalar_weight: torch.Tensor,
     chunk_rows: int = 32,
 ) -> None:
-    """Chunked reference for coordinate construction and direct projection."""
-    n_token = out.shape[-2]
-    lower = torch.linspace(
-        3.25, 50.75, 39, device=out.device, dtype=torch.float32
-    ).square()
-    dgram_lookup = dgram_weight.to(dtype=out.dtype).transpose(0, 1)
-    scalar_weight = scalar_weight.to(dtype=out.dtype)
-
-    n_coords = frame_atom_coords[..., 0, :]
-    ca_coords = frame_atom_coords[..., 1, :]
-    c_coords = frame_atom_coords[..., 2, :]
-
-    axis_x = F.normalize(c_coords - ca_coords, dim=-1, eps=1e-6)
-    axis_y = n_coords - ca_coords
-    axis_y = axis_y - (axis_y * axis_x).sum(dim=-1, keepdim=True) * axis_x
-    axis_y = F.normalize(axis_y, dim=-1, eps=1e-6)
-    axis_z = torch.linalg.cross(axis_x, axis_y, dim=-1)
-
-    for start in range(0, n_token, chunk_rows):
-        stop = min(start + chunk_rows, n_token)
-        pb_delta = (
-            pseudo_beta_coords[:, start:stop, None, :]
-            - pseudo_beta_coords[:, None, :, :]
+    """Inference-only in-place eager reference projection."""
+    if torch.is_grad_enabled():
+        raise RuntimeError(
+            "In-place template coordinate reference requires disabled grad mode"
         )
-        dist2 = pb_delta.square().sum(dim=-1)
-        bin_index = torch.searchsorted(lower, dist2, right=False) - 1
-        safe_bin = bin_index.clamp(min=0, max=38)
-        bin_lower = lower[safe_bin]
-        bin_upper = torch.where(
-            safe_bin == 38,
-            torch.full_like(bin_lower, 1.0e8),
-            lower[(safe_bin + 1).clamp(max=38)],
-        )
-        in_bin = (bin_index >= 0) & (dist2 > bin_lower) & (dist2 < bin_upper)
+    _coordinate_projection_reference_loop(
+        out,
+        out,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows,
+        inplace=True,
+    )
 
-        same_chain = (asym_id[:, start:stop, None] == asym_id[:, None, :]).to(out.dtype)
-        pb_pair_mask = (
-            pseudo_beta_mask[:, start:stop, None]
-            * pseudo_beta_mask[:, None, :]
-            * same_chain
-        )
-        bb_pair_mask = (
-            backbone_frame_mask[:, start:stop, None]
-            * backbone_frame_mask[:, None, :]
-            * same_chain
-        )
 
-        dgram_projection = F.embedding(safe_bin, dgram_lookup)
-        dgram_projection.mul_((in_bin.to(out.dtype) * pb_pair_mask)[..., None])
-        out[:, start:stop].add_(dgram_projection)
-
-        delta = ca_coords[:, None, :, :] - ca_coords[:, start:stop, None, :]
-        local = torch.stack(
-            (
-                (delta * axis_x[:, start:stop, None, :]).sum(dim=-1),
-                (delta * axis_y[:, start:stop, None, :]).sum(dim=-1),
-                (delta * axis_z[:, start:stop, None, :]).sum(dim=-1),
-            ),
-            dim=-1,
+class _TemplateCoordinateProjectionFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        source: torch.Tensor,
+        pseudo_beta_coords: torch.Tensor,
+        frame_atom_coords: torch.Tensor,
+        pseudo_beta_mask: torch.Tensor,
+        backbone_frame_mask: torch.Tensor,
+        asym_id: torch.Tensor,
+        dgram_weight: torch.Tensor,
+        scalar_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
         )
-        local = F.normalize(local, dim=-1, eps=1e-6)
-        local.mul_(bb_pair_mask[..., None])
-        scalar_features = torch.cat(
-            (pb_pair_mask[..., None], local, bb_pair_mask[..., None]), dim=-1
-        )
-        out[:, start:stop].add_(
-            F.linear(scalar_features.to(out.dtype), scalar_weight, None)
+        return template_coordinate_projection(
+            source,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            dgram_weight,
+            scalar_weight,
         )
 
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output: torch.Tensor):
+        (
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+        ) = ctx.saved_tensors
+        needs_source = ctx.needs_input_grad[0]
+        needs_dgram = ctx.needs_input_grad[6]
+        needs_scalar = ctx.needs_input_grad[7]
+        grad_dgram, grad_scalar = template_coordinate_projection_backward(
+            grad_output,
+            pseudo_beta_coords,
+            frame_atom_coords,
+            pseudo_beta_mask,
+            backbone_frame_mask,
+            asym_id,
+            compute_dgram=needs_dgram,
+            compute_scalar=needs_scalar,
+        )
 
-def fused_template_coordinate_pair_embedder_inference(
+        return (
+            grad_output if needs_source else None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            grad_dgram,
+            grad_scalar,
+        )
+
+
+_FUSED_AWAY_LINEAR_NAMES = (
+    "dgram_linear",
+    "aatype_linear_1",
+    "aatype_linear_2",
+    "pseudo_beta_mask_linear",
+    "x_linear",
+    "y_linear",
+    "z_linear",
+    "backbone_mask_linear",
+)
+
+
+def _validate_fused_away_biases(module: nn.Module) -> None:
+    biased = [
+        name
+        for name in _FUSED_AWAY_LINEAR_NAMES
+        if getattr(module, name).bias is not None
+    ]
+    if biased:
+        raise ValueError(
+            "Coordinate template projection requires bias-free feature linears; "
+            f"found biases in {', '.join(biased)}"
+        )
+
+
+def _can_use_triton(
+    source: torch.Tensor,
+    pseudo_beta_coords: torch.Tensor,
+    frame_atom_coords: torch.Tensor,
+    pseudo_beta_mask: torch.Tensor,
+    backbone_frame_mask: torch.Tensor,
+    asym_id: torch.Tensor,
+    dgram_weight: torch.Tensor,
+    scalar_weight: torch.Tensor,
+) -> bool:
+    inputs = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
+    )
+    return (
+        is_fused_template_coordinate_enabled()
+        and source.is_cuda
+        and source.dtype in (torch.float32, torch.bfloat16)
+        and source.shape[0] == 1
+        and source.shape[-1] == 64
+        and dgram_weight.shape == (64, 39)
+        and scalar_weight.shape == (64, 5)
+        and all(x.is_cuda and x.device == source.device for x in inputs)
+    )
+
+
+def fused_template_coordinate_pair_embedder(
     module: nn.Module,
     batch: dict,
     z: torch.Tensor,
     template_index: int,
 ) -> torch.Tensor:
-    """Embed one compact-coordinate template without raw pairwise features."""
-    if module.training or torch.is_grad_enabled():
-        raise RuntimeError(
-            "fused_template_coordinate_pair_embedder_inference is inference-only"
-        )
-    if z.dim() != 4 or z.shape[0] != 1 or z.shape[-3] != z.shape[-2]:
-        raise ValueError("Coordinate template embedding requires z [1,N,N,C]")
+    """Embed one compact-coordinate template with inference/training dispatch."""
+    if z.dim() != 4 or z.shape[-3] != z.shape[-2]:
+        raise ValueError("Coordinate template embedding requires z [B,N,N,C]")
+    _validate_fused_away_biases(module)
 
     dtype = z.dtype
-    a = _chunked_ln_linear_z(z, module, dtype)
+    inference_inplace = not module.training and not torch.is_grad_enabled()
+    if torch.is_grad_enabled():
+        a = module.linear_z(module.layer_norm_z(z))
+    else:
+        a = _chunked_ln_linear_z(z, module, dtype)
     (
         pseudo_beta_coords,
         frame_atom_coords,
@@ -243,39 +484,89 @@ def fused_template_coordinate_pair_embedder_inference(
     ) = _fetch_coordinate_template_slice(
         batch, template_index, dtype=dtype, device=z.device
     )
-    _add_restype_projections_(a, restype, module, dtype)
+    coordinate_tensors = (
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+    )
+    if any(x.requires_grad for x in coordinate_tensors):
+        raise ValueError("Template coordinate inputs are non-differentiable data")
+    a = _add_restype_projections(a, restype, module, dtype, inplace=inference_inplace)
 
-    dgram_weight = module.dgram_linear.weight
-    scalar_weight = _build_scalar_weight(module, dtype)
     asym_id = batch["asym_id"].to(device=z.device, non_blocking=True).contiguous()
-    use_triton = (
-        is_fused_template_coordinate_enabled()
-        and z.is_cuda
-        and dtype == torch.float32
-        and a.shape[-1] == 64
-        and dgram_weight.shape == (64, 39)
-        and scalar_weight.shape == (64, 5)
+    dgram_weight = module.dgram_linear.weight
+    scalar_weight = _build_scalar_weight(module, torch.float32)
+    use_triton = _can_use_triton(
+        a,
+        pseudo_beta_coords,
+        frame_atom_coords,
+        pseudo_beta_mask,
+        backbone_frame_mask,
+        asym_id,
+        dgram_weight,
+        scalar_weight,
     )
     if use_triton:
-        template_coordinate_projection_add_(
-            a,
-            pseudo_beta_coords,
-            frame_atom_coords,
-            pseudo_beta_mask,
-            backbone_frame_mask,
-            asym_id,
-            dgram_weight.contiguous(),
-            scalar_weight.contiguous(),
-        )
+        dgram_weight = dgram_weight.float().contiguous()
+        scalar_weight = scalar_weight.contiguous()
+        with torch.autocast(device_type="cuda", enabled=False):
+            if torch.is_grad_enabled():
+                a = _TemplateCoordinateProjectionFunction.apply(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
+            elif inference_inplace:
+                template_coordinate_projection_add_(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
+            else:
+                a = template_coordinate_projection(
+                    a,
+                    pseudo_beta_coords,
+                    frame_atom_coords,
+                    pseudo_beta_mask,
+                    backbone_frame_mask,
+                    asym_id,
+                    dgram_weight,
+                    scalar_weight,
+                )
     else:
-        template_coordinate_projection_add_reference_(
-            a,
-            pseudo_beta_coords,
-            frame_atom_coords,
-            pseudo_beta_mask,
-            backbone_frame_mask,
-            asym_id,
-            dgram_weight,
-            scalar_weight,
-        )
+        dgram_weight = dgram_weight.to(dtype=dtype)
+        scalar_weight = scalar_weight.to(dtype=dtype)
+        if inference_inplace:
+            template_coordinate_projection_add_reference_(
+                a,
+                pseudo_beta_coords,
+                frame_atom_coords,
+                pseudo_beta_mask,
+                backbone_frame_mask,
+                asym_id,
+                dgram_weight,
+                scalar_weight,
+            )
+        else:
+            a = template_coordinate_projection_reference(
+                a,
+                pseudo_beta_coords,
+                frame_atom_coords,
+                pseudo_beta_mask,
+                backbone_frame_mask,
+                asym_id,
+                dgram_weight,
+                scalar_weight,
+            )
     return a.unsqueeze(-4)

--- a/openfold3/core/utils/atomize_utils.py
+++ b/openfold3/core/utils/atomize_utils.py
@@ -114,6 +114,51 @@ def broadcast_token_feat_to_atoms(
     return atom_feat
 
 
+def _expand_to_batch(tensor: torch.Tensor, batch_dims: torch.Size) -> torch.Tensor:
+    while tensor.ndim - 1 < len(batch_dims):
+        tensor = tensor.unsqueeze(-2)
+    return tensor.expand(*batch_dims, tensor.shape[-1])
+
+
+def broadcast_token_feat_to_atoms_by_index(
+    token_mask: torch.Tensor,
+    atom_to_token_index: torch.Tensor,
+    atom_mask: torch.Tensor,
+    token_feat: torch.Tensor,
+) -> torch.Tensor:
+    """Gather token features onto atoms via ``atom_to_token_index``."""
+    batch_dims = token_feat.shape[:-2]
+    n_token, channels = token_feat.shape[-2:]
+    idx = _expand_to_batch(atom_to_token_index, batch_dims).clamp(0, n_token - 1)
+    idx = idx.long().unsqueeze(-1).expand(*idx.shape, channels)
+    token_mask = _expand_to_batch(token_mask, batch_dims).unsqueeze(-1)
+    atom_mask = _expand_to_batch(atom_mask, batch_dims).unsqueeze(-1)
+    return torch.gather(token_feat * token_mask, -2, idx) * atom_mask
+
+
+def aggregate_atom_feat_to_tokens_segmented(
+    num_atoms_per_token: torch.Tensor,
+    atom_mask: torch.Tensor,
+    atom_feat: torch.Tensor,
+    eps: float = 1e-9,
+) -> torch.Tensor:
+    """Deterministic mean-reduce of packed, token-sorted atoms."""
+    batch_dims = atom_feat.shape[:-2]
+    n_token = num_atoms_per_token.shape[-1]
+    atom_mask = _expand_to_batch(atom_mask, batch_dims)
+    lengths = _expand_to_batch(num_atoms_per_token, batch_dims).long()
+    lengths = torch.cat(
+        [lengths, atom_feat.shape[-2] - lengths.sum(dim=-1, keepdim=True)], dim=-1
+    )
+    token_feat = torch.segment_reduce(
+        atom_feat * atom_mask.unsqueeze(-1), "sum", lengths=lengths, axis=-2
+    )[..., :n_token, :]
+    counts = torch.segment_reduce(
+        atom_mask.to(atom_feat.dtype), "sum", lengths=lengths, axis=-1
+    )[..., :n_token]
+    return token_feat / (counts.unsqueeze(-1) + eps)
+
+
 def aggregate_atom_feat_to_tokens(
     token_mask: torch.Tensor,
     atom_to_token_index: torch.Tensor,

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -68,7 +68,7 @@ def use_chunked_trimul(inplace_safe: bool) -> bool:
 
 
 def transition_chunk_cap() -> int | None:
-    """Optional cap for transition/OPM chunk size (``OPENFOLD3_TRANSITION_CHUNK_CAP``)."""
+    """Optional cap for transition/OPM (``OPENFOLD3_TRANSITION_CHUNK_CAP``)."""
     return _positive_env_int("OPENFOLD3_TRANSITION_CHUNK_CAP")
 
 
@@ -453,6 +453,11 @@ class ChunkSizeTuner:
 
         return consistent
 
+    @staticmethod
+    def _clone_arg_tree(args: Any) -> Any:
+        """Deep-clone tensor leaves so a probe cannot in-place-write live args."""
+        return tree_map(lambda t: t.clone(), args, torch.Tensor)
+
     def tune_chunk_size(
         self,
         representative_fn: Callable,
@@ -462,6 +467,8 @@ class ChunkSizeTuner:
         def remove_tensors(a):
             return (a.shape, a.dtype.itemsize) if type(a) is torch.Tensor else a
 
+        # Cache key is (shape, dtype.itemsize) + max_chunk_size. Look up
+        # before cloning: a hit never needs a pair-sized copy.
         arg_data = tree_map(remove_tensors, args, object)
         for cached_arg_data, cached_max, cached_size in self.cached_chunk_sizes:
             if cached_max == max_chunk_size and self._compare_arg_caches(
@@ -469,9 +476,11 @@ class ChunkSizeTuner:
             ):
                 return cached_size
 
+        # Miss: clone tensor leaves, then trial-run. Probe must not write
+        # in-place into the caller's activations.
         chunk_size = self._determine_favorable_chunk_size(
             fn=representative_fn,
-            args=args,
+            args=self._clone_arg_tree(args),
             max_chunk_size=max_chunk_size,
         )
         self.cached_chunk_sizes.append((arg_data, max_chunk_size, chunk_size))

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -14,6 +14,7 @@
 
 import logging
 import math
+import os
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
@@ -24,6 +25,57 @@ from openfold3.core.utils.tensor_utils import (
     tensor_tree_map,
     tree_map,
 )
+
+
+def _positive_env_int(name: str) -> int | None:
+    """Parse a positive int env var; unset/invalid -> None."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        val = int(raw)
+    except ValueError:
+        return None
+    return val if val > 0 else None
+
+
+def triangle_attn_chunk_cap() -> int | None:
+    """Optional row cap for triangle attention (``OPENFOLD3_TRI_ATTN_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRI_ATTN_CHUNK_CAP")
+
+
+def apply_triangle_attn_chunk_cap(
+    attn_chunk: int,
+    n_tokens: int | None = None,
+) -> int:
+    """Cap triangle-attention rows; no-op when ``n_tokens <= cap``."""
+    cap = triangle_attn_chunk_cap()
+    if cap is None:
+        return attn_chunk
+    if n_tokens is not None and n_tokens <= cap:
+        return attn_chunk
+    return min(attn_chunk, cap)
+
+
+def trimul_chunk_cap() -> int | None:
+    """Optional row chunk for trimul (``OPENFOLD3_TRIMUL_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRIMUL_CHUNK_CAP")
+
+
+def use_chunked_trimul(inplace_safe: bool) -> bool:
+    """Use eager chunked trimul instead of cuEq when a cap is set."""
+    return inplace_safe and trimul_chunk_cap() is not None
+
+
+def transition_chunk_cap() -> int | None:
+    """Optional cap for transition/OPM chunk size (``OPENFOLD3_TRANSITION_CHUNK_CAP``)."""
+    return _positive_env_int("OPENFOLD3_TRANSITION_CHUNK_CAP")
+
+
+def apply_transition_chunk_cap(chunk_size: int) -> int:
+    """Apply ``OPENFOLD3_TRANSITION_CHUNK_CAP`` after chunk-size tuning."""
+    cap = transition_chunk_cap()
+    return chunk_size if cap is None else min(chunk_size, cap)
 
 
 def _fetch_dims(tree):

--- a/openfold3/core/utils/chunk_utils.py
+++ b/openfold3/core/utils/chunk_utils.py
@@ -347,8 +347,9 @@ def chunk_layer(
 
 class ChunkSizeTuner:
     def __init__(self):
-        self.cached_chunk_size = None
-        self.cached_arg_data = None
+        # (arg_data, max_chunk_size, chunk_size) entries so alternating shapes
+        # and distinct max caps can reuse prior tunings.
+        self.cached_chunk_sizes: list[tuple[Any, int, int]] = []
 
     @staticmethod
     def _determine_favorable_chunk_size(fn, args, max_chunk_size):
@@ -410,19 +411,16 @@ class ChunkSizeTuner:
             return (a.shape, a.dtype.itemsize) if type(a) is torch.Tensor else a
 
         arg_data = tree_map(remove_tensors, args, object)
-        if self.cached_arg_data is not None:
-            # If args have changed shape/value, we need to re-tune
-            consistent = self._compare_arg_caches(self.cached_arg_data, arg_data)
-        else:
-            # Otherwise, we can reuse the precomputed value
-            consistent = False
+        for cached_arg_data, cached_max, cached_size in self.cached_chunk_sizes:
+            if cached_max == max_chunk_size and self._compare_arg_caches(
+                cached_arg_data, arg_data
+            ):
+                return cached_size
 
-        if not consistent:
-            self.cached_chunk_size = self._determine_favorable_chunk_size(
-                fn=representative_fn,
-                args=args,
-                max_chunk_size=max_chunk_size,
-            )
-            self.cached_arg_data = arg_data
-
-        return self.cached_chunk_size
+        chunk_size = self._determine_favorable_chunk_size(
+            fn=representative_fn,
+            args=args,
+            max_chunk_size=max_chunk_size,
+        )
+        self.cached_chunk_sizes.append((arg_data, max_chunk_size, chunk_size))
+        return chunk_size

--- a/openfold3/core/utils/relpos.py
+++ b/openfold3/core/utils/relpos.py
@@ -18,7 +18,10 @@ from openfold3.core.utils.tensor_utils import binned_one_hot
 
 
 def relpos_complex(
-    batch: dict, max_relative_idx: int, max_relative_chain: int
+    batch: dict,
+    max_relative_idx: int,
+    max_relative_chain: int,
+    row_slice: slice | None = None,
 ) -> torch.Tensor:
     """
     Args:
@@ -28,16 +31,37 @@ def relpos_complex(
             Maximum relative position and token indices clipped
         max_relative_chain:
             Maximum relative chain indices clipped
+        row_slice:
+            Optional slice over the first spatial dimension (rows of the pair
+            tensor). When provided, returns ``[*, chunk, N_token, C]`` instead
+            of ``[*, N_token, N_token, C]``. Used by the chunked diffusion
+            conditioning path to avoid materializing the full ``[N, N, 139]``
+            relpos tensor.
 
     Returns:
-        [*, N_token, N_token, C_z] Relative position embedding
+        [*, N_token, N_token, C_z] Relative position embedding (or
+        [*, chunk, N_token, C_z] when row_slice is given)
     """
     res_idx = batch["residue_index"]
     asym_id = batch["asym_id"]
     entity_id = batch["entity_id"]
-    same_chain = asym_id[..., None] == asym_id[..., None, :]
-    same_res = res_idx[..., None] == res_idx[..., None, :]
-    same_entity = entity_id[..., None] == entity_id[..., None, :]
+
+    if row_slice is not None:
+        row_asym = asym_id[..., row_slice, None]
+        col_asym = asym_id[..., None, :]
+        same_chain = row_asym == col_asym
+
+        row_res = res_idx[..., row_slice, None]
+        col_res = res_idx[..., None, :]
+        same_res = row_res == col_res
+
+        row_entity = entity_id[..., row_slice, None]
+        col_entity = entity_id[..., None, :]
+        same_entity = row_entity == col_entity
+    else:
+        same_chain = asym_id[..., None] == asym_id[..., None, :]
+        same_res = res_idx[..., None] == res_idx[..., None, :]
+        same_entity = entity_id[..., None] == entity_id[..., None, :]
 
     def relpos(
         pos: torch.Tensor, condition: torch.BoolTensor, rel_clip_idx: int
@@ -54,7 +78,10 @@ def relpos_complex(
             rel_pos:
                 [*, N_token, N_token, 2 * rel_clip_idx + 2] Relative position embedding
         """
-        offset = pos[..., None] - pos[..., None, :]
+        if row_slice is not None:
+            offset = pos[..., row_slice, None] - pos[..., None, :]
+        else:
+            offset = pos[..., None] - pos[..., None, :]
         clipped_offset = torch.clamp(offset + rel_clip_idx, min=0, max=2 * rel_clip_idx)
         final_offset = torch.where(
             condition,

--- a/openfold3/projects/of3_all_atom/config/dataset_config_components.py
+++ b/openfold3/projects/of3_all_atom/config/dataset_config_components.py
@@ -23,7 +23,7 @@ The main sections of the dataset configuration are:
 
 from typing import Annotated
 
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BaseModel, BeforeValidator, model_validator
 
 from openfold3.core.config.config_utils import _convert_molecule_type
 from openfold3.core.data.resources.residues import MoleculeType
@@ -125,6 +125,21 @@ class TemplateSettings(BaseModel):
     take_top_k: bool = False
     min_n_tokens_per_chain: int = 5
     distogram: TemplateDistogramSettings = TemplateDistogramSettings()
+    use_coordinate_pair_features: bool = False
+
+    @model_validator(mode="after")
+    def validate_coordinate_distogram(self):
+        distogram = (
+            self.distogram.min_bin,
+            self.distogram.max_bin,
+            self.distogram.n_bins,
+        )
+        if self.use_coordinate_pair_features and distogram != (3.25, 50.75, 39):
+            raise ValueError(
+                "Coordinate-derived templates currently require the default "
+                "3.25/50.75/39 distogram configuration."
+            )
+        return self
 
 
 class CropWeights(BaseModel):

--- a/openfold3/projects/of3_all_atom/config/features.py
+++ b/openfold3/projects/of3_all_atom/config/features.py
@@ -51,6 +51,8 @@ feature_dict = mlc.ConfigDict(
             "template_backbone_frame_mask": [NUM_TEMPLATES, NUM_TOKENS],
             "template_distogram": [NUM_TEMPLATES, NUM_TOKENS, NUM_TOKENS, 39],
             "template_unit_vector": [NUM_TEMPLATES, NUM_TOKENS, NUM_TOKENS, 3],
+            "template_pseudo_beta_coords": [NUM_TEMPLATES, NUM_TOKENS, 3],
+            "template_frame_atom_coords": [NUM_TEMPLATES, NUM_TOKENS, 3, 3],
             "token_bonds": [NUM_TOKENS, NUM_TOKENS],
             # Features not included in AF3 docs
             "num_atoms_per_token": [NUM_TOKENS],

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -329,6 +329,7 @@ class OpenFold3(nn.Module):
         si_trunk: torch.Tensor,
         zij_trunk: torch.Tensor,
         inplace_safe: bool = False,
+        zij_release: list | None = None,
     ) -> dict:
         """
         Mini diffusion rollout described in section 4.1.
@@ -345,6 +346,8 @@ class OpenFold3(nn.Module):
                 [*, N_token, N_token, C_z] Pair representation output from model trunk
             inplace_safe:
                 Whether inplace operations can be performed
+            zij_release:
+                Optional owned trunk-pair slot cleared before confidence.
 
         Returns:
             Output dictionary containing the predicted trunk embeddings,
@@ -413,8 +416,11 @@ class OpenFold3(nn.Module):
             "zij_trunk": zij_trunk,
             "atom_positions_predicted": atom_positions_predicted,
         }
+        del zij_trunk
+        if zij_release is not None:
+            zij_release[0] = None
 
-        cast_dtype = torch.float32 if self.training else si_trunk.dtype
+        cast_dtype = torch.float32 if self.training else output["si_trunk"].dtype
         with torch.amp.autocast(device_type="cuda", dtype=cast_dtype):
             # Compute confidence logits
             output.update(
@@ -671,13 +677,19 @@ class OpenFold3(nn.Module):
         batch = tensor_tree_map(lambda t: t.unsqueeze(1), batch)
         batch["ref_space_uid_to_perm"] = ref_space_uid_to_perm
 
+        retain_trunk_pair = self.training or "ground_truth" in batch
+        zij_release = None if retain_trunk_pair else [zij_trunk]
+        if zij_release is not None:
+            del zij_trunk
+
         # Mini rollout
         rollout_output = self._rollout(
             batch=batch,
             si_input=si_input,
             si_trunk=si_trunk,
-            zij_trunk=zij_trunk,
+            zij_trunk=(zij_trunk if retain_trunk_pair else zij_release[0]),
             inplace_safe=inplace_safe,
+            zij_release=zij_release,
         )
 
         output.update(rollout_output)

--- a/openfold3/projects/of3_all_atom/model.py
+++ b/openfold3/projects/of3_all_atom/model.py
@@ -577,10 +577,18 @@ class OpenFold3(nn.Module):
                         compute frames
                     "template_distogram" ([*, N_templ, N_token, N_token, 39])
                         A one-hot pairwise feature indicating the distance between
-                        C_beta atoms (C_alpha for glycine) in the template
+                        C_beta atoms (C_alpha for glycine) in the template.
+                        Absent when coordinate-derived template features are used.
                     "template_unit_vector"([*, N_templ, N_token, N_token, 3])
                         The unit vector between pairs of C_alpha atoms within
-                        the local frame of each template residue
+                        the local frame of each template residue.
+                        Absent when coordinate-derived template features are used.
+                    *"template_pseudo_beta_coords" ([*, N_templ, N_token, 3])
+                        Compact pseudo-beta coordinates for the optional
+                        coordinate-derived template path (inference)
+                    *"template_frame_atom_coords" ([*, N_templ, N_token, 3, 3])
+                        Compact N/CA/C coordinates for the optional
+                        coordinate-derived template path (inference)
                     "token_bonds" ([*, N_token, N_token])
                         A 2D matrix indicating if there is a bond between
                         any atom in token i and token j

--- a/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
+++ b/openfold3/tests/core/data/framework/single_datasets/test_inference_seeding.py
@@ -1,0 +1,73 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+
+import numpy as np
+
+from openfold3.core.data.framework.single_datasets.inference import (
+    InferenceDataset,
+    _seeded_feature_creation,
+)
+from openfold3.projects.of3_all_atom.config.inference_query_format import Query
+
+LIGAND_QUERY = Query.model_validate(
+    {
+        "query_name": "ethanol",
+        "chains": [
+            {
+                "molecule_type": "ligand",
+                "chain_ids": "A",
+                "smiles": "CCO",
+            }
+        ],
+    }
+)
+
+
+def _reference_conformer_coords(seed: int) -> np.ndarray:
+    with _seeded_feature_creation(seed):
+        swrm = InferenceDataset.get_structure_with_ref_mols(LIGAND_QUERY)
+    return swrm.processed_reference_mols[0].mol.GetConformer().GetPositions()
+
+
+class TestInferenceFeatureSeeding(unittest.TestCase):
+    def test_same_seed_is_independent_of_global_rng(self):
+        for _ in range(100):
+            random.random()
+        first = _reference_conformer_coords(42)
+        for _ in range(100):
+            random.random()
+        second = _reference_conformer_coords(42)
+        np.testing.assert_allclose(first, second)
+
+    def test_different_seeds_can_differ(self):
+        first = _reference_conformer_coords(1)
+        second = _reference_conformer_coords(2)
+        self.assertFalse(np.allclose(first, second))
+
+    def test_restores_global_python_rng(self):
+        random.seed(7)
+        before = random.random()
+        with _seeded_feature_creation(999):
+            _reference_conformer_coords(999)
+        after = random.random()
+
+        random.seed(7)
+        expected_before = random.random()
+        expected_after = random.random()
+
+        self.assertEqual(before, expected_before)
+        self.assertEqual(after, expected_after)

--- a/openfold3/tests/core/model/latent/test_template_module.py
+++ b/openfold3/tests/core/model/latent/test_template_module.py
@@ -54,6 +54,58 @@ class TestTemplateEmbedderAllAtom(unittest.TestCase):
 
         self.assertTrue(t.shape == (batch_size, n_token, n_token, c_in))
 
+    def test_streaming_matches_full_batch(self):
+        batch_size = 1
+        n_templ = 3
+        n_token = 8
+
+        of3_proj_entry = OF3ProjectEntry()
+        of3_config = of3_proj_entry.get_model_config_with_presets()
+        c_in = of3_config.architecture.template.template_pair_embedder.c_in
+        embedder = TemplateEmbedderAllAtom(of3_config.architecture.template)
+        embedder.eval()
+
+        torch.manual_seed(0)
+        batch = {
+            "token_mask": torch.ones((batch_size, n_token)),
+            "asym_id": torch.ones((batch_size, n_token)),
+            "template_restype": torch.randn((batch_size, n_templ, n_token, 32)),
+            "template_pseudo_beta_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_backbone_frame_mask": torch.ones((batch_size, n_templ, n_token)),
+            "template_distogram": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 39)
+            ),
+            "template_unit_vector": torch.randn(
+                (batch_size, n_templ, n_token, n_token, 3)
+            ),
+        }
+        z = torch.randn((batch_size, n_token, n_token, c_in))
+        pair_mask = torch.ones((batch_size, n_token, n_token))
+
+        with torch.inference_mode():
+            t_stream = embedder(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = embedder._forward(
+                batch=batch,
+                z=z,
+                pair_mask=pair_mask,
+                chunk_size=4,
+                inplace_safe=True,
+            )
+            t_full = torch.sum(t_full, dim=-4) / n_templ
+            t_full = torch.nn.functional.relu(t_full)
+            t_full = embedder.linear_t(t_full)
+
+        self.assertTrue(
+            torch.allclose(t_stream, t_full, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(t_stream - t_full).abs().max().item():.3e}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/test_atomize_utils.py
+++ b/openfold3/tests/test_atomize_utils.py
@@ -22,7 +22,9 @@ from openfold3.core.data.primitives.featurization.structure import (
 )
 from openfold3.core.utils.atomize_utils import (
     aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
     broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
     get_token_atom_index_offset,
     get_token_center_atoms,
     get_token_frame_atoms,
@@ -317,6 +319,21 @@ class TestBroadcastTokenFeatToAtoms(unittest.TestCase):
 
         self.assertTrue((atom_mask == gt_atom_mask).all())
 
+    def test_by_index_matches_repeat_interleave(self):
+        lengths = torch.tensor([[[2, 1, 3]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_mask = torch.ones(1, 1, 6)
+        atom_mask[..., 1] = 0
+        atom_index = create_atom_to_token_index(token_mask, lengths)
+        token_feat = torch.randn(1, 4, 3, 5)
+        expected = broadcast_token_feat_to_atoms(
+            token_mask, lengths, token_feat, -2
+        ) * atom_mask.unsqueeze(-1)
+        actual = broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+        torch.testing.assert_close(actual, expected)
+
 
 class TestAggregateAtomFeatToTokens(unittest.TestCase):
     def test_with_one_batch_dim(self):
@@ -426,6 +443,38 @@ class TestAggregateAtomFeatToTokens(unittest.TestCase):
         )
 
         self.assertTrue((torch.abs(token_feat - gt_token_feat) < 1e-5).all())
+
+
+class TestSegmentedAggregateAtomFeatToTokens(unittest.TestCase):
+    def test_matches_scatter_and_is_cuda_repeatable(self):
+        lengths = torch.tensor([[[3, 2, 1]]])
+        token_mask = torch.ones(1, 1, 3)
+        atom_index = torch.tensor([[[0, 0, 0, 1, 1, 2, 0]]])
+        atom_mask = torch.tensor([[[1, 1, 0, 1, 1, 1, 0]]], dtype=torch.float32)
+        atom_feat = torch.randn(1, 4, 7, 5)
+        expected = aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+        actual = aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+        torch.testing.assert_close(actual, expected)
+
+        if not torch.cuda.is_available():
+            return
+        lengths, atom_mask, atom_feat = (
+            t.cuda() for t in (lengths, atom_mask, atom_feat)
+        )
+        reference = aggregate_atom_feat_to_tokens_segmented(
+            lengths, atom_mask, atom_feat
+        )
+        for _ in range(16):
+            self.assertTrue(
+                torch.equal(
+                    aggregate_atom_feat_to_tokens_segmented(
+                        lengths, atom_mask, atom_feat
+                    ),
+                    reference,
+                )
+            )
 
 
 class TestGetTokenAtomIndex(unittest.TestCase):

--- a/openfold3/tests/test_diffusion_conditioning.py
+++ b/openfold3/tests/test_diffusion_conditioning.py
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
+import pytest
 import torch
 
+import openfold3.tests.utils.compare_utils as compare_utils
+from openfold3.core.kernels.triton.fused_swiglu_transition import (
+    is_fused_swiglu_transition_eligible,
+)
 from openfold3.core.model.layers.diffusion_conditioning import DiffusionConditioning
+from openfold3.core.model.layers.transition import SwiGLUTransition
 from openfold3.core.utils.relpos import relpos_complex
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
@@ -213,6 +220,78 @@ class TestDiffusionConditioning(unittest.TestCase):
 
         self.assertTrue(si.shape == (batch_size, 1, n_token, c_s))
         self.assertTrue(zij.shape == (batch_size, 1, n_token, n_token, c_z))
+
+
+def _cuda_conditioning_module(n_token: int = 64):
+    proj_entry = OF3ProjectEntry()
+    config = proj_entry.get_model_config_with_presets()
+    c_s_input = consts.c_s + 65
+    diff_cond_config = config.architecture.diffusion_module.diffusion_conditioning
+    diff_cond_config.update(
+        {"c_s": consts.c_s, "c_s_input": c_s_input, "c_z": consts.c_z}
+    )
+    return DiffusionConditioning(**diff_cond_config).cuda().eval()
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@compare_utils.skip_unless_cuda_available()
+@compare_utils.skip_unless_triton_installed()
+def test_inference_pair_swiglu_inplace_matches_eager_add(dtype, monkeypatch):
+    monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1")
+    n_token = 64
+    dc = _cuda_conditioning_module(n_token)
+    torch.manual_seed(0)
+    si = torch.randn(1, n_token, consts.c_s, device="cuda", dtype=dtype)
+    zij = torch.randn(1, n_token, n_token, consts.c_z, device="cuda", dtype=dtype)
+    token_mask = torch.ones(1, n_token, device="cuda", dtype=dtype)
+    weights = dc.transition_z[0]._fused_weight_args()
+    if not is_fused_swiglu_transition_eligible(zij, *weights):
+        pytest.skip("fused SwiGLU is not eligible for this shape")
+
+    zij_ref = zij.clone()
+    with torch.no_grad():
+        monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
+        _, zij_eager = dc._forward(si.clone(), zij_ref, token_mask)
+        monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1")
+        ptr_before = zij.data_ptr()
+        calls = {"n": 0}
+        real = SwiGLUTransition._transition_inplace
+
+        def _wrapped(self, *args, **kwargs):
+            calls["n"] += 1
+            return real(self, *args, **kwargs)
+
+        with patch.object(SwiGLUTransition, "_transition_inplace", _wrapped):
+            _, zij_fused = dc._forward(si, zij, token_mask)
+    assert calls["n"] == len(dc.transition_z)
+    assert zij_fused.data_ptr() == ptr_before
+    atol = 2e-2 if dtype == torch.bfloat16 else 2e-4
+    torch.testing.assert_close(zij_fused, zij_eager, atol=atol, rtol=atol)
+
+
+@compare_utils.skip_unless_cuda_available()
+@compare_utils.skip_unless_triton_installed()
+def test_training_pair_swiglu_stays_out_of_place(monkeypatch):
+    monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1")
+    n_token = 64
+    dc = _cuda_conditioning_module(n_token)
+    torch.manual_seed(0)
+    si = torch.randn(1, n_token, consts.c_s, device="cuda", requires_grad=True)
+    zij = torch.randn(
+        1, n_token, n_token, consts.c_z, device="cuda", requires_grad=True
+    )
+    token_mask = torch.ones(1, n_token, device="cuda")
+    ptr_before = zij.data_ptr()
+    with patch.object(
+        SwiGLUTransition,
+        "_transition_inplace",
+        wraps=SwiGLUTransition._transition_inplace,
+    ) as inplace:
+        _, zij_out = dc._forward(si, zij, token_mask)
+        zij_out.square().mean().backward()
+    assert inplace.call_count == 0
+    assert zij_out.data_ptr() != ptr_before
+    assert zij.grad is not None
 
 
 if __name__ == "__main__":

--- a/openfold3/tests/test_diffusion_conditioning.py
+++ b/openfold3/tests/test_diffusion_conditioning.py
@@ -17,11 +17,22 @@ import unittest
 import torch
 
 from openfold3.core.model.layers.diffusion_conditioning import DiffusionConditioning
+from openfold3.core.utils.relpos import relpos_complex
 from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 from openfold3.tests.config import consts
 
 
 class TestDiffusionConditioning(unittest.TestCase):
+    def _batch(self, batch_size: int, n_token: int) -> dict:
+        return {
+            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "token_mask": torch.ones((batch_size, n_token)),
+            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
+            "sym_id": torch.zeros((batch_size, n_token)),
+            "asym_id": torch.zeros((batch_size, n_token)),
+            "entity_id": torch.zeros((batch_size, n_token)),
+        }
+
     def test_without_n_sample_channel(self):
         batch_size = consts.batch_size
         n_token = consts.n_res
@@ -45,14 +56,7 @@ class TestDiffusionConditioning(unittest.TestCase):
             -1.2 + 1.5 * torch.randn(batch_size, device=si_trunk.device)
         )
 
-        batch = {
-            "token_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "token_mask": torch.ones((batch_size, n_token)),
-            "residue_index": torch.arange(0, n_token)[None, :].repeat((batch_size, 1)),
-            "sym_id": torch.zeros((batch_size, n_token)),
-            "asym_id": torch.zeros((batch_size, n_token)),
-            "entity_id": torch.zeros((batch_size, n_token)),
-        }
+        batch = self._batch(batch_size, n_token)
 
         si, zij = dc(
             batch=batch,
@@ -65,6 +69,53 @@ class TestDiffusionConditioning(unittest.TestCase):
 
         self.assertTrue(si.shape == (batch_size, n_token, c_s))
         self.assertTrue(zij.shape == (batch_size, n_token, n_token, c_z))
+
+    def test_relpos_row_slice_matches_full(self):
+        batch_size = 2
+        n_token = 17
+        batch = self._batch(batch_size, n_token)
+        full = relpos_complex(batch, max_relative_idx=32, max_relative_chain=2)
+        chunk = 5
+        parts = [
+            relpos_complex(
+                batch,
+                max_relative_idx=32,
+                max_relative_chain=2,
+                row_slice=slice(i, min(i + chunk, n_token)),
+            )
+            for i in range(0, n_token, chunk)
+        ]
+        rebuilt = torch.cat(parts, dim=-3)
+        self.assertTrue(torch.equal(rebuilt, full))
+
+    def test_chunked_pair_embed_matches_eager(self):
+        batch_size = 1
+        n_token = 37
+        c_s_input = consts.c_s + 65
+        c_s = consts.c_s
+        c_z = consts.c_z
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        diff_cond_config = config.architecture.diffusion_module.diffusion_conditioning
+        diff_cond_config.update({"c_s": c_s, "c_s_input": c_s_input, "c_z": c_z})
+        dc = DiffusionConditioning(**diff_cond_config)
+        dc.eval()
+
+        torch.manual_seed(0)
+        batch = self._batch(batch_size, n_token)
+        zij_trunk = torch.randn(batch_size, n_token, n_token, c_z)
+
+        with torch.no_grad():
+            zij_chunked = dc._embed_zij_chunked(batch, zij_trunk)
+        # Eager path is taken when gradients are enabled.
+        with torch.enable_grad():
+            zij_eager = dc._embed_zij(batch, zij_trunk.detach())
+
+        self.assertTrue(
+            torch.allclose(zij_chunked, zij_eager, atol=1e-5, rtol=1e-5),
+            f"max abs diff={(zij_chunked - zij_eager).abs().max().item():.3e}",
+        )
 
     def test_with_different_schedule(self):
         batch_size = consts.batch_size

--- a/openfold3/tests/test_fused_relpos_embed.py
+++ b/openfold3/tests/test_fused_relpos_embed.py
@@ -26,8 +26,11 @@ import torch
 
 import openfold3.tests.utils.compare_utils as compare_utils
 from openfold3.core.kernels.triton.fused_relpos_embed import (
+    _FusedRelposEmbedFn,
     eager_relpos_embed_add_,
+    eager_relpos_weight_grad,
     fused_relpos_embed_add_,
+    fused_relpos_weight_grad,
     is_fused_relpos_embed_enabled,
 )
 from openfold3.core.model.feature_embedders.input_embedders import InputEmbedderAllAtom
@@ -173,8 +176,121 @@ def test_input_embedder_env_fallback_matches_fused(n_token: int):
     compare_utils.assert_max_abs_diff_small(z_fused, z_eager, 1e-5)
 
 
+@pytest.mark.parametrize("n_token", [8, 17, 64])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_relpos_weight_grad_matches_eager(n_token: int, dtype: torch.dtype):
+    """Split-K Triton dW matches eager index_add accumulate."""
+    torch.manual_seed(21)
+    c_z = 128
+    vocab = 130
+    same_entity_offset = 65
+    grad_z = torch.randn(1, n_token, n_token, c_z, device="cuda", dtype=dtype)
+    idx1 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx2 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx3 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same_entity = torch.randint(
+        0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool
+    )
+
+    grad_ref = eager_relpos_weight_grad(
+        grad_z, idx1, idx2, idx3, same_entity, same_entity_offset, vocab
+    )
+    grad_fused = fused_relpos_weight_grad(
+        grad_z, idx1, idx2, idx3, same_entity, same_entity_offset, vocab
+    )
+    # fp32 reduction order can differ slightly from index_add; keep relative tol.
+    torch.testing.assert_close(grad_fused, grad_ref, atol=2e-3, rtol=1e-4)
+
+
+@pytest.mark.parametrize("n_token", [8, 17, 31])
+def test_fused_relpos_autograd_matches_feature_linear(n_token: int):
+    """Training path grads match relpos_complex + linear_relpos."""
+    torch.manual_seed(9)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    module = InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda()
+    batch = _move_batch_to_device(
+        random_of3_features(
+            batch_size=1,
+            n_token=n_token,
+            n_msa=4,
+            n_templ=1,
+        ),
+        "cuda",
+    )
+    s_input = _synthetic_s_input(module, n_token).requires_grad_(True)
+
+    # Reference classic path with identical weights.
+    s_i = module.linear_z_i(s_input)
+    s_j = module.linear_z_j(s_input)
+    z_ref = s_i[..., None, :] + s_j[..., None, :, :]
+    z_ref = z_ref + module.linear_token_bonds(
+        batch["token_bonds"].to(dtype=z_ref.dtype).unsqueeze(-1)
+    )
+    relpos_feats = relpos_complex(
+        batch=batch,
+        max_relative_idx=module.max_relative_idx,
+        max_relative_chain=module.max_relative_chain,
+    ).to(dtype=z_ref.dtype)
+    z_ref = z_ref + module.linear_relpos(relpos_feats)
+    loss_ref = z_ref.square().mean()
+    loss_ref.backward()
+    grad_s_ref = s_input.grad.detach().clone()
+    grad_w_ref = module.linear_relpos.weight.grad.detach().clone()
+
+    module.zero_grad(set_to_none=True)
+    s_input.grad = None
+    s_input_f = s_input.detach().requires_grad_(True)
+    z_fused = module.embed_z(
+        batch=batch,
+        s_input=s_input_f,
+        dtype=s_input_f.dtype,
+        inplace_safe=False,
+    )
+    loss_fused = z_fused.square().mean()
+    loss_fused.backward()
+
+    torch.testing.assert_close(z_fused, z_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(s_input_f.grad, grad_s_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(
+        module.linear_relpos.weight.grad, grad_w_ref, atol=1e-4, rtol=1e-4
+    )
+
+
+def test_fused_relpos_autograd_kernel_grad_z_and_weight():
+    """Function returns passthrough dZ and transposed dW."""
+    torch.manual_seed(4)
+    n_token, c_z, vocab = 16, 128, 130
+    z = torch.randn(1, n_token, n_token, c_z, device="cuda", requires_grad=True)
+    weight = torch.randn(c_z, vocab, device="cuda", requires_grad=True)
+    idx = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+    offset = 65
+
+    out = _FusedRelposEmbedFn.apply(
+        z,
+        weight,
+        idx,
+        idx,
+        idx,
+        same,
+        torch.tensor(offset, dtype=torch.int64),
+    )
+    (out * torch.arange(c_z, device="cuda")).sum().backward()
+
+    w = weight.detach().t().contiguous()
+    z_e = z.detach().clone().requires_grad_(True)
+    w_e = w.clone().requires_grad_(True)
+    out_e = z_e.clone()
+    eager_relpos_embed_add_(out_e, w_e, idx, idx, idx, same, offset)
+    (out_e * torch.arange(c_z, device="cuda")).sum().backward()
+
+    torch.testing.assert_close(out, out_e, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(z.grad, z_e.grad, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(weight.grad, w_e.grad.t(), atol=1e-4, rtol=1e-4)
+
+
 def test_fused_relpos_compile_reuse_across_lengths():
-    """One filesystem compile must serve every sequence length."""
+    """One filesystem compile must serve every sequence length (fwd + bwd)."""
     script = r"""
 import json
 import os
@@ -184,7 +300,9 @@ import torch
 
 from openfold3.core.kernels.triton.fused_relpos_embed import (
     _fused_relpos_embed_kernel,
+    _fused_relpos_weight_grad_kernel,
     fused_relpos_embed_add_,
+    fused_relpos_weight_grad,
 )
 
 cache_dir = os.environ["TRITON_CACHE_DIR"]
@@ -192,6 +310,7 @@ Path(cache_dir).mkdir(parents=True, exist_ok=True)
 
 def clear():
     _fused_relpos_embed_kernel.device_caches.clear()
+    _fused_relpos_weight_grad_kernel.device_caches.clear()
 
 def count(name):
     return len(list(Path(cache_dir).rglob(f"{name}.json")))
@@ -202,11 +321,15 @@ for n in (16, 32, 48, 64, 96, 127):
     idx = torch.zeros(1, n, n, dtype=torch.int64, device="cuda")
     same = torch.ones(1, n, n, dtype=torch.bool, device="cuda")
     fused_relpos_embed_add_(z, w, idx, idx, idx, same, 65)
+    fused_relpos_weight_grad(z, idx, idx, idx, same, 65, 130)
     clear()
 
-counts = {"forward": count("_fused_relpos_embed_kernel")}
+counts = {
+    "forward": count("_fused_relpos_embed_kernel"),
+    "backward": count("_fused_relpos_weight_grad_kernel"),
+}
 print(json.dumps(counts))
-assert counts == {"forward": 1}, counts
+assert counts == {"forward": 1, "backward": 1}, counts
 """
     with tempfile.TemporaryDirectory() as cache_dir:
         env = os.environ.copy()
@@ -220,6 +343,7 @@ assert counts == {"forward": 1}, counts
             text=True,
         )
         assert '"forward": 1' in result.stdout
+        assert '"backward": 1' in result.stdout
 
 
 @pytest.mark.parametrize("n_token", [64, 256])
@@ -271,3 +395,37 @@ def test_fused_relpos_microbench_faster_or_parity(n_token: int):
         assert fused_s <= eager_s * 1.05, (fused_s, eager_s)
     else:
         assert fused_s < eager_s * 2.0, (fused_s, eager_s)
+
+
+@pytest.mark.parametrize("n_token", [64, 256])
+def test_fused_relpos_bwd_microbench_faster_or_parity(n_token: int):
+    """Warm Triton dW should beat eager index_add at N>=256."""
+    import time
+
+    torch.manual_seed(5)
+    c_z, vocab, offset = 128, 130, 65
+    warmup, reps = 5, 20
+    grad_z = torch.randn(1, n_token, n_token, c_z, device="cuda")
+    idx1 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx2 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx3 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+
+    def _bench(fn):
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        torch.cuda.synchronize()
+        return (time.perf_counter() - t0) / reps
+
+    fused_s = _bench(
+        lambda: fused_relpos_weight_grad(
+            grad_z, idx1, idx2, idx3, same, offset, vocab
+        )
+    )
+    # Correctness/perf smoke: kernel must finish and stay in a sane band.
+    # Absolute speed vs index_add is not a gate (cuBLAS scatter is strong).
+    assert fused_s < 0.05, fused_s

--- a/openfold3/tests/test_fused_relpos_embed.py
+++ b/openfold3/tests/test_fused_relpos_embed.py
@@ -26,6 +26,7 @@ import torch
 
 import openfold3.tests.utils.compare_utils as compare_utils
 from openfold3.core.kernels.triton.fused_relpos_embed import (
+    _can_use_triton,
     _FusedRelposEmbedFn,
     eager_relpos_embed_add_,
     eager_relpos_weight_grad,
@@ -65,12 +66,12 @@ def test_fused_relpos_kernel_matches_eager(n_token: int, dtype: torch.dtype):
     idx1 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
     idx2 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
     idx3 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
-    same_entity = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+    same_entity = torch.randint(
+        0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool
+    )
 
     z_ref = z.clone()
-    eager_relpos_embed_add_(
-        z_ref, w, idx1, idx2, idx3, same_entity, same_entity_offset
-    )
+    eager_relpos_embed_add_(z_ref, w, idx1, idx2, idx3, same_entity, same_entity_offset)
 
     z_fused = z.clone()
     fused_relpos_embed_add_(
@@ -85,6 +86,103 @@ def test_fused_relpos_kernel_matches_eager(n_token: int, dtype: torch.dtype):
         torch.testing.assert_close(z_fused.float(), z_ref.float(), atol=0.15, rtol=1e-2)
 
 
+def _set_tf32(enabled: bool) -> None:
+    torch.backends.cuda.matmul.allow_tf32 = enabled
+    torch.backends.cudnn.allow_tf32 = enabled
+
+
+def test_fused_relpos_precision_eligibility():
+    """IEEE fp32, matching bf16, and bf16-mixed are eligible; fp32+bf16 is not."""
+    z32 = torch.zeros(1, 4, 4, 128, device="cuda", dtype=torch.float32)
+    z16 = torch.zeros(1, 4, 4, 128, device="cuda", dtype=torch.bfloat16)
+    w32 = torch.zeros(130, 128, device="cuda", dtype=torch.float32)
+    w16 = torch.zeros(130, 128, device="cuda", dtype=torch.bfloat16)
+    assert _can_use_triton(z32, w32)
+    assert _can_use_triton(z16, w16)
+    assert _can_use_triton(z16, w32)
+    assert not _can_use_triton(z32, w16)
+
+
+@pytest.mark.parametrize("allow_tf32", [False, True], ids=["ieee", "tf32"])
+def test_fused_relpos_fp32_matches_eager(allow_tf32: bool):
+    """IEEE and TF32 share gather-add math; both match eager fp32."""
+    _set_tf32(allow_tf32)
+    torch.manual_seed(11)
+    n_token, c_z, vocab, offset = 16, 128, 130, 65
+    z = torch.randn(1, n_token, n_token, c_z, device="cuda")
+    w = torch.randn(vocab, c_z, device="cuda")
+    idx = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+    assert _can_use_triton(z, w)
+
+    z_ref = z.clone()
+    eager_relpos_embed_add_(z_ref, w, idx, idx, idx, same, offset)
+    z_fused = z.clone()
+    fused_relpos_embed_add_(z_fused, w, idx, idx, idx, same, offset)
+    compare_utils.assert_max_abs_diff_small(z_ref, z_fused, 1e-5)
+
+
+def test_fused_relpos_bf16_mixed_matches_fp32_ref():
+    """bf16 activations + fp32 masters match fp32 gather-add then store-cast."""
+    _set_tf32(False)
+    torch.manual_seed(12)
+    n_token, c_z, vocab, offset = 16, 128, 130, 65
+    z = torch.randn(1, n_token, n_token, c_z, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(vocab, c_z, device="cuda", dtype=torch.float32)
+    idx = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+    assert _can_use_triton(z, w)
+
+    z_ref = z.float()
+    eager_relpos_embed_add_(z_ref, w, idx, idx, idx, same, offset)
+    z_ref = z_ref.to(torch.bfloat16)
+    z_fused = z.clone()
+    fused_relpos_embed_add_(z_fused, w, idx, idx, idx, same, offset)
+    torch.testing.assert_close(z_fused.float(), z_ref.float(), atol=2e-2, rtol=1e-2)
+
+
+def test_fused_relpos_autograd_bf16_mixed():
+    """Mixed training: bf16 dZ passthrough, fp32 dW vs fp32-then-cast eager."""
+    _set_tf32(False)
+    torch.manual_seed(4)
+    n_token, c_z, vocab, offset = 16, 128, 130, 65
+    z = torch.randn(
+        1,
+        n_token,
+        n_token,
+        c_z,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    weight = torch.randn(
+        c_z, vocab, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    idx = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+
+    out = _FusedRelposEmbedFn.apply(
+        z, weight, idx, idx, idx, same, torch.tensor(offset, dtype=torch.int64)
+    )
+    scale = torch.arange(c_z, device="cuda", dtype=torch.bfloat16)
+    (out * scale).sum().backward()
+
+    w = weight.detach().t().contiguous()
+    z_ref = z.detach().float()
+    eager_relpos_embed_add_(z_ref, w, idx, idx, idx, same, offset)
+    out_ref = z_ref.to(torch.bfloat16)
+    grad_out = scale.expand_as(out).contiguous()
+    dw_ref = eager_relpos_weight_grad(grad_out, idx, idx, idx, same, offset, vocab)
+
+    assert out.dtype == torch.bfloat16
+    assert weight.grad.dtype == torch.float32
+    torch.testing.assert_close(out.float(), out_ref.float(), atol=2e-2, rtol=1e-2)
+    torch.testing.assert_close(z.grad, grad_out)
+    torch.testing.assert_close(
+        weight.grad.float(), dw_ref.t().float(), atol=5e-2, rtol=2e-2
+    )
+
+
 def _synthetic_s_input(module: InputEmbedderAllAtom, n_token: int) -> torch.Tensor:
     c_s_input = module.linear_s.weight.shape[1]
     return torch.randn(1, n_token, c_s_input, device="cuda", dtype=torch.float32)
@@ -97,7 +195,9 @@ def test_input_embedder_fused_relpos_matches_feature_linear(n_token: int):
     torch.manual_seed(7)
 
     of3_config = OF3ProjectEntry().get_model_config_with_presets()
-    module = InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    module = (
+        InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    )
     batch = _move_batch_to_device(
         random_of3_features(
             batch_size=1,
@@ -138,7 +238,9 @@ def test_input_embedder_env_fallback_matches_fused(n_token: int):
     """OPENFOLD3_FUSED_RELPOS=0 uses the eager weight-table path."""
     torch.manual_seed(13)
     of3_config = OF3ProjectEntry().get_model_config_with_presets()
-    module = InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    module = (
+        InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    )
     batch = _move_batch_to_device(
         random_of3_features(
             batch_size=1,
@@ -422,9 +524,7 @@ def test_fused_relpos_bwd_microbench_faster_or_parity(n_token: int):
         return (time.perf_counter() - t0) / reps
 
     fused_s = _bench(
-        lambda: fused_relpos_weight_grad(
-            grad_z, idx1, idx2, idx3, same, offset, vocab
-        )
+        lambda: fused_relpos_weight_grad(grad_z, idx1, idx2, idx3, same, offset, vocab)
     )
     # Correctness/perf smoke: kernel must finish and stay in a sane band.
     # Absolute speed vs index_add is not a gate (cuBLAS scatter is strong).

--- a/openfold3/tests/test_fused_relpos_embed.py
+++ b/openfold3/tests/test_fused_relpos_embed.py
@@ -1,0 +1,273 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity and compile-reuse tests for fused input relpos embedding."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+import torch
+
+import openfold3.tests.utils.compare_utils as compare_utils
+from openfold3.core.kernels.triton.fused_relpos_embed import (
+    eager_relpos_embed_add_,
+    fused_relpos_embed_add_,
+    is_fused_relpos_embed_enabled,
+)
+from openfold3.core.model.feature_embedders.input_embedders import InputEmbedderAllAtom
+from openfold3.core.utils.relpos import relpos_complex
+from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
+from openfold3.tests.utils.data_utils import random_of3_features
+
+pytestmark = [
+    compare_utils.skip_unless_cuda_available(),
+    compare_utils.skip_unless_triton_installed(),
+]
+
+
+def _move_batch_to_device(batch: dict, device: str) -> dict:
+    out = {}
+    for key, value in batch.items():
+        out[key] = value.to(device=device) if torch.is_tensor(value) else value
+    return out
+
+
+@pytest.mark.parametrize("n_token", [16, 76, 127])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_relpos_kernel_matches_eager(n_token: int, dtype: torch.dtype):
+    """Fused gather-add matches four sequential gather-adds."""
+    torch.manual_seed(11)
+    c_z = 128
+    vocab = 130
+    same_entity_offset = 65
+
+    z = torch.randn(1, n_token, n_token, c_z, device="cuda", dtype=dtype)
+    w = torch.randn(vocab, c_z, device="cuda", dtype=dtype)
+    idx1 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx2 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx3 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same_entity = torch.randint(0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool)
+
+    z_ref = z.clone()
+    eager_relpos_embed_add_(
+        z_ref, w, idx1, idx2, idx3, same_entity, same_entity_offset
+    )
+
+    z_fused = z.clone()
+    fused_relpos_embed_add_(
+        z_fused, w, idx1, idx2, idx3, same_entity, same_entity_offset
+    )
+
+    # fp32: fused branch tolerance. bf16: Triton accumulates the four gathers
+    # with a float32 same-entity scale, so allow a few ULPs vs eager bf16.
+    if dtype == torch.float32:
+        compare_utils.assert_max_abs_diff_small(z_ref, z_fused, 1e-5)
+    else:
+        torch.testing.assert_close(z_fused.float(), z_ref.float(), atol=0.15, rtol=1e-2)
+
+
+def _synthetic_s_input(module: InputEmbedderAllAtom, n_token: int) -> torch.Tensor:
+    c_s_input = module.linear_s.weight.shape[1]
+    return torch.randn(1, n_token, c_s_input, device="cuda", dtype=torch.float32)
+
+
+@pytest.mark.parametrize("n_token", [8, 17, 31])
+def test_input_embedder_fused_relpos_matches_feature_linear(n_token: int):
+    """Module path matches materializing relpos_complex + linear_relpos."""
+    assert is_fused_relpos_embed_enabled()
+    torch.manual_seed(7)
+
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    module = InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    batch = _move_batch_to_device(
+        random_of3_features(
+            batch_size=1,
+            n_token=n_token,
+            n_msa=4,
+            n_templ=1,
+        ),
+        "cuda",
+    )
+    s_input = _synthetic_s_input(module, n_token)
+
+    with torch.inference_mode():
+        # Reference: classic one-hot + Linear path (bypass weight-table path).
+        s_input_emb_i = module.linear_z_i(s_input)
+        s_input_emb_j = module.linear_z_j(s_input)
+        z_ref = s_input_emb_i[..., None, :] + s_input_emb_j[..., None, :, :]
+        token_bonds = batch["token_bonds"].to(dtype=z_ref.dtype)
+        z_ref = z_ref + module.linear_token_bonds(token_bonds.unsqueeze(-1))
+        relpos_feats = relpos_complex(
+            batch=batch,
+            max_relative_idx=module.max_relative_idx,
+            max_relative_chain=module.max_relative_chain,
+        ).to(dtype=z_ref.dtype)
+        z_ref = z_ref + module.linear_relpos(relpos_feats)
+
+        z_fused = module.embed_z(
+            batch=batch,
+            s_input=s_input,
+            dtype=s_input.dtype,
+            inplace_safe=True,
+        )
+
+    compare_utils.assert_max_abs_diff_small(z_ref, z_fused, 1e-5)
+
+
+@pytest.mark.parametrize("n_token", [8, 17])
+def test_input_embedder_env_fallback_matches_fused(n_token: int):
+    """OPENFOLD3_FUSED_RELPOS=0 uses the eager weight-table path."""
+    torch.manual_seed(13)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    module = InputEmbedderAllAtom(**of3_config.architecture.input_embedder).cuda().eval()
+    batch = _move_batch_to_device(
+        random_of3_features(
+            batch_size=1,
+            n_token=n_token,
+            n_msa=4,
+            n_templ=1,
+        ),
+        "cuda",
+    )
+    s_input = _synthetic_s_input(module, n_token)
+
+    with torch.inference_mode():
+        z_fused = module.embed_z(
+            batch=batch,
+            s_input=s_input,
+            dtype=s_input.dtype,
+            inplace_safe=True,
+        )
+
+        old = os.environ.get("OPENFOLD3_FUSED_RELPOS")
+        os.environ["OPENFOLD3_FUSED_RELPOS"] = "0"
+        try:
+            z_eager = module.embed_z(
+                batch=batch,
+                s_input=s_input,
+                dtype=s_input.dtype,
+                inplace_safe=True,
+            )
+        finally:
+            if old is None:
+                os.environ.pop("OPENFOLD3_FUSED_RELPOS", None)
+            else:
+                os.environ["OPENFOLD3_FUSED_RELPOS"] = old
+
+    compare_utils.assert_max_abs_diff_small(z_fused, z_eager, 1e-5)
+
+
+def test_fused_relpos_compile_reuse_across_lengths():
+    """One filesystem compile must serve every sequence length."""
+    script = r"""
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from openfold3.core.kernels.triton.fused_relpos_embed import (
+    _fused_relpos_embed_kernel,
+    fused_relpos_embed_add_,
+)
+
+cache_dir = os.environ["TRITON_CACHE_DIR"]
+Path(cache_dir).mkdir(parents=True, exist_ok=True)
+
+def clear():
+    _fused_relpos_embed_kernel.device_caches.clear()
+
+def count(name):
+    return len(list(Path(cache_dir).rglob(f"{name}.json")))
+
+w = torch.randn(130, 128, device="cuda")
+for n in (16, 32, 48, 64, 96, 127):
+    z = torch.zeros(1, n, n, 128, device="cuda")
+    idx = torch.zeros(1, n, n, dtype=torch.int64, device="cuda")
+    same = torch.ones(1, n, n, dtype=torch.bool, device="cuda")
+    fused_relpos_embed_add_(z, w, idx, idx, idx, same, 65)
+    clear()
+
+counts = {"forward": count("_fused_relpos_embed_kernel")}
+print(json.dumps(counts))
+assert counts == {"forward": 1}, counts
+"""
+    with tempfile.TemporaryDirectory() as cache_dir:
+        env = os.environ.copy()
+        env["TRITON_CACHE_DIR"] = cache_dir
+        env["OPENFOLD3_FUSED_RELPOS"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert '"forward": 1' in result.stdout
+
+
+@pytest.mark.parametrize("n_token", [64, 256])
+def test_fused_relpos_microbench_faster_or_parity(n_token: int):
+    """Warm fused kernel should not regress vs eager gather-add at modest N."""
+    import time
+
+    torch.manual_seed(3)
+    c_z = 128
+    vocab = 130
+    same_entity_offset = 65
+    warmup = 5
+    reps = 20
+
+    z = torch.randn(1, n_token, n_token, c_z, device="cuda")
+    w = torch.randn(vocab, c_z, device="cuda")
+    idx1 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx2 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    idx3 = torch.randint(0, vocab, (1, n_token, n_token), device="cuda")
+    same_entity = torch.randint(
+        0, 2, (1, n_token, n_token), device="cuda", dtype=torch.bool
+    )
+
+    def _bench(fn):
+        for _ in range(warmup):
+            z_tmp = z.clone()
+            fn(z_tmp)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            z_tmp = z.clone()
+            fn(z_tmp)
+        torch.cuda.synchronize()
+        return (time.perf_counter() - t0) / reps
+
+    eager_s = _bench(
+        lambda zt: eager_relpos_embed_add_(
+            zt, w, idx1, idx2, idx3, same_entity, same_entity_offset
+        )
+    )
+    fused_s = _bench(
+        lambda zt: fused_relpos_embed_add_(
+            zt, w, idx1, idx2, idx3, same_entity, same_entity_offset
+        )
+    )
+
+    # At N>=256 the fused path should win; smaller N may be launch-bound.
+    if n_token >= 256:
+        assert fused_s <= eager_s * 1.05, (fused_s, eager_s)
+    else:
+        assert fused_s < eager_s * 2.0, (fused_s, eager_s)

--- a/openfold3/tests/test_fused_swiglu_transition.py
+++ b/openfold3/tests/test_fused_swiglu_transition.py
@@ -1,0 +1,396 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity, autograd, and compile-reuse tests for fused SwiGLU transition."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+import torch
+
+import openfold3.tests.utils.compare_utils as compare_utils
+from openfold3.core.kernels.triton.fused_swiglu_transition import (
+    fused_swiglu_transition,
+    is_fused_swiglu_transition_eligible,
+    is_fused_swiglu_transition_enabled,
+)
+from openfold3.core.model.layers.transition import SwiGLUTransition
+
+pytestmark = [
+    compare_utils.skip_unless_cuda_available(),
+    compare_utils.skip_unless_triton_installed(),
+]
+
+CASES = [(128, 4), (128, 2), (64, 2)]
+N_VALUES = [70, 256]
+
+
+def _weights(c, n, dtype, device, requires_grad=False):
+    torch.manual_seed(0)
+    H = n * c
+    g = torch.randn(c, dtype=dtype, device=device, requires_grad=requires_grad)
+    b = torch.randn(c, dtype=dtype, device=device, requires_grad=requires_grad)
+    wa = (torch.randn(H, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
+        requires_grad
+    )
+    wb = (torch.randn(H, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
+        requires_grad
+    )
+    wo = (torch.randn(c, H, dtype=dtype, device=device) / H**0.5).requires_grad_(
+        requires_grad
+    )
+    return g, b, wa, wb, wo
+
+
+def _bind_module(c, n, g, b, wa, wb, wo):
+    module = SwiGLUTransition(c_in=c, n=n).to(device=g.device, dtype=g.dtype)
+    with torch.no_grad():
+        module.layer_norm.weight.copy_(g)
+        module.layer_norm.bias.copy_(b)
+        module.swiglu.linear_a.weight.copy_(wa)
+        module.swiglu.linear_b.weight.copy_(wb)
+        module.linear_out.weight.copy_(wo)
+    return module
+
+
+def _eager(module, x, mask, residual=None):
+    y = module._eager_transition(x, mask)
+    return y if residual is None else residual + y
+
+
+def _set_tf32(enabled: bool) -> None:
+    torch.backends.cuda.matmul.allow_tf32 = enabled
+    torch.backends.cudnn.allow_tf32 = enabled
+
+
+@pytest.fixture(autouse=True)
+def _enable_fused(monkeypatch):
+    monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1")
+
+
+@pytest.mark.parametrize("c,n", CASES)
+@pytest.mark.parametrize("n_token", N_VALUES)
+def test_fused_matches_eager_fp32_baseline(c, n, n_token):
+    """fp32 IEEE fused vs module primitives."""
+    assert is_fused_swiglu_transition_enabled()
+    _set_tf32(False)
+    dtype = torch.float32
+    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
+    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
+    atol, rtol = 1e-5, 1e-5
+
+    with torch.inference_mode():
+        y_ref = _eager(module, x, mask)
+        y_fused = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+        z = x.clone()
+        y_ip = fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z)
+        y_ref_ip = _eager(module, x, mask, residual=x)
+
+    torch.testing.assert_close(y_fused.float(), y_ref.float(), atol=atol, rtol=rtol)
+    assert y_ip.data_ptr() == z.data_ptr()
+    torch.testing.assert_close(y_ip.float(), y_ref_ip.float(), atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("n_token", [70, 256])
+def test_fused_mixed_matches_eager(n_token):
+    """bf16-mixed: fp32 masters, bf16 GEMM, no TF32, vs module primitives."""
+    _set_tf32(False)
+    g, b, wa, wb, wo = _weights(128, 4, torch.float32, "cuda")
+    module = _bind_module(128, 4, g, b, wa, wb, wo).eval()
+    x = torch.randn(1, n_token, n_token, 128, dtype=torch.bfloat16, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, 1, dtype=torch.bfloat16, device="cuda")
+    with torch.inference_mode():
+        y_ref = _eager(module, x, mask)
+        y_fused = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+    torch.testing.assert_close(y_fused.float(), y_ref.float(), atol=5e-2, rtol=2e-2)
+
+
+def test_bf16_weights_are_ineligible():
+    """Triton requires fp32 masters; the module uses primitives."""
+    _set_tf32(False)
+    g, b, wa, wb, wo = _weights(128, 4, torch.bfloat16, "cuda")
+    module = _bind_module(128, 4, g, b, wa, wb, wo).eval()
+    x = torch.randn(1, 70, 70, 128, dtype=torch.bfloat16, device="cuda") * 0.5
+    mask = torch.ones(1, 70, 70, 1, dtype=torch.bfloat16, device="cuda")
+    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
+    with torch.inference_mode():
+        y = module(x, mask=mask.squeeze(-1))
+        y_ref = _eager(module, x, mask)
+    torch.testing.assert_close(y, y_ref)
+
+
+@pytest.mark.parametrize("n_token", [70, 256])
+def test_fused_tf32_vs_default_fp32_baseline(n_token):
+    """TF32 fused error is measured against default FP32 eager, not cuBLAS TF32."""
+    c, n, dtype = 128, 4, torch.float32
+    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
+    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
+
+    _set_tf32(False)
+    with torch.inference_mode():
+        y_fp32 = _eager(module, x, mask)
+
+    _set_tf32(True)
+    with torch.inference_mode():
+        y_fused_tf32 = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+        y_eager_tf32 = _eager(module, x, mask)
+
+    # After round-nearest f32->tf32, fused TF32 matches eager TF32 vs FP32.
+    torch.testing.assert_close(y_fused_tf32, y_fp32, atol=1e-2, rtol=2e-3)
+    torch.testing.assert_close(y_eager_tf32, y_fp32, atol=1e-2, rtol=2e-3)
+    torch.testing.assert_close(y_fused_tf32, y_eager_tf32, atol=5e-3, rtol=2e-3)
+
+
+def test_small_m_uses_module_eager():
+    _set_tf32(False)
+    c, n, n_token, dtype = 128, 4, 32, torch.float32
+    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
+    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
+    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
+    with torch.inference_mode():
+        y = module(x, mask=mask.squeeze(-1))
+        y_ref = _eager(module, x, mask)
+    compare_utils.assert_max_abs_diff_small(y, y_ref, 1e-5)
+
+
+@pytest.mark.parametrize("n_token", [70, 128])
+def test_module_fused_matches_eager_env_off(n_token, monkeypatch):
+    torch.manual_seed(3)
+    _set_tf32(False)
+    module = SwiGLUTransition(c_in=128, n=4).cuda().eval()
+    x = torch.randn(1, n_token, n_token, 128, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, device="cuda")
+    with torch.inference_mode():
+        y_fused = module(x, mask=mask)
+        monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
+        y_eager = module(x, mask=mask)
+    torch.testing.assert_close(y_fused, y_eager, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("n_token", [70, 128])
+def test_autograd_matches_eager_fp32(n_token):
+    _set_tf32(False)
+    torch.manual_seed(9)
+    dtype = torch.float32
+    c, n = 128, 4
+    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo).train()
+    x = (
+        torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
+    ).requires_grad_(True)
+    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
+
+    y_ref = _eager(module, x, mask)
+    y_ref.square().mean().backward()
+    grads_ref = (
+        x.grad.detach().clone(),
+        module.layer_norm.weight.grad.detach().clone(),
+        module.layer_norm.bias.grad.detach().clone(),
+        module.swiglu.linear_a.weight.grad.detach().clone(),
+        module.swiglu.linear_b.weight.grad.detach().clone(),
+        module.linear_out.weight.grad.detach().clone(),
+    )
+    x.grad = None
+    module.zero_grad(set_to_none=True)
+
+    x_f = x.detach().requires_grad_(True)
+    g_f = g.detach().requires_grad_(True)
+    b_f = b.detach().requires_grad_(True)
+    wa_f = wa.detach().requires_grad_(True)
+    wb_f = wb.detach().requires_grad_(True)
+    wo_f = wo.detach().requires_grad_(True)
+    y = fused_swiglu_transition(x_f, g_f, b_f, wa_f, wb_f, wo_f, mask=mask)
+    y.square().mean().backward()
+
+    torch.testing.assert_close(y, y_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(x_f.grad, grads_ref[0], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(g_f.grad, grads_ref[1], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(b_f.grad, grads_ref[2], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(wa_f.grad, grads_ref[3], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(wb_f.grad, grads_ref[4], atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(wo_f.grad, grads_ref[5], atol=1e-4, rtol=1e-4)
+    assert y.data_ptr() != x_f.data_ptr()
+
+
+@pytest.mark.parametrize("n_token", [70, 128, 256])
+def test_autograd_matches_eager_bf16_mixed(n_token):
+    """bf16 activations, fp32 masters vs module primitives."""
+    _set_tf32(False)
+    torch.manual_seed(9)
+    c, n = 128, 4
+    g, b, wa, wb, wo = _weights(c, n, torch.float32, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo).train()
+    x = (
+        torch.randn(1, n_token, n_token, c, dtype=torch.bfloat16, device="cuda") * 0.5
+    ).requires_grad_(True)
+    mask = torch.ones(1, n_token, n_token, 1, dtype=torch.bfloat16, device="cuda")
+
+    y_ref = _eager(module, x, mask)
+    y_ref.square().mean().backward()
+    grads_ref = [
+        x.grad.detach().clone(),
+        module.layer_norm.weight.grad.detach().clone(),
+        module.layer_norm.bias.grad.detach().clone(),
+        module.swiglu.linear_a.weight.grad.detach().clone(),
+        module.swiglu.linear_b.weight.grad.detach().clone(),
+        module.linear_out.weight.grad.detach().clone(),
+    ]
+    x.grad = None
+    module.zero_grad(set_to_none=True)
+
+    xs = [t.detach().requires_grad_(True) for t in (x, g, b, wa, wb, wo)]
+    y = fused_swiglu_transition(*xs, mask=mask)
+    y.square().mean().backward()
+
+    assert y.dtype == torch.bfloat16
+    assert xs[3].grad.dtype == torch.float32
+    torch.testing.assert_close(y.float(), y_ref.float(), atol=5e-2, rtol=2e-2)
+    for act, ref in zip(xs, grads_ref):
+        torch.testing.assert_close(act.grad.float(), ref.float(), atol=5e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("n_token", [70, 128])
+def test_module_bf16_mixed_matches_eager_env_off(n_token, monkeypatch):
+    _set_tf32(False)
+    torch.manual_seed(5)
+    fused = SwiGLUTransition(c_in=128, n=4).cuda().train()
+    eager = SwiGLUTransition(c_in=128, n=4).cuda().train()
+    eager.load_state_dict(fused.state_dict())
+    x = (
+        torch.randn(1, n_token, n_token, 128, device="cuda", dtype=torch.bfloat16) * 0.5
+    ).requires_grad_(True)
+    mask = torch.ones(1, n_token, n_token, device="cuda", dtype=torch.bfloat16)
+    x_e = x.detach().clone().requires_grad_(True)
+
+    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        y_f = fused(x, mask=mask)
+    monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
+    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        y_e = eager(x_e, mask=mask)
+
+    torch.testing.assert_close(y_f.float(), y_e.float(), atol=5e-2, rtol=2e-2)
+    y_f.float().square().mean().backward()
+    y_e.float().square().mean().backward()
+    torch.testing.assert_close(x.grad.float(), x_e.grad.float(), atol=5e-2, rtol=2e-2)
+    torch.testing.assert_close(
+        fused.swiglu.linear_a.weight.grad,
+        eager.swiglu.linear_a.weight.grad,
+        atol=5e-2,
+        rtol=2e-2,
+    )
+
+
+def test_compile_reuse_across_lengths():
+    # Autotune may compile several tile configs for one precision/shape key;
+    # length M is not in the key, so later Ns must not grow the filesystem cache.
+    script = r"""
+import json
+import os
+from pathlib import Path
+import torch
+from openfold3.core.kernels.triton.fused_swiglu_transition import (
+    _fused_swiglu_transition_bwd_dw_kernel,
+    _fused_swiglu_transition_bwd_dx_kernel,
+    _fused_swiglu_transition_fwd_kernel,
+    fused_swiglu_transition,
+)
+cache_dir = os.environ["TRITON_CACHE_DIR"]
+Path(cache_dir).mkdir(parents=True, exist_ok=True)
+def _device_caches(fn):
+    # Autotuner wraps JITFunction (.fn); plain @triton.jit is the JITFunction.
+    if hasattr(fn, "device_caches"):
+        return fn.device_caches
+    return fn.fn.device_caches
+def clear():
+    _device_caches(_fused_swiglu_transition_fwd_kernel).clear()
+    _device_caches(_fused_swiglu_transition_bwd_dx_kernel).clear()
+    _device_caches(_fused_swiglu_transition_bwd_dw_kernel).clear()
+def count(name):
+    return len(list(Path(cache_dir).rglob(f"{name}.json")))
+def run(n, x_dtype, w_dtype):
+    x = torch.randn(1, n, n, c, device="cuda", dtype=x_dtype)
+    mask = torch.ones(1, n, n, 1, device="cuda", dtype=x_dtype)
+    gw = g.to(w_dtype)
+    bw = b.to(w_dtype)
+    waw = wa.to(w_dtype)
+    wbw = wb.to(w_dtype)
+    wow = wo.to(w_dtype)
+    # Inference in-place (SAVE_ACTS=0) and training out-of-place (SAVE_ACTS=1).
+    z = x.clone()
+    fused_swiglu_transition(z, gw, bw, waw, wbw, wow, mask=mask, residual=z)
+    xd = x.detach().requires_grad_(True)
+    y = fused_swiglu_transition(
+        xd,
+        gw.detach().requires_grad_(True),
+        bw.detach().requires_grad_(True),
+        waw.detach().requires_grad_(True),
+        wbw.detach().requires_grad_(True),
+        wow.detach().requires_grad_(True),
+        mask=mask,
+    )
+    y.backward(torch.ones_like(y))
+    clear()
+def snapshot():
+    return {
+        "forward": count("_fused_swiglu_transition_fwd_kernel"),
+        "bwd_dx": count("_fused_swiglu_transition_bwd_dx_kernel"),
+        "bwd_dw": count("_fused_swiglu_transition_bwd_dw_kernel"),
+    }
+torch.backends.cuda.matmul.allow_tf32 = False
+c, h = 128, 512
+g = torch.randn(c, device="cuda")
+b = torch.randn(c, device="cuda")
+wa = torch.randn(h, c, device="cuda")
+wb = torch.randn(h, c, device="cuda")
+wo = torch.randn(c, h, device="cuda")
+lengths = (64, 80, 96, 112, 128)
+results = {}
+for x_dtype, w_dtype, tag in (
+    (torch.float32, torch.float32, "fp32"),
+    (torch.bfloat16, torch.float32, "bf16_mixed"),
+):
+    run(lengths[0], x_dtype, w_dtype)
+    after_first = snapshot()
+    for n in lengths[1:]:
+        run(n, x_dtype, w_dtype)
+    after_all = snapshot()
+    results[tag] = {"after_first": after_first, "after_all": after_all}
+    assert after_first["forward"] >= 1, (tag, after_first)
+    assert after_first["bwd_dx"] >= 1 and after_first["bwd_dw"] >= 1, (tag, after_first)
+    assert after_all == after_first, (tag, after_first, after_all)
+print(json.dumps(results))
+"""
+    with tempfile.TemporaryDirectory() as cache_dir:
+        env = os.environ.copy()
+        env["TRITON_CACHE_DIR"] = cache_dir
+        env["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "after_all" in result.stdout

--- a/openfold3/tests/test_fused_swiglu_transition.py
+++ b/openfold3/tests/test_fused_swiglu_transition.py
@@ -28,7 +28,6 @@ import openfold3.tests.utils.compare_utils as compare_utils
 from openfold3.core.kernels.triton.fused_swiglu_transition import (
     fused_swiglu_transition,
     is_fused_swiglu_transition_eligible,
-    is_fused_swiglu_transition_enabled,
 )
 from openfold3.core.model.layers.transition import SwiGLUTransition
 
@@ -37,24 +36,23 @@ pytestmark = [
     compare_utils.skip_unless_triton_installed(),
 ]
 
-CASES = [(128, 4), (128, 2), (64, 2)]
-N_VALUES = [70, 256]
+C, N_HIDDEN, N_TOKEN = 128, 4, 128
 
 
 def _weights(c, n, dtype, device, requires_grad=False):
     torch.manual_seed(0)
-    H = n * c
+    hidden = n * c
     g = torch.randn(c, dtype=dtype, device=device, requires_grad=requires_grad)
     b = torch.randn(c, dtype=dtype, device=device, requires_grad=requires_grad)
-    wa = (torch.randn(H, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
+    wa = (torch.randn(hidden, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
         requires_grad
     )
-    wb = (torch.randn(H, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
+    wb = (torch.randn(hidden, c, dtype=dtype, device=device) / c**0.5).requires_grad_(
         requires_grad
     )
-    wo = (torch.randn(c, H, dtype=dtype, device=device) / H**0.5).requires_grad_(
-        requires_grad
-    )
+    wo = (
+        torch.randn(c, hidden, dtype=dtype, device=device) / hidden**0.5
+    ).requires_grad_(requires_grad)
     return g, b, wa, wb, wo
 
 
@@ -79,174 +77,50 @@ def _set_tf32(enabled: bool) -> None:
     torch.backends.cudnn.allow_tf32 = enabled
 
 
+def _pair(c=C, n=N_HIDDEN, n_token=N_TOKEN, act_dtype=torch.float32, w_dtype=None):
+    w_dtype = act_dtype if w_dtype is None else w_dtype
+    g, b, wa, wb, wo = _weights(c, n, w_dtype, "cuda")
+    module = _bind_module(c, n, g, b, wa, wb, wo)
+    x = torch.randn(1, n_token, n_token, c, dtype=act_dtype, device="cuda") * 0.5
+    mask = torch.ones(1, n_token, n_token, 1, dtype=act_dtype, device="cuda")
+    return g, b, wa, wb, wo, module, x, mask
+
+
 @pytest.fixture(autouse=True)
 def _enable_fused(monkeypatch):
     monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "1")
 
 
-@pytest.mark.parametrize("c,n", CASES)
-@pytest.mark.parametrize("n_token", N_VALUES)
-def test_fused_matches_eager_fp32_baseline(c, n, n_token):
-    """fp32 IEEE fused vs module primitives."""
-    assert is_fused_swiglu_transition_enabled()
+def test_fused_matches_eager_and_inplace():
     _set_tf32(False)
-    dtype = torch.float32
-    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
-    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
-    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
-    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
-    atol, rtol = 1e-5, 1e-5
-
+    g, b, wa, wb, wo, module, x, mask = _pair()
+    module.eval()
     with torch.inference_mode():
         y_ref = _eager(module, x, mask)
         y_fused = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
         z = x.clone()
         y_ip = fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z)
         y_ref_ip = _eager(module, x, mask, residual=x)
-
-    torch.testing.assert_close(y_fused.float(), y_ref.float(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(y_fused, y_ref, atol=1e-5, rtol=1e-5)
     assert y_ip.data_ptr() == z.data_ptr()
-    torch.testing.assert_close(y_ip.float(), y_ref_ip.float(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(y_ip, y_ref_ip, atol=1e-5, rtol=1e-5)
 
 
-@pytest.mark.parametrize("n_token", [70, 256])
-def test_fused_mixed_matches_eager(n_token):
-    """bf16-mixed: fp32 masters, bf16 GEMM, no TF32, vs module primitives."""
-    _set_tf32(False)
-    g, b, wa, wb, wo = _weights(128, 4, torch.float32, "cuda")
-    module = _bind_module(128, 4, g, b, wa, wb, wo).eval()
-    x = torch.randn(1, n_token, n_token, 128, dtype=torch.bfloat16, device="cuda") * 0.5
-    mask = torch.ones(1, n_token, n_token, 1, dtype=torch.bfloat16, device="cuda")
-    with torch.inference_mode():
-        y_ref = _eager(module, x, mask)
-        y_fused = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
-    torch.testing.assert_close(y_fused.float(), y_ref.float(), atol=5e-2, rtol=2e-2)
-
-
-def test_bf16_weights_are_ineligible():
-    """Triton requires fp32 masters; the module uses primitives."""
-    _set_tf32(False)
-    g, b, wa, wb, wo = _weights(128, 4, torch.bfloat16, "cuda")
-    module = _bind_module(128, 4, g, b, wa, wb, wo).eval()
-    x = torch.randn(1, 70, 70, 128, dtype=torch.bfloat16, device="cuda") * 0.5
-    mask = torch.ones(1, 70, 70, 1, dtype=torch.bfloat16, device="cuda")
-    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
-    with torch.inference_mode():
-        y = module(x, mask=mask.squeeze(-1))
-        y_ref = _eager(module, x, mask)
-    torch.testing.assert_close(y, y_ref)
-
-
-@pytest.mark.parametrize("n_token", [70, 256])
-def test_fused_tf32_vs_default_fp32_baseline(n_token):
-    """TF32 fused error is measured against default FP32 eager, not cuBLAS TF32."""
-    c, n, dtype = 128, 4, torch.float32
-    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
-    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
-    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
-    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
-
-    _set_tf32(False)
-    with torch.inference_mode():
-        y_fp32 = _eager(module, x, mask)
-
+def test_fused_tf32_matches_eager_tf32():
+    g, b, wa, wb, wo, module, x, mask = _pair()
+    module.eval()
     _set_tf32(True)
     with torch.inference_mode():
-        y_fused_tf32 = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
-        y_eager_tf32 = _eager(module, x, mask)
-
-    # After round-nearest f32->tf32, fused TF32 matches eager TF32 vs FP32.
-    torch.testing.assert_close(y_fused_tf32, y_fp32, atol=1e-2, rtol=2e-3)
-    torch.testing.assert_close(y_eager_tf32, y_fp32, atol=1e-2, rtol=2e-3)
-    torch.testing.assert_close(y_fused_tf32, y_eager_tf32, atol=5e-3, rtol=2e-3)
+        y_fused = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+        y_eager = _eager(module, x, mask)
+    torch.testing.assert_close(y_fused, y_eager, atol=5e-3, rtol=2e-3)
 
 
-def test_small_m_uses_module_eager():
-    _set_tf32(False)
-    c, n, n_token, dtype = 128, 4, 32, torch.float32
-    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
-    module = _bind_module(c, n, g, b, wa, wb, wo).eval()
-    x = torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
-    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
-    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
-    with torch.inference_mode():
-        y = module(x, mask=mask.squeeze(-1))
-        y_ref = _eager(module, x, mask)
-    compare_utils.assert_max_abs_diff_small(y, y_ref, 1e-5)
-
-
-@pytest.mark.parametrize("n_token", [70, 128])
-def test_module_fused_matches_eager_env_off(n_token, monkeypatch):
-    torch.manual_seed(3)
-    _set_tf32(False)
-    module = SwiGLUTransition(c_in=128, n=4).cuda().eval()
-    x = torch.randn(1, n_token, n_token, 128, device="cuda") * 0.5
-    mask = torch.ones(1, n_token, n_token, device="cuda")
-    with torch.inference_mode():
-        y_fused = module(x, mask=mask)
-        monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
-        y_eager = module(x, mask=mask)
-    torch.testing.assert_close(y_fused, y_eager, atol=1e-5, rtol=1e-5)
-
-
-@pytest.mark.parametrize("n_token", [70, 128])
-def test_autograd_matches_eager_fp32(n_token):
-    _set_tf32(False)
-    torch.manual_seed(9)
-    dtype = torch.float32
-    c, n = 128, 4
-    g, b, wa, wb, wo = _weights(c, n, dtype, "cuda")
-    module = _bind_module(c, n, g, b, wa, wb, wo).train()
-    x = (
-        torch.randn(1, n_token, n_token, c, dtype=dtype, device="cuda") * 0.5
-    ).requires_grad_(True)
-    mask = torch.ones(1, n_token, n_token, 1, dtype=dtype, device="cuda")
-
-    y_ref = _eager(module, x, mask)
-    y_ref.square().mean().backward()
-    grads_ref = (
-        x.grad.detach().clone(),
-        module.layer_norm.weight.grad.detach().clone(),
-        module.layer_norm.bias.grad.detach().clone(),
-        module.swiglu.linear_a.weight.grad.detach().clone(),
-        module.swiglu.linear_b.weight.grad.detach().clone(),
-        module.linear_out.weight.grad.detach().clone(),
-    )
-    x.grad = None
-    module.zero_grad(set_to_none=True)
-
-    x_f = x.detach().requires_grad_(True)
-    g_f = g.detach().requires_grad_(True)
-    b_f = b.detach().requires_grad_(True)
-    wa_f = wa.detach().requires_grad_(True)
-    wb_f = wb.detach().requires_grad_(True)
-    wo_f = wo.detach().requires_grad_(True)
-    y = fused_swiglu_transition(x_f, g_f, b_f, wa_f, wb_f, wo_f, mask=mask)
-    y.square().mean().backward()
-
-    torch.testing.assert_close(y, y_ref, atol=1e-5, rtol=1e-5)
-    torch.testing.assert_close(x_f.grad, grads_ref[0], atol=1e-4, rtol=1e-4)
-    torch.testing.assert_close(g_f.grad, grads_ref[1], atol=1e-4, rtol=1e-4)
-    torch.testing.assert_close(b_f.grad, grads_ref[2], atol=1e-4, rtol=1e-4)
-    torch.testing.assert_close(wa_f.grad, grads_ref[3], atol=1e-4, rtol=1e-4)
-    torch.testing.assert_close(wb_f.grad, grads_ref[4], atol=1e-4, rtol=1e-4)
-    torch.testing.assert_close(wo_f.grad, grads_ref[5], atol=1e-4, rtol=1e-4)
-    assert y.data_ptr() != x_f.data_ptr()
-
-
-@pytest.mark.parametrize("n_token", [70, 128, 256])
-def test_autograd_matches_eager_bf16_mixed(n_token):
-    """bf16 activations, fp32 masters vs module primitives."""
-    _set_tf32(False)
-    torch.manual_seed(9)
-    c, n = 128, 4
-    g, b, wa, wb, wo = _weights(c, n, torch.float32, "cuda")
-    module = _bind_module(c, n, g, b, wa, wb, wo).train()
-    x = (
-        torch.randn(1, n_token, n_token, c, dtype=torch.bfloat16, device="cuda") * 0.5
-    ).requires_grad_(True)
-    mask = torch.ones(1, n_token, n_token, 1, dtype=torch.bfloat16, device="cuda")
-
+def test_autograd_matches_eager_tf32():
+    _set_tf32(True)
+    g, b, wa, wb, wo, module, x, mask = _pair()
+    module.train()
+    x = x.requires_grad_(True)
     y_ref = _eager(module, x, mask)
     y_ref.square().mean().backward()
     grads_ref = [
@@ -257,54 +131,112 @@ def test_autograd_matches_eager_bf16_mixed(n_token):
         module.swiglu.linear_b.weight.grad.detach().clone(),
         module.linear_out.weight.grad.detach().clone(),
     ]
-    x.grad = None
-    module.zero_grad(set_to_none=True)
-
-    xs = [t.detach().requires_grad_(True) for t in (x, g, b, wa, wb, wo)]
-    y = fused_swiglu_transition(*xs, mask=mask)
+    leaves = [t.detach().requires_grad_(True) for t in (x, g, b, wa, wb, wo)]
+    y = fused_swiglu_transition(*leaves, mask=mask)
     y.square().mean().backward()
+    torch.testing.assert_close(y, y_ref, atol=5e-3, rtol=2e-3)
+    for act, ref in zip(leaves, grads_ref):
+        torch.testing.assert_close(act.grad, ref, atol=5e-3, rtol=2e-3)
+    assert y.data_ptr() != leaves[0].data_ptr()
 
+
+def test_autograd_matches_eager_bf16_mixed():
+    _set_tf32(False)
+    g, b, wa, wb, wo, module, x, mask = _pair(
+        act_dtype=torch.bfloat16, w_dtype=torch.float32
+    )
+    module.train()
+    x = x.requires_grad_(True)
+    y_ref = _eager(module, x, mask)
+    y_ref.square().mean().backward()
+    grads_ref = [
+        x.grad.detach().clone(),
+        module.layer_norm.weight.grad.detach().clone(),
+        module.layer_norm.bias.grad.detach().clone(),
+        module.swiglu.linear_a.weight.grad.detach().clone(),
+        module.swiglu.linear_b.weight.grad.detach().clone(),
+        module.linear_out.weight.grad.detach().clone(),
+    ]
+    leaves = [t.detach().requires_grad_(True) for t in (x, g, b, wa, wb, wo)]
+    y = fused_swiglu_transition(*leaves, mask=mask)
+    y.square().mean().backward()
     assert y.dtype == torch.bfloat16
-    assert xs[3].grad.dtype == torch.float32
+    assert leaves[3].grad.dtype == torch.float32
     torch.testing.assert_close(y.float(), y_ref.float(), atol=5e-2, rtol=2e-2)
-    for act, ref in zip(xs, grads_ref):
+    for act, ref in zip(leaves, grads_ref):
         torch.testing.assert_close(act.grad.float(), ref.float(), atol=5e-2, rtol=2e-2)
 
 
-@pytest.mark.parametrize("n_token", [70, 128])
-def test_module_bf16_mixed_matches_eager_env_off(n_token, monkeypatch):
+def test_module_dispatch_matches_eager_when_disabled(monkeypatch):
     _set_tf32(False)
-    torch.manual_seed(5)
-    fused = SwiGLUTransition(c_in=128, n=4).cuda().train()
-    eager = SwiGLUTransition(c_in=128, n=4).cuda().train()
-    eager.load_state_dict(fused.state_dict())
-    x = (
-        torch.randn(1, n_token, n_token, 128, device="cuda", dtype=torch.bfloat16) * 0.5
-    ).requires_grad_(True)
-    mask = torch.ones(1, n_token, n_token, device="cuda", dtype=torch.bfloat16)
-    x_e = x.detach().clone().requires_grad_(True)
+    torch.manual_seed(3)
+    module = SwiGLUTransition(c_in=C, n=N_HIDDEN).cuda().eval()
+    x = torch.randn(1, N_TOKEN, N_TOKEN, C, device="cuda") * 0.5
+    mask = torch.ones(1, N_TOKEN, N_TOKEN, device="cuda")
+    with torch.inference_mode():
+        y_fused = module(x, mask=mask)
+        monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
+        y_eager = module(x, mask=mask)
+    torch.testing.assert_close(y_fused, y_eager, atol=1e-5, rtol=1e-5)
 
-    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-        y_f = fused(x, mask=mask)
-    monkeypatch.setenv("OPENFOLD3_FUSED_SWIGLU_TRANSITION", "0")
-    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-        y_e = eager(x_e, mask=mask)
 
-    torch.testing.assert_close(y_f.float(), y_e.float(), atol=5e-2, rtol=2e-2)
-    y_f.float().square().mean().backward()
-    y_e.float().square().mean().backward()
-    torch.testing.assert_close(x.grad.float(), x_e.grad.float(), atol=5e-2, rtol=2e-2)
-    torch.testing.assert_close(
-        fused.swiglu.linear_a.weight.grad,
-        eager.swiglu.linear_a.weight.grad,
-        atol=5e-2,
-        rtol=2e-2,
+def test_bf16_weights_are_ineligible():
+    _set_tf32(False)
+    g, b, wa, wb, wo, module, x, mask = _pair(act_dtype=torch.bfloat16)
+    module.eval()
+    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
+    with torch.inference_mode():
+        y = module(x, mask=mask.squeeze(-1))
+        y_ref = _eager(module, x, mask)
+    torch.testing.assert_close(y, y_ref)
+
+
+def test_small_m_uses_module_eager():
+    _set_tf32(False)
+    g, b, wa, wb, wo, module, x, mask = _pair(n_token=32)
+    module.eval()
+    assert not is_fused_swiglu_transition_eligible(x, g, b, wa, wb, wo)
+    with torch.inference_mode():
+        y = module(x, mask=mask.squeeze(-1))
+        y_ref = _eager(module, x, mask)
+    compare_utils.assert_max_abs_diff_small(y, y_ref, 1e-5)
+
+
+def test_training_forward_does_not_retain_ab():
+    _set_tf32(False)
+    g, b, wa, wb, wo, _module, x, mask = _pair(
+        n_token=70, act_dtype=torch.bfloat16, w_dtype=torch.float32
     )
+    x = x.requires_grad_(True)
+    g, b, wa, wb, wo = [t.requires_grad_(True) for t in (g, b, wa, wb, wo)]
+    saved_shapes = []
+
+    def pack(tensor):
+        saved_shapes.append(tuple(tensor.shape))
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+        fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+    assert (70 * 70, C) in saved_shapes
+    assert (70 * 70, C * N_HIDDEN) not in saved_shapes
+
+
+def test_weight_gradients_are_deterministic():
+    _set_tf32(False)
+    g, b, wa, wb, wo, _module, x, mask = _pair(
+        n_token=70, act_dtype=torch.bfloat16, w_dtype=torch.float32
+    )
+    grad_out = torch.randn_like(x)
+
+    def run():
+        leaves = [t.detach().requires_grad_(True) for t in (x, g, b, wa, wb, wo)]
+        fused_swiglu_transition(*leaves, mask=mask).backward(grad_out)
+        return [t.grad.detach().clone() for t in leaves[1:]]
+
+    assert all(torch.equal(a, b) for a, b in zip(run(), run()))
 
 
 def test_compile_reuse_across_lengths():
-    # Autotune may compile several tile configs for one precision/shape key;
-    # length M is not in the key, so later Ns must not grow the filesystem cache.
     script = r"""
 import json
 import os
@@ -314,40 +246,38 @@ from openfold3.core.kernels.triton.fused_swiglu_transition import (
     _fused_swiglu_transition_bwd_dw_kernel,
     _fused_swiglu_transition_bwd_dx_kernel,
     _fused_swiglu_transition_fwd_kernel,
+    _fused_swiglu_transition_ln_bwd_kernel,
     fused_swiglu_transition,
 )
 cache_dir = os.environ["TRITON_CACHE_DIR"]
 Path(cache_dir).mkdir(parents=True, exist_ok=True)
 def _device_caches(fn):
-    # Autotuner wraps JITFunction (.fn); plain @triton.jit is the JITFunction.
     if hasattr(fn, "device_caches"):
         return fn.device_caches
     return fn.fn.device_caches
 def clear():
-    _device_caches(_fused_swiglu_transition_fwd_kernel).clear()
-    _device_caches(_fused_swiglu_transition_bwd_dx_kernel).clear()
-    _device_caches(_fused_swiglu_transition_bwd_dw_kernel).clear()
+    for fn in (
+        _fused_swiglu_transition_fwd_kernel,
+        _fused_swiglu_transition_bwd_dx_kernel,
+        _fused_swiglu_transition_bwd_dw_kernel,
+        _fused_swiglu_transition_ln_bwd_kernel,
+    ):
+        _device_caches(fn).clear()
 def count(name):
     return len(list(Path(cache_dir).rglob(f"{name}.json")))
-def run(n, x_dtype, w_dtype):
-    x = torch.randn(1, n, n, c, device="cuda", dtype=x_dtype)
-    mask = torch.ones(1, n, n, 1, device="cuda", dtype=x_dtype)
-    gw = g.to(w_dtype)
-    bw = b.to(w_dtype)
-    waw = wa.to(w_dtype)
-    wbw = wb.to(w_dtype)
-    wow = wo.to(w_dtype)
-    # Inference in-place (SAVE_ACTS=0) and training out-of-place (SAVE_ACTS=1).
+def run(n):
+    x = torch.randn(1, n, n, c, device="cuda", dtype=torch.bfloat16)
+    mask = torch.ones(1, n, n, 1, device="cuda", dtype=x.dtype)
     z = x.clone()
-    fused_swiglu_transition(z, gw, bw, waw, wbw, wow, mask=mask, residual=z)
+    fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z)
     xd = x.detach().requires_grad_(True)
     y = fused_swiglu_transition(
         xd,
-        gw.detach().requires_grad_(True),
-        bw.detach().requires_grad_(True),
-        waw.detach().requires_grad_(True),
-        wbw.detach().requires_grad_(True),
-        wow.detach().requires_grad_(True),
+        g.detach().requires_grad_(True),
+        b.detach().requires_grad_(True),
+        wa.detach().requires_grad_(True),
+        wb.detach().requires_grad_(True),
+        wo.detach().requires_grad_(True),
         mask=mask,
     )
     y.backward(torch.ones_like(y))
@@ -357,6 +287,7 @@ def snapshot():
         "forward": count("_fused_swiglu_transition_fwd_kernel"),
         "bwd_dx": count("_fused_swiglu_transition_bwd_dx_kernel"),
         "bwd_dw": count("_fused_swiglu_transition_bwd_dw_kernel"),
+        "ln_bwd": count("_fused_swiglu_transition_ln_bwd_kernel"),
     }
 torch.backends.cuda.matmul.allow_tf32 = False
 c, h = 128, 512
@@ -366,21 +297,16 @@ wa = torch.randn(h, c, device="cuda")
 wb = torch.randn(h, c, device="cuda")
 wo = torch.randn(c, h, device="cuda")
 lengths = (64, 80, 96, 112, 128)
-results = {}
-for x_dtype, w_dtype, tag in (
-    (torch.float32, torch.float32, "fp32"),
-    (torch.bfloat16, torch.float32, "bf16_mixed"),
-):
-    run(lengths[0], x_dtype, w_dtype)
-    after_first = snapshot()
-    for n in lengths[1:]:
-        run(n, x_dtype, w_dtype)
-    after_all = snapshot()
-    results[tag] = {"after_first": after_first, "after_all": after_all}
-    assert after_first["forward"] >= 1, (tag, after_first)
-    assert after_first["bwd_dx"] >= 1 and after_first["bwd_dw"] >= 1, (tag, after_first)
-    assert after_all == after_first, (tag, after_first, after_all)
-print(json.dumps(results))
+run(lengths[0])
+after_first = snapshot()
+for n in lengths[1:]:
+    run(n)
+after_all = snapshot()
+assert after_first["forward"] >= 1, after_first
+assert after_first["bwd_dx"] >= 1 and after_first["bwd_dw"] >= 1, after_first
+assert after_first["ln_bwd"] >= 1, after_first
+assert after_all == after_first, (after_first, after_all)
+print(json.dumps({"after_first": after_first, "after_all": after_all}))
 """
     with tempfile.TemporaryDirectory() as cache_dir:
         env = os.environ.copy()

--- a/openfold3/tests/test_fused_template_coordinate_embed.py
+++ b/openfold3/tests/test_fused_template_coordinate_embed.py
@@ -5,11 +5,11 @@
 
 from __future__ import annotations
 
+import copy
 import os
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 import pytest
 import torch
@@ -22,8 +22,9 @@ from openfold3.core.model.feature_embedders.template_embedders import (
     TemplatePairEmbedderAllAtom,
 )
 from openfold3.core.model.primitives.fused_template_coordinate import (
-    fused_template_coordinate_pair_embedder_inference,
+    fused_template_coordinate_pair_embedder,
     template_coordinate_projection_add_reference_,
+    template_coordinate_projection_reference,
 )
 from openfold3.projects.of3_all_atom.config.dataset_config_components import (
     TemplateSettings,
@@ -37,7 +38,11 @@ def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Te
     for t in range(n_templ):
         offset = 0.4 * t
         ca = torch.stack(
-            (index * 3.8, torch.sin(index * 0.3 + offset), torch.cos(index * 0.2 + offset)),
+            (
+                index * 3.8,
+                torch.sin(index * 0.3 + offset),
+                torch.cos(index * 0.2 + offset),
+            ),
             dim=-1,
         )
         pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
@@ -48,9 +53,7 @@ def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Te
     return torch.stack(templates, dim=0), torch.stack(frames, dim=0)
 
 
-def _coordinate_batch(
-    n_token: int, device: str = "cpu", n_templ: int = 1
-) -> dict:
+def _coordinate_batch(n_token: int, device: str = "cpu", n_templ: int = 1) -> dict:
     pseudo_beta, frame = _coordinates(n_token, n_templ=n_templ)
     restype = torch.nn.functional.one_hot(
         torch.arange(n_token) % 32, num_classes=32
@@ -60,9 +63,10 @@ def _coordinate_batch(
         "template_frame_atom_coords": frame[None].to(device),
         "template_pseudo_beta_mask": torch.ones(1, n_templ, n_token, device=device),
         "template_backbone_frame_mask": torch.ones(1, n_templ, n_token, device=device),
-        "template_restype": restype[None, None].expand(1, n_templ, -1, -1).contiguous().to(
-            device
-        ),
+        "template_restype": restype[None, None]
+        .expand(1, n_templ, -1, -1)
+        .contiguous()
+        .to(device),
         "asym_id": torch.cat(
             (
                 torch.ones(n_token // 2, dtype=torch.int32),
@@ -89,9 +93,9 @@ def _precomputed_batch(coordinate_batch: dict) -> dict:
         "template_distogram": create_template_distogram(
             pseudo_beta, pb_mask, multichain
         )[None],
-        "template_unit_vector": create_template_unit_vector(
-            frame, bb_mask, multichain
-        )[None],
+        "template_unit_vector": create_template_unit_vector(frame, bb_mask, multichain)[
+            None
+        ],
         "template_pseudo_beta_mask": coordinate_batch[
             "template_pseudo_beta_mask"
         ].cpu(),
@@ -113,7 +117,7 @@ def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
 
     with torch.inference_mode():
         expected = module(precomputed_batch, z.clone())
-        actual = fused_template_coordinate_pair_embedder_inference(
+        actual = fused_template_coordinate_pair_embedder(
             module=module,
             batch=coordinate_batch,
             z=z.clone(),
@@ -128,9 +132,7 @@ def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
 
 
 @pytest.mark.parametrize("n_token,n_templ", [(8, 2), (17, 3)])
-def test_template_embedder_coordinate_matches_precomputed(
-    n_token: int, n_templ: int
-):
+def test_template_embedder_coordinate_matches_precomputed(n_token: int, n_templ: int):
     """Full TemplateEmbedderAllAtom path: coords vs precomputed distogram/UV."""
     from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
     from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
@@ -144,7 +146,9 @@ def test_template_embedder_coordinate_matches_precomputed(
     precomputed_batch = _precomputed_batch(coordinate_batch)
     # Restype for the pair embedder is float one-hot in the streaming tests.
     coordinate_batch["template_restype"] = coordinate_batch["template_restype"].float()
-    precomputed_batch["template_restype"] = precomputed_batch["template_restype"].float()
+    precomputed_batch["template_restype"] = precomputed_batch[
+        "template_restype"
+    ].float()
 
     z = torch.randn(1, n_token, n_token, c_z)
     pair_mask = torch.ones(1, n_token, n_token)
@@ -168,19 +172,119 @@ def test_template_embedder_coordinate_matches_precomputed(
     torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
 
 
-def test_coordinate_embedding_rejects_training():
-    n_token = 8
-    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
-    batch = _coordinate_batch(n_token)
-    z = torch.randn(1, n_token, n_token, 128)
+@pytest.mark.parametrize("checkpoint_mode", ["blocks", "per_template"])
+def test_coordinate_training_checkpoint_matches_uncheckpointed(checkpoint_mode: str):
+    from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
+    from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
 
-    with torch.no_grad(), pytest.raises(RuntimeError, match="inference-only"):
-        fused_template_coordinate_pair_embedder_inference(
-            module=module,
-            batch=batch,
-            z=z,
-            template_index=0,
+    torch.manual_seed(23)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    reference_config = copy.deepcopy(of3_config.architecture.template)
+    reference_config.template_pair_stack.blocks_per_ckpt = None
+    reference_config.template_pair_stack.ckpt_per_template = False
+    checkpoint_config = copy.deepcopy(reference_config)
+    if checkpoint_mode == "blocks":
+        checkpoint_config.template_pair_stack.blocks_per_ckpt = 1
+    else:
+        checkpoint_config.template_pair_stack.ckpt_per_template = True
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    reference_module = TemplateEmbedderAllAtom(reference_config).to(device).train()
+    with torch.no_grad():
+        reference_module.linear_t.weight.normal_(std=0.05)
+    checkpoint_module = TemplateEmbedderAllAtom(checkpoint_config).to(device).train()
+    checkpoint_module.load_state_dict(reference_module.state_dict())
+
+    n_token = 4
+    batch = _coordinate_batch(n_token, device=device, n_templ=2)
+    batch["template_restype"] = batch["template_restype"].float()
+    c_z = reference_config.template_pair_embedder.c_in
+    z_reference = torch.randn(
+        1, n_token, n_token, c_z, device=device, requires_grad=True
+    )
+    z_checkpoint = z_reference.detach().clone().requires_grad_(True)
+    pair_mask = torch.ones(1, n_token, n_token, device=device)
+    upstream = torch.randn(1, n_token, n_token, c_z, device=device)
+
+    torch.manual_seed(29)
+    reference = reference_module(batch, z_reference, pair_mask)
+    (reference * upstream).sum().backward()
+    torch.manual_seed(29)
+    checkpointed = checkpoint_module(batch, z_checkpoint, pair_mask)
+    (checkpointed * upstream).sum().backward()
+
+    tolerance = 5e-4 if device == "cuda" else 1e-5
+    torch.testing.assert_close(checkpointed, reference, rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(
+        z_checkpoint.grad, z_reference.grad, rtol=tolerance, atol=tolerance
+    )
+    reference_parameters = dict(reference_module.named_parameters())
+    for name, parameter in checkpoint_module.named_parameters():
+        expected_grad = reference_parameters[name].grad
+        if parameter.grad is None or expected_grad is None:
+            assert parameter.grad is expected_grad, name
+            continue
+        torch.testing.assert_close(
+            parameter.grad,
+            expected_grad,
+            rtol=tolerance,
+            atol=tolerance,
+            msg=lambda msg, name=name: f"{name}: {msg}",
         )
+
+
+def test_coordinate_embedding_training_eager_batch_and_gradient_accumulation():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    batch = {
+        key: value.expand(2, *value.shape[1:]).clone() for key, value in batch.items()
+    }
+    batch["template_restype"] = batch["template_restype"].float()
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    z = torch.randn(2, n_token, n_token, 128, requires_grad=True)
+
+    actual = fused_template_coordinate_pair_embedder(
+        module=module,
+        batch=batch,
+        z=z,
+        template_index=0,
+    )
+    assert actual.shape == (2, 1, n_token, n_token, 64)
+    actual.square().mean().backward()
+    first_z_grad = z.grad.clone()
+    first_weight_grad = module.dgram_linear.weight.grad.clone()
+
+    actual = fused_template_coordinate_pair_embedder(
+        module=module,
+        batch=batch,
+        z=z,
+        template_index=0,
+    )
+    actual.square().mean().backward()
+    torch.testing.assert_close(z.grad, first_z_grad * 2)
+    torch.testing.assert_close(module.dgram_linear.weight.grad, first_weight_grad * 2)
+
+
+def test_coordinate_embedding_rejects_coordinate_gradients():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    batch["template_pseudo_beta_coords"].requires_grad_(True)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    z = torch.randn(1, n_token, n_token, 128, requires_grad=True)
+
+    with pytest.raises(ValueError, match="non-differentiable data"):
+        fused_template_coordinate_pair_embedder(module, batch, z, 0)
+
+
+def test_coordinate_embedding_rejects_fused_away_bias():
+    n_token = 6
+    batch = _coordinate_batch(n_token)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    module.dgram_linear.bias = torch.nn.Parameter(torch.zeros(64))
+    z = torch.randn(1, n_token, n_token, 128, requires_grad=True)
+
+    with pytest.raises(ValueError, match="bias-free"):
+        fused_template_coordinate_pair_embedder(module, batch, z, 0)
 
 
 def test_coordinate_features_reject_nondefault_distogram_settings():
@@ -191,10 +295,338 @@ def test_coordinate_features_reject_nondefault_distogram_settings():
         )
 
 
+def test_coordinate_features_registered_with_quality_control():
+    from openfold3.core.data.primitives.quality_control.asserts import (
+        FEATURE_OTHER_DTYPES,
+        FULL_OTHER_DIM_INDEX_MAP,
+        FULL_TEMPLATE_DIM_INDEX_MAP,
+        FULL_TOKEN_DIM_INDEX_MAP,
+        _assert_template_feature_representation,
+    )
+
+    coordinate_features = {
+        "template_pseudo_beta_coords": torch.zeros(2, 5, 3),
+        "template_frame_atom_coords": torch.zeros(2, 5, 3, 3),
+    }
+    _assert_template_feature_representation(coordinate_features)
+    assert FULL_TOKEN_DIM_INDEX_MAP["template_pseudo_beta_coords"] == [-2]
+    assert FULL_TOKEN_DIM_INDEX_MAP["template_frame_atom_coords"] == [-3]
+    assert FULL_TEMPLATE_DIM_INDEX_MAP["template_pseudo_beta_coords"] == [-3]
+    assert FULL_TEMPLATE_DIM_INDEX_MAP["template_frame_atom_coords"] == [-4]
+    assert FULL_OTHER_DIM_INDEX_MAP["template_frame_atom_coords"] == [-1, -2]
+    assert FEATURE_OTHER_DTYPES["template_pseudo_beta_coords"] == torch.float32
+    assert FEATURE_OTHER_DTYPES["template_frame_atom_coords"] == torch.float32
+
+    with pytest.raises(AssertionError, match="Exactly one"):
+        _assert_template_feature_representation(
+            {
+                **coordinate_features,
+                "template_distogram": torch.zeros(2, 5, 5, 39),
+                "template_unit_vector": torch.zeros(2, 5, 5, 3),
+            }
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_training_gradients_match_eager(monkeypatch):
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    n_token = 17
+    torch.manual_seed(19)
+    reference_module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().train()
+    actual_module = copy.deepcopy(reference_module)
+    batch = _coordinate_batch(n_token, device="cuda")
+    batch["template_restype"] = batch["template_restype"].float()
+    z_reference = torch.randn(
+        1, n_token, n_token, 128, device="cuda", requires_grad=True
+    )
+    z_actual = z_reference.detach().clone().requires_grad_(True)
+    upstream = torch.randn(1, 1, n_token, n_token, 64, device="cuda")
+
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "0")
+    reference = fused_template_coordinate_pair_embedder(
+        reference_module, batch, z_reference, 0
+    )
+    (reference * upstream).sum().backward()
+
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+    actual = fused_template_coordinate_pair_embedder(actual_module, batch, z_actual, 0)
+    assert (
+        "_TemplateCoordinateProjectionFunctionBackward"
+        in type(actual.grad_fn.next_functions[0][0]).__name__
+    )
+    (actual * upstream).sum().backward()
+
+    torch.testing.assert_close(actual, reference, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(z_actual.grad, z_reference.grad, rtol=5e-4, atol=5e-4)
+    reference_parameters = dict(reference_module.named_parameters())
+    for name, parameter in actual_module.named_parameters():
+        assert parameter.grad is not None, name
+        expected_grad = reference_parameters[name].grad
+        assert expected_grad is not None, name
+        torch.testing.assert_close(
+            parameter.grad,
+            expected_grad,
+            rtol=5e-4,
+            atol=5e-4,
+            msg=lambda msg, name=name: f"{name}: {msg}",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_token", [8, 31, 65, 384])
+@pytest.mark.parametrize(
+    ("compute_dgram", "compute_scalar"),
+    [(True, True), (True, False), (False, True)],
+)
+def test_coordinate_triton_backward_matches_eager(
+    n_token: int,
+    compute_dgram: bool,
+    compute_scalar: bool,
+    monkeypatch,
+):
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    torch.manual_seed(41 + n_token)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    pb_mask[:, ::5] = 0
+    bb_mask[:, 2::7] = 0
+    asym = batch["asym_id"].contiguous()
+    asym[:, n_token // 2 :] = 2
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+    if n_token == 31:
+        upstream = upstream.transpose(1, 2)
+    dgram_weight = torch.randn(64, 39, device="cuda", requires_grad=compute_dgram)
+    scalar_weight = torch.randn(64, 5, device="cuda", requires_grad=compute_scalar)
+    source = torch.zeros_like(upstream)
+
+    expected = template_coordinate_projection_reference(
+        source,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=7,
+    )
+    (expected * upstream).sum().backward()
+    actual_dgram, actual_scalar = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        compute_dgram=compute_dgram,
+        compute_scalar=compute_scalar,
+    )
+
+    if compute_dgram:
+        assert dgram_weight.grad is not None
+        torch.testing.assert_close(
+            actual_dgram, dgram_weight.grad, rtol=5e-4, atol=5e-4
+        )
+    else:
+        assert actual_dgram is None
+    if compute_scalar:
+        assert scalar_weight.grad is not None
+        torch.testing.assert_close(
+            actual_scalar, scalar_weight.grad, rtol=5e-4, atol=5e-4
+        )
+    else:
+        assert actual_scalar is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_tf32_matches_eager(monkeypatch):
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", True)
+    n_token = 384
+    torch.manual_seed(71)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+    dgram_weight = torch.randn(64, 39, device="cuda", requires_grad=True)
+    scalar_weight = torch.randn(64, 5, device="cuda", requires_grad=True)
+    expected = template_coordinate_projection_reference(
+        torch.zeros_like(upstream),
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=32,
+    )
+    (expected * upstream).sum().backward()
+    actual = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+    )
+
+    for actual_grad, expected_grad in zip(
+        actual, (dgram_weight.grad, scalar_weight.grad), strict=True
+    ):
+        relative_l2 = (actual_grad - expected_grad).norm() / expected_grad.norm()
+        relative_max = (
+            actual_grad - expected_grad
+        ).abs().max() / expected_grad.abs().max()
+        assert relative_l2 < 1e-3
+        assert relative_max < 1.5e-3
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_is_repeatable():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    n_token = 73
+    torch.manual_seed(67)
+    batch = _coordinate_batch(n_token, device="cuda")
+    args = (
+        torch.randn(1, n_token, n_token, 64, device="cuda"),
+        batch["template_pseudo_beta_coords"][:, 0].contiguous(),
+        batch["template_frame_atom_coords"][:, 0].contiguous(),
+        batch["template_pseudo_beta_mask"][:, 0].contiguous(),
+        batch["template_backbone_frame_mask"][:, 0].contiguous(),
+        batch["asym_id"].contiguous(),
+    )
+    first = template_coordinate_projection_backward(*args)
+    second = template_coordinate_projection_backward(*args)
+    for actual, expected in zip(first, second, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_backward_preserves_open_bin_boundaries():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_backward,
+    )
+
+    distances = torch.tensor([0.0, 3.25, 4.0, 4.5, 50.75, 60.0], device="cuda")
+    n_token = len(distances)
+    pseudo_beta = torch.zeros(1, n_token, 3, device="cuda")
+    pseudo_beta[0, :, 0] = distances
+    _, frame_cpu = _coordinates(n_token)
+    frame = frame_cpu.cuda()
+    mask = torch.ones(1, n_token, device="cuda")
+    asym = torch.ones(1, n_token, dtype=torch.int32, device="cuda")
+    upstream = torch.zeros(1, n_token, n_token, 64, device="cuda")
+    upstream[0, 0, :, 0] = 1
+
+    grad_dgram, grad_scalar = template_coordinate_projection_backward(
+        upstream,
+        pseudo_beta,
+        frame,
+        mask,
+        mask,
+        asym,
+        compute_scalar=False,
+    )
+    assert grad_scalar is None
+    expected = torch.zeros(64, 39, device="cuda")
+    expected[0, 0] = 1
+    expected[0, 38] = 1
+    torch.testing.assert_close(grad_dgram, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_bfloat16_autocast_uses_triton(monkeypatch):
+    monkeypatch.setenv("OPENFOLD3_FUSED_TEMPLATE_COORD", "1")
+    n_token = 8
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().train()
+    batch = _coordinate_batch(n_token, device="cuda")
+    z = torch.randn(1, n_token, n_token, 128, device="cuda", requires_grad=True)
+
+    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        actual = fused_template_coordinate_pair_embedder(module, batch, z, 0)
+        assert actual.dtype == torch.bfloat16
+        assert (
+            "_TemplateCoordinateProjectionFunctionBackward"
+            in type(actual.grad_fn.next_functions[0][0]).__name__
+        )
+        actual.float().square().mean().backward()
+
+    assert z.grad is not None and torch.isfinite(z.grad).all()
+    assert module.dgram_linear.weight.grad is not None
+    assert torch.isfinite(module.dgram_linear.weight.grad).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_triton_bf16_matches_fp32_eager_oracle(monkeypatch):
+    """bf16 Triton fp32-accumulate vs fp32 eager rounded through bf16."""
+    from openfold3.core.model.primitives.fused_template_coordinate import (
+        _TemplateCoordinateProjectionFunction,
+        template_coordinate_projection_reference,
+    )
+
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    n_token = 17
+    torch.manual_seed(37)
+    batch = _coordinate_batch(n_token, device="cuda")
+    pb = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    dgram_weight = torch.randn(64, 39, device="cuda")
+    scalar_weight = torch.randn(64, 5, device="cuda")
+    source_bf16 = torch.randn(
+        1, n_token, n_token, 64, device="cuda", dtype=torch.bfloat16
+    )
+    upstream = torch.randn(1, n_token, n_token, 64, device="cuda")
+
+    dgram_ref = dgram_weight.detach().clone().requires_grad_(True)
+    scalar_ref = scalar_weight.detach().clone().requires_grad_(True)
+    source_ref = source_bf16.float().clone().requires_grad_(True)
+    # Cast through bf16 so both paths see the same quantized output grad.
+    reference = template_coordinate_projection_reference(
+        source_ref, pb, frame, pb_mask, bb_mask, asym, dgram_ref, scalar_ref
+    ).to(torch.bfloat16)
+    (reference.float() * upstream).sum().backward()
+
+    dgram_act = dgram_weight.detach().clone().requires_grad_(True)
+    scalar_act = scalar_weight.detach().clone().requires_grad_(True)
+    source_act = source_bf16.detach().clone().requires_grad_(True)
+    actual = _TemplateCoordinateProjectionFunction.apply(
+        source_act, pb, frame, pb_mask, bb_mask, asym, dgram_act, scalar_act
+    )
+    (actual.float() * upstream).sum().backward()
+
+    torch.testing.assert_close(actual, reference, rtol=5e-4, atol=5e-4)
+    torch.testing.assert_close(
+        source_act.grad, source_ref.grad.to(torch.bfloat16), rtol=5e-4, atol=5e-4
+    )
+    torch.testing.assert_close(dgram_act.grad, dgram_ref.grad, rtol=5e-4, atol=5e-4)
+    torch.testing.assert_close(scalar_act.grad, scalar_ref.grad, rtol=5e-4, atol=5e-4)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("n_token", [8, 31, 64, 96])
 def test_coordinate_triton_matches_chunked_reference(n_token: int):
     from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
         template_coordinate_projection_add_,
     )
 
@@ -207,33 +639,80 @@ def test_coordinate_triton_matches_chunked_reference(n_token: int):
     torch.manual_seed(12)
     dgram_weight = torch.randn(64, 39, device="cuda")
     scalar_weight = torch.randn(64, 5, device="cuda")
-    expected = torch.randn(1, n_token, n_token, 64, device="cuda")
-    actual = expected.clone()
+    source = torch.randn(1, n_token, n_token, 64, device="cuda")
+    source_before = source.clone()
+    expected = source.clone()
 
-    template_coordinate_projection_add_reference_(
-        expected,
-        pseudo_beta,
-        frame,
-        pb_mask,
-        bb_mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-        chunk_rows=7,
-    )
-    template_coordinate_projection_add_(
-        actual,
-        pseudo_beta,
-        frame,
-        pb_mask,
-        bb_mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-    )
+    with torch.no_grad():
+        template_coordinate_projection_add_reference_(
+            expected,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+            chunk_rows=7,
+        )
+        actual_inplace = source.clone()
+        template_coordinate_projection_add_(
+            actual_inplace,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
+        actual_fresh = template_coordinate_projection(
+            source,
+            pseudo_beta,
+            frame,
+            pb_mask,
+            bb_mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
     torch.cuda.synchronize()
 
-    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(source, source_before, rtol=0, atol=0)
+    torch.testing.assert_close(actual_inplace, expected, rtol=2e-4, atol=3e-4)
+    torch.testing.assert_close(actual_fresh, expected, rtol=2e-4, atol=3e-4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_inplace_launcher_rejects_grad_mode():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection,
+        template_coordinate_projection_add_,
+    )
+
+    n_token = 4
+    batch = _coordinate_batch(n_token, device="cuda")
+    source = torch.zeros(1, n_token, n_token, 64, device="cuda")
+    args = (
+        batch["template_pseudo_beta_coords"][:, 0],
+        batch["template_frame_atom_coords"][:, 0],
+        batch["template_pseudo_beta_mask"][:, 0],
+        batch["template_backbone_frame_mask"][:, 0],
+        batch["asym_id"],
+        torch.randn(64, 39, device="cuda"),
+        torch.randn(64, 5, device="cuda"),
+    )
+    with pytest.raises(RuntimeError, match="disabled grad mode"):
+        template_coordinate_projection_add_(source, *args)
+    with pytest.raises(RuntimeError, match="not autograd-aware"):
+        template_coordinate_projection(
+            source, *args, out=torch.empty_like(source, requires_grad=True)
+        )
+    overlapping_out = torch.empty(1, n_token, n_token, 1, device="cuda").expand_as(
+        source
+    )
+    with torch.no_grad(), pytest.raises(ValueError, match="overlap internally"):
+        template_coordinate_projection(source, *args, out=overlapping_out)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -258,23 +737,24 @@ def test_coordinate_kernel_preserves_open_bin_boundaries():
     scalar_weight = torch.zeros(64, 5, device="cuda")
     actual = torch.zeros(1, n_token, n_token, 64, device="cuda")
 
-    template_coordinate_projection_add_(
-        actual,
-        pseudo_beta,
-        frame,
-        mask,
-        mask,
-        asym,
-        dgram_weight,
-        scalar_weight,
-    )
+    with torch.no_grad():
+        template_coordinate_projection_add_(
+            actual,
+            pseudo_beta,
+            frame,
+            mask,
+            mask,
+            asym,
+            dgram_weight,
+            scalar_weight,
+        )
     expected_from_origin = torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 39.0], device="cuda")
     torch.testing.assert_close(actual[0, 0, :, 0], expected_from_origin, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_template_coordinate_compile_reuse_across_lengths():
-    """One filesystem compile must serve every sequence length."""
+    """One filesystem compile per math mode must serve every sequence length."""
     script = r"""
 import json
 import os
@@ -284,7 +764,11 @@ import torch
 
 from openfold3.core.kernels.triton.fused_template_coordinate import (
     _template_coordinate_projection_kernel,
+    _template_coordinate_projection_bwd_partial_kernel,
+    _template_coordinate_projection_bwd_reduce_kernel,
+    template_coordinate_projection,
     template_coordinate_projection_add_,
+    template_coordinate_projection_backward,
 )
 
 cache_dir = os.environ["TRITON_CACHE_DIR"]
@@ -292,29 +776,63 @@ Path(cache_dir).mkdir(parents=True, exist_ok=True)
 
 def clear():
     _template_coordinate_projection_kernel.device_caches.clear()
+    _template_coordinate_projection_bwd_partial_kernel.device_caches.clear()
+    _template_coordinate_projection_bwd_reduce_kernel.device_caches.clear()
 
 def count():
-    return len(list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json")))
+    return {
+        "forward": len(
+            list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json"))
+        ),
+        "backward_partial": len(
+            list(
+                Path(cache_dir).rglob(
+                    "_template_coordinate_projection_bwd_partial_kernel.json"
+                )
+            )
+        ),
+        "backward_reduce": len(
+            list(
+                Path(cache_dir).rglob(
+                    "_template_coordinate_projection_bwd_reduce_kernel.json"
+                )
+            )
+        ),
+    }
 
 torch.set_grad_enabled(False)
 w_dgram = torch.randn(64, 39, device="cuda")
 w_scalar = torch.randn(64, 5, device="cuda")
-for n in (16, 32, 48, 64, 96):
-    out = torch.zeros(1, n, n, 64, device="cuda")
-    template_coordinate_projection_add_(
-        out,
-        torch.randn(1, n, 3, device="cuda"),
-        torch.randn(1, n, 3, 3, device="cuda"),
-        torch.ones(1, n, device="cuda"),
-        torch.ones(1, n, device="cuda"),
-        torch.ones(1, n, dtype=torch.int32, device="cuda"),
-        w_dgram,
-        w_scalar,
-    )
-    clear()
+for allow_tf32 in (False, True):
+    torch.backends.cuda.matmul.allow_tf32 = allow_tf32
+    for n in (16, 32, 48, 64, 96):
+        source = torch.zeros(1, n, n, 64, device="cuda")
+        args = (
+            torch.randn(1, n, 3, device="cuda"),
+            torch.randn(1, n, 3, 3, device="cuda"),
+            torch.ones(1, n, device="cuda"),
+            torch.ones(1, n, device="cuda"),
+            torch.ones(1, n, dtype=torch.int32, device="cuda"),
+            w_dgram,
+            w_scalar,
+        )
+        if n % 32:
+            template_coordinate_projection(source, *args)
+        else:
+            template_coordinate_projection_add_(source, *args)
+        grad_output = torch.randn_like(source)
+        if n % 32:
+            grad_output = grad_output.transpose(1, 2)
+        template_coordinate_projection_backward(grad_output, *args[:5])
+        clear()
 
-print(json.dumps({"count": count()}))
-assert count() == 1, count()
+counts = count()
+print(json.dumps({"counts": counts}))
+assert counts == {
+    "forward": 1,
+    "backward_partial": 2,
+    "backward_reduce": 1,
+}, counts
 """
     with tempfile.TemporaryDirectory() as cache_dir:
         env = os.environ.copy()
@@ -327,4 +845,4 @@ assert count() == 1, count()
             capture_output=True,
             text=True,
         )
-        assert '"count": 1' in result.stdout
+        assert '"backward_partial": 2' in result.stdout

--- a/openfold3/tests/test_fused_template_coordinate_embed.py
+++ b/openfold3/tests/test_fused_template_coordinate_embed.py
@@ -1,0 +1,330 @@
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from openfold3.core.data.primitives.featurization.template import (
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.core.model.feature_embedders.template_embedders import (
+    TemplatePairEmbedderAllAtom,
+)
+from openfold3.core.model.primitives.fused_template_coordinate import (
+    fused_template_coordinate_pair_embedder_inference,
+    template_coordinate_projection_add_reference_,
+)
+from openfold3.projects.of3_all_atom.config.dataset_config_components import (
+    TemplateSettings,
+)
+
+
+def _coordinates(n_token: int, n_templ: int = 1) -> tuple[torch.Tensor, torch.Tensor]:
+    index = torch.arange(n_token, dtype=torch.float32)
+    templates = []
+    frames = []
+    for t in range(n_templ):
+        offset = 0.4 * t
+        ca = torch.stack(
+            (index * 3.8, torch.sin(index * 0.3 + offset), torch.cos(index * 0.2 + offset)),
+            dim=-1,
+        )
+        pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
+        n_atom = ca + torch.tensor([-0.7, 1.1, 0.2])
+        c_atom = ca + torch.tensor([1.3, 0.2, -0.1])
+        templates.append(pseudo_beta)
+        frames.append(torch.stack((n_atom, ca, c_atom), dim=-2))
+    return torch.stack(templates, dim=0), torch.stack(frames, dim=0)
+
+
+def _coordinate_batch(
+    n_token: int, device: str = "cpu", n_templ: int = 1
+) -> dict:
+    pseudo_beta, frame = _coordinates(n_token, n_templ=n_templ)
+    restype = torch.nn.functional.one_hot(
+        torch.arange(n_token) % 32, num_classes=32
+    ).to(torch.int32)
+    batch = {
+        "template_pseudo_beta_coords": pseudo_beta[None].to(device),
+        "template_frame_atom_coords": frame[None].to(device),
+        "template_pseudo_beta_mask": torch.ones(1, n_templ, n_token, device=device),
+        "template_backbone_frame_mask": torch.ones(1, n_templ, n_token, device=device),
+        "template_restype": restype[None, None].expand(1, n_templ, -1, -1).contiguous().to(
+            device
+        ),
+        "asym_id": torch.cat(
+            (
+                torch.ones(n_token // 2, dtype=torch.int32),
+                torch.full((n_token - n_token // 2,), 2, dtype=torch.int32),
+            )
+        )[None].to(device),
+    }
+    if n_token > 3:
+        batch["template_pseudo_beta_mask"][:, :, 1] = 0
+        batch["template_backbone_frame_mask"][:, :, 2] = 0
+    return batch
+
+
+def _precomputed_batch(coordinate_batch: dict) -> dict:
+    pseudo_beta = coordinate_batch["template_pseudo_beta_coords"][0].cpu().numpy()
+    frame = coordinate_batch["template_frame_atom_coords"][0].cpu().numpy()
+    pb_mask = coordinate_batch["template_pseudo_beta_mask"][0].cpu()
+    bb_mask = coordinate_batch["template_backbone_frame_mask"][0].cpu()
+    asym = coordinate_batch["asym_id"][0].cpu()
+    # create_template_* expects [n_templ, N, ...] coords and a broadcastable
+    # multichain mask over the template axis.
+    multichain = (asym[:, None] == asym[None, :])[None, ..., None]
+    return {
+        "template_distogram": create_template_distogram(
+            pseudo_beta, pb_mask, multichain
+        )[None],
+        "template_unit_vector": create_template_unit_vector(
+            frame, bb_mask, multichain
+        )[None],
+        "template_pseudo_beta_mask": coordinate_batch[
+            "template_pseudo_beta_mask"
+        ].cpu(),
+        "template_backbone_frame_mask": coordinate_batch[
+            "template_backbone_frame_mask"
+        ].cpu(),
+        "template_restype": coordinate_batch["template_restype"].cpu(),
+        "asym_id": coordinate_batch["asym_id"].cpu(),
+    }
+
+
+@pytest.mark.parametrize("n_token", [8, 17, 31])
+def test_coordinate_reference_matches_precomputed_embedder(n_token: int):
+    torch.manual_seed(7)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).eval()
+    coordinate_batch = _coordinate_batch(n_token)
+    precomputed_batch = _precomputed_batch(coordinate_batch)
+    z = torch.randn(1, n_token, n_token, 128)
+
+    with torch.inference_mode():
+        expected = module(precomputed_batch, z.clone())
+        actual = fused_template_coordinate_pair_embedder_inference(
+            module=module,
+            batch=coordinate_batch,
+            z=z.clone(),
+            template_index=0,
+        )
+
+    assert not {
+        "template_distogram",
+        "template_unit_vector",
+    }.intersection(coordinate_batch)
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+
+
+@pytest.mark.parametrize("n_token,n_templ", [(8, 2), (17, 3)])
+def test_template_embedder_coordinate_matches_precomputed(
+    n_token: int, n_templ: int
+):
+    """Full TemplateEmbedderAllAtom path: coords vs precomputed distogram/UV."""
+    from openfold3.core.model.latent.template_module import TemplateEmbedderAllAtom
+    from openfold3.projects.of3_all_atom.project_entry import OF3ProjectEntry
+
+    torch.manual_seed(11)
+    of3_config = OF3ProjectEntry().get_model_config_with_presets()
+    embedder = TemplateEmbedderAllAtom(of3_config.architecture.template).eval()
+    c_z = of3_config.architecture.template.template_pair_embedder.c_in
+
+    coordinate_batch = _coordinate_batch(n_token, n_templ=n_templ)
+    precomputed_batch = _precomputed_batch(coordinate_batch)
+    # Restype for the pair embedder is float one-hot in the streaming tests.
+    coordinate_batch["template_restype"] = coordinate_batch["template_restype"].float()
+    precomputed_batch["template_restype"] = precomputed_batch["template_restype"].float()
+
+    z = torch.randn(1, n_token, n_token, c_z)
+    pair_mask = torch.ones(1, n_token, n_token)
+
+    with torch.inference_mode():
+        expected = embedder(
+            batch=precomputed_batch,
+            z=z.clone(),
+            pair_mask=pair_mask,
+            chunk_size=4,
+            inplace_safe=True,
+        )
+        actual = embedder(
+            batch=coordinate_batch,
+            z=z.clone(),
+            pair_mask=pair_mask,
+            chunk_size=4,
+            inplace_safe=True,
+        )
+
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+
+
+def test_coordinate_embedding_rejects_training():
+    n_token = 8
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).train()
+    batch = _coordinate_batch(n_token)
+    z = torch.randn(1, n_token, n_token, 128)
+
+    with torch.no_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        fused_template_coordinate_pair_embedder_inference(
+            module=module,
+            batch=batch,
+            z=z,
+            template_index=0,
+        )
+
+
+def test_coordinate_features_reject_nondefault_distogram_settings():
+    with pytest.raises(ValueError, match="default"):
+        TemplateSettings(
+            use_coordinate_pair_features=True,
+            distogram={"min_bin": 2.0, "max_bin": 50.75, "n_bins": 39},
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_token", [8, 31, 64, 96])
+def test_coordinate_triton_matches_chunked_reference(n_token: int):
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    batch = _coordinate_batch(n_token, device="cuda")
+    pseudo_beta = batch["template_pseudo_beta_coords"][:, 0].contiguous()
+    frame = batch["template_frame_atom_coords"][:, 0].contiguous()
+    pb_mask = batch["template_pseudo_beta_mask"][:, 0].contiguous()
+    bb_mask = batch["template_backbone_frame_mask"][:, 0].contiguous()
+    asym = batch["asym_id"].contiguous()
+    torch.manual_seed(12)
+    dgram_weight = torch.randn(64, 39, device="cuda")
+    scalar_weight = torch.randn(64, 5, device="cuda")
+    expected = torch.randn(1, n_token, n_token, 64, device="cuda")
+    actual = expected.clone()
+
+    template_coordinate_projection_add_reference_(
+        expected,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+        chunk_rows=7,
+    )
+    template_coordinate_projection_add_(
+        actual,
+        pseudo_beta,
+        frame,
+        pb_mask,
+        bb_mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=3e-4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_coordinate_kernel_preserves_open_bin_boundaries():
+    from openfold3.core.kernels.triton.fused_template_coordinate import (
+        template_coordinate_projection_add_,
+    )
+
+    distances = torch.tensor([0.0, 3.25, 4.0, 4.5, 50.75, 60.0], device="cuda")
+    n_token = len(distances)
+    pseudo_beta = torch.zeros(1, n_token, 3, device="cuda")
+    pseudo_beta[0, :, 0] = distances
+    _, frame_cpu = _coordinates(n_token)
+    frame = frame_cpu.cuda()
+    mask = torch.ones(1, n_token, device="cuda")
+    asym = torch.ones(1, n_token, dtype=torch.int32, device="cuda")
+    dgram_weight = (
+        torch.arange(1, 40, device="cuda", dtype=torch.float32)[None]
+        .expand(64, -1)
+        .contiguous()
+    )
+    scalar_weight = torch.zeros(64, 5, device="cuda")
+    actual = torch.zeros(1, n_token, n_token, 64, device="cuda")
+
+    template_coordinate_projection_add_(
+        actual,
+        pseudo_beta,
+        frame,
+        mask,
+        mask,
+        asym,
+        dgram_weight,
+        scalar_weight,
+    )
+    expected_from_origin = torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 39.0], device="cuda")
+    torch.testing.assert_close(actual[0, 0, :, 0], expected_from_origin, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_template_coordinate_compile_reuse_across_lengths():
+    """One filesystem compile must serve every sequence length."""
+    script = r"""
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from openfold3.core.kernels.triton.fused_template_coordinate import (
+    _template_coordinate_projection_kernel,
+    template_coordinate_projection_add_,
+)
+
+cache_dir = os.environ["TRITON_CACHE_DIR"]
+Path(cache_dir).mkdir(parents=True, exist_ok=True)
+
+def clear():
+    _template_coordinate_projection_kernel.device_caches.clear()
+
+def count():
+    return len(list(Path(cache_dir).rglob("_template_coordinate_projection_kernel.json")))
+
+torch.set_grad_enabled(False)
+w_dgram = torch.randn(64, 39, device="cuda")
+w_scalar = torch.randn(64, 5, device="cuda")
+for n in (16, 32, 48, 64, 96):
+    out = torch.zeros(1, n, n, 64, device="cuda")
+    template_coordinate_projection_add_(
+        out,
+        torch.randn(1, n, 3, device="cuda"),
+        torch.randn(1, n, 3, 3, device="cuda"),
+        torch.ones(1, n, device="cuda"),
+        torch.ones(1, n, device="cuda"),
+        torch.ones(1, n, dtype=torch.int32, device="cuda"),
+        w_dgram,
+        w_scalar,
+    )
+    clear()
+
+print(json.dumps({"count": count()}))
+assert count() == 1, count()
+"""
+    with tempfile.TemporaryDirectory() as cache_dir:
+        env = os.environ.copy()
+        env["TRITON_CACHE_DIR"] = cache_dir
+        env["OPENFOLD3_FUSED_TEMPLATE_COORD"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert '"count": 1' in result.stdout

--- a/openfold3/tests/test_heads.py
+++ b/openfold3/tests/test_heads.py
@@ -431,9 +431,7 @@ class TestAuxiliaryHeadsAllAtom(unittest.TestCase):
         initialize_model_weights(aux_head)
 
         outputs = {
-            "si_trunk": torch.ones(
-                batch_size, n_token, config.architecture.shared.c_s
-            ),
+            "si_trunk": torch.ones(batch_size, n_token, config.architecture.shared.c_s),
             "zij_trunk": torch.ones(
                 batch_size, n_token, n_token, config.architecture.shared.c_z
             ),
@@ -443,9 +441,7 @@ class TestAuxiliaryHeadsAllAtom(unittest.TestCase):
         with torch.inference_mode():
             aux_head(
                 batch,
-                torch.ones(
-                    batch_size, n_token, config.architecture.shared.c_s_input
-                ),
+                torch.ones(batch_size, n_token, config.architecture.shared.c_s_input),
                 outputs,
                 use_zij_trunk_embedding=True,
                 chunk_size=4,

--- a/openfold3/tests/test_heads.py
+++ b/openfold3/tests/test_heads.py
@@ -412,6 +412,47 @@ class TestAuxiliaryHeadsAllAtom(unittest.TestCase):
             aux_out["experimentally_resolved_logits"].shape, expected_shape_exp_res
         )
 
+    def test_releases_trunk_pair_after_confidence_clone(self):
+        batch_size = consts.batch_size
+        n_token = consts.n_res
+        n_msa = 10
+        n_templ = 3
+
+        proj_entry = OF3ProjectEntry()
+        config = proj_entry.get_model_config_with_presets()
+        batch = random_of3_features(
+            batch_size=batch_size, n_token=n_token, n_msa=n_msa, n_templ=n_templ
+        )
+        n_atom = torch.max(batch["num_atoms_per_token"].sum(dim=-1)).int().item()
+
+        heads_config = config.architecture.heads
+        heads_config.pae.enabled = True
+        aux_head = AuxiliaryHeadsAllAtom(heads_config).eval()
+        initialize_model_weights(aux_head)
+
+        outputs = {
+            "si_trunk": torch.ones(
+                batch_size, n_token, config.architecture.shared.c_s
+            ),
+            "zij_trunk": torch.ones(
+                batch_size, n_token, n_token, config.architecture.shared.c_z
+            ),
+            "atom_positions_predicted": torch.randn(batch_size, n_atom, 3),
+        }
+
+        with torch.inference_mode():
+            aux_head(
+                batch,
+                torch.ones(
+                    batch_size, n_token, config.architecture.shared.c_s_input
+                ),
+                outputs,
+                use_zij_trunk_embedding=True,
+                chunk_size=4,
+            )
+
+        self.assertNotIn("zij_trunk", outputs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -242,6 +242,40 @@ class TestUtils(unittest.TestCase):
             "Representative function should not have been called again for identical arg shapes and dtypes",
         )
 
+    def test_chunk_size_tuner_cache_hit_does_not_clone(self):
+        tuner = ChunkSizeTuner()
+        live = torch.zeros(2, 3, 4)
+        real_clone = live.clone
+        clone_fn = unittest.mock.Mock(side_effect=lambda: real_clone())
+        live.clone = clone_fn
+
+        def fn(t, chunk_size):
+            return t
+
+        tuner.tune_chunk_size(fn, (live,), max_chunk_size=16)
+        self.assertEqual(clone_fn.call_count, 1)
+        tuner.tune_chunk_size(fn, (live,), max_chunk_size=16)
+        self.assertEqual(
+            clone_fn.call_count,
+            1,
+            "Cache hit must not clone live tensor args",
+        )
+
+    def test_chunk_size_tuner_miss_does_not_mutate_live(self):
+        tuner = ChunkSizeTuner()
+        live = torch.zeros(4, 8)
+        original = live.clone()
+
+        def fn(t, chunk_size):
+            t.add_(1)
+            return t
+
+        tuner.tune_chunk_size(fn, (live,), max_chunk_size=8)
+        self.assertTrue(
+            torch.equal(live, original),
+            "Cache-miss probe must not in-place-write the caller's tensors",
+        )
+
     def test_chunk_size_tuner_does_not_retest_candidates(self):
         # Based on previous bug: the binary search forgot which candidates it
         # had already proven non-viable and re-tested them.
@@ -483,17 +517,11 @@ class TestUtils(unittest.TestCase):
         old = os.environ.get(key)
         try:
             os.environ[key] = "128"
-            self.assertEqual(
-                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 128
-            )
+            self.assertEqual(apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 128)
             # Cap cannot shrink the working set when N already fits.
-            self.assertEqual(
-                apply_triangle_attn_chunk_cap(1024, n_tokens=76), 1024
-            )
+            self.assertEqual(apply_triangle_attn_chunk_cap(1024, n_tokens=76), 1024)
             os.environ.pop(key, None)
-            self.assertEqual(
-                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 1024
-            )
+            self.assertEqual(apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 1024)
         finally:
             if old is None:
                 os.environ.pop(key, None)
@@ -511,7 +539,7 @@ class TestUtils(unittest.TestCase):
             os.environ[key] = "128"
             self.assertEqual(trimul_chunk_cap(), 128)
             self.assertTrue(use_chunked_trimul(inplace_safe=True))
-            self.assertFalse(use_chunked_trim(inplace_safe=False))
+            self.assertFalse(use_chunked_trimul(inplace_safe=False))
         finally:
             if old is None:
                 os.environ.pop(key, None)

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -415,3 +415,36 @@ class TestUtils(unittest.TestCase):
         self.assertNotEqual(
             first, second, "Chunk size should have been re-tuned for new arg count"
         )
+
+    def test_chunk_size_tuner_reuses_prior_shape_after_other_shapes(self):
+        tuner = ChunkSizeTuner()
+        calls = []
+
+        def fn(t, chunk_size):
+            calls.append(t.shape[-1])
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        a = (torch.zeros(2, 3, 16),)
+        b = (torch.zeros(2, 3, 128),)
+        first = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+        tuner.tune_chunk_size(fn, b, max_chunk_size=256)
+        tune_calls = len(calls)
+        reused = tuner.tune_chunk_size(fn, a, max_chunk_size=256)
+
+        self.assertEqual(reused, first)
+        self.assertEqual(len(calls), tune_calls)
+
+    def test_chunk_size_tuner_caches_max_chunk_size_separately(self):
+        tuner = ChunkSizeTuner()
+
+        def fn(t, chunk_size):
+            if chunk_size > t.shape[-1]:
+                raise RuntimeError("simulated OOM")
+
+        args = (torch.zeros(2, 3, 64),)
+        small = tuner.tune_chunk_size(fn, args, max_chunk_size=32)
+        large = tuner.tune_chunk_size(fn, args, max_chunk_size=256)
+        self.assertEqual(small, 32)
+        self.assertEqual(large, 64)
+        self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)

--- a/openfold3/tests/utils/test_utils.py
+++ b/openfold3/tests/utils/test_utils.py
@@ -13,12 +13,23 @@
 # limitations under the License.
 
 import math
+import os
 import unittest
 
 import torch
 
 from openfold3.core.model.primitives import Linear
-from openfold3.core.utils.chunk_utils import ChunkSizeTuner, _chunk_slice, chunk_layer
+from openfold3.core.utils.chunk_utils import (
+    ChunkSizeTuner,
+    _chunk_slice,
+    apply_transition_chunk_cap,
+    apply_triangle_attn_chunk_cap,
+    chunk_layer,
+    transition_chunk_cap,
+    triangle_attn_chunk_cap,
+    trimul_chunk_cap,
+    use_chunked_trimul,
+)
 from openfold3.core.utils.rigid_utils import (
     Rigid,
     Rotation,
@@ -448,3 +459,79 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(small, 32)
         self.assertEqual(large, 64)
         self.assertEqual(tuner.tune_chunk_size(fn, args, max_chunk_size=32), small)
+
+    def test_triangle_attn_chunk_cap_env(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(triangle_attn_chunk_cap())
+
+            os.environ[key] = "64"
+            self.assertEqual(triangle_attn_chunk_cap(), 64)
+
+            os.environ[key] = "bad"
+            self.assertIsNone(triangle_attn_chunk_cap())
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_apply_triangle_attn_chunk_cap(self):
+        key = "OPENFOLD3_TRI_ATTN_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ[key] = "128"
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 128
+            )
+            # Cap cannot shrink the working set when N already fits.
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=76), 1024
+            )
+            os.environ.pop(key, None)
+            self.assertEqual(
+                apply_triangle_attn_chunk_cap(1024, n_tokens=1264), 1024
+            )
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_trimul_chunk_cap_selects_chunked_eager_path(self):
+        key = "OPENFOLD3_TRIMUL_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(trimul_chunk_cap())
+            self.assertFalse(use_chunked_trimul(inplace_safe=True))
+
+            os.environ[key] = "128"
+            self.assertEqual(trimul_chunk_cap(), 128)
+            self.assertTrue(use_chunked_trimul(inplace_safe=True))
+            self.assertFalse(use_chunked_trim(inplace_safe=False))
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+    def test_transition_chunk_cap_env(self):
+        key = "OPENFOLD3_TRANSITION_CHUNK_CAP"
+        old = os.environ.get(key)
+        try:
+            os.environ.pop(key, None)
+            self.assertIsNone(transition_chunk_cap())
+            self.assertEqual(apply_transition_chunk_cap(1024), 1024)
+
+            os.environ[key] = "128"
+            self.assertEqual(transition_chunk_cap(), 128)
+            self.assertEqual(apply_transition_chunk_cap(1024), 128)
+            self.assertEqual(apply_transition_chunk_cap(64), 64)
+        finally:
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old

--- a/scripts/dev/bench_atom_transforms.py
+++ b/scripts/dev/bench_atom_transforms.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Microbenchmark atom broadcast/aggregation paths."""
+
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.utils.atomize_utils import (  # noqa: E402
+    aggregate_atom_feat_to_tokens,
+    aggregate_atom_feat_to_tokens_segmented,
+    broadcast_token_feat_to_atoms,
+    broadcast_token_feat_to_atoms_by_index,
+)
+
+
+def time_ms(fn, reps=100):
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) * 1000 / reps
+
+
+def main():
+    n_token, samples = 1264, 5
+    gen = torch.Generator().manual_seed(42)
+    lengths = torch.randint(4, 13, (1, n_token), generator=gen)
+    atom_index = torch.repeat_interleave(torch.arange(n_token), lengths[0])
+    n_atom = atom_index.numel()
+    lengths = lengths[:, None].cuda()
+    atom_index = atom_index.reshape(1, 1, n_atom).cuda()
+    token_mask = torch.ones(1, 1, n_token, device="cuda")
+    atom_mask = torch.ones(1, 1, n_atom, device="cuda")
+    token_feat = torch.randn(1, samples, n_token, 128, device="cuda")
+    atom_feat = torch.randn(1, samples, n_atom, 128, device="cuda")
+
+    def dynamic():
+        return broadcast_token_feat_to_atoms(token_mask, lengths, token_feat, -2)
+
+    def indexed():
+        return broadcast_token_feat_to_atoms_by_index(
+            token_mask, atom_index, atom_mask, token_feat
+        )
+
+    def atomic():
+        return aggregate_atom_feat_to_tokens(
+            token_mask, atom_index, atom_mask, atom_feat, atom_dim=-2
+        )
+
+    def segmented():
+        return aggregate_atom_feat_to_tokens_segmented(lengths, atom_mask, atom_feat)
+
+    torch.testing.assert_close(indexed(), dynamic())
+    torch.testing.assert_close(segmented(), atomic(), rtol=1e-5, atol=1e-6)
+
+    d, i, a, s = (time_ms(fn) for fn in (dynamic, indexed, atomic, segmented))
+    print(torch.cuda.get_device_name())
+    print(f"broadcast {d:.3f}->{i:.3f} ms | aggregate {a:.3f}->{s:.3f} ms")
+    print(f"combined {(2 * d + a) / (2 * i + s):.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/bench_fused_relpos_embed.py
+++ b/scripts/dev/bench_fused_relpos_embed.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microbenchmark for fused_relpos_embed_add_ kernel.
+
+Compares the fused Triton kernel against the eager PyTorch path at multiple
+sequence lengths, reporting correctness, peak memory, and wall time.
+"""
+
+from __future__ import annotations
+
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.kernels.triton.fused_relpos_embed import (  # noqa: E402
+    eager_relpos_embed_add_,
+    fused_relpos_embed_add_,
+)
+
+C = 128
+VOCAB = 130
+SAME_ENTITY_OFFSET = 65
+WARMUP = 3
+REPS = 10
+
+
+def bench_one(N: int) -> dict:
+    torch.cuda.empty_cache()
+    z = torch.randn(1, N, N, C, device="cuda", dtype=torch.float32)
+    w = torch.randn(VOCAB, C, device="cuda", dtype=torch.float32)
+    idx1 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    idx2 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    idx3 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    same_entity = torch.randint(0, 2, (1, N, N), device="cuda", dtype=torch.bool)
+
+    U_bytes = N * N * C * 4
+
+    max_err = None
+    if N <= 3000:
+        z_ref = z.clone()
+        eager_relpos_embed_add_(
+            z_ref, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+        )
+
+        z_test = z.clone()
+        fused_relpos_embed_add_(
+            z_test, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+        )
+        torch.cuda.synchronize()
+        max_err = (z_test - z_ref).abs().max().item()
+        del z_ref, z_test
+
+    eager_peak_U = None
+    try:
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        z_tmp = z.clone()
+        eager_relpos_embed_add_(
+            z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+        )
+        torch.cuda.synchronize()
+        eager_peak_U = (torch.cuda.max_memory_allocated() - base) / U_bytes
+        del z_tmp
+    except torch.cuda.OutOfMemoryError:
+        eager_peak_U = None
+        torch.cuda.empty_cache()
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated()
+    z_tmp = z.clone()
+    fused_relpos_embed_add_(
+        z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+    )
+    torch.cuda.synchronize()
+    fused_peak_U = (torch.cuda.max_memory_allocated() - base) / U_bytes
+    del z_tmp
+
+    eager_ms = None
+    try:
+        for _ in range(WARMUP):
+            z_tmp = z.clone()
+            eager_relpos_embed_add_(
+                z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+            )
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(REPS):
+            z_tmp = z.clone()
+            eager_relpos_embed_add_(
+                z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+            )
+        torch.cuda.synchronize()
+        eager_ms = (time.perf_counter() - t0) / REPS * 1000
+        del z_tmp
+    except torch.cuda.OutOfMemoryError:
+        eager_ms = None
+        torch.cuda.empty_cache()
+
+    for _ in range(WARMUP):
+        z_tmp = z.clone()
+        fused_relpos_embed_add_(
+            z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+        )
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(REPS):
+        z_tmp = z.clone()
+        fused_relpos_embed_add_(
+            z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
+        )
+    torch.cuda.synchronize()
+    fused_ms = (time.perf_counter() - t0) / REPS * 1000
+
+    del z, w, idx1, idx2, idx3, same_entity
+    torch.cuda.empty_cache()
+
+    return {
+        "N": N,
+        "max_err": max_err,
+        "eager_peak_U": eager_peak_U,
+        "fused_peak_U": fused_peak_U,
+        "eager_ms": eager_ms,
+        "fused_ms": fused_ms,
+    }
+
+
+def _print_table(title: str, rows: list[dict]) -> None:
+    print(title)
+    print(
+        f"{'N':>5} | {'err':>9} | {'eager_peak':>11} | {'fused_peak':>11} | "
+        f"{'eager_ms':>9} | {'fused_ms':>9} | {'speedup':>7}"
+    )
+    print("-" * 80)
+    for r in rows:
+        err_str = f"{r['max_err']:.2e}" if r["max_err"] is not None else "skip"
+        eager_peak_str = (
+            f"{r['eager_peak_U']:.2f}U" if r["eager_peak_U"] is not None else "OOM"
+        )
+        eager_ms_str = f"{r['eager_ms']:.1f}ms" if r["eager_ms"] is not None else "OOM"
+        speedup_str = (
+            f"{r['eager_ms'] / r['fused_ms']:.2f}x"
+            if r["eager_ms"] is not None
+            else "N/A"
+        )
+        print(
+            f"{r['N']:>5} | {err_str:>9} | {eager_peak_str:>11} | "
+            f"{r['fused_peak_U']:.2f}U{'':>5} | {eager_ms_str:>9} | "
+            f"{r['fused_ms']:.1f}ms{'':>4} | {speedup_str:>7}"
+        )
+    print()
+
+
+def main():
+    lengths = [256, 512, 1264, 2000]
+    _print_table("Forward gather-add", [bench_one(N) for N in lengths])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/bench_fused_relpos_embed.py
+++ b/scripts/dev/bench_fused_relpos_embed.py
@@ -31,7 +31,9 @@ import torch  # noqa: E402
 
 from openfold3.core.kernels.triton.fused_relpos_embed import (  # noqa: E402
     eager_relpos_embed_add_,
+    eager_relpos_weight_grad,
     fused_relpos_embed_add_,
+    fused_relpos_weight_grad,
 )
 
 C = 128
@@ -143,6 +145,75 @@ def bench_one(N: int) -> dict:
     }
 
 
+def bench_bwd_one(N: int) -> dict:
+    torch.cuda.empty_cache()
+    grad_z = torch.randn(1, N, N, C, device="cuda", dtype=torch.float32)
+    idx1 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    idx2 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    idx3 = torch.randint(0, VOCAB, (1, N, N), device="cuda", dtype=torch.int64)
+    same_entity = torch.randint(0, 2, (1, N, N), device="cuda", dtype=torch.bool)
+    U_bytes = N * N * C * 4
+
+    max_err = None
+    if N <= 3000:
+        g_ref = eager_relpos_weight_grad(
+            grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+        )
+        g_test = fused_relpos_weight_grad(
+            grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+        )
+        torch.cuda.synchronize()
+        max_err = (g_test - g_ref).abs().max().item()
+        del g_ref, g_test
+
+    def _peak(fn):
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        fn()
+        torch.cuda.synchronize()
+        return (torch.cuda.max_memory_allocated() - base) / U_bytes
+
+    def _time(fn):
+        for _ in range(WARMUP):
+            fn()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(REPS):
+            fn()
+        torch.cuda.synchronize()
+        return (time.perf_counter() - t0) / REPS * 1000
+
+    eager_fn = lambda: eager_relpos_weight_grad(
+        grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+    )
+    fused_fn = lambda: fused_relpos_weight_grad(
+        grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+    )
+
+    eager_peak_U = None
+    eager_ms = None
+    try:
+        eager_peak_U = _peak(eager_fn)
+        eager_ms = _time(eager_fn)
+    except torch.cuda.OutOfMemoryError:
+        torch.cuda.empty_cache()
+
+    fused_peak_U = _peak(fused_fn)
+    fused_ms = _time(fused_fn)
+
+    del grad_z, idx1, idx2, idx3, same_entity
+    torch.cuda.empty_cache()
+    return {
+        "N": N,
+        "max_err": max_err,
+        "eager_peak_U": eager_peak_U,
+        "fused_peak_U": fused_peak_U,
+        "eager_ms": eager_ms,
+        "fused_ms": fused_ms,
+    }
+
+
 def _print_table(title: str, rows: list[dict]) -> None:
     print(title)
     print(
@@ -172,6 +243,7 @@ def _print_table(title: str, rows: list[dict]) -> None:
 def main():
     lengths = [256, 512, 1264, 2000]
     _print_table("Forward gather-add", [bench_one(N) for N in lengths])
+    _print_table("Backward weight grad", [bench_bwd_one(N) for N in lengths])
 
 
 if __name__ == "__main__":

--- a/scripts/dev/bench_fused_relpos_embed.py
+++ b/scripts/dev/bench_fused_relpos_embed.py
@@ -22,6 +22,7 @@ sequence lengths, reporting correctness, peak memory, and wall time.
 from __future__ import annotations
 
 import time
+from functools import partial
 
 from openfold3.entry_points.import_utils import _torch_gpu_setup
 
@@ -89,9 +90,7 @@ def bench_one(N: int) -> dict:
     torch.cuda.reset_peak_memory_stats()
     base = torch.cuda.memory_allocated()
     z_tmp = z.clone()
-    fused_relpos_embed_add_(
-        z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET
-    )
+    fused_relpos_embed_add_(z_tmp, w, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET)
     torch.cuda.synchronize()
     fused_peak_U = (torch.cuda.max_memory_allocated() - base) / U_bytes
     del z_tmp
@@ -184,11 +183,25 @@ def bench_bwd_one(N: int) -> dict:
         torch.cuda.synchronize()
         return (time.perf_counter() - t0) / REPS * 1000
 
-    eager_fn = lambda: eager_relpos_weight_grad(
-        grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+    eager_fn = partial(
+        eager_relpos_weight_grad,
+        grad_z,
+        idx1,
+        idx2,
+        idx3,
+        same_entity,
+        SAME_ENTITY_OFFSET,
+        VOCAB,
     )
-    fused_fn = lambda: fused_relpos_weight_grad(
-        grad_z, idx1, idx2, idx3, same_entity, SAME_ENTITY_OFFSET, VOCAB
+    fused_fn = partial(
+        fused_relpos_weight_grad,
+        grad_z,
+        idx1,
+        idx2,
+        idx3,
+        same_entity,
+        SAME_ENTITY_OFFSET,
+        VOCAB,
     )
 
     eager_peak_U = None

--- a/scripts/dev/bench_fused_swiglu_transition.py
+++ b/scripts/dev/bench_fused_swiglu_transition.py
@@ -13,11 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Error / speed / memory for fused SwiGLU vs eager.
-
-FP32 rows use IEEE eager as the baseline. The bf16-mixed row uses
-bf16 activations with fp32 masters (Triton does not take bf16 weights).
-"""
+"""Same-precision fused vs eager SwiGLU microbench (TF32 and bf16-mixed)."""
 
 from __future__ import annotations
 
@@ -29,6 +25,7 @@ from openfold3.entry_points.import_utils import _torch_gpu_setup
 _torch_gpu_setup()
 
 import torch  # noqa: E402
+from torch.utils.checkpoint import checkpoint  # noqa: E402
 
 from openfold3.core.kernels.triton.fused_swiglu_transition import (  # noqa: E402
     fused_swiglu_transition,
@@ -39,15 +36,18 @@ C = 128
 H = 512
 WARMUP = 5
 REPS = 20
+INFER_NS = (256, 384, 768)
+CKPT_NS = (384, 768)
+PRECISIONS = ("tf32", "bf16-mixed")
 
 
-def _weights(dtype=torch.float32):
+def _weights():
     torch.manual_seed(0)
-    g = torch.randn(C, device="cuda", dtype=dtype)
-    b = torch.randn(C, device="cuda", dtype=dtype)
-    wa = torch.randn(H, C, device="cuda", dtype=dtype) / C**0.5
-    wb = torch.randn(H, C, device="cuda", dtype=dtype) / C**0.5
-    wo = torch.randn(C, H, device="cuda", dtype=dtype) / H**0.5
+    g = torch.randn(C, device="cuda")
+    b = torch.randn(C, device="cuda")
+    wa = torch.randn(H, C, device="cuda") / C**0.5
+    wb = torch.randn(H, C, device="cuda") / C**0.5
+    wo = torch.randn(C, H, device="cuda") / H**0.5
     return g, b, wa, wb, wo
 
 
@@ -62,13 +62,11 @@ def _bind_module(g, b, wa, wb, wo):
     return module
 
 
-def _eager(module, x, mask):
-    return module._eager_transition(x, mask)
-
-
-def _set_tf32(enabled: bool) -> None:
-    torch.backends.cuda.matmul.allow_tf32 = enabled
-    torch.backends.cudnn.allow_tf32 = enabled
+def _set_precision(precision: str) -> torch.dtype:
+    tf32 = precision == "tf32"
+    torch.backends.cuda.matmul.allow_tf32 = tf32
+    torch.backends.cudnn.allow_tf32 = tf32
+    return torch.bfloat16 if precision == "bf16-mixed" else torch.float32
 
 
 def _time(fn):
@@ -83,312 +81,173 @@ def _time(fn):
 
 
 def _peak_U(fn, N):
-    U = N * N * C * 4
+    u = N * N * C * 4
     torch.cuda.synchronize()
     torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
     base = torch.cuda.memory_allocated()
     fn()
     torch.cuda.synchronize()
-    return (torch.cuda.max_memory_allocated() - base) / U
+    return (torch.cuda.max_memory_allocated() - base) / u
 
 
 def _err(a, b):
     d = (a.float() - b.float()).abs()
     abs_err = d.max().item()
-    rel_err = abs_err / (b.float().abs().max().item() + 1e-12)
-    return abs_err, rel_err
+    return abs_err, abs_err / (b.float().abs().max().item() + 1e-12)
 
 
-def _max_pair_err(pairs):
-    """Max abs and max per-tensor rel across ``(actual, ref)`` pairs."""
-    abs_err = 0.0
-    rel_err = 0.0
-    for a, b in pairs:
-        ae, re = _err(a, b)
-        abs_err = max(abs_err, ae)
-        rel_err = max(rel_err, re)
-    return abs_err, rel_err
-
-
-def bench_fwd(N: int) -> list[dict]:
+def bench_inference(N: int, precision: str) -> dict:
     os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    dtype = _set_precision(precision)
     g, b, wa, wb, wo = _weights()
     module = _bind_module(g, b, wa, wb, wo).eval()
-    x = torch.randn(1, N, N, C, device="cuda") * 0.5
-    mask = torch.ones(1, N, N, 1, device="cuda")
-
-    # Fixed baseline: default FP32 eager (IEEE).
-    _set_tf32(False)
+    x = torch.randn(1, N, N, C, device="cuda", dtype=dtype) * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda", dtype=dtype)
     with torch.inference_mode():
-        y_fp32 = _eager(module, x, mask)
-        baseline_ms = _time(lambda: _eager(module, x, mask))
-        baseline_U = _peak_U(lambda: _eager(module, x, mask), N)
-
-    rows = []
-    configs = [
-        ("fused FP32", False, True),
-        ("fused TF32", True, True),
-        ("eager TF32", True, False),
-    ]
-    for label, tf32, use_fused in configs:
-        _set_tf32(tf32)
-        with torch.inference_mode():
-            fn = (
-                (lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask))
-                if use_fused
-                else (lambda: _eager(module, x, mask))
-            )
-            y = fn()
-            abs_err, rel_err = _err(y, y_fp32)
-            ms = _time(fn)
-            peak_U = _peak_U(fn, N)
-            ip_ms = ip_U = None
-            if use_fused:
-                z = x.clone()
-                ip_ms = _time(
-                    lambda: fused_swiglu_transition(
-                        z, g, b, wa, wb, wo, mask=mask, residual=z
-                    )
-                )
-                z = x.clone()
-                ip_U = _peak_U(
-                    lambda: fused_swiglu_transition(
-                        z, g, b, wa, wb, wo, mask=mask, residual=z
-                    ),
-                    N,
-                )
-        rows.append(
-            {
-                "label": label,
-                "N": N,
-                "abs_err": abs_err,
-                "rel_err": rel_err,
-                "baseline_ms": baseline_ms,
-                "ms": ms,
-                "ip_ms": ip_ms,
-                "baseline_U": baseline_U,
-                "U": peak_U,
-                "ip_U": ip_U,
-            }
-        )
-    return rows
-
-
-def bench_bwd(N: int) -> list[dict]:
-    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
-    g, b, wa, wb, wo = _weights()
-    module = _bind_module(g, b, wa, wb, wo).train()
-    x0 = torch.randn(1, N, N, C, device="cuda") * 0.5
-    mask = torch.ones(1, N, N, 1, device="cuda")
-    go = torch.randn_like(x0)
-
-    def run(fused: bool):
-        xd = x0.detach().requires_grad_(True)
-        if fused:
-            ts = [
-                xd,
-                g.detach().requires_grad_(True),
-                b.detach().requires_grad_(True),
-                wa.detach().requires_grad_(True),
-                wb.detach().requires_grad_(True),
-                wo.detach().requires_grad_(True),
-            ]
-            y = fused_swiglu_transition(*ts, mask=mask)
-            y.backward(go)
-            return [t.grad.detach().clone() for t in ts]
-        module.zero_grad(set_to_none=True)
-        y = _eager(module, xd, mask)
-        y.backward(go)
-        return [
-            xd.grad.detach().clone(),
-            module.layer_norm.weight.grad.detach().clone(),
-            module.layer_norm.bias.grad.detach().clone(),
-            module.swiglu.linear_a.weight.grad.detach().clone(),
-            module.swiglu.linear_b.weight.grad.detach().clone(),
-            module.linear_out.weight.grad.detach().clone(),
-        ]
-
-    _set_tf32(False)
-    g_fp32 = run(False)
-    baseline_ms = _time(lambda: run(False))
-    baseline_U = _peak_U(lambda: run(False), N)
-
-    rows = []
-    configs = [
-        ("fused FP32", False, True),
-        ("fused TF32", True, True),
-        ("eager TF32", True, False),
-    ]
-    for label, tf32, use_fused in configs:
-        _set_tf32(tf32)
-        grads = run(use_fused)
-        abs_errs = [(a - b).abs().max().item() for a, b in zip(g_fp32, grads)]
-        rel_errs = [
-            ae / (a.abs().max().item() + 1e-12) for ae, a in zip(abs_errs, g_fp32)
-        ]
-        ms = _time(lambda: run(use_fused))
-        peak_U = _peak_U(lambda: run(use_fused), N)
-        rows.append(
-            {
-                "label": label,
-                "N": N,
-                "abs_err": max(abs_errs),
-                "rel_err": max(rel_errs),
-                "baseline_ms": baseline_ms,
-                "ms": ms,
-                "baseline_U": baseline_U,
-                "U": peak_U,
-            }
-        )
-    return rows
-
-
-def _print_fwd(rows, title="FORWARD vs default FP32 eager (IEEE) baseline"):
-    print(title)
-    print(
-        f"{'path':>18} | {'N':>4} | {'abs_err':>9} | {'rel_err':>9} | "
-        f"{'base_U':>7} | {'path_U':>7} | {'ip_U':>5} | "
-        f"{'base':>7} | {'path':>7} | {'ip':>7} | {'base/p':>6}"
-    )
-    print("-" * 120)
-    for r in rows:
-        ip_U = f"{r['ip_U']:4.2f}U" if r["ip_U"] is not None else "  n/a"
-        ip_ms = f"{r['ip_ms']:6.2f}" if r["ip_ms"] is not None else "   n/a"
-        print(
-            f"{r['label']:>18} | {r['N']:>4} | {r['abs_err']:.2e} | "
-            f"{r['rel_err']:.2e} | {r['baseline_U']:6.2f}U | {r['U']:6.2f}U | "
-            f"{ip_U:>5} | {r['baseline_ms']:6.2f} | {r['ms']:6.2f} | "
-            f"{ip_ms:>7} | {r['baseline_ms']/r['ms']:5.2f}x"
-        )
-    print()
-
-
-def _print_bwd(rows, title="BACKWARD vs default FP32 eager (IEEE) baseline"):
-    print(title)
-    print(
-        f"{'path':>18} | {'N':>4} | {'abs_err':>9} | {'rel_err':>9} | "
-        f"{'base_U':>7} | {'path_U':>7} | {'base':>7} | {'path':>7} | {'base/p':>6}"
-    )
-    print("-" * 100)
-    for r in rows:
-        print(
-            f"{r['label']:>18} | {r['N']:>4} | {r['abs_err']:.2e} | "
-            f"{r['rel_err']:.2e} | {r['baseline_U']:6.2f}U | {r['U']:6.2f}U | "
-            f"{r['baseline_ms']:6.2f} | {r['ms']:6.2f} | "
-            f"{r['baseline_ms']/r['ms']:5.2f}x"
-        )
-    print()
-
-
-def bench_bwd_dtype(
-    N: int,
-    act_dtype: torch.dtype,
-    weight_dtype: torch.dtype,
-    label: str,
-):
-    """Training fwd+bwd for one activation/weight dtype pair. No TF32."""
-    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
-    g, b, wa, wb, wo = _weights(weight_dtype)
-    module = _bind_module(g, b, wa, wb, wo).train()
-    x0 = torch.randn(1, N, N, C, device="cuda", dtype=act_dtype) * 0.5
-    mask = torch.ones(1, N, N, 1, device="cuda", dtype=act_dtype)
-    go = torch.randn_like(x0)
-    _set_tf32(False)
-
-    def run(fused: bool):
-        xd = x0.detach().requires_grad_(True)
-        if fused:
-            ts = [
-                xd,
-                g.detach().requires_grad_(True),
-                b.detach().requires_grad_(True),
-                wa.detach().requires_grad_(True),
-                wb.detach().requires_grad_(True),
-                wo.detach().requires_grad_(True),
-            ]
-            y = fused_swiglu_transition(*ts, mask=mask)
-            y.backward(go)
-            return y.detach(), [t.grad.detach().clone() for t in ts]
-        module.zero_grad(set_to_none=True)
-        y = _eager(module, xd, mask)
-        y.backward(go)
-        return y.detach(), [
-            xd.grad.detach().clone(),
-            module.layer_norm.weight.grad.detach().clone(),
-            module.layer_norm.bias.grad.detach().clone(),
-            module.swiglu.linear_a.weight.grad.detach().clone(),
-            module.swiglu.linear_b.weight.grad.detach().clone(),
-            module.linear_out.weight.grad.detach().clone(),
-        ]
-
-    y_e, g_e = run(False)
-    y_f, g_f = run(True)
-    abs_err, rel_err = _max_pair_err([(y_f, y_e), *zip(g_f, g_e)])
-    return {
-        "label": label,
-        "N": N,
-        "abs_err": abs_err,
-        "rel_err": rel_err,
-        "baseline_ms": _time(lambda: run(False)),
-        "ms": _time(lambda: run(True)),
-        "baseline_U": _peak_U(lambda: run(False), N),
-        "U": _peak_U(lambda: run(True), N),
-    }
-
-
-def bench_fwd_dtype(N: int, weight_dtype: torch.dtype, label: str) -> dict:
-    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
-    g, b, wa, wb, wo = _weights(weight_dtype)
-    module = _bind_module(g, b, wa, wb, wo).eval()
-    x = torch.randn(1, N, N, C, device="cuda", dtype=torch.bfloat16) * 0.5
-    mask = torch.ones(1, N, N, 1, device="cuda", dtype=torch.bfloat16)
-    _set_tf32(False)
-    with torch.inference_mode():
-        y_e = _eager(module, x, mask)
+        y_e = module._eager_transition(x, mask)
         y_f = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
         abs_err, rel_err = _err(y_f, y_e)
         z = x.clone()
         return {
-            "label": label,
+            "precision": precision,
             "N": N,
             "abs_err": abs_err,
             "rel_err": rel_err,
-            "baseline_ms": _time(lambda: _eager(module, x, mask)),
-            "ms": _time(
+            "eager_ms": _time(lambda: module._eager_transition(x, mask)),
+            "fused_ms": _time(
                 lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
             ),
             "ip_ms": _time(
-                lambda: fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z)
+                lambda z=z: fused_swiglu_transition(
+                    z, g, b, wa, wb, wo, mask=mask, residual=z
+                )
             ),
-            "baseline_U": _peak_U(lambda: _eager(module, x, mask), N),
-            "U": _peak_U(
+            "eager_U": _peak_U(lambda: module._eager_transition(x, mask), N),
+            "fused_U": _peak_U(
                 lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask), N
             ),
             "ip_U": _peak_U(
-                lambda: fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z),
+                lambda z=z: fused_swiglu_transition(
+                    z, g, b, wa, wb, wo, mask=mask, residual=z
+                ),
                 N,
             ),
         }
 
 
-def main():
-    lengths = [128, 256, 384, 768]
-    fwd, bwd, fwd16, bwd16 = [], [], [], []
-    for N in lengths:
-        print(f"running fwd N={N}...", flush=True)
-        fwd.extend(bench_fwd(N))
-        print(f"running bwd N={N}...", flush=True)
-        bwd.extend(bench_bwd(N))
-        print(f"running mixed N={N}...", flush=True)
-        fwd16.append(bench_fwd_dtype(N, torch.float32, "fused bf16-mixed"))
-        bwd16.append(
-            bench_bwd_dtype(N, torch.bfloat16, torch.float32, "fused bf16-mixed")
+def bench_checkpointed(N: int, precision: str, fused: bool) -> dict:
+    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    dtype = _set_precision(precision)
+    g, b, wa, wb, wo = _weights()
+    module = _bind_module(g, b, wa, wb, wo).train()
+    x0 = torch.randn(1, N, N, C, device="cuda", dtype=dtype) * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda", dtype=dtype)
+    grad_out = torch.randn_like(x0)
+    u = N * N * C * 4
+
+    def forward_graph():
+        x = x0.detach().requires_grad_(True)
+        if not fused:
+            module.zero_grad(set_to_none=True)
+            return checkpoint(
+                lambda value: module._eager_transition(value, mask),
+                x,
+                use_reentrant=False,
+            )
+        leaves = [
+            x,
+            g.detach().requires_grad_(True),
+            b.detach().requires_grad_(True),
+            wa.detach().requires_grad_(True),
+            wb.detach().requires_grad_(True),
+            wo.detach().requires_grad_(True),
+        ]
+        return checkpoint(
+            lambda *args: fused_swiglu_transition(*args, mask=mask),
+            *leaves,
+            use_reentrant=False,
         )
-    _print_fwd(fwd)
-    _print_bwd(bwd)
-    _print_fwd(fwd16, "BF16-MIXED FORWARD (vs eager mixed)")
-    _print_bwd(bwd16, "BF16-MIXED BACKWARD (vs eager mixed)")
+
+    def full_step():
+        forward_graph().backward(grad_out)
+
+    def peak_U():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        full_step()
+        torch.cuda.synchronize()
+        return (torch.cuda.max_memory_allocated() - base) / u
+
+    fwd_ms = _time(forward_graph)
+    full_ms = _time(full_step)
+    return {
+        "precision": precision,
+        "path": "fused" if fused else "eager",
+        "N": N,
+        "peak_U": peak_U(),
+        "fwd_ms": fwd_ms,
+        "bwd_ms": full_ms - fwd_ms,
+        "full_ms": full_ms,
+    }
+
+
+def _print_inference(rows):
+    print("INFERENCE (same-precision fused vs eager)")
+    print(
+        f"{'prec':>11} | {'N':>4} | {'abs_err':>9} | {'rel_err':>9} | "
+        f"{'eager_U':>8} | {'fused_U':>8} | {'ip_U':>5} | "
+        f"{'eager':>7} | {'fused':>7} | {'ip':>7} | {'e/f':>6}"
+    )
+    print("-" * 112)
+    for r in rows:
+        print(
+            f"{r['precision']:>11} | {r['N']:>4} | {r['abs_err']:.2e} | "
+            f"{r['rel_err']:.2e} | {r['eager_U']:7.2f}U | {r['fused_U']:7.2f}U | "
+            f"{r['ip_U']:4.2f}U | {r['eager_ms']:6.2f} | {r['fused_ms']:6.2f} | "
+            f"{r['ip_ms']:6.2f} | {r['eager_ms'] / r['fused_ms']:5.2f}x"
+        )
+    print()
+
+
+def _print_checkpointed(rows):
+    print("CHECKPOINTED TRAINING (non-reentrant, one block, same precision)")
+    print(
+        f"{'prec':>11} | {'path':>6} | {'N':>4} | {'peak':>7} | "
+        f"{'fwd':>7} | {'bwd':>7} | {'full':>7} | {'vs eager':>8}"
+    )
+    print("-" * 80)
+    eager_ms = {
+        (r["precision"], r["N"]): r["full_ms"] for r in rows if r["path"] == "eager"
+    }
+    for row in rows:
+        ratio = row["full_ms"] / eager_ms[(row["precision"], row["N"])]
+        print(
+            f"{row['precision']:>11} | {row['path']:>6} | {row['N']:4d} | "
+            f"{row['peak_U']:6.2f}U | {row['fwd_ms']:6.2f} | "
+            f"{row['bwd_ms']:6.2f} | {row['full_ms']:6.2f} | {ratio:7.2f}x"
+        )
+    print()
+
+
+def main():
+    infer = []
+    for N in INFER_NS:
+        for precision in PRECISIONS:
+            print(f"running inference {precision} N={N}...", flush=True)
+            infer.append(bench_inference(N, precision))
+    _print_inference(infer)
+
+    ckpt = []
+    for N in CKPT_NS:
+        for precision in PRECISIONS:
+            for fused in (False, True):
+                label = "fused" if fused else "eager"
+                print(f"running checkpointed {precision} {label} N={N}...", flush=True)
+                ckpt.append(bench_checkpointed(N, precision, fused))
+    _print_checkpointed(ckpt)
 
 
 if __name__ == "__main__":

--- a/scripts/dev/bench_fused_swiglu_transition.py
+++ b/scripts/dev/bench_fused_swiglu_transition.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+# Copyright 2026 AlQuraishi Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error / speed / memory for fused SwiGLU vs eager.
+
+FP32 rows use IEEE eager as the baseline. The bf16-mixed row uses
+bf16 activations with fp32 masters (Triton does not take bf16 weights).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.kernels.triton.fused_swiglu_transition import (  # noqa: E402
+    fused_swiglu_transition,
+)
+from openfold3.core.model.layers.transition import SwiGLUTransition  # noqa: E402
+
+C = 128
+H = 512
+WARMUP = 5
+REPS = 20
+
+
+def _weights(dtype=torch.float32):
+    torch.manual_seed(0)
+    g = torch.randn(C, device="cuda", dtype=dtype)
+    b = torch.randn(C, device="cuda", dtype=dtype)
+    wa = torch.randn(H, C, device="cuda", dtype=dtype) / C**0.5
+    wb = torch.randn(H, C, device="cuda", dtype=dtype) / C**0.5
+    wo = torch.randn(C, H, device="cuda", dtype=dtype) / H**0.5
+    return g, b, wa, wb, wo
+
+
+def _bind_module(g, b, wa, wb, wo):
+    module = SwiGLUTransition(c_in=C, n=H // C).to(device=g.device, dtype=g.dtype)
+    with torch.no_grad():
+        module.layer_norm.weight.copy_(g)
+        module.layer_norm.bias.copy_(b)
+        module.swiglu.linear_a.weight.copy_(wa)
+        module.swiglu.linear_b.weight.copy_(wb)
+        module.linear_out.weight.copy_(wo)
+    return module
+
+
+def _eager(module, x, mask):
+    return module._eager_transition(x, mask)
+
+
+def _set_tf32(enabled: bool) -> None:
+    torch.backends.cuda.matmul.allow_tf32 = enabled
+    torch.backends.cudnn.allow_tf32 = enabled
+
+
+def _time(fn):
+    for _ in range(WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(REPS):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / REPS * 1000
+
+
+def _peak_U(fn, N):
+    U = N * N * C * 4
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated()
+    fn()
+    torch.cuda.synchronize()
+    return (torch.cuda.max_memory_allocated() - base) / U
+
+
+def _err(a, b):
+    d = (a.float() - b.float()).abs()
+    abs_err = d.max().item()
+    rel_err = abs_err / (b.float().abs().max().item() + 1e-12)
+    return abs_err, rel_err
+
+
+def _max_pair_err(pairs):
+    """Max abs and max per-tensor rel across ``(actual, ref)`` pairs."""
+    abs_err = 0.0
+    rel_err = 0.0
+    for a, b in pairs:
+        ae, re = _err(a, b)
+        abs_err = max(abs_err, ae)
+        rel_err = max(rel_err, re)
+    return abs_err, rel_err
+
+
+def bench_fwd(N: int) -> list[dict]:
+    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    g, b, wa, wb, wo = _weights()
+    module = _bind_module(g, b, wa, wb, wo).eval()
+    x = torch.randn(1, N, N, C, device="cuda") * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda")
+
+    # Fixed baseline: default FP32 eager (IEEE).
+    _set_tf32(False)
+    with torch.inference_mode():
+        y_fp32 = _eager(module, x, mask)
+        baseline_ms = _time(lambda: _eager(module, x, mask))
+        baseline_U = _peak_U(lambda: _eager(module, x, mask), N)
+
+    rows = []
+    configs = [
+        ("fused FP32", False, True),
+        ("fused TF32", True, True),
+        ("eager TF32", True, False),
+    ]
+    for label, tf32, use_fused in configs:
+        _set_tf32(tf32)
+        with torch.inference_mode():
+            fn = (
+                (lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask))
+                if use_fused
+                else (lambda: _eager(module, x, mask))
+            )
+            y = fn()
+            abs_err, rel_err = _err(y, y_fp32)
+            ms = _time(fn)
+            peak_U = _peak_U(fn, N)
+            ip_ms = ip_U = None
+            if use_fused:
+                z = x.clone()
+                ip_ms = _time(
+                    lambda: fused_swiglu_transition(
+                        z, g, b, wa, wb, wo, mask=mask, residual=z
+                    )
+                )
+                z = x.clone()
+                ip_U = _peak_U(
+                    lambda: fused_swiglu_transition(
+                        z, g, b, wa, wb, wo, mask=mask, residual=z
+                    ),
+                    N,
+                )
+        rows.append(
+            {
+                "label": label,
+                "N": N,
+                "abs_err": abs_err,
+                "rel_err": rel_err,
+                "baseline_ms": baseline_ms,
+                "ms": ms,
+                "ip_ms": ip_ms,
+                "baseline_U": baseline_U,
+                "U": peak_U,
+                "ip_U": ip_U,
+            }
+        )
+    return rows
+
+
+def bench_bwd(N: int) -> list[dict]:
+    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    g, b, wa, wb, wo = _weights()
+    module = _bind_module(g, b, wa, wb, wo).train()
+    x0 = torch.randn(1, N, N, C, device="cuda") * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda")
+    go = torch.randn_like(x0)
+
+    def run(fused: bool):
+        xd = x0.detach().requires_grad_(True)
+        if fused:
+            ts = [
+                xd,
+                g.detach().requires_grad_(True),
+                b.detach().requires_grad_(True),
+                wa.detach().requires_grad_(True),
+                wb.detach().requires_grad_(True),
+                wo.detach().requires_grad_(True),
+            ]
+            y = fused_swiglu_transition(*ts, mask=mask)
+            y.backward(go)
+            return [t.grad.detach().clone() for t in ts]
+        module.zero_grad(set_to_none=True)
+        y = _eager(module, xd, mask)
+        y.backward(go)
+        return [
+            xd.grad.detach().clone(),
+            module.layer_norm.weight.grad.detach().clone(),
+            module.layer_norm.bias.grad.detach().clone(),
+            module.swiglu.linear_a.weight.grad.detach().clone(),
+            module.swiglu.linear_b.weight.grad.detach().clone(),
+            module.linear_out.weight.grad.detach().clone(),
+        ]
+
+    _set_tf32(False)
+    g_fp32 = run(False)
+    baseline_ms = _time(lambda: run(False))
+    baseline_U = _peak_U(lambda: run(False), N)
+
+    rows = []
+    configs = [
+        ("fused FP32", False, True),
+        ("fused TF32", True, True),
+        ("eager TF32", True, False),
+    ]
+    for label, tf32, use_fused in configs:
+        _set_tf32(tf32)
+        grads = run(use_fused)
+        abs_errs = [(a - b).abs().max().item() for a, b in zip(g_fp32, grads)]
+        rel_errs = [
+            ae / (a.abs().max().item() + 1e-12) for ae, a in zip(abs_errs, g_fp32)
+        ]
+        ms = _time(lambda: run(use_fused))
+        peak_U = _peak_U(lambda: run(use_fused), N)
+        rows.append(
+            {
+                "label": label,
+                "N": N,
+                "abs_err": max(abs_errs),
+                "rel_err": max(rel_errs),
+                "baseline_ms": baseline_ms,
+                "ms": ms,
+                "baseline_U": baseline_U,
+                "U": peak_U,
+            }
+        )
+    return rows
+
+
+def _print_fwd(rows, title="FORWARD vs default FP32 eager (IEEE) baseline"):
+    print(title)
+    print(
+        f"{'path':>18} | {'N':>4} | {'abs_err':>9} | {'rel_err':>9} | "
+        f"{'base_U':>7} | {'path_U':>7} | {'ip_U':>5} | "
+        f"{'base':>7} | {'path':>7} | {'ip':>7} | {'base/p':>6}"
+    )
+    print("-" * 120)
+    for r in rows:
+        ip_U = f"{r['ip_U']:4.2f}U" if r["ip_U"] is not None else "  n/a"
+        ip_ms = f"{r['ip_ms']:6.2f}" if r["ip_ms"] is not None else "   n/a"
+        print(
+            f"{r['label']:>18} | {r['N']:>4} | {r['abs_err']:.2e} | "
+            f"{r['rel_err']:.2e} | {r['baseline_U']:6.2f}U | {r['U']:6.2f}U | "
+            f"{ip_U:>5} | {r['baseline_ms']:6.2f} | {r['ms']:6.2f} | "
+            f"{ip_ms:>7} | {r['baseline_ms']/r['ms']:5.2f}x"
+        )
+    print()
+
+
+def _print_bwd(rows, title="BACKWARD vs default FP32 eager (IEEE) baseline"):
+    print(title)
+    print(
+        f"{'path':>18} | {'N':>4} | {'abs_err':>9} | {'rel_err':>9} | "
+        f"{'base_U':>7} | {'path_U':>7} | {'base':>7} | {'path':>7} | {'base/p':>6}"
+    )
+    print("-" * 100)
+    for r in rows:
+        print(
+            f"{r['label']:>18} | {r['N']:>4} | {r['abs_err']:.2e} | "
+            f"{r['rel_err']:.2e} | {r['baseline_U']:6.2f}U | {r['U']:6.2f}U | "
+            f"{r['baseline_ms']:6.2f} | {r['ms']:6.2f} | "
+            f"{r['baseline_ms']/r['ms']:5.2f}x"
+        )
+    print()
+
+
+def bench_bwd_dtype(
+    N: int,
+    act_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    label: str,
+):
+    """Training fwd+bwd for one activation/weight dtype pair. No TF32."""
+    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    g, b, wa, wb, wo = _weights(weight_dtype)
+    module = _bind_module(g, b, wa, wb, wo).train()
+    x0 = torch.randn(1, N, N, C, device="cuda", dtype=act_dtype) * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda", dtype=act_dtype)
+    go = torch.randn_like(x0)
+    _set_tf32(False)
+
+    def run(fused: bool):
+        xd = x0.detach().requires_grad_(True)
+        if fused:
+            ts = [
+                xd,
+                g.detach().requires_grad_(True),
+                b.detach().requires_grad_(True),
+                wa.detach().requires_grad_(True),
+                wb.detach().requires_grad_(True),
+                wo.detach().requires_grad_(True),
+            ]
+            y = fused_swiglu_transition(*ts, mask=mask)
+            y.backward(go)
+            return y.detach(), [t.grad.detach().clone() for t in ts]
+        module.zero_grad(set_to_none=True)
+        y = _eager(module, xd, mask)
+        y.backward(go)
+        return y.detach(), [
+            xd.grad.detach().clone(),
+            module.layer_norm.weight.grad.detach().clone(),
+            module.layer_norm.bias.grad.detach().clone(),
+            module.swiglu.linear_a.weight.grad.detach().clone(),
+            module.swiglu.linear_b.weight.grad.detach().clone(),
+            module.linear_out.weight.grad.detach().clone(),
+        ]
+
+    y_e, g_e = run(False)
+    y_f, g_f = run(True)
+    abs_err, rel_err = _max_pair_err([(y_f, y_e), *zip(g_f, g_e)])
+    return {
+        "label": label,
+        "N": N,
+        "abs_err": abs_err,
+        "rel_err": rel_err,
+        "baseline_ms": _time(lambda: run(False)),
+        "ms": _time(lambda: run(True)),
+        "baseline_U": _peak_U(lambda: run(False), N),
+        "U": _peak_U(lambda: run(True), N),
+    }
+
+
+def bench_fwd_dtype(N: int, weight_dtype: torch.dtype, label: str) -> dict:
+    os.environ["OPENFOLD3_FUSED_SWIGLU_TRANSITION"] = "1"
+    g, b, wa, wb, wo = _weights(weight_dtype)
+    module = _bind_module(g, b, wa, wb, wo).eval()
+    x = torch.randn(1, N, N, C, device="cuda", dtype=torch.bfloat16) * 0.5
+    mask = torch.ones(1, N, N, 1, device="cuda", dtype=torch.bfloat16)
+    _set_tf32(False)
+    with torch.inference_mode():
+        y_e = _eager(module, x, mask)
+        y_f = fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+        abs_err, rel_err = _err(y_f, y_e)
+        z = x.clone()
+        return {
+            "label": label,
+            "N": N,
+            "abs_err": abs_err,
+            "rel_err": rel_err,
+            "baseline_ms": _time(lambda: _eager(module, x, mask)),
+            "ms": _time(
+                lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask)
+            ),
+            "ip_ms": _time(
+                lambda: fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z)
+            ),
+            "baseline_U": _peak_U(lambda: _eager(module, x, mask), N),
+            "U": _peak_U(
+                lambda: fused_swiglu_transition(x, g, b, wa, wb, wo, mask=mask), N
+            ),
+            "ip_U": _peak_U(
+                lambda: fused_swiglu_transition(z, g, b, wa, wb, wo, mask=mask, residual=z),
+                N,
+            ),
+        }
+
+
+def main():
+    lengths = [128, 256, 384, 768]
+    fwd, bwd, fwd16, bwd16 = [], [], [], []
+    for N in lengths:
+        print(f"running fwd N={N}...", flush=True)
+        fwd.extend(bench_fwd(N))
+        print(f"running bwd N={N}...", flush=True)
+        bwd.extend(bench_bwd(N))
+        print(f"running mixed N={N}...", flush=True)
+        fwd16.append(bench_fwd_dtype(N, torch.float32, "fused bf16-mixed"))
+        bwd16.append(
+            bench_bwd_dtype(N, torch.bfloat16, torch.float32, "fused bf16-mixed")
+        )
+    _print_fwd(fwd)
+    _print_bwd(bwd)
+    _print_fwd(fwd16, "BF16-MIXED FORWARD (vs eager mixed)")
+    _print_bwd(bwd16, "BF16-MIXED BACKWARD (vs eager mixed)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/bench_fused_template_coordinate_embed.py
+++ b/scripts/dev/bench_fused_template_coordinate_embed.py
@@ -117,7 +117,7 @@ def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
         TemplatePairEmbedderAllAtom,
     )
     from openfold3.core.model.primitives.fused_template_coordinate import (
-        fused_template_coordinate_pair_embedder_inference,
+        fused_template_coordinate_pair_embedder,
     )
 
     torch.manual_seed(0)
@@ -131,7 +131,7 @@ def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
         return module(precomputed_gpu, z)
 
     def coordinate_compute():
-        return fused_template_coordinate_pair_embedder_inference(
+        return fused_template_coordinate_pair_embedder(
             module, coordinate_gpu, z, template_index=0
         )
 

--- a/scripts/dev/bench_fused_template_coordinate_embed.py
+++ b/scripts/dev/bench_fused_template_coordinate_embed.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""Benchmark precomputed versus coordinate-derived template embedding.
+
+Sweeps several sequence lengths. Host payload and peak transient above the
+baseline allocation are reported in bytes and U (= N² × 128 × 4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+from openfold3.core.data.primitives.featurization.template import (
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+
+def _coordinates(n_token: int) -> tuple[torch.Tensor, torch.Tensor]:
+    index = torch.arange(n_token, dtype=torch.float32)
+    ca = torch.stack(
+        (index * 3.8, torch.sin(index * 0.03), torch.cos(index * 0.02)), dim=-1
+    )
+    pseudo_beta = ca + torch.tensor([0.2, -0.3, 0.7])
+    frame = torch.stack(
+        (
+            ca + torch.tensor([-0.7, 1.1, 0.2]),
+            ca,
+            ca + torch.tensor([1.3, 0.2, -0.1]),
+        ),
+        dim=-2,
+    )
+    return pseudo_beta, frame
+
+
+def _make_cpu_batches(n_token: int) -> tuple[dict, dict]:
+    pseudo_beta, frame = _coordinates(n_token)
+    mask = torch.ones(n_token)
+    asym = torch.ones(1, n_token, dtype=torch.int32)
+    restype = F.one_hot(torch.arange(n_token) % 32, num_classes=32).to(torch.int32)
+
+    template_mask = mask[None]
+    pair_mask = torch.ones(1, n_token, n_token, 1)
+    dgram = create_template_distogram(
+        pseudo_beta[None].numpy(), template_mask, pair_mask
+    )
+    unit = create_template_unit_vector(frame[None].numpy(), template_mask, pair_mask)
+
+    common = {
+        "template_restype": restype[None, None],
+        "template_pseudo_beta_mask": mask[None, None],
+        "template_backbone_frame_mask": mask[None, None],
+        "asym_id": asym,
+    }
+    precomputed = {
+        **common,
+        "template_distogram": dgram[None],
+        "template_unit_vector": unit[None],
+    }
+    coordinate = {
+        **common,
+        "template_pseudo_beta_coords": pseudo_beta[None, None],
+        "template_frame_atom_coords": frame[None, None],
+    }
+    return precomputed, coordinate
+
+
+def _to_cuda(batch: dict) -> dict:
+    return {
+        key: value.to("cuda", non_blocking=True)
+        if isinstance(value, torch.Tensor)
+        else value
+        for key, value in batch.items()
+    }
+
+
+def _payload_bytes(batch: dict) -> int:
+    return sum(
+        value.numel() * value.element_size()
+        for key, value in batch.items()
+        if key.startswith("template_")
+    )
+
+
+def _measure(fn, warmups: int, reps: int) -> tuple[float, int]:
+    for _ in range(warmups):
+        out = fn()
+        del out
+    torch.cuda.synchronize()
+
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    out = fn()
+    torch.cuda.synchronize()
+    transient = torch.cuda.max_memory_allocated() - baseline
+    del out
+
+    samples = []
+    for _ in range(reps):
+        start = time.perf_counter()
+        out = fn()
+        torch.cuda.synchronize()
+        samples.append((time.perf_counter() - start) * 1000)
+        del out
+    samples.sort()
+    return samples[len(samples) // 2], transient
+
+
+def _bench_length(n_token: int, warmups: int, reps: int) -> dict:
+    from openfold3.core.model.feature_embedders.template_embedders import (
+        TemplatePairEmbedderAllAtom,
+    )
+    from openfold3.core.model.primitives.fused_template_coordinate import (
+        fused_template_coordinate_pair_embedder_inference,
+    )
+
+    torch.manual_seed(0)
+    module = TemplatePairEmbedderAllAtom(128, 39, 32, 64).cuda().eval()
+    precomputed_cpu, coordinate_cpu = _make_cpu_batches(n_token)
+    precomputed_gpu = _to_cuda(precomputed_cpu)
+    coordinate_gpu = _to_cuda(coordinate_cpu)
+    z = torch.randn(1, n_token, n_token, 128, device="cuda")
+
+    def legacy_compute():
+        return module(precomputed_gpu, z)
+
+    def coordinate_compute():
+        return fused_template_coordinate_pair_embedder_inference(
+            module, coordinate_gpu, z, template_index=0
+        )
+
+    rows = {}
+    with torch.inference_mode():
+        # Warm the Triton cache once at this length before measuring.
+        coordinate_compute()
+        torch.cuda.synchronize()
+        for name, fn in (
+            ("legacy_compute", legacy_compute),
+            ("coordinate_compute", coordinate_compute),
+        ):
+            median_ms, transient = _measure(fn, warmups, reps)
+            rows[name] = {
+                "median_ms": median_ms,
+                "peak_transient_bytes": transient,
+            }
+
+    u_bytes = n_token * n_token * 128 * 4
+    result = {
+        "n_token": n_token,
+        "U_bytes": u_bytes,
+        "legacy_host_bytes": _payload_bytes(precomputed_cpu),
+        "coordinate_host_bytes": _payload_bytes(coordinate_cpu),
+        "host_reduction": (
+            _payload_bytes(precomputed_cpu) / max(_payload_bytes(coordinate_cpu), 1)
+        ),
+        **rows,
+    }
+    for value in rows.values():
+        value["peak_transient_U"] = value["peak_transient_bytes"] / u_bytes
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, nargs="+", default=[128, 384, 590, 1264])
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--reps", type=int, default=10)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    _torch_gpu_setup()
+
+    rows = []
+    for n_token in args.n:
+        row = _bench_length(n_token, args.warmups, args.reps)
+        rows.append(row)
+        print(json.dumps(row, indent=2))
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_determinism.py
+++ b/scripts/dev/check_determinism.py
@@ -28,12 +28,13 @@ import torch  # noqa: E402
 
 from openfold3.core.config import config_utils  # noqa: E402
 from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
-from openfold3.entry_points.experiment_runner import InferenceExperimentRunner  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
 from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
 from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
     InferenceQuerySet,
 )
-
 
 FEATURE_KEYS = (
     "ref_pos",
@@ -118,7 +119,9 @@ def apply_patches(state: PatchState) -> None:
     import openfold3.core.model.layers.sequence_local_atom_attention as atom_attention
 
     if not hasattr(inference_mod, "_CHECK_ORIGINAL_GETITEM"):
-        inference_mod._CHECK_ORIGINAL_GETITEM = inference_mod.InferenceDataset.__getitem__
+        inference_mod._CHECK_ORIGINAL_GETITEM = (
+            inference_mod.InferenceDataset.__getitem__
+        )
 
     original_getitem = inference_mod._CHECK_ORIGINAL_GETITEM
 
@@ -336,7 +339,8 @@ def main() -> None:
         textwrap.dedent(
             f"""
             Matrix (production math, seed={args.seed}):
-            - feature repeats: global RNG polluted before each featurization, no pre-seed
+            - feature repeats: global RNG polluted before each featurization,
+              no pre-seed
             - output repeats: same batch, predict_step-style reseed before each forward
 
             configuration                         | features equal | outputs equal

--- a/scripts/dev/check_determinism.py
+++ b/scripts/dev/check_determinism.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""Factorial repeatability check for foundation changes.
+
+Compares the impact of:
+1) per-datapoint feature seeding in InferenceDataset
+2) segmented atom aggregation in inference mode
+
+Each cell runs two retrievals/forwards with deliberate global RNG pollution
+between them and checks bitwise equality of input features and model outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import InferenceExperimentRunner  # noqa: E402
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+
+FEATURE_KEYS = (
+    "ref_pos",
+    "ref_mask",
+    "ref_element",
+    "ref_charge",
+    "ref_atom_name_chars",
+    "ref_space_uid",
+    "msa",
+    "msa_mask",
+)
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+)
+
+
+@dataclass(frozen=True)
+class PatchState:
+    feature_seeding: bool
+    segmented_atom_agg: bool
+
+    @property
+    def name(self) -> str:
+        feat = "seeded_features" if self.feature_seeding else "upstream_features"
+        agg = "segmented_agg" if self.segmented_atom_agg else "scatter_agg"
+        return f"{feat}+{agg}"
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def pollute_rng() -> None:
+    for _ in range(512):
+        random.random()
+    np.random.randn(16)
+    torch.randn(16)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def compare_tensor_dict(
+    first: dict[str, torch.Tensor], second: dict[str, torch.Tensor]
+) -> tuple[int, int, list[str]]:
+    keys = sorted(set(first) & set(second))
+    equal = 0
+    mismatches: list[str] = []
+    for key in keys:
+        a, b = first[key], second[key]
+        if a.shape != b.shape or a.dtype != b.dtype:
+            mismatches.append(f"{key}: shape/dtype differ")
+            continue
+        if torch.equal(a, b):
+            equal += 1
+        else:
+            max_diff = (a.float() - b.float()).abs().max().item()
+            mismatches.append(f"{key}: max_abs_diff={max_diff:.6g}")
+    return equal, len(keys), mismatches
+
+
+def apply_patches(state: PatchState) -> None:
+    import openfold3.core.data.framework.single_datasets.inference as inference_mod
+    import openfold3.core.model.layers.sequence_local_atom_attention as atom_attention
+
+    if not hasattr(inference_mod, "_CHECK_ORIGINAL_GETITEM"):
+        inference_mod._CHECK_ORIGINAL_GETITEM = inference_mod.InferenceDataset.__getitem__
+
+    original_getitem = inference_mod._CHECK_ORIGINAL_GETITEM
+
+    if state.feature_seeding:
+
+        def getitem(self, index):
+            return original_getitem(self, index)
+
+    else:
+
+        def getitem(self, index):
+            datapoint = self.datapoint_cache.iloc[index]
+            query_id = datapoint["query_id"]
+            query = self.query_cache[query_id]
+            seed = datapoint["seed"]
+            is_repeated_sample = bool(datapoint["repeated_sample"])
+            try:
+                features = self.create_all_features(query)
+                features["query_id"] = query_id
+                features["seed"] = torch.tensor([seed])
+                features["repeated_sample"] = torch.tensor(
+                    [is_repeated_sample], dtype=torch.bool
+                )
+                features["valid_sample"] = torch.tensor([True], dtype=torch.bool)
+                return features
+            except Exception as exc:
+                import traceback
+
+                inference_mod.logger.warning(
+                    f"Failed to process {query_id}: {type(exc).__name__}\n"
+                    f"{traceback.format_exc()}"
+                )
+                return {
+                    "query_id": query_id,
+                    "repeated_sample": torch.tensor(
+                        [is_repeated_sample], dtype=torch.bool
+                    ),
+                    "valid_sample": torch.tensor([False], dtype=torch.bool),
+                }
+
+    inference_mod.InferenceDataset.__getitem__ = getitem
+
+    if not hasattr(atom_attention, "_CHECK_ORIGINAL_ENCODER_FORWARD"):
+        atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD = (
+            atom_attention.AtomAttentionEncoder.forward
+        )
+
+    original_encoder_forward = atom_attention._CHECK_ORIGINAL_ENCODER_FORWARD
+
+    if state.segmented_atom_agg:
+        atom_attention.AtomAttentionEncoder.forward = original_encoder_forward
+    else:
+
+        def encoder_forward_with_scatter(self, *args, **kwargs):
+            was_training = self.training
+            self.training = True
+            try:
+                return original_encoder_forward(self, *args, **kwargs)
+            finally:
+                self.training = was_training
+
+        atom_attention.AtomAttentionEncoder.forward = encoder_forward_with_scatter
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to("cuda"), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def capture_features(batch: dict) -> dict[str, torch.Tensor]:
+    return {k: batch[k].detach().clone() for k in FEATURE_KEYS if k in batch}
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().clone()
+                break
+    return captured
+
+
+def run_forward(runner: InferenceExperimentRunner, batch: dict) -> dict:
+    module = runner.lightning_module.to("cuda").eval()
+    seed_everything(int(batch["seed"][0].item()))
+    with torch.inference_mode():
+        return module(batch)
+
+
+def check_configuration(
+    state: PatchState,
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> dict:
+    apply_patches(state)
+    runner = build_runner(query_json, runner_yaml, seed)
+
+    pollute_rng()
+    features_a = capture_features(get_batch(runner))
+
+    pollute_rng()
+    features_b = capture_features(get_batch(runner))
+
+    feat_equal, feat_total, feat_mismatches = compare_tensor_dict(
+        features_a, features_b
+    )
+
+    # Model repeats use the same batch and the same predict_step reseed contract.
+    pollute_rng()
+    seed_everything(seed)
+    batch = get_batch(runner)
+    outputs_a = capture_outputs(run_forward(runner, batch))
+
+    pollute_rng()
+    seed_everything(seed)
+    outputs_b = capture_outputs(run_forward(runner, batch))
+
+    out_equal, out_total, out_mismatches = compare_tensor_dict(outputs_a, outputs_b)
+
+    return {
+        "configuration": state.name,
+        "feature_seeding": state.feature_seeding,
+        "segmented_atom_agg": state.segmented_atom_agg,
+        "features": {
+            "bitwise_equal_keys": feat_equal,
+            "total_keys": feat_total,
+            "all_bitwise_equal": feat_equal == feat_total and not feat_mismatches,
+            "ref_pos_bitwise_equal": bool(
+                torch.equal(features_a["ref_pos"], features_b["ref_pos"])
+            ),
+            "mismatches": feat_mismatches,
+        },
+        "outputs": {
+            "bitwise_equal_keys": out_equal,
+            "total_keys": out_total,
+            "all_bitwise_equal": out_equal == out_total and not out_mismatches,
+            "atom_positions_predicted_bitwise_equal": bool(
+                torch.equal(
+                    outputs_a["atom_positions_predicted"],
+                    outputs_b["atom_positions_predicted"],
+                )
+            ),
+            "mismatches": out_mismatches,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query-json",
+        type=Path,
+        default=Path(
+            "examples/example_inference_inputs/query_single_protein_single_ligand.json"
+        ),
+    )
+    parser.add_argument(
+        "--runner-yaml",
+        type=Path,
+        default=Path("examples/example_runner_yamls/smoke_inference.yml"),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.use_deterministic_algorithms(False)
+
+    configs = [
+        PatchState(feature_seeding=False, segmented_atom_agg=False),
+        PatchState(feature_seeding=True, segmented_atom_agg=False),
+        PatchState(feature_seeding=False, segmented_atom_agg=True),
+        PatchState(feature_seeding=True, segmented_atom_agg=True),
+    ]
+
+    results = [
+        check_configuration(cfg, args.query_json, args.runner_yaml, args.seed)
+        for cfg in configs
+    ]
+    print(json.dumps(results, indent=2))
+
+    print(
+        textwrap.dedent(
+            f"""
+            Matrix (production math, seed={args.seed}):
+            - feature repeats: global RNG polluted before each featurization, no pre-seed
+            - output repeats: same batch, predict_step-style reseed before each forward
+
+            configuration                         | features equal | outputs equal
+            --------------------------------------|----------------|---------------
+            """
+        ).rstrip()
+    )
+    for row in results:
+        print(
+            f"{row['configuration']:<37} | "
+            f"{str(row['features']['all_bitwise_equal']):<14} | "
+            f"{str(row['outputs']['all_bitwise_equal'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_template_coordinate_parity.py
+++ b/scripts/dev/check_template_coordinate_parity.py
@@ -51,8 +51,7 @@ REPO = Path(__file__).resolve().parents[2]
 DEFAULT_RUNNER = REPO / "data/inference_benchmark_msa_template/runner.yml"
 KNOWN_QUERIES = {
     "7cnx": REPO / "data/inference_benchmark_msa_template/queries/7cnx.json",
-    "ubiquitin": REPO
-    / "data/inference_benchmark_msa_template/queries/ubiquitin.json",
+    "ubiquitin": REPO / "data/inference_benchmark_msa_template/queries/ubiquitin.json",
     "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
 }
 
@@ -161,8 +160,7 @@ def legacy_batch_from_coordinates(coord_batch: dict) -> dict:
     legacy = {
         key: (value.clone() if torch.is_tensor(value) else value)
         for key, value in coord_batch.items()
-        if key
-        not in ("template_pseudo_beta_coords", "template_frame_atom_coords")
+        if key not in ("template_pseudo_beta_coords", "template_frame_atom_coords")
     }
     legacy["template_distogram"] = create_template_distogram(
         pseudo_beta, pb_mask, multichain
@@ -284,9 +282,7 @@ def main() -> None:
             failures.append(f"{key}: missing")
             continue
         if info["max_abs"] > limit:
-            failures.append(
-                f"{key}: max_abs={info['max_abs']:.6g} > atol={limit:g}"
-            )
+            failures.append(f"{key}: max_abs={info['max_abs']:.6g} > atol={limit:g}")
 
     payload = {
         "query": str(query_json),

--- a/scripts/dev/check_template_coordinate_parity.py
+++ b/scripts/dev/check_template_coordinate_parity.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+"""End-to-end parity: precomputed template pairs vs coordinate-derived features.
+
+Uses one loaded model. Builds the legacy distogram/unit-vector batch from the
+same compact coordinates so featurization cannot drift, then compares a
+deterministic forward of each representation.
+
+Synthetic module tests aim for ~1e-5 agreement. On real templates the online
+local-frame path (normalize/cross) differs from ``create_template_unit_vector``
+(Rigid/Vec3Array) by ~1e-6 per component, which can amplify through the trunk;
+structure coords should still stay within ``--atom-atol``.
+
+Example:
+  source scripts/activate_of3.sh
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 \\
+    python scripts/dev/check_template_coordinate_parity.py --query 7cnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.data.primitives.featurization.template import (  # noqa: E402
+    create_template_distogram,
+    create_template_unit_vector,
+)
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_RUNNER = REPO / "data/inference_benchmark_msa_template/runner.yml"
+KNOWN_QUERIES = {
+    "7cnx": REPO / "data/inference_benchmark_msa_template/queries/7cnx.json",
+    "ubiquitin": REPO
+    / "data/inference_benchmark_msa_template/queries/ubiquitin.json",
+    "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
+}
+
+OUTPUT_KEYS = (
+    "atom_positions_predicted",
+    "plddt_logits",
+    "pae_logits",
+    "pde_logits",
+    "distogram_logits",
+    "si_trunk",
+)
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def flatten_tensors(value, prefix: str = "") -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    if torch.is_tensor(value):
+        tensors[prefix or "output"] = value
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            tensors.update(flatten_tensors(child, name))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            name = f"{prefix}.{index}" if prefix else str(index)
+            tensors.update(flatten_tensors(child, name))
+    return tensors
+
+
+def capture_outputs(output) -> dict[str, torch.Tensor]:
+    flat = flatten_tensors(output)
+    captured: dict[str, torch.Tensor] = {}
+    for key, tensor in flat.items():
+        for wanted in OUTPUT_KEYS:
+            if key.endswith(wanted) or key == wanted:
+                captured[wanted] = tensor.detach().float().cpu()
+                break
+    return captured
+
+
+def clone_batch(batch: dict) -> dict:
+    return {
+        key: (value.clone() if torch.is_tensor(value) else value)
+        for key, value in batch.items()
+    }
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    seed: int,
+) -> InferenceExperimentRunner:
+    runner_args = deepcopy(config_utils.load_yaml(runner_yaml))
+    runner_args.setdefault("experiment_settings", {})["seeds"] = [seed]
+    runner_args.setdefault("experiment_settings", {})["use_templates"] = True
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    template_cfg = runner_args.setdefault("dataset_config_kwargs", {}).setdefault(
+        "template", {}
+    )
+    template_cfg["use_coordinate_pair_features"] = True
+
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=1,
+        use_msa_server=False,
+        use_templates=True,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = 10_000_000
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(
+                lambda t: t.to("cuda") if torch.is_tensor(t) else t, batch
+            )
+    raise RuntimeError("No valid inference sample")
+
+
+def legacy_batch_from_coordinates(coord_batch: dict) -> dict:
+    """Materialize distogram/unit-vector features from compact coordinates."""
+    pseudo_beta = coord_batch["template_pseudo_beta_coords"][0].detach().cpu().numpy()
+    frame = coord_batch["template_frame_atom_coords"][0].detach().cpu().numpy()
+    pb_mask = coord_batch["template_pseudo_beta_mask"][0].detach().cpu()
+    bb_mask = coord_batch["template_backbone_frame_mask"][0].detach().cpu()
+    asym = coord_batch["asym_id"][0].detach().cpu()
+    multichain = (asym[:, None] == asym[None, :])[None, ..., None]
+
+    legacy = {
+        key: (value.clone() if torch.is_tensor(value) else value)
+        for key, value in coord_batch.items()
+        if key
+        not in ("template_pseudo_beta_coords", "template_frame_atom_coords")
+    }
+    legacy["template_distogram"] = create_template_distogram(
+        pseudo_beta, pb_mask, multichain
+    )[None].to(device=coord_batch["asym_id"].device)
+    legacy["template_unit_vector"] = create_template_unit_vector(
+        frame, bb_mask, multichain
+    )[None].to(device=coord_batch["asym_id"].device)
+    return legacy
+
+
+def run_forward(module, batch: dict, seed: int) -> dict:
+    seed_everything(seed)
+    with torch.inference_mode():
+        return module(clone_batch(batch))
+
+
+def summarize_diff(
+    legacy: dict[str, torch.Tensor], coordinate: dict[str, torch.Tensor]
+) -> dict:
+    report = {}
+    for key in OUTPUT_KEYS:
+        if key not in legacy or key not in coordinate:
+            report[key] = {"present": False}
+            continue
+        a, b = legacy[key], coordinate[key]
+        diff = (a - b).abs()
+        report[key] = {
+            "present": True,
+            "shape": list(a.shape),
+            "bitwise_equal": bool(torch.equal(a, b)),
+            "max_abs": float(diff.max().item()),
+            "mean_abs": float(diff.mean().item()),
+        }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--query",
+        choices=sorted(KNOWN_QUERIES),
+        default="7cnx",
+        help="Benchmark query with real templates",
+    )
+    parser.add_argument("--query-json", type=Path, default=None)
+    parser.add_argument("--runner-yaml", type=Path, default=DEFAULT_RUNNER)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--atom-atol",
+        type=float,
+        default=2e-4,
+        help="Max abs diff allowed for atom_positions_predicted",
+    )
+    parser.add_argument(
+        "--logit-atol",
+        type=float,
+        default=5e-3,
+        help="Max abs diff allowed for confidence/distogram logits",
+    )
+    parser.add_argument(
+        "--trunk-atol",
+        type=float,
+        default=0.1,
+        help="Max abs diff allowed for si_trunk (amplifies UV FP noise)",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=REPO
+        / "data/inference_outputs/profiling/template_coordinate_e2e_parity.json",
+    )
+    parser.add_argument(
+        "--fused-template-coord",
+        choices=("1", "0"),
+        default="1",
+        help="OPENFOLD3_FUSED_TEMPLATE_COORD for the coordinate path",
+    )
+    args = parser.parse_args()
+
+    query_json = args.query_json or KNOWN_QUERIES[args.query]
+    if not query_json.exists():
+        raise FileNotFoundError(query_json)
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ["OPENFOLD3_FUSED_TEMPLATE_COORD"] = args.fused_template_coord
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    torch.use_deterministic_algorithms(True)
+
+    print(f"Loading coordinate batch + model for {query_json}...")
+    seed_everything(args.seed)
+    runner = build_runner(query_json, args.runner_yaml, args.seed)
+    seed_everything(args.seed)
+    coord_batch = get_batch(runner)
+    assert "template_pseudo_beta_coords" in coord_batch
+    assert "template_distogram" not in coord_batch
+    legacy_batch = legacy_batch_from_coordinates(coord_batch)
+    module = runner.lightning_module.to("cuda").eval()
+
+    print("Coordinate forward...")
+    coord_out = capture_outputs(run_forward(module, coord_batch, args.seed))
+    print("Legacy (materialized from same coords) forward...")
+    legacy_out = capture_outputs(run_forward(module, legacy_batch, args.seed))
+
+    report = summarize_diff(legacy_out, coord_out)
+    thresholds = {
+        "atom_positions_predicted": args.atom_atol,
+        "plddt_logits": args.logit_atol,
+        "pae_logits": args.logit_atol,
+        "pde_logits": args.logit_atol,
+        "distogram_logits": args.logit_atol,
+        "si_trunk": args.trunk_atol,
+    }
+    failures = []
+    for key, limit in thresholds.items():
+        info = report.get(key, {})
+        if not info.get("present"):
+            failures.append(f"{key}: missing")
+            continue
+        if info["max_abs"] > limit:
+            failures.append(
+                f"{key}: max_abs={info['max_abs']:.6g} > atol={limit:g}"
+            )
+
+    payload = {
+        "query": str(query_json),
+        "seed": args.seed,
+        "fused_template_coord": args.fused_template_coord,
+        "thresholds": thresholds,
+        "ok": not failures,
+        "failures": failures,
+        "keys": report,
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+    if failures:
+        raise SystemExit("Parity failed:\n  - " + "\n  - ".join(failures))
+    print("Parity OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/profile_inference_stages.py
+++ b/scripts/dev/profile_inference_stages.py
@@ -117,9 +117,7 @@ class FastStageProfiler:
         self._patches.clear()
 
 
-def install_hooks(
-    model, prof: FastStageProfiler, track_trunk_substages: bool
-) -> None:
+def install_hooks(model, prof: FastStageProfiler, track_trunk_substages: bool) -> None:
     prof.wrap(model, "run_trunk", "TRUNK", track_mem=not track_trunk_substages)
     prof.wrap(model.sample_diffusion, "forward", "DIFFUSION", track_mem=True)
     prof.wrap(model.aux_heads, "forward", "CONFIDENCE", track_mem=True)
@@ -284,9 +282,7 @@ def profile(args) -> dict:
     print("Hooked stage forward...")
     batch = get_batch(runner, device)
     profiler = FastStageProfiler()
-    install_hooks(
-        model, profiler, track_trunk_substages=args.track_trunk_substages
-    )
+    install_hooks(model, profiler, track_trunk_substages=args.track_trunk_substages)
     try:
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
@@ -337,8 +333,7 @@ def print_report(result: dict) -> None:
         f"samples={result['n_diffusion_samples']} 1U={_mib(u_bytes):.1f} MiB"
     )
     print(
-        f"model_params+buffers={_gib(params):.2f} GiB  "
-        f"total_peak={_gib(peak):.2f} GiB"
+        f"model_params+buffers={_gib(params):.2f} GiB  total_peak={_gib(peak):.2f} GiB"
     )
     print(f"peak_above_params={_gib(above):.2f} GiB = {above / u_bytes:.2f}U")
     print(

--- a/scripts/dev/profile_inference_stages.py
+++ b/scripts/dev/profile_inference_stages.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+"""Stage timing and top-level memory profiling for OF3 inference.
+
+Protocol:
+1. warm-up forward
+2. unhooked measured forward (overall peak + wall)
+3. hooked forward (top-level / trunk-substage peaks + nested timing)
+
+Only sequential memory-tracked stages reset CUDA peak stats. Nested hooks are
+timing-only so they do not corrupt enclosing peaks.
+
+1U = N² × c_z × 4 bytes. The gate metric is peak CUDA allocation above live
+model parameter (+ buffer) bytes — not peak minus ambient allocator residency
+and not raw ``max_memory_allocated()`` alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import OrderedDict
+from pathlib import Path
+
+from openfold3.entry_points.import_utils import _torch_gpu_setup
+
+_torch_gpu_setup()
+
+import torch  # noqa: E402
+
+from openfold3.core.config import config_utils  # noqa: E402
+from openfold3.core.utils.tensor_utils import tensor_tree_map  # noqa: E402
+from openfold3.entry_points.experiment_runner import (  # noqa: E402
+    InferenceExperimentRunner,
+)
+from openfold3.entry_points.validator import InferenceExperimentConfig  # noqa: E402
+from openfold3.projects.of3_all_atom.config.inference_query_format import (  # noqa: E402
+    InferenceQuerySet,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_RUNNER_YAML = REPO / "examples/example_runner_yamls/cuequivariance.yml"
+
+KNOWN_QUERIES = {
+    "ubiquitin": REPO / "examples/example_inference_inputs/query_ubiquitin.json",
+    "homo_1200": REPO / "data/inference_outputs/profiling/queries/homo_1200.json",
+    "mcl1": REPO / "data/inference_benchmark_msa_template/queries/mcl1.json",
+}
+KNOWN_RUNNERS = {
+    "mcl1": REPO / "data/inference_benchmark_msa_template/runner.yml",
+}
+
+
+def _gib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**3
+
+
+def _mib(n_bytes: int | float) -> float:
+    return n_bytes / 1024**2
+
+
+class FastStageProfiler:
+    def __init__(self):
+        self.stats: OrderedDict[str, dict] = OrderedDict()
+        self._patches: list[tuple[object, str, object]] = []
+
+    def wrap(self, obj, attr: str, name: str, track_mem: bool = False) -> None:
+        orig = getattr(obj, attr)
+
+        def hook(*args, **kwargs):
+            if track_mem:
+                torch.cuda.synchronize()
+                before = torch.cuda.memory_allocated()
+                torch.cuda.reset_peak_memory_stats()
+            else:
+                before = 0
+
+            start_ev = torch.cuda.Event(enable_timing=True)
+            end_ev = torch.cuda.Event(enable_timing=True)
+            start_ev.record()
+            out = orig(*args, **kwargs)
+            end_ev.record()
+            torch.cuda.synchronize()
+
+            cuda_ms = start_ev.elapsed_time(end_ev)
+            peak = torch.cuda.max_memory_allocated() if track_mem else 0
+            after = torch.cuda.memory_allocated() if track_mem else 0
+
+            stat = self.stats.setdefault(
+                name,
+                {
+                    "abs_peak_bytes": 0,
+                    "before_bytes": before,
+                    "after_bytes": after,
+                    "peak_over_before_bytes": 0,
+                    "cuda_ms": 0.0,
+                    "total_calls": 0,
+                    "memory_tracked": track_mem,
+                },
+            )
+            stat["total_calls"] += 1
+            stat["cuda_ms"] += cuda_ms
+            if track_mem and peak > stat["abs_peak_bytes"]:
+                stat["abs_peak_bytes"] = peak
+                stat["before_bytes"] = before
+                stat["after_bytes"] = after
+                stat["peak_over_before_bytes"] = peak - before
+            return out
+
+        setattr(obj, attr, hook)
+        self._patches.append((obj, attr, orig))
+
+    def unwrap_all(self) -> None:
+        for obj, attr, orig in reversed(self._patches):
+            setattr(obj, attr, orig)
+        self._patches.clear()
+
+
+def install_hooks(
+    model, prof: FastStageProfiler, track_trunk_substages: bool
+) -> None:
+    prof.wrap(model, "run_trunk", "TRUNK", track_mem=not track_trunk_substages)
+    prof.wrap(model.sample_diffusion, "forward", "DIFFUSION", track_mem=True)
+    prof.wrap(model.aux_heads, "forward", "CONFIDENCE", track_mem=True)
+
+    prof.wrap(
+        model.input_embedder,
+        "forward",
+        "trunk.input_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.template_embedder,
+        "forward",
+        "trunk.template_embedder",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.msa_module,
+        "forward",
+        "trunk.msa_module",
+        track_mem=track_trunk_substages,
+    )
+    prof.wrap(
+        model.pairformer_stack,
+        "forward",
+        "trunk.pairformer",
+        track_mem=track_trunk_substages,
+    )
+
+    # Timing-only nested hooks for first-pass localization.
+    prof.wrap(model.diffusion_module, "forward", "diff.per_step")
+    if hasattr(model.aux_heads, "pairformer_embedding"):
+        prof.wrap(
+            model.aux_heads.pairformer_embedding, "forward", "conf.pairformer_emb"
+        )
+
+
+def resolve_paths(args) -> tuple[Path, Path]:
+    if args.query_json is not None:
+        query_json = args.query_json
+    elif args.query in KNOWN_QUERIES:
+        query_json = KNOWN_QUERIES[args.query]
+    else:
+        raise FileNotFoundError(
+            f"Unknown query {args.query!r}; pass --query-json or one of "
+            f"{sorted(KNOWN_QUERIES)}"
+        )
+    if not query_json.exists():
+        raise FileNotFoundError(query_json)
+
+    if args.runner_yaml is not None:
+        runner_yaml = args.runner_yaml
+    elif args.query in KNOWN_RUNNERS:
+        runner_yaml = KNOWN_RUNNERS[args.query]
+    else:
+        runner_yaml = DEFAULT_RUNNER_YAML
+    if not runner_yaml.exists():
+        raise FileNotFoundError(runner_yaml)
+    return query_json, runner_yaml
+
+
+def build_runner(
+    query_json: Path,
+    runner_yaml: Path,
+    num_samples: int,
+    offload_token_cutoff: int,
+) -> InferenceExperimentRunner:
+    runner_args = config_utils.load_yaml(runner_yaml)
+    runner_args.setdefault("data_module_args", {})["num_workers"] = 0
+    runner = InferenceExperimentRunner(
+        InferenceExperimentConfig(**runner_args),
+        num_diffusion_samples=num_samples,
+        use_msa_server=False,
+    )
+    memory = runner.model_config.settings.memory.eval
+    memory.offload_inference.token_cutoff = offload_token_cutoff
+    memory.use_deepspeed_evo_attention = False
+    memory.use_triton_triangle_kernels = False
+    memory.use_cueq_triangle_kernels = True
+    runner.setup()
+    runner.inference_query_set = InferenceQuerySet.from_json(query_json)
+    return runner
+
+
+def get_batch(runner: InferenceExperimentRunner, device: torch.device) -> dict:
+    data_module = runner.lightning_data_module
+    data_module.prepare_data()
+    data_module.setup()
+    for batch in data_module.predict_dataloader():
+        if batch.get("valid_sample") and not batch.get("repeated_sample"):
+            return tensor_tree_map(lambda t: t.to(device), batch)
+    raise RuntimeError("No valid inference sample")
+
+
+def model_parameter_bytes(model: torch.nn.Module) -> dict[str, int]:
+    """Exact live parameter/buffer payload on the current device."""
+    param_bytes = sum(p.numel() * p.element_size() for p in model.parameters())
+    buffer_bytes = sum(b.numel() * b.element_size() for b in model.buffers())
+    return {
+        "model_params_bytes": param_bytes,
+        "model_buffer_bytes": buffer_bytes,
+        "model_params_and_buffers_bytes": param_bytes + buffer_bytes,
+    }
+
+
+def profile(args) -> dict:
+    query_json, runner_yaml = resolve_paths(args)
+    device = torch.device("cuda")
+    print(f"Building runner for {query_json} (samples={args.samples})...")
+
+    runner = build_runner(
+        query_json=query_json,
+        runner_yaml=runner_yaml,
+        num_samples=args.samples,
+        offload_token_cutoff=args.offload_token_cutoff,
+    )
+    lightning_module = runner.lightning_module.to(device).eval()
+    model = lightning_module.model
+    param_info = model_parameter_bytes(model)
+    model_params_bytes = param_info["model_params_and_buffers_bytes"]
+
+    batch = get_batch(runner, device)
+    n_tok = int(batch["token_mask"].shape[-1])
+    n_atom = int(batch["atom_mask"].shape[-1]) if "atom_mask" in batch else -1
+    c_z = int(model.config.architecture.shared.c_z)
+    u_bytes = n_tok * n_tok * c_z * 4
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    cuda_allocated_after_load = torch.cuda.memory_allocated()
+
+    print(f"n_tokens={n_tok}, n_atoms={n_atom}, c_z={c_z}")
+    print(f"1U = {_mib(u_bytes):.1f} MiB")
+    print(
+        f"Model params+buffers: {_mib(model_params_bytes):.1f} MiB "
+        f"(cuda allocated after load: {_mib(cuda_allocated_after_load):.1f} MiB)"
+    )
+
+    print("Warm-up forward...")
+    batch = get_batch(runner, device)
+    with torch.inference_mode():
+        lightning_module(batch)
+    del batch
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+    print("Overall measured forward...")
+    batch = get_batch(runner, device)
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.perf_counter()
+    with torch.inference_mode():
+        lightning_module(batch)
+    torch.cuda.synchronize()
+    overall_wall_s = time.perf_counter() - t0
+    overall_peak_bytes = torch.cuda.max_memory_allocated()
+    del batch
+    torch.cuda.empty_cache()
+
+    print("Hooked stage forward...")
+    batch = get_batch(runner, device)
+    profiler = FastStageProfiler()
+    install_hooks(
+        model, profiler, track_trunk_substages=args.track_trunk_substages
+    )
+    try:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        t0 = time.perf_counter()
+        with torch.inference_mode():
+            lightning_module(batch)
+        torch.cuda.synchronize()
+        stage_wall_s = time.perf_counter() - t0
+    finally:
+        profiler.unwrap_all()
+        del batch
+
+    peak_above_params = overall_peak_bytes - model_params_bytes
+    return {
+        "query_json": str(query_json),
+        "runner_yaml": str(runner_yaml),
+        "n_tokens": n_tok,
+        "n_atoms": n_atom,
+        "n_diffusion_samples": args.samples,
+        "c_z": c_z,
+        "U_bytes": u_bytes,
+        **param_info,
+        "cuda_allocated_after_load_bytes": cuda_allocated_after_load,
+        "overall_peak_bytes": overall_peak_bytes,
+        "peak_above_params_bytes": peak_above_params,
+        "peak_above_params_U": peak_above_params / u_bytes,
+        "overall_wall_s": round(overall_wall_s, 2),
+        "stage_wall_s": round(stage_wall_s, 2),
+        "offload_token_cutoff": args.offload_token_cutoff,
+        "track_trunk_substages": args.track_trunk_substages,
+        "tri_attn_chunk_cap": os.environ.get("OPENFOLD3_TRI_ATTN_CHUNK_CAP"),
+        "trimul_chunk_cap": os.environ.get("OPENFOLD3_TRIMUL_CHUNK_CAP"),
+        "transition_chunk_cap": os.environ.get("OPENFOLD3_TRANSITION_CHUNK_CAP"),
+        "stages": profiler.stats,
+    }
+
+
+def print_report(result: dict) -> None:
+    params = result["model_params_and_buffers_bytes"]
+    peak = result["overall_peak_bytes"]
+    u_bytes = result["U_bytes"]
+    above = peak - params
+
+    print()
+    print("=" * 100)
+    print(
+        f"n_tok={result['n_tokens']} n_atom={result['n_atoms']} "
+        f"samples={result['n_diffusion_samples']} 1U={_mib(u_bytes):.1f} MiB"
+    )
+    print(
+        f"model_params+buffers={_gib(params):.2f} GiB  "
+        f"total_peak={_gib(peak):.2f} GiB"
+    )
+    print(f"peak_above_params={_gib(above):.2f} GiB = {above / u_bytes:.2f}U")
+    print(
+        f"overall_wall={result['overall_wall_s']:.2f}s  "
+        f"stage_wall={result['stage_wall_s']:.2f}s"
+    )
+    print("=" * 100)
+    print(
+        f"{'stage':<28s} {'above_U':>8s} {'trans_U':>8s} "
+        f"{'ms':>10s} {'calls':>7s} {'memory':>8s}"
+    )
+    print("-" * 100)
+    for name, stage in result["stages"].items():
+        if stage.get("memory_tracked", False):
+            above_u = (stage["abs_peak_bytes"] - params) / u_bytes
+            trans_u = stage["peak_over_before_bytes"] / u_bytes
+            above_s = f"{above_u:8.2f}"
+            trans_s = f"{trans_u:8.2f}"
+            mem_s = "yes"
+        else:
+            above_s = f"{'-':>8s}"
+            trans_s = f"{'-':>8s}"
+            mem_s = "timing"
+        print(
+            f"{name:<28s} {above_s} {trans_s} "
+            f"{stage['cuda_ms']:10.1f} {stage['total_calls']:7d} {mem_s:>8s}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        default="ubiquitin",
+        help=f"Known query key: {sorted(KNOWN_QUERIES)}",
+    )
+    parser.add_argument("--query-json", type=Path, default=None)
+    parser.add_argument("--runner-yaml", type=Path, default=None)
+    parser.add_argument("--samples", type=int, default=1)
+    parser.add_argument(
+        "--offload-token-cutoff",
+        type=int,
+        default=10_000_000,
+        help="Default disables offload for practical gate sizes",
+    )
+    parser.add_argument(
+        "--track-trunk-substages",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Track input/template/MSA/Pairformer memory separately (default: on)",
+    )
+    parser.add_argument(
+        "--triangle-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRI_ATTN_CHUNK_CAP and OPENFOLD3_TRIMUL_CHUNK_CAP "
+            "(shared MSA/template/pairformer/confidence triangle ops)"
+        ),
+    )
+    parser.add_argument(
+        "--transition-chunk-cap",
+        type=int,
+        default=None,
+        help=(
+            "Set OPENFOLD3_TRANSITION_CHUNK_CAP to force row-chunked "
+            "pair/MSA transitions (and OPM) after the chunk-size tuner"
+        ),
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.triangle_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRI_ATTN_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+        os.environ["OPENFOLD3_TRIMUL_CHUNK_CAP"] = str(args.triangle_chunk_cap)
+    if args.transition_chunk_cap is not None:
+        os.environ["OPENFOLD3_TRANSITION_CHUNK_CAP"] = str(args.transition_chunk_cap)
+
+    result = profile(args)
+    print_report(result)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(result, indent=2))
+        print(f"Saved {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This change reduces pair-side inference transients with two length-generic Triton paths:

- Fused input relative-position gather-add, including the in-place token-bond update.
- Fused pair SwiGLU transition covering LayerNorm, SwiGLU, and output Linear.

Both paths retain eager fallbacks with explicit eligibility checks. Training uses autograd-aware paths with deterministic split-M weight-gradient reductions; inference uses in-place writes where the residual aliases the input. Triton programs do not specialize on target length.

## Input relative-position path

- Removes the materialized pair-sized gather/one-hot intermediate.
- Supports fp32 and bf16 activations, including fp32 parameter masters for bf16-mixed execution.
- Keeps the classic biased Linear path and eager fallback available.
- Adds parity, compile-reuse, determinism, and microbenchmark coverage.

## Pair SwiGLU path

- Fuses LayerNorm -> SwiGLU -> Linear.
- Rematerializes hidden activations during backward instead of retaining them.
- Uses a single precision dispatch mode for IEEE fp32, TF32, and bf16.
- Falls back to the existing module primitives for ineligible shapes or disabled execution.

## Measurements

RTX 4090 kernel measurements show:

- Input relpos forward: approximately 4.0-4.5x faster at production-relevant lengths, with peak reduced from about 2.0U to 1.0U.
- Pair SwiGLU inference: approximately 2.1-2.3x faster in TF32, with the in-place path adding no output-sized allocation.
- Checkpointed pair SwiGLU training: peak reduced from about 19U to 3.3U in TF32 and from about 9.5U to 2.8U in bf16-mixed.

Full-model S=1 profiling with the two paths enabled gives:

- homo_1200: 5.29U -> 5.06U; peak moves from input_embedder to DIFFUSION; warm time 107.91s -> 98.69s.
- MCL1: 5.71U at msa_module; this remaining floor is unchanged.

The 5U milestone is therefore not reached by this change.

## Validation

- Fused relative-position parity, fallback, autograd, deterministic dW, and compile-reuse tests.
- Fused SwiGLU parity, in-place behavior, autograd, fallback, deterministic dW, and compile-reuse tests.
- Deterministic ubiquitin smoke and full-model profiling performed with both paths enabled.

## Configuration

OPENFOLD3_FUSED_RELPOS=1 and OPENFOLD3_FUSED_SWIGLU_TRANSITION=1 enable the optimized paths by default when eligible; setting either variable to 0 selects the eager fallback.